### PR TITLE
Raise InvalidSignature in verify_from

### DIFF
--- a/nucypher/characters.py
+++ b/nucypher/characters.py
@@ -57,6 +57,11 @@ class Character:
         This exception is raised when a piece of logic can't proceed without more Ursulas.
         """
 
+    class InvalidSignature(Exception):
+        """
+        Raised when a signature doesn't pass validation/verification.
+        """
+
     def __init__(self, is_me=True,
                  network_middleware=None,
                  crypto_power: CryptoPower = None,
@@ -494,16 +499,16 @@ class Character:
 
         if signature_to_use:
             is_valid = signature_to_use.verify(message, sender_pubkey_sig)
+            if not is_valid:
+                raise self.InvalidSignature("Signature for message isn't valid.")
         else:
-            # Meh, we didn't even get a signature.  Not much we can do.
-            is_valid = False
-
-        return is_valid, cleartext
+            raise self.InvalidSignature("No signature provided -- signature presumed invalid.")
+        return cleartext
 
         """
         Next we have decrypt(), sign(), and generate_self_signed_certificate() - these use the private 
         keys of their respective powers; any character who has these powers can use these functions.
-        
+
         If they don't have the correct Power, the appropriate PowerUpError is raised.
         """
 

--- a/nucypher/characters.py
+++ b/nucypher/characters.py
@@ -500,7 +500,7 @@ class Character:
         if signature_to_use:
             is_valid = signature_to_use.verify(message, sender_pubkey_sig)
             if not is_valid:
-                raise self.InvalidSignature("Signature for message isn't valid.")
+                raise mystery_stranger.InvalidSignature("Signature for message isn't valid: {}".format(signature_to_use))
         else:
             raise self.InvalidSignature("No signature provided -- signature presumed invalid.")
         return cleartext

--- a/nucypher/characters.py
+++ b/nucypher/characters.py
@@ -863,7 +863,6 @@ class Bob(Character):
 
     def join_policy(self, label, alice_pubkey_sig,
                     node_list=None, verify_sig=True):
-        hrac = keccak_digest(bytes(alice_pubkey_sig) + bytes(self.stamp) + label)
         if node_list:
             self._node_ids_to_learn_about_immediately.update(node_list)
         treasure_map = self.get_treasure_map(alice_pubkey_sig, label)
@@ -887,15 +886,15 @@ class Bob(Character):
             cfrags = self.get_reencrypted_cfrags(work_order)
             message_kit.capsule.attach_cfrag(cfrags[0])
 
-            verified, delivered_cleartext = self.verify_from(data_source,
-                                                             message_kit,
-                                                             decrypt=True,
-                                                             delegator_signing_key=alice_verifying_key)
-
-            if verified:
-                cleartexts.append(delivered_cleartext)
+            try:
+                delivered_cleartext = self.verify_from(data_source,
+                                                       message_kit,
+                                                       decrypt=True,
+                                                       delegator_signing_key=alice_verifying_key)
+            except self.InvalidSignature as e:
+                raise RuntimeError(e)
             else:
-                raise RuntimeError("Not verified - replace this with real message.")  # TODO: Actually raise an error in verify_from instead of here 358
+                cleartexts.append(delivered_cleartext)
         return cleartexts
 
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -226,11 +226,12 @@ class ProxyRESTServer:
 
         alice = self._alice_class.from_public_keys({SigningPower: policy_message_kit.sender_pubkey_sig})
 
-        verified, cleartext = self.verify_from(alice, policy_message_kit, decrypt=True)
-
-        if not verified:
+        try:
+            verified, cleartext = self.verify_from(alice, policy_message_kit, decrypt=True)
+        except self.InvalidSignature:
             # TODO: What do we do if the Policy isn't signed properly?
             pass
+
         #
         # alices_signature, policy_payload =BytestringSplitter(Signature)(cleartext, return_remainder=True)
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -227,7 +227,7 @@ class ProxyRESTServer:
         alice = self._alice_class.from_public_keys({SigningPower: policy_message_kit.sender_pubkey_sig})
 
         try:
-            verified, cleartext = self.verify_from(alice, policy_message_kit, decrypt=True)
+            cleartext = self.verify_from(alice, policy_message_kit, decrypt=True)
         except self.InvalidSignature:
             # TODO: What do we do if the Policy isn't signed properly?
             pass

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -10,7 +10,7 @@ import msgpack
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow import constants
 from nucypher.characters import Alice
-from nucypher.characters import Bob, Ursula
+from nucypher.characters import Bob, Ursula, Character
 from nucypher.crypto.api import keccak_digest, encrypt_and_sign, secure_random
 from nucypher.crypto.constants import PUBLIC_ADDRESS_LENGTH, KECCAK_DIGEST_LENGTH
 from nucypher.crypto.kits import UmbralMessageKit
@@ -423,13 +423,14 @@ class TreasureMap:
         When Bob receives the TreasureMap, he'll pass a compass (a callable which can verify and decrypt the
         payload message kit).
         """
-        verified, map_in_the_clear = compass(message_kit=self.message_kit)
-        if verified:
-            self.m = map_in_the_clear[0]
-            self.destinations = dict(self.node_id_splitter.repeat(map_in_the_clear[1:]))
-        else:
+        try:
+            map_in_the_clear = compass(message_kit=self.message_kit)
+        except Character.InvalidSignature:
             raise self.InvalidSignature(
                 "This TreasureMap does not contain the correct signature from Alice to Bob.")
+        else:
+            self.m = map_in_the_clear[0]
+            self.destinations = dict(self.node_id_splitter.repeat(map_in_the_clear[1:]))
 
     def __eq__(self, other):
         return bytes(self) == bytes(other)

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -243,8 +243,7 @@ def test_bob_gathers_and_combines(enacted_federated_policy, bob, alice, capsule_
 
     # Now.
     # At long last.
-    is_valid, cleartext = bob.verify_from(the_data_source, the_message_kit,
-                                          decrypt=True,
-                                          delegator_signing_key=alice.stamp.as_umbral_pubkey())
+    cleartext = bob.verify_from(the_data_source, the_message_kit,
+                                decrypt=True,
+                                delegator_signing_key=alice.stamp.as_umbral_pubkey())
     assert cleartext == b'Welcome to the flippering.'
-    assert is_valid


### PR DESCRIPTION
### What this does:
1. Adds an exception class to `Character` as `InvalidSignature`.
2. Raises `InvalidSignature`if `verify_from` in all cases where `is_valid == False`.
3. Adds try/except blocks for `InvalidSignature` in places in `network.server` and `characters` where `verify_from` is called.
4. Fixes tests for this pattern.
5. Removes unused `hrac` variable in `characters.Bob.join_policy`.
6. Raises the Cryptography.io `InvalidSignature` error in `crypto.api.ecdsa_verify` if the signature was invalid instead of returning the boolean.
6. Resolves #358 