### PR TITLE
Uniting Finnegan's Wake demo logic with current master.

### DIFF
--- a/examples/run_ursula_with_rest_and_dht_but_no_mining.py
+++ b/examples/run_ursula_with_rest_and_dht_but_no_mining.py
@@ -19,14 +19,19 @@ from nucypher.crypto.api import generate_self_signed_certificate
 
 DB_NAME = "non-mining-proxy-node"
 
-_URSULA = Ursula(dht_port=3501, rest_port=3601, ip_address="localhost", db_name=DB_NAME, federated_only=True)
+_URSULA = Ursula(dht_port=3501,
+                 rest_port=3601,
+                 rest_host="localhost",
+                 dht_host="localhost",
+                 db_name=DB_NAME,
+                 federated_only=True)
 _URSULA.dht_listen()
 
 CURVE = ec.SECP256R1
 cert, private_key = generate_self_signed_certificate(_URSULA.stamp.fingerprint().decode(), CURVE)
 
 deployer = HendrixDeployTLS("start",
-                            {"wsgi":_URSULA.rest_app, "https_port": _URSULA.rest_port},
+                            {"wsgi":_URSULA.rest_app, "https_port": _URSULA.rest_interface.port},
                             key=private_key,
                             cert=X509.from_cryptography(cert),
                             context_factory=ExistingKeyTLSContextFactory,

--- a/nucypher/characters.py
+++ b/nucypher/characters.py
@@ -674,7 +674,7 @@ class Bob(Character):
         from nucypher.policy.models import WorkOrderHistory  # Need a bigger strategy to avoid circulars.
         self._saved_work_orders = WorkOrderHistory()
 
-    def peek_at_treasure_map(self, map_id):
+    def peek_at_treasure_map(self, treasure_map=None, map_id=None):
         """
         Take a quick gander at the TreasureMap matching map_id to see which
         nodes are already kwown to us.
@@ -684,7 +684,14 @@ class Bob(Character):
 
         Return two sets: nodes that are unknown to us, nodes that are known to us.
         """
-        treasure_map = self.treasure_maps[map_id]
+        if not treasure_map:
+            if map_id:
+                treasure_map = self.treasure_maps[map_id]
+            else:
+                raise ValueError("You need to pass either treasure_map or map_id.")
+        else:
+            if map_id:
+                raise ValueError("Don't pass both treasure_map and map_id - pick one or the other.")
 
         # The intersection of the map and our known nodes will be the known Ursulas...
         known_treasure_ursulas = treasure_map.destinations.keys() & self._known_nodes.keys()
@@ -694,7 +701,11 @@ class Bob(Character):
 
         return unknown_treasure_ursulas, known_treasure_ursulas
 
-    def follow_treasure_map(self, map_id, block=False, new_thread=False,
+    def follow_treasure_map(self,
+                            treasure_map=None,
+                            map_id=None,
+                            block=False,
+                            new_thread=False,
                             timeout=10,
                             allow_missing=0):
         """
@@ -712,7 +723,16 @@ class Bob(Character):
 
         # TODO: Check if nodes are up, declare them phantom if not.
         """
-        unknown_ursulas, known_ursulas = self.peek_at_treasure_map(map_id)
+        if not treasure_map:
+            if map_id:
+                treasure_map = self.treasure_maps[map_id]
+            else:
+                raise ValueError("You need to pass either treasure_map or map_id.")
+        else:
+            if map_id:
+                raise ValueError("Don't pass both treasure_map and map_id - pick one or the other.")
+
+        unknown_ursulas, known_ursulas = self.peek_at_treasure_map(treasure_map=treasure_map)
 
         if unknown_ursulas:
             self.learn_about_specific_nodes(unknown_ursulas)

--- a/nucypher/characters.py
+++ b/nucypher/characters.py
@@ -842,7 +842,7 @@ class Bob(Character):
 
         return generated_work_orders
 
-    def get_reencrypted_c_frags(self, work_order):
+    def get_reencrypted_cfrags(self, work_order):
         cfrags = self.network_middleware.reencrypt(work_order)
         if not len(work_order) == len(cfrags):
             raise ValueError("Ursula gave back the wrong number of cfrags.  She's up to something.")
@@ -881,10 +881,8 @@ class Bob(Character):
         if len(intersection) < treasure_map.m:
             raise RuntimeError("Not enough known nodes.  Try following the TreasureMap again.")
 
-        work_orders = self.generate_work_orders(hrac, message_kit.capsule)
-        for node_id in self.treasure_maps[hrac]:
-            node = self._known_nodes[UmbralPublicKey.from_bytes(node_id)]
-            cfrags = self.get_reencrypted_c_frags(work_orders[bytes(node.stamp)])
+        for work_order in work_orders.values():
+            cfrags = self.get_reencrypted_cfrags(work_order)
             message_kit.capsule.attach_cfrag(cfrags[0])
         verified, delivered_cleartext = self.verify_from(data_source,
                                                          message_kit,

--- a/nucypher/crypto/signing.py
+++ b/nucypher/crypto/signing.py
@@ -1,5 +1,5 @@
-from nucypher.crypto.api import keccak_digest
 from bytestring_splitter import BytestringSplitter
+from nucypher.crypto.api import keccak_digest
 from umbral.signing import Signature, Signer
 
 signature_splitter = BytestringSplitter(Signature)
@@ -11,7 +11,7 @@ class SignatureStamp(object):
     key as bytes.
     """
 
-    def __init__(self, verifying_key, signer: Signer=None):
+    def __init__(self, verifying_key, signer: Signer = None):
         self.__signer = signer
         self._as_bytes = bytes(verifying_key)
         self._as_umbral_pubkey = verifying_key
@@ -56,6 +56,8 @@ class StrangerStamp(SignatureStamp):
     """
     SignatureStamp of a stranger (ie, can only be used to glean public key, not to sign)
     """
+
     def __call__(self, *args, **kwargs):
+        from nucypher.crypto.powers import NoSigningPower
         message = "This isn't your SignatureStamp; it belongs to (a Stranger).  You can't sign with it."
-        raise TypeError(message)
+        raise NoSigningPower(message)

--- a/nucypher/keystore/keystore.py
+++ b/nucypher/keystore/keystore.py
@@ -118,7 +118,7 @@ class KeyStore(object):
         policy_arrangement = session.query(PolicyArrangement).filter_by(id=arrangement_id).first()
 
         if not policy_arrangement:
-            raise NotFound("No PolicyArrangement {} found.".format(arrangement_id))
+              raise NotFound("No PolicyArrangement {} found.".format(arrangement_id))
         return policy_arrangement
 
     def del_policy_arrangement(self, arrangement_id: bytes, session=None):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -18,27 +18,27 @@ class RestMiddleware:
         return NotImplemented
 
     def get_treasure_map_from_node(self, node, map_id):
-        port = node.rest_port
-        address = node.ip_address
-        endpoint = "https://{}:{}/treasure_map/{}".format(address, port, map_id.hex())
+        port = node.rest_interface.port
+        address = node.rest_interface.host
+        endpoint = "https://{}:{}/treasure_map/{}".format(address, port, map_id)
         response = requests.get(endpoint, verify=False)
         return response
 
     def put_treasure_map_on_node(self, node, map_id, map_payload):
-        port = node.rest_port
-        address = node.ip_address
-        endpoint = "https://{}:{}/treasure_map/{}".format(address, port, map_id.hex())
+        port = node.rest_interface.port
+        address = node.rest_interface.host
+        endpoint = "https://{}:{}/treasure_map/{}".format(address, port, map_id)
         response = requests.post(endpoint, data=map_payload, verify=False)
         return response
 
     def send_work_order_payload_to_ursula(self, work_order):
         payload = work_order.payload()
-        hrac_as_hex = work_order.kfrag_hrac.hex()
-        return requests.post('https://{}/kFrag/{}/reencrypt'.format(work_order.ursula.rest_url(), hrac_as_hex),
+        id_as_hex = work_order.arrangement_id.hex()
+        return requests.post('https://{}/kFrag/{}/reencrypt'.format(work_order.ursula.rest_url(), id_as_hex),
                              payload, verify=False)
 
-    def ursula_from_rest_interface(self, address, port):
-        return requests.get("https://{}:{}/public_keys".format(address, port), verify=False)  # TODO: TLS-only.
+    def node_information(self, host, port):
+        return requests.get("https://{}:{}/public_information".format(host, port), verify=False)  # TODO: TLS-only.
 
     def get_nodes_via_rest(self, address, port, node_ids=None):
         if node_ids:

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -103,10 +103,6 @@ class NucypherSeedOnlyDHTServer(NucypherDHTServer):
 
 
 class ProxyRESTServer:
-    public_information_splitter = BytestringSplitter(Signature,
-                                                     (UmbralPublicKey, int(PUBLIC_KEY_LENGTH)),
-                                                     (UmbralPublicKey, int(PUBLIC_KEY_LENGTH)),
-                                                     int(PUBLIC_ADDRESS_LENGTH))
 
     def __init__(self, host=None, port=None, db_name=None, *args, **kwargs):
         self.rest_interface = InterfaceInfo(host=host, port=port)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -171,7 +171,7 @@ class ProxyRESTServer:
         self.db_engine = engine
 
     def rest_url(self):
-        return "{}:{}".format(self.ip_address, self.rest_port)
+        return "{}:{}".format(self.rest_interface.host, self.rest_interface.port)
 
     #####################################
     # Actual REST Endpoints and utilities
@@ -182,13 +182,8 @@ class ProxyRESTServer:
         REST endpoint for public keys and address..
         """
         headers = {'Content-Type': 'application/octet-stream'}
-        # TODO: Calling public_address() works here because this is mixed in with Character, but it's not really right.
-        message = bytes(self.public_key(SigningPower)) + bytes(
-            self.public_key(EncryptingPower)) + self.canonical_public_address
-        signature = self.stamp(message)
-
         response = Response(
-            content=signature + message,
+            content=bytes(self),
             headers=headers)
 
         return response

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -76,7 +76,13 @@ class NucypherDHTServer(Server):
         return loop.run_until_complete(self.get(bytes(key)))
 
     def set_now(self, key, value):
-        loop = asyncio.get_event_loop()
+        try:
+            loop = asyncio.get_event_loop()
+        except RuntimeError:
+            # Terrible.  We cant' get off the DHT soon enough.
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+
         return loop.run_until_complete(self.set(key, value))
 
     async def set(self, key, value):

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -67,17 +67,3 @@ def test_grant(alice, bob, three_agents):
         retrieved_kfrag = KFrag.from_bytes(retrieved_policy.k_frag)
 
         assert kfrag == retrieved_kfrag
-
-
-@pytest.mark.usefixtures('testerchain')
-def test_alice_can_get_ursulas_keys_via_rest(ursulas):
-    ursula = ursulas.pop()
-    mock_client = TestClient(ursula.rest_app)
-    response = mock_client.get('http://localhost/public_information')
-    signature, signing_key, encrypting_key, public_address = Ursula.public_information_splitter(response.content)
-    public_keys = {SigningPower: signing_key, EncryptingPower: encrypting_key}
-    stranger_ursula_from_public_keys = Ursula.from_public_keys(public_keys,
-                                                               rest_port=5000,
-                                                               rest_host="not real")
-    assert stranger_ursula_from_public_keys == ursula
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 from cryptography.hazmat.primitives.asymmetric import ec
 from umbral.config import set_default_curve
+from umbral.curve import SECP256K1
 
-set_default_curve(ec.SECP256K1())
+set_default_curve(SECP256K1)
 
 """NOTICE:  Depends on fixture modules; do not delete"""
 from .fixtures import *

--- a/tests/network/test_network_actors.py
+++ b/tests/network/test_network_actors.py
@@ -122,7 +122,7 @@ def test_treasure_map_stored_by_ursula_is_the_correct_one_for_bob(alice, bob, ur
     hrac_by_bob = bob.construct_policy_hrac(alice.stamp, enacted_federated_policy.label)
     assert enacted_federated_policy.hrac() == hrac_by_bob
 
-    map_id_by_bob = bob.construct_map_id(alice.stamp, enacted_federated_policy.label)
+    hrac, map_id_by_bob = bob.construct_hrac_and_map_id(alice.stamp, enacted_federated_policy.label)
     assert map_id_by_bob == treasure_map_as_set_on_network.public_id()
 
 


### PR DESCRIPTION
* Updates all of the demo machinery (non-mining node script, middleware, demo script) with new features and semantics
* Cleans up signing logic for node verification
* Allows TreasureMaps to *either* be passed in *or* looked up by ID, instead of needing two steps
* Cleans up some tests in light of #356 