### PR TITLE
Create a BlockchainPower with signing and verifying methods

### DIFF
--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -410,15 +410,12 @@ class DeployerCircumflex(ControlCircumflex):
         else:
             return self.w3.eth.sign(account, data=message) # Technically deprecated...
 
-    def call_backend_verify(self, pubkey: bytes , signature: str, msg_hash: bytes):
+    def call_backend_verify(self, pubkey: PublicKey, signature: Signature, msg_hash: bytes):
         """
         Verifies a hex string signature and message hash are from the provided
         public key.
         """
-        eth_sig = Signature(signature_bytes=unhexlify(signature[2:]))
-        eth_pubkey = PublicKey(public_key_bytes=pubkey)
+        is_valid_sig = signature.verify_msg_hash(msg_hash, pubkey)
+        sig_pubkey = signature.recover_public_key_from_msg_hash(msg_hash)
 
-        is_valid_sig = eth_sig.verify_msg_hash(msg_hash, eth_pubkey)
-        sig_pubkey = eth_sig.recovery_public_key_from_msg_hash(msg_hash)
-
-        return is_valid_sig and (sig_pubkey == eth_pubkey)
+        return is_valid_sig and (sig_pubkey == pubkey)

--- a/nucypher/characters.py
+++ b/nucypher/characters.py
@@ -464,6 +464,7 @@ class Alice(Character, PolicyAuthor):
     _default_crypto_powerups = [SigningPower, EncryptingPower, DelegatingPower]
 
     def __init__(self, is_me=True, federated_only=False, *args, **kwargs):
+
         Character.__init__(self, is_me=is_me, federated_only=federated_only, *args, **kwargs)
         if is_me and not federated_only:  # TODO: 289
             PolicyAuthor.__init__(self, *args, **kwargs)

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -93,8 +93,14 @@ class BlockchainPower(CryptoPowerUp):
         if not self.is_unlocked:
             raise PowerUpError("Account is not unlocked.")
 
-        signature = Eth.sign(self.account, data=message)
+        signature = self.blockchain.interface.call_backend_sign(self.account, message)
         return signature
+
+    def __del__(self):
+        """
+        Deletes the blockchain power and locks the account.
+        """
+        self.blockchain.interface.w3.personal.lockAccount(self.account)
 
 
 class KeyPairBasedPower(CryptoPowerUp):

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -6,7 +6,6 @@ from nucypher.keystore import keypairs
 from nucypher.keystore.keypairs import SigningKeypair, EncryptingKeypair
 from umbral.keys import UmbralPublicKey, UmbralPrivateKey, UmbralKeyingMaterial
 from umbral import pre
-from web3.eth import Eth
 
 
 class PowerUpError(TypeError):
@@ -68,19 +67,22 @@ class BlockchainPower(CryptoPowerUp):
     Allows for transacting on a Blockchain via web3 backend.
     """
 
-    def __init__(self, account: str):
+    def __init__(self, blockchain: 'Blockchain', account: str):
         """
         Instantiates a BlockchainPower for the given account id.
         """
+        self.blockchain = blockchain
         self.account = account
+        self.is_unlocked = False
 
     def unlock_account(self, password: str, duration: int = None):
         """
         Unlocks the account for the specified duration. If no duration is
         provided, it will remain unlocked indefinitely.
         """
-        self.is_unlocked = web3.personal.unlockAccount(self.account, password,
-                                                       duration=duration)
+        self.is_unlocked = self.blockchain.interface.w3.personal.unlockAccount(
+                self.account, password, duration=duration)
+
         if not self.is_unlocked:
             raise PowerUpError("Account failed to unlock for {}".format(self.account))
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -6,6 +6,7 @@ from nucypher.keystore import keypairs
 from nucypher.keystore.keypairs import SigningKeypair, EncryptingKeypair
 from umbral.keys import UmbralPublicKey, UmbralPrivateKey, UmbralKeyingMaterial
 from umbral import pre
+from web3.eth import Eth
 
 
 class PowerUpError(TypeError):
@@ -78,10 +79,20 @@ class BlockchainPower(CryptoPowerUp):
         Unlocks the account for the specified duration. If no duration is
         provided, it will remain unlocked indefinitely.
         """
-        is_unlocked = web3.personal.unlockAccount(self.account, password,
-                                                  duration=duration)
-        if not is_unlocked:
+        self.is_unlocked = web3.personal.unlockAccount(self.account, password,
+                                                       duration=duration)
+        if not self.is_unlocked:
             raise PowerUpError("Account failed to unlock for {}".format(self.account))
+
+    def sign_message(self, message: bytes):
+        """
+        Signs the message with the private key of the BlockchainPower.
+        """
+        if not self.is_unlocked:
+            raise PowerUpError("Account is not unlocked.")
+
+        signature = Eth.sign(self.account, data=message)
+        return signature
 
 
 class KeyPairBasedPower(CryptoPowerUp):

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -1,4 +1,5 @@
 import inspect
+import web3
 from typing import List, Union
 
 from nucypher.keystore import keypairs
@@ -59,6 +60,28 @@ class CryptoPowerUp(object):
     Gives you MORE CryptoPower!
     """
     confers_public_key = False
+
+
+class BlockchainPower(CryptoPowerUp):
+    """
+    Allows for transacting on a Blockchain via web3 backend.
+    """
+
+    def __init__(self, account: str):
+        """
+        Instantiates a BlockchainPower for the given account id.
+        """
+        self.account = account
+
+    def unlock_account(self, password: str, duration: int = None):
+        """
+        Unlocks the account for the specified duration. If no duration is
+        provided, it will remain unlocked indefinitely.
+        """
+        is_unlocked = web3.personal.unlockAccount(self.account, password,
+                                                  duration=duration)
+        if not is_unlocked:
+            raise PowerUpError("Account failed to unlock for {}".format(self.account))
 
 
 class KeyPairBasedPower(CryptoPowerUp):


### PR DESCRIPTION
### What this does:
1. Adds `BlockchainPower` with `sign_message` and `verify_message` methods.
2. Adds `call_backend_sign` and `call_backend_verify` methods on `DeployerCircumflex`.
3. `call_backend_sign` uses some `eth_tester` stuff to sign messages if the `EthereumTester` provider is being used, otherwise, it defaults to the (deprecated) `w3.eth.sign` which might be problematic.