### PR TITLE
Remove Kademlia digest function 

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ name = "pypi"
 #
 constantSorrow = {git = "https://github.com/nucypher/constantSorrow.git", ref = "nucypher-depend"}
 bytestringSplitter = "*"
-rpcudp = {git = "https://github.com/nucypher/rpcudp", ref = "nucypher-depend"}
 pyumbral = {git = "https://github.com/nucypher/pyumbral.git", ref = "nucypher-depend"}
 #
 # Third-Party

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,6 @@ name = "pypi"
 constantSorrow = {git = "https://github.com/nucypher/constantSorrow.git", ref = "nucypher-depend"}
 bytestringSplitter = "*"
 rpcudp = {git = "https://github.com/nucypher/rpcudp", ref = "nucypher-depend"}
-kademlia = {git = "https://github.com/nucypher/kademlia", ref = "nucypher-depend"}
 pyumbral = {git = "https://github.com/nucypher/pyumbral.git", ref = "nucypher-depend"}
 #
 # Third-Party

--- a/nucypher/network/protocols.py
+++ b/nucypher/network/protocols.py
@@ -1,4 +1,10 @@
 from bytestring_splitter import VariableLengthBytestring
+from constant_sorrow import default_constant_splitter, constants
+from kademlia.node import Node
+from kademlia.protocol import KademliaProtocol
+
+from nucypher.crypto.api import keccak_digest
+from nucypher.network.routing import NucypherRoutingTable
 
 
 class SuspiciousActivity(RuntimeError):

--- a/nucypher/network/protocols.py
+++ b/nucypher/network/protocols.py
@@ -1,10 +1,6 @@
 from bytestring_splitter import VariableLengthBytestring
 from constant_sorrow import default_constant_splitter, constants
-from kademlia.node import Node
-from kademlia.protocol import KademliaProtocol
-
 from nucypher.crypto.api import keccak_digest
-from nucypher.network.routing import NucypherRoutingTable
 
 
 class SuspiciousActivity(RuntimeError):

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -7,10 +7,10 @@ from apistar.http import Response, Request, QueryParams
 from bytestring_splitter import VariableLengthBytestring
 from constant_sorrow import constants
 from hendrix.experience import crosstown_traffic
-from kademlia.utils import digest
 from umbral import pre
 from umbral.fragments import KFrag
 
+from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import SigningPower, KeyPairBasedPower, PowerUpError
 from nucypher.keystore.keypairs import HostingKeypair
@@ -240,7 +240,7 @@ class ProxyRESTRoutes:
         headers = {'Content-Type': 'application/octet-stream'}
 
         try:
-            treasure_map = self._treasure_map_tracker[digest(treasure_map_id)]
+            treasure_map = self._treasure_map_tracker[keccak_digest(binascii.unhexlify(treasure_map_id))]
             response = Response(content=bytes(treasure_map), headers=headers)
             self.log.info("{} providing TreasureMap {}".format(self._node_bytes_caster(),
                                                                treasure_map_id))
@@ -273,7 +273,7 @@ class ProxyRESTRoutes:
             # # # #
 
             # TODO 341 - what if we already have this TreasureMap?
-            self._treasure_map_tracker[digest(treasure_map_id)] = treasure_map
+            self._treasure_map_tracker[keccak_digest(binascii.unhexlify(treasure_map_id))] = treasure_map
             return Response(content=bytes(treasure_map), status_code=202)
         else:
             # TODO: Make this a proper 500 or whatever.

--- a/tests/network/test_network_actors.py
+++ b/tests/network/test_network_actors.py
@@ -1,9 +1,9 @@
 import os
 
 import pytest
+from binascii import unhexlify
 from hendrix.experience import crosstown_traffic
 from hendrix.utils.test_utils import crosstownTaskListDecoratorFactory
-from kademlia.utils import digest
 
 from nucypher.characters.lawful import Ursula
 from nucypher.characters.unlawful import Vladimir
@@ -58,7 +58,7 @@ def test_alice_sets_treasure_map(enacted_federated_policy, federated_ursulas):
     enacted_federated_policy.publish_treasure_map(network_middleware=MockRestMiddleware())
 
     treasure_map_as_set_on_network = list(federated_ursulas)[0].treasure_maps[
-        digest(enacted_federated_policy.treasure_map.public_id())]
+        keccak_digest(unhexlify(enacted_federated_policy.treasure_map.public_id()))]
     assert treasure_map_as_set_on_network == enacted_federated_policy.treasure_map
 
 
@@ -67,7 +67,7 @@ def test_treasure_map_stored_by_ursula_is_the_correct_one_for_bob(federated_alic
     The TreasureMap given by Alice to Ursula is the correct one for Bob; he can decrypt and read it.
     """
     treasure_map_as_set_on_network = list(federated_ursulas)[0].treasure_maps[
-        digest(enacted_federated_policy.treasure_map.public_id())]
+        keccak_digest(unhexlify(enacted_federated_policy.treasure_map.public_id()))]
 
     hrac_by_bob = federated_bob.construct_policy_hrac(federated_alice.stamp, enacted_federated_policy.label)
     assert enacted_federated_policy.hrac() == hrac_by_bob


### PR DESCRIPTION
### What this does:
1. Removes the Kademlia `digest` function and uses `nucypher.crypto.api.keccak_digest` instead.
2. Calls `unhexlify` on the `treasure_map_id` to hash the raw bytes instead of the digest.
3. Removes `rpcudp` dependency
4. Resolves #472 #474 