### PR TITLE
Changes storage of 33 bytes

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -195,7 +195,8 @@ class Miner(NucypherTokenActor):
     def publish_data(self, data) -> str:
         """Store new data"""
 
-        txhash = self.miner_agent.contract.functions.setMinerId(data).transact({'from': self.address})
+        txhash = self.miner_agent.contract.functions.setMinerId(
+            self.blockchain.interface.w3.toBytes(data[0]), data[1:]).transact({'from': self.address})
         self.blockchain.wait_for_receipt(txhash)
 
         self._transactions.append((datetime.utcnow(), txhash))
@@ -212,7 +213,7 @@ class Miner(NucypherTokenActor):
         miner_ids = list()
         for index in range(count):
             miner_id = self.miner_agent.contract.functions.getMinerId(self.address, index).call()
-            miner_ids.append(miner_id)
+            miner_ids.append(miner_id[0] + miner_id[1])
         return tuple(miner_ids)
 
 

--- a/nucypher/blockchain/eth/sol/source/proxy/Upgradeable.sol
+++ b/nucypher/blockchain/eth/sol/source/proxy/Upgradeable.sol
@@ -56,21 +56,20 @@ contract Upgradeable is Ownable {
     {
         bytes4 targetCall = bytes4(keccak256(abi.encodePacked(_signature)));
         assembly {
-            let freeMemAddress := mload(0x40)
-            mstore(freeMemAddress, targetCall)
+            memoryAddress := mload(0x40)
+            mstore(memoryAddress, targetCall)
             if gt(_numberOfArguments, 0) {
-                mstore(add(freeMemAddress, 0x04), _argument1)
+                mstore(add(memoryAddress, 0x04), _argument1)
             }
             if gt(_numberOfArguments, 1) {
-                mstore(add(freeMemAddress, 0x24), _argument2)
+                mstore(add(memoryAddress, 0x24), _argument2)
             }
-            switch delegatecall(gas, _target, freeMemAddress, add(0x04, mul(0x20, _numberOfArguments)), 0, 0)
+            switch delegatecall(gas, _target, memoryAddress, add(0x04, mul(0x20, _numberOfArguments)), 0, 0)
                 case 0 {
-                    revert(freeMemAddress, 0)
+                    revert(memoryAddress, 0)
                 }
                 default {
-                    returndatacopy(freeMemAddress, 0x0, returndatasize)
-                    memoryAddress := freeMemAddress
+                    returndatacopy(memoryAddress, 0x0, returndatasize)
                 }
         }
     }

--- a/tests/blockchain/eth/contracts/test_miners_escrow.py
+++ b/tests/blockchain/eth/contracts/test_miners_escrow.py
@@ -890,17 +890,16 @@ def test_miner_id(web3, chain, token, escrow_contract):
 
     # Set miner ids
     miner_id = os.urandom(33)
-    tx = escrow.functions.setMinerId(miner_id).transact({'from': miner})
+    tx = escrow.functions.setMinerId(web3.toBytes(miner_id[0]), miner_id[1:]).transact({'from': miner})
     chain.wait_for_receipt(tx)
     assert 1 == escrow.functions.getMinerIdsLength(miner).call()
+    assert [web3.toBytes(miner_id[0]), miner_id[1:]] == escrow.functions.getMinerId(miner, 0).call()
 
-    assert miner_id == escrow.functions.getMinerId(miner, 0).call()
-    miner_id = os.urandom(66)
-    tx = escrow.functions.setMinerId(miner_id).transact({'from': miner})
+    miner_id = os.urandom(33)
+    tx = escrow.functions.setMinerId(web3.toBytes(miner_id[0]), miner_id[1:]).transact({'from': miner})
     chain.wait_for_receipt(tx)
     assert 2 == escrow.functions.getMinerIdsLength(miner).call()
-
-    assert miner_id == escrow.functions.getMinerId(miner, 1).call()
+    assert [web3.toBytes(miner_id[0]), miner_id[1:]] == escrow.functions.getMinerId(miner, 1).call()
 
 
 @pytest.mark.slow
@@ -940,7 +939,8 @@ def test_verifying_state(web3, chain, token):
     chain.wait_for_receipt(tx)
     tx = contract.functions.deposit(balance, 1000).transact({'from': miner})
     chain.wait_for_receipt(tx)
-    tx = contract.functions.setMinerId(web3.toBytes(111)).transact({'from': miner})
+    miner_id = os.urandom(33)
+    tx = contract.functions.setMinerId(web3.toBytes(miner_id[0]), miner_id[1:]).transact({'from': miner})
     chain.wait_for_receipt(tx)
 
     # Upgrade to the second version
@@ -952,7 +952,7 @@ def test_verifying_state(web3, chain, token):
     assert policy_manager.address == contract.functions.policyManager().call()
     assert 2 == contract.functions.valueToCheck().call()
     assert 1 == web3.toInt(contract.functions.getMinerIdsLength(miner).call())
-    assert 111 == web3.toInt(contract.functions.getMinerId(miner, 0).call())
+    assert [web3.toBytes(miner_id[0]), miner_id[1:]] == contract.functions.getMinerId(miner, 0).call()
     tx = contract.functions.setValueToCheck(3).transact({'from': creator})
     chain.wait_for_receipt(tx)
     assert 3 == contract.functions.valueToCheck().call()

--- a/tests/blockchain/eth/entities/test_actors.py
+++ b/tests/blockchain/eth/entities/test_actors.py
@@ -64,7 +64,7 @@ class TestMiner:
     def test_publish_miner_datastore(self, miner):
 
         # Publish Miner IDs to the DHT
-        some_data = os.urandom(32)
+        some_data = os.urandom(33)
         _txhash = miner.publish_data(some_data)
 
         # Fetch the miner Ids
@@ -74,7 +74,7 @@ class TestMiner:
         assert some_data == stored_miner_ids[0]
 
         # Repeat, with another miner ID
-        another_mock_miner_id = os.urandom(32)
+        another_mock_miner_id = os.urandom(33)
         _txhash = miner.publish_data(another_mock_miner_id)
 
         stored_miner_ids = miner.fetch_data()
@@ -83,7 +83,7 @@ class TestMiner:
         assert another_mock_miner_id == stored_miner_ids[1]
 
         supposedly_the_same_miner_id = miner.miner_agent.contract.functions.getMinerId(miner.address, 1).call()
-        assert another_mock_miner_id == supposedly_the_same_miner_id
+        assert another_mock_miner_id == supposedly_the_same_miner_id[0] + supposedly_the_same_miner_id[1]
 
 
 class TestPolicyAuthor:


### PR DESCRIPTION
I tried other several options: `byte[33]`, `bytes32` + `bool`, `bytes` as input and `bytes32` + `byte` as storage.
`bytes32` + `bool` and `bytes32` + `byte` has the same gas consumption and contract size.
`byte[33]` looks like `bytes32[33]`, so it's not an option.
`bytes` as input has the same gas consumption as `bytes32` + `byte` but bigger contract size.