### PR TITLE
Nicknames

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -1090,21 +1090,21 @@ def status(config,
     color_index = {
         'self': 'yellow',
         'known': 'white',
-        'bootnode': 'blue'
+        'seednode': 'blue'
     }
     for node_type, color in color_index.items():
         click.secho('{0:<6} | '.format(node_type), fg=color, nl=False)
     click.echo('\n')
 
-    bootnode_addresses = list(bn.checksum_address for bn in BOOTNODES)
+    seednode_addresses = list(bn.checksum_address for bn in BOOTNODES)
     for node in known_nodes:
         row_template = "{} | {} | {}"
         node_type = 'known'
         if node.checksum_public_address == config.node_configuration.checksum_address:
             node_type = 'self'
             row_template += ' ({})'.format(node_type)
-        if node.checksum_public_address in bootnode_addresses:
-            node_type = 'bootnode'
+        if node.checksum_public_address in seednode_addresses:
+            node_type = 'seednode'
             row_template += ' ({})'.format(node_type)
         click.secho(row_template.format(node.checksum_public_address,
                                         node.rest_url(),
@@ -1196,8 +1196,8 @@ def ursula(config,
     config.operating_mode = "federated" if ursula_config.federated_only else "decentralized"
     click.secho("Running in {} mode".format(config.operating_mode), fg='blue')
 
-    # Bootnodes, Seeds, Known Nodes
-    ursula_config.load_bootnodes()
+    # seednodes, Seeds, Known Nodes
+    ursula_config.load_seednodes()
     quantity_known_nodes = len(ursula_config.known_nodes)
     if quantity_known_nodes > 0:
         click.secho("Loaded {} known nodes from storages".format(quantity_known_nodes, fg='blue'))

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -354,8 +354,9 @@ class Learner:
                 elif not self._learning_task.running:
                     raise self.NotEnoughTeachers("The learning loop is not running.  Start it with start_learning().")
                 else:
-                    raise self.NotEnoughTeachers("After {} seconds and {} rounds, didn't find these {} nodes: {}".format(
-                        timeout, rounds_undertaken, len(still_unknown), still_unknown))
+                    raise self.NotEnoughTeachers(
+                        "After {} seconds and {} rounds, didn't find these {} nodes: {}".format(
+                            timeout, rounds_undertaken, len(still_unknown), still_unknown))
 
             else:
                 time.sleep(.1)
@@ -431,7 +432,8 @@ class Learner:
         try:
 
             # TODO: Streamline path generation
-            certificate_filepath = current_teacher.get_certificate_filepath(certificates_dir=self.known_certificates_dir)
+            certificate_filepath = current_teacher.get_certificate_filepath(
+                certificates_dir=self.known_certificates_dir)
             response = self.network_middleware.get_nodes_via_rest(url=rest_url,
                                                                   nodes_i_need=self._node_ids_to_learn_about_immediately,
                                                                   announce_nodes=announce_nodes,
@@ -462,7 +464,8 @@ class Learner:
 
             try:
                 if eager:
-                    certificate_filepath = current_teacher.get_certificate_filepath(certificates_dir=certificate_filepath)
+                    certificate_filepath = current_teacher.get_certificate_filepath(
+                        certificates_dir=certificate_filepath)
                     node.verify_node(self.network_middleware,
                                      accept_federated_only=self.federated_only,  # TODO: 466
                                      certificate_filepath=certificate_filepath)
@@ -548,7 +551,7 @@ class Character(Learner):
 
         """
 
-        self.federated_only = federated_only           # type: bool
+        self.federated_only = federated_only  # type: bool
 
         #
         # Powers
@@ -558,7 +561,7 @@ class Character(Learner):
         crypto_power_ups = crypto_power_ups or list()  # type: list
 
         if crypto_power:
-            self._crypto_power = crypto_power          # type: CryptoPower
+            self._crypto_power = crypto_power  # type: CryptoPower
         elif crypto_power_ups:
             self._crypto_power = CryptoPower(power_ups=crypto_power_ups)
         else:
@@ -572,7 +575,7 @@ class Character(Learner):
                 self.blockchain = blockchain or Blockchain.connect()
 
             self.keyring_dir = keyring_dir  # type: str
-            self.treasure_maps = {}         # type: dict
+            self.treasure_maps = {}  # type: dict
             self.network_middleware = network_middleware or RestMiddleware()
 
             #
@@ -580,7 +583,7 @@ class Character(Learner):
             #
             try:
                 signing_power = self._crypto_power.power_ups(SigningPower)  # type: SigningPower
-                self._stamp = signing_power.get_signature_stamp()           # type: SignatureStamp
+                self._stamp = signing_power.get_signature_stamp()  # type: SignatureStamp
             except NoSigningPower:
                 self._stamp = constants.NO_SIGNING_POWER
 

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -152,8 +152,13 @@ class Learner:
         if len(unresponsive_seed_nodes) > 0:
             self.log.info("No Bootnodes were availible after {} attempts".format(retry_attempts))
 
-        # if read_storages is True:
-        #     self.read_known_nodes()
+        if read_storages is True:
+            self.read_nodes_from_storage()
+
+    def read_nodes_from_storage(self) -> set:
+        stored_nodes = self.node_storage.all(federated_only=self.federated_only)  # TODO: 466
+        for node in stored_nodes:
+            self.remember_node(node)
 
     def remember_node(self, node, force_verification_check=False):
 

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -29,6 +29,7 @@ from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import CryptoPower, SigningPower, EncryptingPower, NoSigningPower, CryptoPowerUp
 from nucypher.crypto.signing import signature_splitter, StrangerStamp, SignatureStamp
 from nucypher.network.middleware import RestMiddleware
+from nucypher.network.nicknames import nickname_from_seed
 from nucypher.network.nodes import VerifiableNode
 
 
@@ -607,6 +608,7 @@ class Character(Learner):
                 if not checksum_address == self.checksum_public_address:
                     error = "Federated-only Characters derive their address from their Signing key; got {} instead."
                     raise self.SuspiciousActivity(error.format(checksum_address))
+        self.nickname, self.nickname_metadata = nickname_from_seed(self.checksum_public_address)
 
     def __eq__(self, other) -> bool:
         return bytes(self.stamp) == bytes(other.stamp)
@@ -616,8 +618,8 @@ class Character(Learner):
 
     def __repr__(self):
         class_name = self.__class__.__name__
-        r = "{} {}"
-        r = r.format(class_name, self.canonical_public_address)
+        r = "⇀{}↽ ({})"
+        r = r.format(self.nickname, self.checksum_public_address)
         return r
 
     @property

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -494,11 +494,7 @@ class Character(Learner):
     _crashed = False
 
     from nucypher.network.protocols import SuspiciousActivity  # Ship this exception with every Character.
-
-    class InvalidSignature(Exception):
-        """
-        Raised when a signature doesn't pass validation/verification.
-        """
+    from nucypher.crypto.signing import InvalidSignature
 
     def __init__(self,
                  is_me: bool = True,

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -608,7 +608,14 @@ class Character(Learner):
                 if not checksum_address == self.checksum_public_address:
                     error = "Federated-only Characters derive their address from their Signing key; got {} instead."
                     raise self.SuspiciousActivity(error.format(checksum_address))
-        self.nickname, self.nickname_metadata = nickname_from_seed(self.checksum_public_address)
+        try:
+            self.nickname, self.nickname_metadata = nickname_from_seed(self.checksum_public_address)
+        except SigningPower.not_found_error:
+            if self.federated_only:
+                self.nickname = self.nickname_metadata = constants.NO_NICKNAME
+            else:
+                raise
+
 
     def __eq__(self, other) -> bool:
         return bytes(self.stamp) == bytes(other.stamp)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -321,10 +321,7 @@ class Bob(Character):
 
     def get_reencrypted_cfrags(self, work_order):
         cfrags = self.network_middleware.reencrypt(work_order)
-        if not len(work_order) == len(cfrags):
-            raise ValueError("Ursula gave back the wrong number of cfrags.  She's up to something.")
         for counter, capsule in enumerate(work_order.capsules):
-            # TODO: Ursula is actually supposed to sign this.  See #141.
             # TODO: Maybe just update the work order here instead of setting it anew.
             work_orders_by_ursula = self._saved_work_orders[work_order.ursula.checksum_public_address]
             work_orders_by_ursula[capsule] = work_order

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -355,11 +355,6 @@ class NodeConfiguration:
             self.validate(config_root=self.config_root, no_registry=no_registry or self.federated_only)
         return self.config_root
 
-    def read_known_nodes(self) -> set:
-        """Read known nodes from metadata, and use them when producing a character"""
-        known_nodes = self.node_storage.all(federated_only=self.federated_only)
-        return known_nodes
-
     def read_keyring(self, *args, **kwargs):
         if self.checksum_address is None:
             raise self.ConfigurationError("No account specified to unlock keyring")

--- a/nucypher/crypto/api.py
+++ b/nucypher/crypto/api.py
@@ -1,8 +1,8 @@
-import os
+import datetime
 from ipaddress import IPv4Address
 from random import SystemRandom
+from typing import Tuple
 
-import datetime
 import sha3
 from constant_sorrow import constants
 from cryptography import x509
@@ -12,10 +12,8 @@ from cryptography.hazmat.backends.openssl.ec import _EllipticCurvePrivateKey
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
-from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate
 from cryptography.x509.oid import NameOID
-from typing import Tuple
 from umbral import pre
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
 
@@ -120,7 +118,6 @@ def generate_self_signed_certificate(host: str,
                                      private_key: _EllipticCurvePrivateKey = None,
                                      days_valid: int = 365
                                      ) -> Tuple[Certificate, _EllipticCurvePrivateKey]:
-
     if not private_key:
         private_key = ec.generate_private_key(curve, default_backend())
 
@@ -128,8 +125,8 @@ def generate_self_signed_certificate(host: str,
 
     now = datetime.datetime.utcnow()
     subject = issuer = x509.Name([
-             x509.NameAttribute(NameOID.COMMON_NAME, host),
-        ])
+        x509.NameAttribute(NameOID.COMMON_NAME, host),
+    ])
     cert = x509.CertificateBuilder().subject_name(subject)
     cert = cert.issuer_name(issuer)
     cert = cert.public_key(public_key)
@@ -148,7 +145,6 @@ def encrypt_and_sign(recipient_pubkey_enc: UmbralPublicKey,
                      signer: 'SignatureStamp',
                      sign_plaintext: bool = True
                      ) -> Tuple[UmbralMessageKit, 'SignatureStamp']:
-
     if signer is not constants.DO_NOT_SIGN:
         # The caller didn't expressly tell us not to sign; we'll sign.
         if sign_plaintext:

--- a/nucypher/crypto/signing.py
+++ b/nucypher/crypto/signing.py
@@ -62,3 +62,7 @@ class StrangerStamp(SignatureStamp):
         from nucypher.crypto.powers import NoSigningPower
         message = "This isn't your SignatureStamp; it belongs to (a Stranger).  You can't sign with it."
         raise NoSigningPower(message)
+
+
+class InvalidSignature(Exception):
+    """Raised when a Signature is not valid."""

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -19,16 +19,41 @@ class RestMiddleware:
             raise RuntimeError("Bad response: {}".format(response.content))
         return response
 
+
+    def learn_from_seednode(self, seednode_metadata, timeout=3, accept_federated_only=False):
+        from nucypher.characters.lawful import Ursula
+        # Pre-fetch certificate
+        self.log.info("Fetching bootnode {} TLS certificate".format(seednode_metadata.checksum_address))
+
+        certificate, filepath = self._get_certificate(seednode_metadata.rest_host, seednode_metadata.rest_port)
+
+        potential_seed_node = Ursula.from_rest_url(self,
+                                                   seednode_metadata.rest_host,
+                                                   seednode_metadata.rest_port,
+                                                   certificate_filepath=filepath,
+                                                   federated_only=True)  # TODO: 466
+
+        if not seednode_metadata.checksum_address == potential_seed_node.checksum_public_address:
+            raise potential_seed_node.SuspiciousActivity(
+                "This seed node has a different wallet address: {} (was hoping for {}).  Are you sure this is a seed node?".format(
+                    potential_seed_node.checksum_public_address,
+                    bootnode.checksum_address))
+        try:
+            potential_seed_node.verify_node(self, accept_federated_only=accept_federated_only)
+        except potential_seed_node.InvalidNode:
+            raise  # TODO: What if our seed node fails verification?
+
+        return potential_seed_node
+
     def _get_certificate(self, hostname, port):
-        bootnode_certificate = ssl.get_server_certificate(hostname, port)
-        certificate = x509.load_pem_x509_certificate(bootnode_certificate.encode(),
+        seednode_certificate = ssl.get_server_certificate(hostname, port)
+        certificate = x509.load_pem_x509_certificate(seednode_certificate.encode(),
                                                      backend=default_backend())
         # Write certificate
-        filename = '{}.{}'.format(bootnode.checksum_address, Encoding.PEM.name.lower())
+        filename = '{}.{}'.format(seednode.checksum_address, Encoding.PEM.name.lower())
         certificate_filepath = os.path.join(self.known_certificates_dir, filename)
         _write_tls_certificate(certificate=certificate, full_filepath=certificate_filepath, force=True)
-        self.log.info("Saved bootnode {} TLS certificate".format(bootnode.checksum_address))
-
+        self.log.info("Saved seednode {} TLS certificate".format(seednode.checksum_address))
 
     def enact_policy(self, ursula, id, payload):
         response = requests.post('https://{}/kFrag/{}'.format(ursula.rest_interface, id.hex()), payload,

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -1,5 +1,7 @@
 import os
+import socket
 import ssl
+import time
 
 import requests
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
@@ -28,13 +30,17 @@ class RestMiddleware:
     def learn_about_seednode(self, seednode_metadata, known_certs_dir, timeout=3, accept_federated_only=False):
         from nucypher.characters.lawful import Ursula
         # Pre-fetch certificate
-        self.log.info("Fetching bootnode {} TLS certificate".format(seednode_metadata.checksum_address))
+        self.log.info("Fetching seednode {} TLS certificate".format(seednode_metadata.checksum_address))
 
         # TODO: Utilize timeout.
         certificate, filepath = self._get_certificate(checksum_address=seednode_metadata.checksum_address,
                                                       hostname=seednode_metadata.rest_host,
                                                       port=seednode_metadata.rest_port,
-                                                      certs_dir=known_certs_dir,)
+                                                      certs_dir=known_certs_dir,
+                                                      timeout=timeout)
+
+        if certificate is False:
+            return False
 
         potential_seed_node = Ursula.from_rest_url(self,
                                                    seednode_metadata.rest_host,
@@ -46,7 +52,7 @@ class RestMiddleware:
             raise potential_seed_node.SuspiciousActivity(
                 "This seed node has a different wallet address: {} (was hoping for {}).  Are you sure this is a seed node?".format(
                     potential_seed_node.checksum_public_address,
-                    bootnode.checksum_address))
+                    seednode_metadata.checksum_address))
         try:
             potential_seed_node.verify_node(self,
                                             accept_federated_only=accept_federated_only,
@@ -56,8 +62,21 @@ class RestMiddleware:
 
         return potential_seed_node
 
-    def _get_certificate(self, checksum_address, certs_dir, hostname, port):
-        seednode_certificate = ssl.get_server_certificate(addr=(hostname, port))
+    def _get_certificate(self, checksum_address, certs_dir, hostname, port,
+                         timeout=3, retry_attempts: int=3, retry_rate: int = 2,):
+        socket.setdefaulttimeout(timeout)  # Set Socket Timeout
+        current_attempt = 0
+        try:
+            seednode_certificate = ssl.get_server_certificate(addr=(hostname, port))
+        except socket.timeout:
+            if current_attempt == retry_attempts:
+                message = "No Response from seednode {} after {} attempts"
+                self.log.info(message.format(checksum_address, retry_attempts))
+                return False, False
+            self.log.info(
+                "No Response from seednode {}. Retrying in {} seconds...".format(checksum_address, retry_rate))
+            time.sleep(retry_rate)
+
         certificate = x509.load_pem_x509_certificate(seednode_certificate.encode(),
                                                      backend=default_backend())
         # Write certificate

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -99,7 +99,7 @@ class RestMiddleware:
         cfrags_and_signatures = BytestringSplitter((CapsuleFrag, VariableLengthBytestring), Signature).repeat(
             ursula_rest_response.content)
         cfrags = work_order.complete(
-            cfrags_and_signatures)  # TODO: We'll do verification of Ursula's signature here.  #141
+            cfrags_and_signatures)
         return cfrags
 
     def get_competitive_rate(self):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -1,9 +1,15 @@
+import os
+import ssl
+
 import requests
-
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
-
-from umbral.fragments import CapsuleFrag
+from cryptography import x509
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.serialization import Encoding
 from twisted.logger import Logger
+from umbral.fragments import CapsuleFrag
+
+from nucypher.config.keyring import _write_tls_certificate
 
 
 class RestMiddleware:

--- a/nucypher/network/nicknames/__init__.py
+++ b/nucypher/network/nicknames/__init__.py
@@ -1,0 +1,30 @@
+import json
+import random
+from os.path import abspath, dirname, join
+
+HERE = BASE_DIR = abspath(dirname(__file__))
+with open(join(HERE, 'web_colors.json')) as f:
+    colors = json.load(f)
+
+with open(join(HERE, 'zodiac.json')) as f:
+    zodiac = json.load(f)
+
+eastern = zodiac['eastern_zodiac']
+western = zodiac['western_zodiac']
+
+eastern_list = list(eastern.keys())
+western_list = list(western.keys())
+
+colors = colors['colors']
+pairs = []
+
+
+def nickname_from_seed(seed):
+    random.seed(seed)
+    color1 = random.choice(colors)
+    color2 = random.choice(colors)
+    western_symbol = random.choice(western_list)
+    eastern_symbol = random.choice(eastern_list)
+    nickname = "{}ish {} {} {}".format(color1['color'], color2['color'], western_symbol, eastern_symbol)
+    nickname_metadata = (color1, color2, western[western_symbol], eastern[eastern_symbol])
+    return nickname, nickname_metadata

--- a/nucypher/network/nicknames/__init__.py
+++ b/nucypher/network/nicknames/__init__.py
@@ -9,22 +9,23 @@ with open(join(HERE, 'web_colors.json')) as f:
 with open(join(HERE, 'zodiac.json')) as f:
     zodiac = json.load(f)
 
-eastern = zodiac['eastern_zodiac']
-western = zodiac['western_zodiac']
-
-eastern_list = list(eastern.keys())
-western_list = list(western.keys())
-
 colors = colors['colors']
 pairs = []
+
+zodiac_signs = zodiac['eastern_zodiac']
+zodiac_signs.update(zodiac['western_zodiac'])
 
 
 def nickname_from_seed(seed):
     random.seed(seed)
     color1 = random.choice(colors)
     color2 = random.choice(colors)
-    western_symbol = random.choice(western_list)
-    eastern_symbol = random.choice(eastern_list)
-    nickname = "{}ish {} {} {}".format(color1['color'], color2['color'], western_symbol, eastern_symbol)
-    nickname_metadata = (color1, color2, western[western_symbol], eastern[eastern_symbol])
+
+    zodiac_list = list(zodiac_signs.keys())
+
+    symbol1 = random.choice(zodiac_list)
+    zodiac_list.remove(symbol1)
+    symbol2 = random.choice(zodiac_list)
+    nickname = "{} {} {} {}".format(color1['color'], symbol1, color2['color'], symbol2)
+    nickname_metadata = (color1, zodiac_signs[symbol1], color2, zodiac_signs[symbol2])
     return nickname, nickname_metadata

--- a/nucypher/network/nicknames/web_colors.json
+++ b/nucypher/network/nicknames/web_colors.json
@@ -1,0 +1,565 @@
+{
+    "description": "List of named HTML colors",
+    "colors": [
+        {
+            "color": "AliceBlue",
+            "hex": "#F0F8FF"
+        },
+        {
+            "color": "AntiqueWhite",
+            "hex": "#FAEBD7"
+        },
+        {
+            "color": "Aqua",
+            "hex": "#00FFFF"
+        },
+        {
+            "color": "Aquamarine",
+            "hex": "#7FFFD4"
+        },
+        {
+            "color": "Azure",
+            "hex": "#F0FFFF"
+        },
+        {
+            "color": "Beige",
+            "hex": "#F5F5DC"
+        },
+        {
+            "color": "Bisque",
+            "hex": "#FFE4C4"
+        },
+        {
+            "color": "Black",
+            "hex": "#000000"
+        },
+        {
+            "color": "BlanchedAlmond",
+            "hex": "#FFEBCD"
+        },
+        {
+            "color": "Blue",
+            "hex": "#0000FF"
+        },
+        {
+            "color": "BlueViolet",
+            "hex": "#8A2BE2"
+        },
+        {
+            "color": "Brown",
+            "hex": "#A52A2A"
+        },
+        {
+            "color": "BurlyWood",
+            "hex": "#DEB887"
+        },
+        {
+            "color": "CadetBlue",
+            "hex": "#5F9EA0"
+        },
+        {
+            "color": "Chartreuse",
+            "hex": "#7FFF00"
+        },
+        {
+            "color": "Chocolate",
+            "hex": "#D2691E"
+        },
+        {
+            "color": "Coral",
+            "hex": "#FF7F50"
+        },
+        {
+            "color": "CornflowerBlue",
+            "hex": "#6495ED"
+        },
+        {
+            "color": "Cornsilk",
+            "hex": "#FFF8DC"
+        },
+        {
+            "color": "Crimson",
+            "hex": "#DC143C"
+        },
+        {
+            "color": "Cyan",
+            "hex": "#00FFFF"
+        },
+        {
+            "color": "DarkBlue",
+            "hex": "#00008B"
+        },
+        {
+            "color": "DarkCyan",
+            "hex": "#008B8B"
+        },
+        {
+            "color": "DarkGoldenRod",
+            "hex": "#B8860B"
+        },
+        {
+            "color": "DarkGray",
+            "hex": "#A9A9A9"
+        },
+        {
+            "color": "DarkGreen",
+            "hex": "#006400"
+        },
+        {
+            "color": "DarkKhaki",
+            "hex": "#BDB76B"
+        },
+        {
+            "color": "DarkMagenta",
+            "hex": "#8B008B"
+        },
+        {
+            "color": "DarkOliveGreen",
+            "hex": "#556B2F"
+        },
+        {
+            "color": "DarkOrange",
+            "hex": "#FF8C00"
+        },
+        {
+            "color": "DarkOrchid",
+            "hex": "#9932CC"
+        },
+        {
+            "color": "DarkRed",
+            "hex": "#8B0000"
+        },
+        {
+            "color": "DarkSalmon",
+            "hex": "#E9967A"
+        },
+        {
+            "color": "DarkSeaGreen",
+            "hex": "#8FBC8F"
+        },
+        {
+            "color": "DarkSlateBlue",
+            "hex": "#483D8B"
+        },
+        {
+            "color": "DarkSlateGray",
+            "hex": "#2F4F4F"
+        },
+        {
+            "color": "DarkTurquoise",
+            "hex": "#00CED1"
+        },
+        {
+            "color": "DarkViolet",
+            "hex": "#9400D3"
+        },
+        {
+            "color": "DeepPink",
+            "hex": "#FF1493"
+        },
+        {
+            "color": "DeepSkyBlue",
+            "hex": "#00BFFF"
+        },
+        {
+            "color": "DimGray",
+            "hex": "#696969"
+        },
+        {
+            "color": "DodgerBlue",
+            "hex": "#1E90FF"
+        },
+        {
+            "color": "FireBrick",
+            "hex": "#B22222"
+        },
+        {
+            "color": "FloralWhite",
+            "hex": "#FFFAF0"
+        },
+        {
+            "color": "ForestGreen",
+            "hex": "#228B22"
+        },
+        {
+            "color": "Fuchsia",
+            "hex": "#FF00FF"
+        },
+        {
+            "color": "Gainsboro",
+            "hex": "#DCDCDC"
+        },
+        {
+            "color": "GhostWhite",
+            "hex": "#F8F8FF"
+        },
+        {
+            "color": "Gold",
+            "hex": "#FFD700"
+        },
+        {
+            "color": "GoldenRod",
+            "hex": "#DAA520"
+        },
+        {
+            "color": "Gray",
+            "hex": "#808080"
+        },
+        {
+            "color": "Green",
+            "hex": "#008000"
+        },
+        {
+            "color": "GreenYellow",
+            "hex": "#ADFF2F"
+        },
+        {
+            "color": "HoneyDew",
+            "hex": "#F0FFF0"
+        },
+        {
+            "color": "HotPink",
+            "hex": "#FF69B4"
+        },
+        {
+            "color": "IndianRed ",
+            "hex": "#CD5C5C"
+        },
+        {
+            "color": "Indigo ",
+            "hex": "#4B0082"
+        },
+        {
+            "color": "Ivory",
+            "hex": "#FFFFF0"
+        },
+        {
+            "color": "Khaki",
+            "hex": "#F0E68C"
+        },
+        {
+            "color": "Lavender",
+            "hex": "#E6E6FA"
+        },
+        {
+            "color": "LavenderBlush",
+            "hex": "#FFF0F5"
+        },
+        {
+            "color": "LawnGreen",
+            "hex": "#7CFC00"
+        },
+        {
+            "color": "LemonChiffon",
+            "hex": "#FFFACD"
+        },
+        {
+            "color": "LightBlue",
+            "hex": "#ADD8E6"
+        },
+        {
+            "color": "LightCoral",
+            "hex": "#F08080"
+        },
+        {
+            "color": "LightCyan",
+            "hex": "#E0FFFF"
+        },
+        {
+            "color": "LightGoldenRodYellow",
+            "hex": "#FAFAD2"
+        },
+        {
+            "color": "LightGray",
+            "hex": "#D3D3D3"
+        },
+        {
+            "color": "LightGreen",
+            "hex": "#90EE90"
+        },
+        {
+            "color": "LightPink",
+            "hex": "#FFB6C1"
+        },
+        {
+            "color": "LightSalmon",
+            "hex": "#FFA07A"
+        },
+        {
+            "color": "LightSeaGreen",
+            "hex": "#20B2AA"
+        },
+        {
+            "color": "LightSkyBlue",
+            "hex": "#87CEFA"
+        },
+        {
+            "color": "LightSlateGray",
+            "hex": "#778899"
+        },
+        {
+            "color": "LightSteelBlue",
+            "hex": "#B0C4DE"
+        },
+        {
+            "color": "LightYellow",
+            "hex": "#FFFFE0"
+        },
+        {
+            "color": "Lime",
+            "hex": "#00FF00"
+        },
+        {
+            "color": "LimeGreen",
+            "hex": "#32CD32"
+        },
+        {
+            "color": "Linen",
+            "hex": "#FAF0E6"
+        },
+        {
+            "color": "Magenta",
+            "hex": "#FF00FF"
+        },
+        {
+            "color": "Maroon",
+            "hex": "#800000"
+        },
+        {
+            "color": "MediumAquaMarine",
+            "hex": "#66CDAA"
+        },
+        {
+            "color": "MediumBlue",
+            "hex": "#0000CD"
+        },
+        {
+            "color": "MediumOrchid",
+            "hex": "#BA55D3"
+        },
+        {
+            "color": "MediumPurple",
+            "hex": "#9370DB"
+        },
+        {
+            "color": "MediumSeaGreen",
+            "hex": "#3CB371"
+        },
+        {
+            "color": "MediumSlateBlue",
+            "hex": "#7B68EE"
+        },
+        {
+            "color": "MediumSpringGreen",
+            "hex": "#00FA9A"
+        },
+        {
+            "color": "MediumTurquoise",
+            "hex": "#48D1CC"
+        },
+        {
+            "color": "MediumVioletRed",
+            "hex": "#C71585"
+        },
+        {
+            "color": "MidnightBlue",
+            "hex": "#191970"
+        },
+        {
+            "color": "MintCream",
+            "hex": "#F5FFFA"
+        },
+        {
+            "color": "MistyRose",
+            "hex": "#FFE4E1"
+        },
+        {
+            "color": "Moccasin",
+            "hex": "#FFE4B5"
+        },
+        {
+            "color": "NavajoWhite",
+            "hex": "#FFDEAD"
+        },
+        {
+            "color": "Navy",
+            "hex": "#000080"
+        },
+        {
+            "color": "OldLace",
+            "hex": "#FDF5E6"
+        },
+        {
+            "color": "Olive",
+            "hex": "#808000"
+        },
+        {
+            "color": "OliveDrab",
+            "hex": "#6B8E23"
+        },
+        {
+            "color": "Orange",
+            "hex": "#FFA500"
+        },
+        {
+            "color": "OrangeRed",
+            "hex": "#FF4500"
+        },
+        {
+            "color": "Orchid",
+            "hex": "#DA70D6"
+        },
+        {
+            "color": "PaleGoldenRod",
+            "hex": "#EEE8AA"
+        },
+        {
+            "color": "PaleGreen",
+            "hex": "#98FB98"
+        },
+        {
+            "color": "PaleTurquoise",
+            "hex": "#AFEEEE"
+        },
+        {
+            "color": "PaleVioletRed",
+            "hex": "#DB7093"
+        },
+        {
+            "color": "PapayaWhip",
+            "hex": "#FFEFD5"
+        },
+        {
+            "color": "PeachPuff",
+            "hex": "#FFDAB9"
+        },
+        {
+            "color": "Peru",
+            "hex": "#CD853F"
+        },
+        {
+            "color": "Pink",
+            "hex": "#FFC0CB"
+        },
+        {
+            "color": "Plum",
+            "hex": "#DDA0DD"
+        },
+        {
+            "color": "PowderBlue",
+            "hex": "#B0E0E6"
+        },
+        {
+            "color": "Purple",
+            "hex": "#800080"
+        },
+        {
+            "color": "Red",
+            "hex": "#FF0000"
+        },
+        {
+            "color": "RosyBrown",
+            "hex": "#BC8F8F"
+        },
+        {
+            "color": "RoyalBlue",
+            "hex": "#4169E1"
+        },
+        {
+            "color": "SaddleBrown",
+            "hex": "#8B4513"
+        },
+        {
+            "color": "Salmon",
+            "hex": "#FA8072"
+        },
+        {
+            "color": "SandyBrown",
+            "hex": "#F4A460"
+        },
+        {
+            "color": "SeaGreen",
+            "hex": "#2E8B57"
+        },
+        {
+            "color": "SeaShell",
+            "hex": "#FFF5EE"
+        },
+        {
+            "color": "Sienna",
+            "hex": "#A0522D"
+        },
+        {
+            "color": "Silver",
+            "hex": "#C0C0C0"
+        },
+        {
+            "color": "SkyBlue",
+            "hex": "#87CEEB"
+        },
+        {
+            "color": "SlateBlue",
+            "hex": "#6A5ACD"
+        },
+        {
+            "color": "SlateGray",
+            "hex": "#708090"
+        },
+        {
+            "color": "Snow",
+            "hex": "#FFFAFA"
+        },
+        {
+            "color": "SpringGreen",
+            "hex": "#00FF7F"
+        },
+        {
+            "color": "SteelBlue",
+            "hex": "#4682B4"
+        },
+        {
+            "color": "Tan",
+            "hex": "#D2B48C"
+        },
+        {
+            "color": "Teal",
+            "hex": "#008080"
+        },
+        {
+            "color": "Thistle",
+            "hex": "#D8BFD8"
+        },
+        {
+            "color": "Tomato",
+            "hex": "#FF6347"
+        },
+        {
+            "color": "Turquoise",
+            "hex": "#40E0D0"
+        },
+        {
+            "color": "Violet",
+            "hex": "#EE82EE"
+        },
+        {
+            "color": "Wheat",
+            "hex": "#F5DEB3"
+        },
+        {
+            "color": "White",
+            "hex": "#FFFFFF"
+        },
+        {
+            "color": "WhiteSmoke",
+            "hex": "#F5F5F5"
+        },
+        {
+            "color": "Yellow",
+            "hex": "#FFFF00"
+        },
+        {
+            "color": "YellowGreen",
+            "hex": "#9ACD32"
+        }
+    ]
+}

--- a/nucypher/network/nicknames/zodiac.json
+++ b/nucypher/network/nicknames/zodiac.json
@@ -1,0 +1,262 @@
+{
+    "description": "Zodiac signs and associated information, both Western and Eastern.",
+    "source": "https://en.wikipedia.org/wiki/Astrological_sign",
+    "western_zodiac": {
+        "Aries": {
+            "longitude_start": "0",
+            "longitude_end": "30",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Aries.svg",
+            "unicode_symbol": "♈",
+            "gloss": "The Ram",
+            "element": "Fire",
+            "ruling_body_classic": "Mars",
+            "ruling_body_modern": "Mars"
+        },
+        "Taurus": {
+            "longitude_start": "30",
+            "longitude_end": "60",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Taurus.svg",
+            "unicode_symbol": "♉",
+            "gloss": "The Bull",
+            "element": "Earth",
+            "ruling_body_classic": "Venus",
+            "ruling_body_modern": "Earth"
+        },
+        "Gemini": {
+            "longitude_start": "60",
+            "longitude_end": "90",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Gemini.svg",
+            "unicode_symbol": "♊",
+            "gloss": "The Twins",
+            "element": "Air",
+            "ruling_body_classic": "Mercury",
+            "ruling_body_modern": "Mercury"
+        },
+        "Cancer": {
+            "longitude_start": "90",
+            "longitude_end": "120",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Cancer.svg",
+            "unicode_symbol": "♋",
+            "gloss": "The Crab",
+            "element": "Water",
+            "ruling_body_classic": "Moon",
+            "ruling_body_modern": "Moon"
+        },
+        "Leo": {
+            "longitude_start": "120",
+            "longitude_end": "150",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Leo.svg",
+            "unicode_symbol": "♌",
+            "gloss": "The Lion",
+            "element": "Fire",
+            "ruling_body_classic": "Sun",
+            "ruling_body_modern": "Sun"
+        },
+        "Virgo": {
+            "longitude_start": "150",
+            "longitude_end": "180",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Virgo.svg",
+            "unicode_symbol": "♍",
+            "gloss": "The Maiden",
+            "element": "Earth",
+            "ruling_body_classic": "Mercury",
+            "ruling_body_modern": "Ceres"
+        },
+        "Libra": {
+            "longitude_start": "180",
+            "longitude_end": "210",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Libra.svg",
+            "unicode_symbol": "♎",
+            "gloss": "The Scales",
+            "element": "Air",
+            "ruling_body_classic": "Venus",
+            "ruling_body_modern": "Venus"
+        },
+        "Scorpio": {
+            "longitude_start": "210",
+            "longitude_end": "240",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Scorpio.svg",
+            "unicode_symbol": "♏",
+            "gloss": "The Scorpion",
+            "element": "Water",
+            "ruling_body_classic": "Mars",
+            "ruling_body_modern": "Pluto"
+        },
+        "Sagittarius": {
+            "longitude_start": "240",
+            "longitude_end": "270",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Sagittarius.svg",
+            "unicode_symbol": "♐",
+            "gloss": "The Archer",
+            "element": "Fire",
+            "ruling_body_classic": "Jupiter",
+            "ruling_body_modern": "Jupiter"
+        },
+        "Capricorn": {
+            "longitude_start": "270",
+            "longitude_end": "300",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Capricorn.svg",
+            "unicode_symbol": "♑",
+            "gloss": "The Mountain Sea-goat",
+            "element": "Earth",
+            "ruling_body_classic": "Saturn",
+            "ruling_body_modern": "Saturn"
+        },
+        "Aquarius": {
+            "longitude_start": "300",
+            "longitude_end": "330",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Aquarius.svg",
+            "unicode_symbol": "♒",
+            "gloss": "The Water-bearer",
+            "element": "Air",
+            "ruling_body_classic": "Saturn",
+            "ruling_body_modern": "Uranus"
+        },
+        "Pisces": {
+            "longitude_start": "330",
+            "longitude_end": "360",
+            "svg_symbol": "https://en.wikipedia.org/wiki/File:Pisces.svg",
+            "unicode_symbol": "♓",
+            "gloss": "The Fish",
+            "element": "Water",
+            "ruling_body_classic": "Jupiter",
+            "ruling_body_modern": "Neptune"
+        }
+    },
+    "eastern_zodiac": {
+        "Rat": {
+            "yin-yang": "Yang",
+            "direction": "North",
+            "season": "Mid-Winter",
+            "element": "Water",
+            "trine": "1st",
+            "years": [
+                1900, 1912, 1924, 1936, 1948, 1960, 1972, 1984, 1996, 2008, 2020, 2032
+            ],
+            "unicode_symbol": "子"
+        },
+        "Ox": {
+            "yin-yang": "Yin",
+            "direction": "North",
+            "season": "Late Winter",
+            "element": "Earth",
+            "trine": "2nd",
+            "years": [
+                1901, 1913, 1925, 1937, 1949, 1961, 1973, 1985, 1997, 2009, 2021, 2033
+            ],
+            "unicode_symbol": "丑"
+        },
+        "Tiger": {
+            "yin-yang": "Yang",
+            "direction": "East",
+            "season": "Early Spring",
+            "element": "Wood",
+            "trine": "3rd",
+            "years": [
+                1902, 1914, 1926, 1938, 1950, 1962, 1974, 1986, 1998, 2010, 2022, 2034
+            ],
+            "unicode_symbol": "寅"
+        },
+        "Rabbit": {
+            "yin-yang": "Yin",
+            "direction": "East",
+            "season": "Mid-Spring",
+            "element": "Wood",
+            "trine": "4th",
+            "years": [
+                1903, 1915, 1927, 1939, 1951, 1963, 1975, 1987, 1999, 2011, 2023, 2035
+            ],
+            "unicode_symbol": "卯"
+        },
+        "Dragon": {
+            "yin-yang": "Yang",
+            "direction": "East",
+            "season": "Late Spring",
+            "element": "Earth",
+            "trine": "1st",
+            "years": [
+                1904, 1916, 1928, 1940, 1952, 1964, 1976, 1988, 2000, 2012, 2024, 2036
+            ],
+            "unicode_symbol": "辰"
+        },
+        "Snake": {
+            "yin-yang": "Yin",
+            "direction": "South",
+            "season": "Early Summer",
+            "element": "Fire",
+            "trine": "2nd",
+            "years": [
+                1905, 1917, 1929, 1941, 1953, 1965, 1977, 1989, 2001, 2013, 2025, 2037
+            ],
+            "unicode_symbol": "巳"
+        },
+        "Horse": {
+            "yin-yang": "Yang",
+            "direction": "South",
+            "season": "Mid-Summer",
+            "element": "Fire",
+            "trine": "3rd",
+            "years": [
+                1906, 1918, 1930, 1942, 1954, 1966, 1978, 1990, 2002, 2014, 2026, 2038
+            ],
+            "unicode_symbol": "午"
+        },
+        "Goat": {
+            "yin-yang": "Yin",
+            "direction": "South",
+            "season": "Late Summer",
+            "element": "Earth",
+            "trine": "4th",
+            "years": [
+                1907, 1919, 1931, 1943, 1955, 1967, 1979, 1991, 2003, 2015, 2027, 2039
+            ],
+            "unicode_symbol": "未"
+        },
+        "Monkey": {
+            "yin-yang": "Yang",
+            "direction": "West",
+            "season": "Early Autumn",
+            "element": "Metal",
+            "trine": "1st",
+            "years": [
+                1908, 1920, 1932, 1944, 1956, 1968, 1980, 1992, 2004, 2016, 2028, 2040
+            ],
+            "unicode_symbol": "申"
+        },
+        "Rooster": {
+            "yin-yang": "Yin",
+            "direction": "West",
+            "season": "Mid-Autumn",
+            "element": "Metal",
+            "trine": "2nd",
+            "years": [
+                1909, 1921, 1933, 1945, 1957, 1969, 1981, 1993, 2005, 2017, 2029, 2041
+            ],
+            "unicode_symbol": "酉"
+        },
+        "Dog": {
+            "yin-yang": "Yang",
+            "direction": "West",
+            "season": "Late Autumn",
+            "element": "Earth",
+            "trine": "3rd",
+            "years": [
+                1910, 1922, 1934, 1946, 1958, 1970, 1982, 1994, 2006, 2018, 2030, 2042
+            ],
+            "unicode_symbol": "戌"
+        },
+        "Pig": {
+            "yin-yang": "Yin",
+            "direction": "North",
+            "season": "Early Winter",
+            "element": "Water",
+            "trine": "4th",
+            "years": [
+                1911, 1923, 1935, 1947, 1959, 1971, 1983, 1995, 2007, 2019, 2031, 2043
+            ],
+            "unicode_symbol": "亥"
+        }
+        
+    }
+    
+}

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -10,7 +10,9 @@ from eth_keys.datatypes import Signature as EthSignature
 
 from nucypher.config.constants import SeednodeMetadata
 from nucypher.config.keyring import _write_tls_certificate
+from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.powers import BlockchainPower, SigningPower, EncryptingPower, NoSigningPower
+from nucypher.network.nicknames import nickname_from_seed
 from nucypher.network.protocols import SuspiciousActivity
 from nucypher.network.server import TLSHostingPower
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -248,10 +248,10 @@ class ProxyRESTRoutes:
             capsule_signed_by_both = bytes(self._stamp(capsule_signature))
 
             capsule.set_correctness_keys(verifying=alices_verifying_key)
-            # TODO: Sign the result of this.  See #141.
             cfrag = pre.reencrypt(kfrag, capsule, metadata=capsule_signed_by_both)
             self.log.info("Re-encrypting for {}, made {}.".format(capsule, cfrag))
-            cfrag_byte_stream += VariableLengthBytestring(cfrag)
+            signature = self._stamp(bytes(cfrag))
+            cfrag_byte_stream += VariableLengthBytestring(cfrag) + signature
 
         # TODO: Put this in Ursula's datastore
         self._work_order_tracker.append(work_order)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -46,9 +46,6 @@ class ProxyRESTServer:
 class ProxyRESTRoutes:
     log = getLogger("characters")
 
-    class InvalidSignature(Exception):
-        """Raised when a received signature is not valid."""
-
     def __init__(self,
                  db_name,
                  db_filepath,

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -250,7 +250,7 @@ class ProxyRESTRoutes:
             capsule.set_correctness_keys(verifying=alices_verifying_key)
             cfrag = pre.reencrypt(kfrag, capsule, metadata=capsule_signed_by_both)
             self.log.info("Re-encrypting for {}, made {}.".format(capsule, cfrag))
-            signature = self._stamp(bytes(cfrag))
+            signature = self._stamp(bytes(cfrag) + bytes(capsule))
             cfrag_byte_stream += VariableLengthBytestring(cfrag) + signature
 
         # TODO: Put this in Ursula's datastore

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -219,6 +219,7 @@ class ProxyRESTRoutes:
                 kfrag,
                 session=session)
 
+        # TODO: Sign the arrangement here.  #495
         return  # TODO: Return A 200, with whatever policy metadata.
 
     def reencrypt_via_rest(self, id_as_hex, request: Request):

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -486,7 +486,7 @@ class WorkOrder(object):
         self.receipt_bytes = receipt_bytes
         self.receipt_signature = receipt_signature
         self.ursula = ursula  # TODO: We may still need a more elegant system for ID'ing Ursula.  See #136.
-
+        self.completed = False
 
     def __repr__(self):
         return "WorkOrder for hrac {hrac}: (capsules: {capsule_bytes}) for Ursula: {node}".format(
@@ -538,10 +538,16 @@ class WorkOrder(object):
             (self.receipt_bytes, msgpack.dumps(capsules_as_bytes), msgpack.dumps(capsule_signatures_as_bytes)))
         return bytes(self.receipt_signature) + self.bob.stamp + packed_receipt_and_capsules
 
-    def complete(self, cfrags):
-        # TODO: Verify that this is in fact complete - right number of CFrags and properly signed.
-        # TODO: Mark it complete with datetime.
-        pass
+    def complete(self, cfrags_and_signatures):
+        good_cfrags = []
+        for cfrag, signature in cfrags_and_signatures:
+            if signature.verify(bytes(cfrag), self.ursula.stamp.as_umbral_pubkey()):
+                good_cfrags.append(cfrag)
+            else:
+                raise cfrag.NoProofProvided("This CFrag is not properly signed by Ursula.")
+        else:
+            self.completed = maya.now()
+            return good_cfrags
 
 
 class WorkOrderHistory:

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -332,8 +332,7 @@ class TreasureMap:
                                   )
     node_id_splitter = BytestringSplitter((to_checksum_address, int(PUBLIC_ADDRESS_LENGTH)), Arrangement.ID_LENGTH)
 
-    class InvalidSignature(Exception):
-        """Raised when the public signature (typically intended for Ursula) is not valid."""
+    from nucypher.crypto.signing import InvalidSignature  # Raised when the public signature (typically intended for Ursula) is not valid.
 
     def __init__(self,
                  m: int = None,
@@ -547,7 +546,7 @@ class WorkOrder(object):
             if signature.verify(bytes(cfrag) + bytes(capsule), self.ursula.stamp.as_umbral_pubkey()):
                 good_cfrags.append(cfrag)
             else:
-                raise cfrag.NoProofProvided("This CFrag is not properly signed by Ursula.")
+                raise self.ursula.InvalidSignature("This CFrag is not properly signed by Ursula.")
         else:
             self.completed = maya.now()
             return good_cfrags

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -540,8 +540,11 @@ class WorkOrder(object):
 
     def complete(self, cfrags_and_signatures):
         good_cfrags = []
-        for cfrag, signature in cfrags_and_signatures:
-            if signature.verify(bytes(cfrag), self.ursula.stamp.as_umbral_pubkey()):
+        if not len(self) == len(cfrags_and_signatures):
+            raise ValueError("Ursula gave back the wrong number of cfrags.  She's up to something.")
+        for counter, capsule in enumerate(self.capsules):
+            cfrag, signature = cfrags_and_signatures[counter]
+            if signature.verify(bytes(cfrag) + bytes(capsule), self.ursula.stamp.as_umbral_pubkey()):
                 good_cfrags.append(cfrag)
             else:
                 raise cfrag.NoProofProvided("This CFrag is not properly signed by Ursula.")

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -37,7 +37,7 @@ class MockRestMiddleware(RestMiddleware):
             raise RuntimeError(
                 "Can't find an Ursula with port {} - did you spin up the right test ursulas?".format(port))
 
-    def _get_certificate(self, hostname, port):
+    def _get_certificate(self, checksum_address, certs_dir, hostname, port):
         ursula = self._get_ursula_by_port(port)
         return ursula.certificate, ursula.certificate_filepath
 

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -37,30 +37,6 @@ class MockRestMiddleware(RestMiddleware):
             raise RuntimeError(
                 "Can't find an Ursula with port {} - did you spin up the right test ursulas?".format(port))
 
-    def learn_from_seednode(self, seednode_metadata, timeout=3, accept_federated_only=False):
-        # Pre-fetch certificate
-        self.log.info("Fetching bootnode {} TLS certificate".format(seednode_metadata.checksum_address))
-
-        certificate, filepath = self._get_certificate(seednode_metadata.rest_host, seednode_metadata.rest_port)
-
-        potential_seed_node = Ursula.from_rest_url(self,
-                                                   seednode_metadata.rest_host,
-                                                   seednode_metadata.rest_port,
-                                                   certificate_filepath=filepath,
-                                                   federated_only=True)  # TODO: 466
-
-        if not seednode_metadata.checksum_address == potential_seed_node.checksum_public_address:
-            raise potential_seed_node.SuspiciousActivity(
-                "This seed node has a different wallet address: {} (was hoping for {}).  Are you sure this is a seed node?".format(
-                    potential_seed_node.checksum_public_address,
-                    bootnode.checksum_address))
-        try:
-            potential_seed_node.verify_node(self, accept_federated_only=accept_federated_only)
-        except potential_seed_node.InvalidNode:
-            raise  # TODO: What if our seed node fails verification?
-
-        return potential_seed_node
-
     def _get_certificate(self, hostname, port):
         ursula = self._get_ursula_by_port(port)
         return ursula.certificate, ursula.certificate_filepath

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -1,9 +1,4 @@
-from urllib.parse import urlparse
-
 from apistar import TestClient
-from cryptography import x509
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.serialization import Encoding
 
 from nucypher.characters.lawful import Ursula
 from nucypher.network.middleware import RestMiddleware
@@ -37,7 +32,8 @@ class MockRestMiddleware(RestMiddleware):
             raise RuntimeError(
                 "Can't find an Ursula with port {} - did you spin up the right test ursulas?".format(port))
 
-    def _get_certificate(self, checksum_address, certs_dir, hostname, port):
+    def _get_certificate(self, checksum_address, certs_dir, hostname, port, timeout=3, retry_attempts: int = 3,
+                         retry_rate: int = 2, ):
         ursula = self._get_ursula_by_port(port)
         return ursula.certificate, ursula.certificate_filepath
 

--- a/nucypher/utilities/sandbox/ursula.py
+++ b/nucypher/utilities/sandbox/ursula.py
@@ -143,21 +143,21 @@ class UrsulaCommandProtocol(LineReceiver):
         color_index = {
             'self': 'yellow',
             'known': 'white',
-            'bootnode': 'blue'
+            'seednode': 'blue'
         }
         for node_type, color in color_index.items():
             click.secho('{0:<6} | '.format(node_type), fg=color, nl=False)
         click.echo('\n')
 
-        bootnode_addresses = list(bn.checksum_address for bn in BOOTNODES)
+        seednode_addresses = list(bn.checksum_address for bn in BOOTNODES)
         for address, node in known_nodes.items():
             row_template = "{} | {} | {}"
             node_type = 'known'
             if node.checksum_public_address == self.ursula.checksum_public_address:
                 node_type = 'self'
                 row_template += ' ({})'.format(node_type)
-            if node.checksum_public_address in bootnode_addresses:
-                node_type = 'bootnode'
+            if node.checksum_public_address in seednode_addresses:
+                node_type = 'seednode'
                 row_template += ' ({})'.format(node_type)
             click.secho(row_template.format(node.checksum_public_address,
                                             node.rest_url(),

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -1,5 +1,6 @@
 from tempfile import TemporaryDirectory
 
+import maya
 import pytest
 import pytest_twisted
 from twisted.internet import threads
@@ -152,12 +153,18 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
 
     ursula_id, work_order = list(work_orders.items())[0]
 
+    # The work order is not yet complete, of course.
+    assert work_order.completed is False
+
     # **** RE-ENCRYPTION HAPPENS HERE! ****
     cfrags = federated_bob.get_reencrypted_cfrags(work_order)
 
     # We only gave one Capsule, so we only got one cFrag.
     assert len(cfrags) == 1
     the_cfrag = cfrags[0]
+
+    # ...and the work order is complete.
+    assert work_order.completed
 
     # Attach the CFrag to the Capsule.
     capsule = capsule_side_channel[0].capsule

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -1,6 +1,5 @@
 from tempfile import TemporaryDirectory
 
-import maya
 import pytest
 import pytest_twisted
 from twisted.internet import threads

--- a/tests/config/test_firstula_circumstances.py
+++ b/tests/config/test_firstula_circumstances.py
@@ -10,8 +10,8 @@ def test_proper_seed_node_instantiation(ursula_federated_test_config):
                                   know_each_other=False)
 
     firstula = lonely_ursula_maker().pop()
-
-    any_other_ursula = lonely_ursula_maker(seed_nodes=[firstula.seed_node_metadata()]).pop()
+    firstula_as_seed_node = firstula.seed_node_metadata()
+    any_other_ursula = lonely_ursula_maker(seed_nodes=[firstula_as_seed_node]).pop()
 
     assert not any_other_ursula.known_nodes
     any_other_ursula.start_learning_loop()

--- a/tests/config/test_firstula_circumstances.py
+++ b/tests/config/test_firstula_circumstances.py
@@ -1,6 +1,13 @@
 from functools import partial
 
+import maya
+import pytest
+import pytest_twisted
+from twisted.internet.threads import deferToThread
+
+from nucypher.network.middleware import RestMiddleware
 from nucypher.utilities.sandbox.ursula import make_federated_ursulas
+from cryptography.hazmat.primitives import serialization
 
 
 def test_proper_seed_node_instantiation(ursula_federated_test_config):
@@ -14,5 +21,38 @@ def test_proper_seed_node_instantiation(ursula_federated_test_config):
     any_other_ursula = lonely_ursula_maker(seed_nodes=[firstula_as_seed_node]).pop()
 
     assert not any_other_ursula.known_nodes
-    any_other_ursula.start_learning_loop()
+    any_other_ursula.start_learning_loop(now=True)
+    assert firstula in any_other_ursula.known_nodes.values()
+
+
+@pytest_twisted.inlineCallbacks
+def test_get_cert_from_running_seed_node(ursula_federated_test_config):
+    lonely_ursula_maker = partial(make_federated_ursulas,
+                                  ursula_config=ursula_federated_test_config,
+                                  quantity=1,
+                                  know_each_other=False)
+    firstula = lonely_ursula_maker().pop()
+    node_deployer = firstula.get_deployer()
+
+    node_deployer.addServices()
+    node_deployer.catalogServers(node_deployer.hendrix)
+    node_deployer.start()
+
+    cert = node_deployer.cert.to_cryptography()
+    cert_bytes = cert.public_bytes(serialization.Encoding.PEM)
+
+    firstula_as_seed_node = firstula.seed_node_metadata()
+    any_other_ursula = lonely_ursula_maker(seed_nodes=[firstula_as_seed_node],
+                                           network_middleware=RestMiddleware()).pop()
+    assert not any_other_ursula.known_nodes
+
+    def start_lonely_learning_loop():
+        any_other_ursula.start_learning_loop()
+        start = maya.now()
+        while not firstula in any_other_ursula.known_nodes.values():
+            passed = maya.now() - start
+            if passed.seconds > 2:
+                pytest.fail("Didn't find the seed node.")
+
+    yield deferToThread(start_lonely_learning_loop)
     assert firstula in any_other_ursula.known_nodes.values()

--- a/tests/config/test_firstula_circumstances.py
+++ b/tests/config/test_firstula_circumstances.py
@@ -38,8 +38,7 @@ def test_get_cert_from_running_seed_node(ursula_federated_test_config):
     node_deployer.catalogServers(node_deployer.hendrix)
     node_deployer.start()
 
-    cert = node_deployer.cert.to_cryptography()
-    cert_bytes = cert.public_bytes(serialization.Encoding.PEM)
+    certificate_as_deployed = node_deployer.cert.to_cryptography()
 
     firstula_as_seed_node = firstula.seed_node_metadata()
     any_other_ursula = lonely_ursula_maker(seed_nodes=[firstula_as_seed_node],
@@ -56,3 +55,6 @@ def test_get_cert_from_running_seed_node(ursula_federated_test_config):
 
     yield deferToThread(start_lonely_learning_loop)
     assert firstula in any_other_ursula.known_nodes.values()
+
+    certificate_as_learned = list(any_other_ursula.known_nodes.values())[0].certificate
+    assert certificate_as_learned == certificate_as_deployed

--- a/tests/config/test_storages.py
+++ b/tests/config/test_storages.py
@@ -6,7 +6,7 @@ from moto import mock_s3
 from nucypher.characters.lawful import Ursula
 from nucypher.config.storages import S3NodeStorage, InMemoryNodeStorage, TemporaryFileBasedNodeStorage, NodeStorage
 
-MOCK_S3_BUCKET_NAME = 'mock-bootnodes'
+MOCK_S3_BUCKET_NAME = 'mock-seednodes'
 S3_DOMAIN_NAME = 's3.amazonaws.com'
 
 

--- a/tests/network/test_network_upgrade.py
+++ b/tests/network/test_network_upgrade.py
@@ -1,6 +1,4 @@
 import os
-
-import pytest
 import pytest_twisted
 import requests
 from cryptography.hazmat.primitives import serialization
@@ -40,13 +38,7 @@ def test_federated_nodes_connect_via_tls_and_verify(ursula_federated_test_config
 
     try:
         with open("test-cert", "wb") as f:
-            # f.write(cert.tbs_certificate_bytes.hex())
             f.write(cert_bytes)
         yield threads.deferToThread(check_node_with_cert, node, "test-cert")
     finally:
         os.remove("test-cert")
-
-
-@pytest.mark.skip(reason="To be implemented")
-def test_node_metadata_contains_proper_cert():
-    pass

--- a/tests/network/test_node_storage.py
+++ b/tests/network/test_node_storage.py
@@ -1,6 +1,21 @@
-import pytest
+from nucypher.utilities.sandbox.ursula import make_federated_ursulas
 
 
-@pytest.mark.skip("To be implemented.")
-def test_eager_learn_from_teacher():
-    assert False
+def test_one_node_stores_a_bunch_of_others(federated_ursulas, ursula_federated_test_config):
+    the_chosen_seednode = list(federated_ursulas)[2]
+    seed_node = the_chosen_seednode.seed_node_metadata()
+    newcomer = make_federated_ursulas(
+        ursula_config=ursula_federated_test_config,
+        quantity=1,
+        know_each_other=False,
+        save_metadata=True,
+        seed_nodes=[seed_node]).pop()
+
+    assert not newcomer.known_nodes
+    newcomer.start_learning_loop()
+
+    # The known_nodes are all saved in storage (and no others have been saved)
+    assert list(newcomer.known_nodes.values()) == list(newcomer.node_storage.all(True))
+
+    # ...and the_chosen_seednode is in there.
+    assert the_chosen_seednode in newcomer.node_storage.all(federated_only=True)

--- a/tests/network/test_node_storage.py
+++ b/tests/network/test_node_storage.py
@@ -1,6 +1,12 @@
+import maya
+import pytest
+import pytest_twisted
+from twisted.internet.threads import deferToThread
+
 from nucypher.utilities.sandbox.ursula import make_federated_ursulas
 
 
+@pytest_twisted.inlineCallbacks
 def test_one_node_stores_a_bunch_of_others(federated_ursulas, ursula_federated_test_config):
     the_chosen_seednode = list(federated_ursulas)[2]
     seed_node = the_chosen_seednode.seed_node_metadata()
@@ -12,10 +18,17 @@ def test_one_node_stores_a_bunch_of_others(federated_ursulas, ursula_federated_t
         seed_nodes=[seed_node]).pop()
 
     assert not newcomer.known_nodes
-    newcomer.start_learning_loop()
+
+    def start_lonely_learning_loop():
+        newcomer.start_learning_loop()
+        start = maya.now()
+        # Loop until the_chosen_seednode is in storage.
+        while not the_chosen_seednode in newcomer.node_storage.all(federated_only=True):
+            passed = maya.now() - start
+            if passed.seconds > 2:
+                pytest.fail("Didn't find the seed node.")
+
+    yield deferToThread(start_lonely_learning_loop)
 
     # The known_nodes are all saved in storage (and no others have been saved)
     assert list(newcomer.known_nodes.values()) == list(newcomer.node_storage.all(True))
-
-    # ...and the_chosen_seednode is in there.
-    assert the_chosen_seednode in newcomer.node_storage.all(federated_only=True)


### PR DESCRIPTION
Nodes now get nicknames generated based on their checksum address in the format:

"{color}ish color {western zodiac sign} {eatern zodiac sign}"

For example:

* Aquaish DarkTurquoise Leo Dragon
* SeaGreenish CadetBlue Pisces Goat

These names are not generated in a cryptographically-secure way; they are meant for use only in monitoring dashboards or other places where human-readability is paramount and verification can occur against the actual checksum address.  The total space is only 10819200, so we can expect an honest collision every 5000 or so nodes.

In addition to the `nickname`, nodes are also given `nickname_metadata`, which contains information useful for making visual icons based on the nickname: hex values for the two colors and unicode characters for the two signs.