### PR TITLE
Protection against node metadata replay attacks.

### DIFF
--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -541,7 +541,7 @@ class Character(Learner):
 
         # TODO: This doesn't make sense - a decentralized node can still learn about a federated-only node.
         from nucypher.characters.lawful import Ursula
-        node_list = Ursula.batch_from_bytes(nodes, federated_only=self.federated_only)
+        node_list = Ursula.batch_from_bytes(nodes, federated_only=self.federated_only)  # TODO: 466
 
         new_nodes = []
         for node in node_list:
@@ -553,7 +553,7 @@ class Character(Learner):
                 if eager:
                     node.verify_node(self.network_middleware, accept_federated_only=self.federated_only)
                 else:
-                    node.validate_metadata(accept_federated_only=self.federated_only)
+                    node.validate_metadata(accept_federated_only=self.federated_only)  # TODO: 466
             except node.SuspiciousActivity:
                 # TODO: Account for possibility that stamp, rather than interface, was bad.
                 message = "Suspicious Activity: Discovered node with bad signature: {}.  " \

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -89,6 +89,13 @@ class Learner(ABC):
 
     def remember_node(self, node, force_verification_check=False):
 
+        # First, determine if this is an outdated representation of an already known node.
+        with suppress(KeyError):
+            already_known_node = self.known_nodes[node.checksum_public_address]
+            if not node.timestamp > already_known_node.timestamp:
+                # This node is already known.  We can safely return.
+                return
+
         node.verify_node(self.network_middleware,  # TODO: Take middleware directly in this class?
                          force=force_verification_check,
                          accept_federated_only=self.federated_only)  # TODO: 466

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -359,8 +359,6 @@ class Character(Learner):
             represented by zero Characters or by more than one Character.
 
         """
-        super().__init__(*args, **kwargs)
-
         self.federated_only = federated_only                     # type: bool
         self.known_certificates_dir = known_certificates_dir
 
@@ -399,6 +397,9 @@ class Character(Learner):
                 raise TypeError(
                     "Can't attach network middleware to a Character who isn't me.  What are you even trying to do?")
             self._stamp = StrangerStamp(self.public_keys(SigningPower))
+
+        # Init the Learner superclass.
+        Learner.__init__(self, *args, **kwargs)
 
         # Decentralized
         if not federated_only:

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -87,8 +87,12 @@ class Learner(ABC):
     def known_nodes(self):
         return self.__known_nodes
 
-    def remember_node(self, node):
-        # TODO: 334
+    def remember_node(self, node, force_verification_check=False):
+
+        node.verify_node(self.network_middleware,  # TODO: Take middleware directly in this class?
+                         force=force_verification_check,
+                         accept_federated_only=self.federated_only)  # TODO: 466
+
         listeners = self._learning_listeners.pop(node.checksum_public_address, ())
         address = node.checksum_public_address
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -403,6 +403,7 @@ class Ursula(Character, VerifiableNode, Miner):
                  db_filepath: str = None,
                  is_me: bool = True,
                  interface_signature=None,
+                 timestamp=None,
 
                  # Blockchain
                  miner_agent=None,
@@ -525,7 +526,8 @@ class Ursula(Character, VerifiableNode, Miner):
         VerifiableNode.__init__(self,
                                 certificate=certificate,
                                 certificate_filepath=certificate_filepath,
-                                interface_signature=interface_signature)
+                                interface_signature=interface_signature,
+                                timestamp=timestamp)
 
         if is_me:
             message = "Initialized Self {} | {}".format(self.__class__.__name__, self.checksum_public_address)
@@ -604,8 +606,10 @@ class Ursula(Character, VerifiableNode, Miner):
          rest_info) = cls._internal_splitter(ursula_as_bytes)
         certificate = load_pem_x509_certificate(certificate_vbytes.message_as_bytes,
                                                 default_backend())
+        timestamp = maya.MayaDT(timestamp)
         stranger_ursula_from_public_keys = cls.from_public_keys(
             {SigningPower: verifying_key, EncryptingPower: encrypting_key},
+            timestamp=timestamp,
             interface_signature=signature,
             checksum_address=to_checksum_address(public_address),
             rest_host=rest_info.host,
@@ -636,11 +640,13 @@ class Ursula(Character, VerifiableNode, Miner):
              rest_info) in ursulas_attrs:
             certificate = load_pem_x509_certificate(certificate_vbytes.message_as_bytes,
                                                     default_backend())
+            timestamp = maya.MayaDT(timestamp)
             stranger_ursula_from_public_keys = cls.from_public_keys(
                 {SigningPower: verifying_key,
                  EncryptingPower: encrypting_key,
                  },
                 interface_signature=signature,
+                timestamp=timestamp,
                 checksum_address=to_checksum_address(public_address),
                 certificate=certificate,
                 rest_host=rest_info.host,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -559,9 +559,7 @@ class Ursula(Character, VerifiableNode, Miner):
         certificate = self.rest_server_certificate()
         cert_vbytes = VariableLengthBytestring(certificate.public_bytes(Encoding.PEM))
 
-        timestamp = maya.now().epoch.to_bytes(4, 'big')
-
-        as_bytes = bytes().join((timestamp,
+        as_bytes = bytes().join((self._timestamp,
                                  bytes(self._interface_signature),
                                  bytes(identity_evidence),
                                  bytes(self.public_keys(SigningPower)),

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -460,7 +460,7 @@ class Ursula(Character, VerifiableNode, Miner):
                     db_name=db_name,
                     db_filepath=db_filepath,
                     network_middleware=self.network_middleware,
-                    federated_only=self.federated_only,
+                    federated_only=self.federated_only,   # TODO: 466
                     treasure_map_tracker=self.treasure_maps,
                     node_tracker=self.known_nodes,
                     node_bytes_caster=self.__bytes__,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -561,7 +561,7 @@ class Ursula(Character, VerifiableNode, Miner):
         certificate = self.rest_server_certificate()
         cert_vbytes = VariableLengthBytestring(certificate.public_bytes(Encoding.PEM))
 
-        as_bytes = bytes().join((self._timestamp,
+        as_bytes = bytes().join((self.timestamp_bytes(),
                                  bytes(self._interface_signature),
                                  bytes(identity_evidence),
                                  bytes(self.public_keys(SigningPower)),

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -1,3 +1,4 @@
+import maya
 from eth_tester.exceptions import ValidationError
 
 from nucypher.characters.lawful import Ursula

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -35,7 +35,9 @@ class Vladimir(Ursula):
                        certificate=target_ursula.rest_server_certificate(),
                        is_me=False)
 
-        vladimir._interface_signature_object = target_ursula._interface_signature_object  # Asshole.
+        # Asshole.
+        vladimir._interface_signature_object = target_ursula._interface_signature_object
+        vladimir._timestamp = target_ursula._timestamp
 
         cls.attach_transacting_key(blockchain=target_ursula.blockchain)
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -122,7 +122,7 @@ class NodeConfiguration:
         base_payload = dict(
                             # Identity
                             is_me=self.is_me,
-                            federated_only=self.federated_only,
+                            federated_only=self.federated_only,  # TODO: 466
                             checksum_address=self.checksum_address,
                             # keyring_dir=self.keyring_dir,  # TODO: local private keys
 
@@ -228,7 +228,7 @@ class NodeConfiguration:
 
         for metadata_path in metadata_paths:
             from nucypher.characters.lawful import Ursula
-            node = Ursula.from_metadata_file(filepath=abspath(metadata_path), federated_only=self.federated_only)
+            node = Ursula.from_metadata_file(filepath=abspath(metadata_path), federated_only=self.federated_only)  # TODO: 466
             self.known_nodes.add(node)
 
     def write_default_configuration_file(self, filepath: str = DEFAULT_CONFIG_FILE_LOCATION):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -79,7 +79,8 @@ class VerifiableNode:
         """
         Checks that the interface info is valid for this node's canonical address.
         """
-        message = self._signable_interface_info_message()  # Contains canonical address.
+        interface_info_message = self._signable_interface_info_message()  # Contains canonical address.
+        message = self.timestamp_bytes() + interface_info_message
         interface_is_valid = self._interface_signature.verify(message, self.public_keys(SigningPower))
         self.verified_interface = interface_is_valid
         if interface_is_valid:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -136,6 +136,8 @@ class VerifiableNode:
             if not verifying_keys_match:
                 self.log.warning("Verifying key swapped out.  It appears that someone is impersonating this node.")
             raise self.InvalidNode("Wrong cryptographic material for this node - something fishy going on.")
+        else:
+            self._verified_node = True
 
     def substantiate_stamp(self):
         blockchain_power = self._crypto_power.power_ups(BlockchainPower)

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -146,28 +146,31 @@ class VerifiableNode:
         message = self.canonical_public_address + self.rest_information()[0]
         return message
 
-    def _sign_interface_info(self):
+    def _sign_and_date_interface_info(self):
         message = self._signable_interface_info_message()
-        self._timestamp_bytes = maya.now().epoch.to_bytes(4, 'big')
-        self._interface_signature_object = self.stamp(self._timestamp + message)
+        self._timestamp = maya.now()
+        self._interface_signature_object = self.stamp(self.timestamp_bytes() + message)
 
     @property
     def _interface_signature(self):
         if not self._interface_signature_object:
             try:
-                self._sign_interface_info()
+                self._sign_and_date_interface_info()
             except NoSigningPower:
                 raise NoSigningPower("This Node is a Stranger; you didn't init with an interface signature, so you can't verify.")
         return self._interface_signature_object
 
     @property
-    def _timestamp(self):
-        if not self._timestamp_bytes:
+    def timestamp(self):
+        if not self._timestamp:
             try:
-                self._sign_interface_info()
+                self._sign_and_date_interface_info()
             except NoSigningPower:
                 raise NoSigningPower("This Node is a Stranger; you didn't init with a timestamp, so you can't verify.")
-        return self._timestamp_bytes
+        return self._timestamp
+
+    def timestamp_bytes(self):
+        return self.timestamp.epoch.to_bytes(4, 'big')
 
     @property
     def common_name(self):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -152,8 +152,17 @@ class VerifiableNode:
             try:
                 self._sign_interface_info()
             except NoSigningPower:
-                raise NoSigningPower("This Ursula is a Stranger; you didn't init with an interface signature, so you can't verify.")
+                raise NoSigningPower("This Node is a Stranger; you didn't init with an interface signature, so you can't verify.")
         return self._interface_signature_object
+
+    @property
+    def _timestamp(self):
+        if not self._timestamp_bytes:
+            try:
+                self._sign_interface_info()
+            except NoSigningPower:
+                raise NoSigningPower("This Node is a Stranger; you didn't init with a timestamp, so you can't verify.")
+        return self._timestamp_bytes
 
     @property
     def common_name(self):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -19,16 +19,19 @@ class VerifiableNode:
     verified_stamp = False
     verified_interface = False
     _verified_node = False
+    _interface_info_splitter = (int, 4, {'byteorder': 'big'})
 
     def __init__(self,
                  certificate: Certificate,
                  certificate_filepath: str,
                  interface_signature=constants.NOT_SIGNED.bool_value(False),
+                 timestamp=constants.NOT_SIGNED,
                  ) -> None:
 
         self.certificate = certificate
         self.certificate_filepath = certificate_filepath
         self._interface_signature_object = interface_signature
+        self._timestamp = timestamp
 
     class InvalidNode(SuspiciousActivity):
         """

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1,6 +1,7 @@
 import os
 
 import OpenSSL
+import maya
 from constant_sorrow import constants
 from cryptography.x509 import Certificate
 from eth_keys.datatypes import Signature as EthSignature
@@ -144,7 +145,8 @@ class VerifiableNode:
 
     def _sign_interface_info(self):
         message = self._signable_interface_info_message()
-        self._interface_signature_object = self.stamp(message)
+        self._timestamp_bytes = maya.now().epoch.to_bytes(4, 'big')
+        self._interface_signature_object = self.stamp(self._timestamp + message)
 
     @property
     def _interface_signature(self):

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -131,7 +131,7 @@ class ProxyRESTRoutes:
 
     def node_metadata_exchange(self, request: Request, query_params: QueryParams):
         nodes = self._node_class.batch_from_bytes(request.body,
-                                                  federated_only=self.federated_only,
+                                                  federated_only=self.federated_only,  # TODO: 466
                                                   )
         # TODO: This logic is basically repeated in learn_from_teacher_node.  Let's find a better way.
         for node in nodes:
@@ -142,7 +142,7 @@ class ProxyRESTRoutes:
             @crosstown_traffic()
             def learn_about_announced_nodes():
                 try:
-                    node.verify_node(self.network_middleware, accept_federated_only=self.federated_only)
+                    node.verify_node(self.network_middleware, accept_federated_only=self.federated_only)  # TODO: 466
                 except node.SuspiciousActivity:
                     # TODO: Account for possibility that stamp, rather than interface, was bad.
                     message = "Suspicious Activity: Discovered node with bad signature: {}.  " \

--- a/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
+++ b/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
@@ -99,7 +99,7 @@ def test_vladimir_uses_his_own_signing_key(blockchain_alice, blockchain_ursulas)
     vladimir = Vladimir.from_target_ursula(target_ursula=his_target)
 
     message = vladimir._signable_interface_info_message()
-    signature = vladimir._crypto_power.power_ups(SigningPower).sign(message)
+    signature = vladimir._crypto_power.power_ups(SigningPower).sign(vladimir.timestamp_bytes() + message)
     vladimir._interface_signature_object = signature
 
     vladimir.substantiate_stamp()

--- a/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
+++ b/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
@@ -51,7 +51,7 @@ def test_blockchain_ursula_verifies_stamp(blockchain_ursulas):
     first_ursula = list(blockchain_ursulas)[0]
 
     # This Ursula does not yet have a verified stamp
-    assert not first_ursula.verified_stamp
+    first_ursula.verified_stamp = False
     first_ursula.stamp_is_valid()
 
     # ...but now it's verified.

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -2,6 +2,8 @@ import os
 import tempfile
 
 import datetime
+from unittest.mock import Mock
+
 import maya
 import pytest
 from constant_sorrow import constants
@@ -77,7 +79,8 @@ def ursula_federated_test_config():
                                         is_me=True,
                                         start_learning_now=False,
                                         abort_on_learning_error=True,
-                                        federated_only=True)
+                                        federated_only=True,
+                                        network_middleware=MockRestMiddleware())
     yield ursula_config
     ursula_config.cleanup()
 
@@ -92,7 +95,8 @@ def ursula_decentralized_test_config(three_agents):
                                         start_learning_now=False,
                                         abort_on_learning_error=True,
                                         miner_agent=miner_agent,
-                                        federated_only=False)
+                                        federated_only=False,
+                                        network_middleware=MockRestMiddleware())
     yield ursula_config
     ursula_config.cleanup()
 


### PR DESCRIPTION
Previously, it was possible for a chaotic actor to replay old node metadata, causing out-of-date information, including possibly public keys for compromised keypairs, to propagate across the network.

This PR address this in the following way:
* Ursula now creates a new timestamp whenever she signs her interface info (building on @tuxxy's previous work on timestamp)
* When nodes are remembered, their timestamp is kept as an attribute.
* When a node is passed to `remember_node` it is only remembered if it is the newest timestamp among those nodes.

Other things:

* Learners now fully verify nodes at "remember time" (recall that, if the learning loop is not run in eager mode, they only validate the metadata, rather than fully verifying the node during learning).  (This essentially nullifies eagerness for the moment, so it probably makes sense to move this logic further down the line during testnet).
* Vladimir now steals the timestamp in addition to the interface signature.