### PR TITLE
Push contract API down to Agents 

### DIFF
--- a/nucypher/blockchain/eth/chains.py
+++ b/nucypher/blockchain/eth/chains.py
@@ -103,7 +103,7 @@ class TesterBlockchain(Blockchain):
     def ether_airdrop(self, amount: int) -> List[str]:
         """Airdrops ether from creator address to all other addresses!"""
 
-        coinbase, *addresses = self.__interface.w3.eth.accounts
+        coinbase, *addresses = self.interface.w3.eth.accounts
 
         tx_hashes = list()
         for address in addresses:

--- a/nucypher/blockchain/eth/constants.py
+++ b/nucypher/blockchain/eth/constants.py
@@ -5,8 +5,9 @@ These values are static and do not need to be changed during runtime;
 Once the NuCypherToken contract is deployed to a network with one set of constant values,
 those values are then required to be compatible with the rest of the network.
 """
+import math
 
-
+import maya
 from constant_sorrow.constants import (NULL_ADDRESS, TOKEN_SATURATION, MINING_COEFFICIENT, TOKEN_SUPPLY,
                                        M, HOURS_PER_PERIOD, MIN_LOCKED_PERIODS, MAX_MINTING_PERIODS,
                                        MIN_ALLOWED_LOCKED, MAX_ALLOWED_LOCKED, )
@@ -15,6 +16,8 @@ from constant_sorrow.constants import (NULL_ADDRESS, TOKEN_SATURATION, MINING_CO
 #
 # Token
 #
+from nucypher.blockchain.eth.chains import Blockchain
+
 
 class TokenConfigError(ValueError):
     pass
@@ -89,7 +92,7 @@ def validate_locktime(lock_periods: int, raise_on_fail=True) -> bool:
 
     rulebook = (
 
-        (MIN_LOCKED_PERIODS <= lock_periods ,
+        (MIN_LOCKED_PERIODS <= lock_periods,
          'Locktime ({locktime}) too short; must be at least {minimum}'
          .format(minimum=MIN_LOCKED_PERIODS, locktime=lock_periods)),
 

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -10,8 +10,8 @@ from .chains import Blockchain
 
 class ContractDeployer:
 
-    _interface_class = DeployerCircumflex
     agency = NotImplemented
+    _interface_class = DeployerCircumflex
     _contract_name = NotImplemented
     _arming_word = "I UNDERSTAND"
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -4,6 +4,7 @@ import warnings
 from pathlib import Path
 from typing import Tuple, List
 
+from constant_sorrow import constants
 from web3 import Web3, WebsocketProvider, HTTPProvider, IPCProvider
 from web3.contract import Contract
 
@@ -341,10 +342,17 @@ class DeployerCircumflex(ControlCircumflex):
 
         # Depends on web3 instance
         super().__init__(*args, **kwargs)
+        self.__deployer_address = deployer_address if deployer_address is not None else constants.NO_DEPLOYER_CONFIGURED
 
-        if deployer_address is None:
-            deployer_address = self.w3.eth.coinbase  # provider's coinbase / etherbase is default
-        self.deployer_address = deployer_address
+    @property
+    def deployer_address(self):
+        return self.__deployer_address
+
+    @deployer_address.setter
+    def deployer_address(self, ether_address: str) -> None:
+        if self.deployer_address is not constants.NO_DEPLOYER_CONFIGURED:
+            raise RuntimeError("{} already has a deployer address set.".format(self.__class__.__name__))
+        self.__deployer_address = ether_address
 
     def deploy_contract(self, contract_name: str, *args, **kwargs) -> Tuple[Contract, str]:
         """

--- a/nucypher/blockchain/eth/policies.py
+++ b/nucypher/blockchain/eth/policies.py
@@ -64,7 +64,7 @@ class BlockchainArrangement(Arrangement):
     def revoke(self) -> str:
         """Revoke this arrangement and return the transaction hash as hex."""
 
-        txhash = self.policy_agent.revoke_arrangement(self.id, author=self.author)
+        txhash = self.policy_agent.revoke_policy(self.id, author=self.author)
         self.revoke_transaction = txhash
         self.is_revoked = True
         return txhash

--- a/nucypher/characters.py
+++ b/nucypher/characters.py
@@ -732,7 +732,7 @@ class Ursula(Character, ProxyRESTServer, Miner):
 
         value = self.interface_info_with_metadata()
         setter = self.dht_server.set(key=ursula_id, value=value)
-        self._publish_datastore(ursula_id)
+        self.publish_datastore(ursula_id)
         loop = asyncio.get_event_loop()
         loop.run_until_complete(setter)
 

--- a/tests/blockchain/eth/entities/test_actors.py
+++ b/tests/blockchain/eth/entities/test_actors.py
@@ -12,20 +12,28 @@ class TestMiner:
 
     @pytest.fixture(scope='class')
     def miner(self, testerchain, mock_token_agent, mock_miner_agent):
-        mock_token_agent.token_airdrop(amount=100000 * constants.M)
-        _origin, ursula, *everybody_else = testerchain.interface.w3.eth.accounts
-        miner = Miner(miner_agent=mock_miner_agent, ether_address=ursula)
+        origin, *everybody_else = testerchain.interface.w3.eth.accounts
+        mock_token_agent.token_airdrop(origin=origin, addresses=everybody_else, amount=100000*constants.M)
+        miner = Miner(miner_agent=mock_miner_agent, ether_address=everybody_else[0])
         return miner
 
+    @pytest.mark.usefixtures("mock_policy_agent")
     def test_miner_locking_tokens(self, testerchain, miner, mock_miner_agent):
 
-        assert constants.MIN_ALLOWED_LOCKED < miner.token_balance(), "Insufficient miner balance"
+        testerchain.ether_airdrop(amount=10000)
+
+        assert constants.MIN_ALLOWED_LOCKED < miner.token_balance, "Insufficient miner balance"
+
+        now = maya.now()
+        expiration = now.add(days=constants.MIN_LOCKED_PERIODS)
 
         miner.stake(amount=constants.MIN_ALLOWED_LOCKED,         # Lock the minimum amount of tokens
-                    lock_periods=constants.MIN_LOCKED_PERIODS)   # ... for the fewest number of periods
+                    expiration=expiration)
+                    # lock_periods=constants.MIN_LOCKED_PERIODS)   # ... for the fewest number of periods
 
         # Verify that the escrow is "approved" to receive tokens
-        assert mock_miner_agent.token_agent.contract.functions.allowance(miner.ether_address, mock_miner_agent.contract_address).call() == 0
+        assert mock_miner_agent.token_agent.contract.functions.allowance(miner.ether_address,
+                                                                         mock_miner_agent.contract_address).call() == 0
 
         # Staking starts after one period
         assert mock_miner_agent.contract.functions.getLockedTokens(miner.ether_address).call() == 0
@@ -37,26 +45,26 @@ class TestMiner:
 
     @pytest.mark.slow()
     @pytest.mark.usefixtures("mock_policy_agent")
-    def test_miner_collects_staking_reward_tokens(self, testerchain, miner, mock_token_agent, mock_miner_agent):
+    def test_miner_collects_staking_reward(self, deployed_testerchain, miner, mock_token_agent, mock_miner_agent):
 
         # Capture the current token balance of the miner
-        initial_balance = miner.token_balance()
-        assert mock_token_agent.get_balance(miner.ether_address) == miner.token_balance()
+        initial_balance = miner.token_balance
+        assert mock_token_agent.get_balance(miner.ether_address) == miner.token_balance
 
         miner.stake(amount=constants.MIN_ALLOWED_LOCKED,         # Lock the minimum amount of tokens
                     lock_periods=constants.MIN_LOCKED_PERIODS)   # ... for the fewest number of periods
 
         # Have other address lock tokens
-        _origin, ursula, *everybody_else = testerchain.interface.w3.eth.accounts
+        _origin, ursula, *everybody_else = deployed_testerchain.interface.w3.eth.accounts
         mock_miner_agent.spawn_random_miners(addresses=everybody_else)
 
         # ...wait out the lock period...
         for _ in range(28):
-            testerchain.time_travel(periods=1)
+            deployed_testerchain.time_travel(periods=1)
             miner.confirm_activity()
 
         # ...wait more...
-        testerchain.time_travel(periods=2)
+        deployed_testerchain.time_travel(periods=2)
         miner.mint()
         miner.collect_staking_reward()
 

--- a/tests/blockchain/eth/entities/test_actors.py
+++ b/tests/blockchain/eth/entities/test_actors.py
@@ -1,5 +1,7 @@
+import math
 import os
 
+import maya
 import pytest
 
 from nucypher.blockchain.eth.actors import Miner, PolicyAuthor
@@ -61,21 +63,21 @@ class TestMiner:
         final_balance = mock_token_agent.get_balance(miner.ether_address)
         assert final_balance > initial_balance
 
-    def test_publish_miner_datastore(self, miner):
+    def test_miner_contract_datastore(self, miner):
 
         # Publish Miner IDs to the DHT
         some_data = os.urandom(32)
-        _txhash = miner._publish_datastore(data=some_data)
+        _txhash = miner.publish_datastore(data=some_data)
 
         # Fetch the miner Ids
-        stored_miner_id = miner._read_datastore(refresh=True)
+        stored_miner_id = miner.read_datastore(refresh=True)
         assert len(stored_miner_id) == 32
 
         # Repeat, with another miner ID
         another_mock_miner_id = os.urandom(32)
-        _txhash = miner._publish_datastore(data=another_mock_miner_id)
+        _txhash = miner.publish_datastore(data=another_mock_miner_id)
 
-        stored_miner_id = miner._read_datastore(refresh=True)
+        stored_miner_id = miner.read_datastore(refresh=True)
 
         assert another_mock_miner_id == stored_miner_id
 

--- a/tests/blockchain/eth/entities/test_actors.py
+++ b/tests/blockchain/eth/entities/test_actors.py
@@ -96,14 +96,13 @@ class TestMiner:
 class TestPolicyAuthor:
 
     @pytest.fixture(scope='class')
-    def author(self, testerchain, mock_token_agent, mock_policy_agent):
+    def author(self, deployed_testerchain, mock_token_agent, mock_policy_agent):
         mock_token_agent.ether_airdrop(amount=100000 * constants.M)
-        _origin, ursula, alice, *everybody_else = testerchain.interface.w3.eth.accounts
+        _origin, ursula, alice, *everybody_else = deployed_testerchain.interface.w3.eth.accounts
         miner = PolicyAuthor(ether_address=alice, policy_agent=mock_policy_agent)
         return miner
 
-    def test_create_policy_author(self, testerchain, mock_policy_agent):
-        _origin, ursula, alice, *everybody_else = testerchain.interface.w3.eth.accounts
-
+    def test_create_policy_author(self, deployed_testerchain, mock_policy_agent):
+        _origin, ursula, alice, *everybody_else = deployed_testerchain.interface.w3.eth.accounts
         policy_author = PolicyAuthor(policy_agent=mock_policy_agent, ether_address=alice)
         assert policy_author.ether_address == alice

--- a/tests/blockchain/eth/entities/test_agents.py
+++ b/tests/blockchain/eth/entities/test_agents.py
@@ -8,20 +8,13 @@ M = 10 ** 6
 
 
 @pytest.mark.slow()
+@pytest.mark.usefixtures("miners")
 @pytest.mark.usefixtures("mock_policy_agent")
-def test_get_swarm(testerchain, mock_token_agent, mock_miner_agent):
-
-    mock_token_agent.token_airdrop(amount=100000 * constants.M)
-
-    creator, *addresses = testerchain.interface.w3.eth.accounts
-
-    mock_miner_agent.spawn_random_miners(addresses=addresses)
-
-    testerchain.time_travel(periods=1)
+def test_get_swarm(mock_miner_agent):
 
     swarm = mock_miner_agent.swarm()
     swarm_addresses = list(swarm)
-    assert len(swarm_addresses) == 9
+    assert len(swarm_addresses) == constants.NUMBER_OF_TEST_ETH_ACCOUNTS - 1  # exclude etherbase
 
     # Grab a miner address from the swarm
     miner_addr = swarm_addresses[0]
@@ -35,18 +28,12 @@ def test_get_swarm(testerchain, mock_token_agent, mock_miner_agent):
 
 
 @pytest.mark.slow()
-def test_sample_miners(testerchain, mock_miner_agent, mock_token_agent):
-    mock_token_agent.token_airdrop(amount=100000 * constants.M)
-
-    # Have other address lock tokens
-    _origin, ursula, *everybody_else = testerchain.interface.w3.eth.accounts
-    mock_miner_agent.spawn_random_miners(addresses=everybody_else)
-
-    testerchain.time_travel(periods=1)
+@pytest.mark.usefixtures("miners")
+def test_sample_miners(mock_miner_agent):
 
     with pytest.raises(MinerAgent.NotEnoughMiners):
         mock_miner_agent.sample(quantity=100)  # Waay more than we have deployed
 
     miners = mock_miner_agent.sample(quantity=3)
-    assert len(miners) == 3
-    assert len(set(miners)) == 3
+    assert len(miners) == 3       # Three..
+    assert len(set(miners)) == 3  # ..unique addresses

--- a/tests/blockchain/eth/test_api.py
+++ b/tests/blockchain/eth/test_api.py
@@ -7,13 +7,14 @@ from nucypher.blockchain.eth.interfaces import EthereumContractRegistrar
 
 
 def test_token_deployer_and_agent(testerchain):
+    origin, *everybody_else = testerchain.interface.w3.eth.accounts
 
     # Trying to get token from blockchain before it's been published fails
     with pytest.raises(EthereumContractRegistrar.UnknownContract):
         NucypherTokenAgent(blockchain=testerchain)
 
     # The big day...
-    deployer = NucypherTokenDeployer(blockchain=testerchain)
+    deployer = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)
 
     with pytest.raises(NucypherTokenDeployer.ContractDeploymentError):
         deployer.deploy()
@@ -54,20 +55,21 @@ def test_deploy_ethereum_contracts(testerchain):
     - UserEscrow
     - Issuer
     """
+    origin, *everybody_else = testerchain.interface.w3.eth.accounts
 
-    token_deployer = NucypherTokenDeployer(blockchain=testerchain)
+    token_deployer = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)
     token_deployer.arm()
     token_deployer.deploy()
 
     token_agent = NucypherTokenAgent(blockchain=testerchain)
 
-    miner_escrow_deployer = MinerEscrowDeployer(token_agent=token_agent)
+    miner_escrow_deployer = MinerEscrowDeployer(token_agent=token_agent, deployer_address=origin)
     miner_escrow_deployer.arm()
     miner_escrow_deployer.deploy()
 
     miner_agent = MinerAgent(token_agent=token_agent)
 
-    policy_manager_contract = PolicyManagerDeployer(miner_agent=miner_agent)
+    policy_manager_contract = PolicyManagerDeployer(miner_agent=miner_agent, deployer_address=origin)
     policy_manager_contract.arm()
     policy_manager_contract.deploy()
 

--- a/tests/blockchain/eth/test_setup.py
+++ b/tests/blockchain/eth/test_setup.py
@@ -11,5 +11,7 @@ def test_chain_creation(testerchain):
 
 def test_nucypher_contract_compiled(testerchain):
     # Ensure that solidity smart contacts are available, post-compile.
-    token_contract_identifier = NucypherTokenDeployer(blockchain=testerchain)._contract_name
+    origin, *everybody_else = testerchain.interface.w3.eth.accounts
+
+    token_contract_identifier = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)._contract_name
     assert token_contract_identifier in testerchain.interface._ControlCircumflex__raw_contract_cache

--- a/tests/blockchain/eth/utilities.py
+++ b/tests/blockchain/eth/utilities.py
@@ -15,15 +15,12 @@ from nucypher.blockchain.eth.deployers import MinerEscrowDeployer, NucypherToken
 
 class MockTokenAgent(NucypherTokenAgent):
 
-    def token_airdrop(self, amount: int, addresses: List[str]=None):
+    def token_airdrop(self, amount: int, origin: str, addresses: List[str]):
         """Airdrops tokens from creator address to all other addresses!"""
-
-        if addresses is None:
-            _creator, *addresses = self.blockchain.interface.w3.eth.accounts
 
         def txs():
             for address in addresses:
-                txhash = self.contract.functions.transfer(address, amount).transact({'from': self.origin})
+                txhash = self.contract.functions.transfer(address, amount).transact({'from': origin})
                 yield txhash
 
         receipts = list()
@@ -49,7 +46,7 @@ class MockMinerAgent(MinerAgent):
             miners.append(miner)
 
             # stake a random amount
-            min_stake, balance = constants.MIN_ALLOWED_LOCKED, miner.token_balance()
+            min_stake, balance = constants.MIN_ALLOWED_LOCKED, miner.token_balance
             amount = random.randint(min_stake, balance)
 
             # for a random lock duration

--- a/tests/utilities.py
+++ b/tests/utilities.py
@@ -43,7 +43,7 @@ def make_ursulas(ether_addresses: list, ursula_starting_port: int, miners=False)
         ursula.dht_listen()
 
         if miners is True:
-            # # stake a random amount
+            # stake a random amount
             # min_stake, balance = constants.MIN_ALLOWED_LOCKED, ursula.token_balance()
             # amount = random.randint(min_stake, balance)
             #
@@ -53,6 +53,7 @@ def make_ursulas(ether_addresses: list, ursula_starting_port: int, miners=False)
             #
             # ursula.stake(amount=amount, lock_periods=periods)
             # ursula.miner_agent.blockchain.time_travel(periods=1)
+            pass
 
         _ursulas.append(ursula)
 


### PR DESCRIPTION
This was the original design of the blockchain client, that can now be revisited. Agents have a close relationship to the smart contracts code they can execute, and TokenActors compose their usage.

Overall, this PR is mostly relocation of code, but some additional solidity methods are also exposed, as well as the Agents API usage on Actors and Characters, and several utility functions.

This PR is very similar to #297, but utilizing an esoteric feature of Python that causes it to run properly in the absence of syntax errors. It is also very similar to #299, but with a fresh history, since GH did not update the diff.