### PR TITLE
Store test Results; Upgrade Web3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,17 +52,19 @@ jobs:
       - save_cache:
           paths:
             - "~/.local/share/virtualenvs/"
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
 
   blockchain_interface_unit:
     <<: *python_36_base
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Blockchain Interface Tests
-          command: pipenv run pytest --cov=nucypher/blockchain/eth -v --runslow tests/blockchain/eth/interfaces tests/blockchain/eth/entities
+          command: pipenv run pytest --cov=nucypher/blockchain/eth -v --runslow tests/blockchain/eth/interfaces tests/blockchain/eth/entities --junitxml=./reports/pytest/results.xml
+      - store_test_results:
+          path: ./reports/pytest/
 
   eth_contract_unit:
     <<: *python_36_base
@@ -70,7 +72,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Ethereum Contract Unit Tests
           command: |
@@ -83,60 +85,74 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Crypto Character Tests
-          command: pipenv run pytest --cov=nucypher/crypto -v --runslow tests/crypto
+          command: pipenv run pytest --cov=nucypher/crypto -v --runslow tests/crypto --junitxml=./reports/pytest/results.xml
+      - store_test_results:
+          path: ./reports/pytest/
 
   network_unit:
     <<: *python_36_base
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Network Tests
-          command: pipenv run pytest --cov=nucypher/network -v --runslow tests/network
+          command: pipenv run pytest --cov=nucypher/network -v --runslow tests/network --junitxml=./reports/pytest/results.xml
+      - store_test_results:
+          path: ./reports/pytest/
 
   keystore_unit:
     <<: *python_36_base
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Keystore Tests
-          command: pipenv run pytest --cov=nucypher/keystore -v --runslow tests/keystore
+          command: pipenv run pytest --cov=nucypher/keystore -v --runslow tests/keystore --junitxml=./reports/pytest/results.xml
+      - store_test_results:
+          path: ./reports/pytest/
 
   character:
     <<: *python_36_base
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Character Tests
-          command: pipenv run pytest --cov=nucypher/characters -v --runslow tests/characters
+          command: pipenv run pytest --cov=nucypher/characters -v --runslow tests/characters --junitxml=./reports/pytest/results.xml
+      - store_test_results:
+          path: ./reports/pytest/
 
   intercontract_integration:
     <<: *python_36_base
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Ethereum Inter-Contract Integration Test
           command: |
-            pipenv run pytest -v --runslow tests/blockchain/eth/contracts/integration
+            pipenv run pytest -v --runslow tests/blockchain/eth/contracts/integration --junitxml=./reports/pytest/results.xml
+      - store_test_results:
+          path: ./reports/pytest/
 
   mypy_type_check:
     <<: *python_36_base
     steps:
       - checkout
       - restore_cache:
-          key: v1-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
+          key: v3-deps-{{ .Environment.CIRCLE_WORKFLOW_ID }}-{{ checksum "Pipfile" }}
       - run:
           name: Run Mypy Static Type Checks
-          command: pipenv run mypy --xslt-html-report ./mypy_report ./nucypher --config-file=mypy.ini
+          command: |
+              mkdir ./mypy_reports ./mypy_results
+              pipenv run mypy ./nucypher --config-file=mypy.ini --xslt-html-report ./mypy_reports/html/ --linecount-report ./mypy_reports/linecount --junit-xml ./mypy_results/results.xml
       - store_artifacts:
-          path: ./mypy_report
+          path: ./mypy_reports
+      - store_test_results:
+          path: ./mypy_results

--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,7 @@ pynacl = "*"
 pysha3 = "*"
 py_ecc = "*"
 pyumbral = {git = "https://github.com/nucypher/pyumbral.git", ref = "nucypher-depend"}
-web3 = "*"
+web3 = "==4.4.1"
 
 [dev-packages]
 pytest = "*"
@@ -33,8 +33,8 @@ codecov = "*"
 coverage = "*"
 pytest-cov = "*"
 py-solc = "*"
-py-evm = "*"
-eth-tester = "*"
+py-evm = "==0.2.0a18"
+eth-tester = "==0.1.0b28"
 
 [pipenv]
 allow_prereleases = true


### PR DESCRIPTION
- Store XML Test result summary for circleci API
- Updates web3.py to 4.4.1 (Causes secondary Issue requiring a downgrade of `py-evm` + `eth-tester`). 
- Fixes `Pipfile` versioning for PR #329 
- Removes unused dependencies
- Organize and label `Pipfile`

Prior Issue reference with working versions: PR #301 