### PR TITLE
Remove Pinned GitHub Dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,33 +7,42 @@ name = "pypi"
 #
 # NuCypher
 #
-constantSorrow = {git = "https://github.com/nucypher/constantSorrow.git", ref = "nucypher-depend"}
+constant-sorrow = "*"
 bytestringSplitter = "*"
+hendrix = ">=3.1.0"
+# Pinned Nucypher
 pyumbral = {git = "https://github.com/nucypher/pyumbral.git", ref = "nucypher-depend"}
 #
 # Third-Party
 #
 cryptography = ">=2.3"
 pysha3="*"
-hendrix = ">=3.1.0"
 requests = "*"
-maya = "*"
 sqlalchemy = "*"
 apistar = "==0.5.42"
-click = "*"
 tzlocal = "==2.0.0b1"
+maya = "*"
 #
 # Third-Party Ethereum
 #
 coincurve = ">=8.0.2"
 eth-utils="*"
 eth-keys="*"
+eth-tester = ">=0.1.0b33"
+py-evm = ">=0.2.0a33"
+py-solc = "*"
 web3 = "*"
+#
+# CLI / Config
+#
 appdirs = "*"
+click = "*"
 colorama = "*"
+moto = "*"
+boto3 = "*"
+nucypher = {editable = true, path = "."}
 
 [dev-packages]
-ipdb = "*"
 #
 # Pytest
 #
@@ -44,19 +53,6 @@ pytest-cov = "*"
 mypy = "*"
 codecov = "*"
 coverage = "*"
-#
-# Ethereum
-#
-py-solc = "*"
-#eth-tester = "*"
-eth-tester = {git = "https://github.com/KPrasch/eth-tester.git", ref = "ef4bb2fa793af8aa964b83536b20f525aa74d4e4"}
-py-evm = ">=0.2.0a31"
-#
-# CLI
-#
-moto = "*"
-boto3 = "*"
-nucypher = {editable = true, path = "."}
 
 [pipenv]
 allow_prereleases = true

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -206,9 +206,8 @@ class BlockchainInterface:
             if uri_breakdown.scheme == 'tester':
 
                 if uri_breakdown.netloc == 'pyevm':
-
-                    # TODO: Update to newest eth-tester after #123 is merged
-                    pyevm_backend = PyEVMBackend.from_genesis_overrides(parameter_overrides={'gas_limit': NUCYPHER_GAS_LIMIT})
+                    genesis_params = PyEVMBackend._generate_genesis_params(overrides={'gas_limit': NUCYPHER_GAS_LIMIT})
+                    pyevm_backend = PyEVMBackend(genesis_parameters=genesis_params)
                     eth_tester = EthereumTester(backend=pyevm_backend, auto_mine_transactions=True)
                     provider = EthereumTesterProvider(ethereum_tester=eth_tester)
 


### PR DESCRIPTION
- Integrates `eth-tester==0.1.0b33`
- Removes pinned dependency for constantSorrow; Use `constant-sorrow` on PyPI