### PR TITLE
Inline Teacher URI Option; CLI Touch-ups

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,7 +19,7 @@ pysha3="*"
 requests = "*"
 sqlalchemy = "*"
 apistar = "==0.5.42"
-tzlocal = "==2.0.0b1"
+tzlocal = "==1.5.1"
 maya = "*"
 #
 # Third-Party Ethereum
@@ -38,7 +38,6 @@ appdirs = "*"
 click = "*"
 colorama = "*"
 moto = "*"
-nucypher = {editable = true, path = "."}
 
 [dev-packages]
 #
@@ -54,6 +53,7 @@ coverage = "*"
 boto3 = "*"
 sentry-sdk = "==0.5.2"
 ansible = "*"
+nucypher = {editable = true, path = "."}
 
 [pipenv]
 allow_prereleases = true

--- a/Pipfile
+++ b/Pipfile
@@ -37,7 +37,7 @@ web3 = "*"
 appdirs = "*"
 click = "*"
 colorama = "*"
-moto = "*"
+boto3 = "*"
 
 [dev-packages]
 #
@@ -50,10 +50,10 @@ pytest-cov = "*"
 mypy = "*"
 codecov = "*"
 coverage = "*"
-boto3 = "*"
 sentry-sdk = "==0.5.2"
 ansible = "*"
 nucypher = {editable = true, path = "."}
+moto = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/nucypher/__init__.py
+++ b/nucypher/__init__.py
@@ -58,7 +58,6 @@ if not hasattr(sys, '_pytest_is_running'):
             release='{}@{}'.format(PACKAGE_NAME, __version__)
         )
 
-
 # Twisted Log Observer #
 ########################
 

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -21,7 +21,7 @@ from nucypher.config.constants import REPORT_TO_SENTRY
 
 @provider(ILogObserver)
 def simpleObserver(event):
-    print(event)
+    print(event.get('log_format'))
 
 
 if REPORT_TO_SENTRY:

--- a/scripts/install_solc.sh
+++ b/scripts/install_solc.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-SOLC_VER="0.4.24"
+SOLC_VER="0.4.25"
 SOL_BIN_PATH="$(pipenv --venv)/bin/solc"
 
 echo "Downloading solidity compiler binary to: ${SOL_BIN_PATH}"

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ ABOUT = dict()
 with open(os.path.join(BASE_DIR, PACKAGE_NAME, "__about__.py")) as f:
     exec(f.read(), ABOUT)
 
-
 with open(os.path.join(BASE_DIR, "README.md")) as f:
     long_description = f.read()
 
@@ -82,7 +81,7 @@ INSTALL_REQUIRES = [
     'requests',
     'sqlalchemy',
     'apistar==0.5.42',
-    'tzlocal==2.0.0b1',
+    'tzlocal==1.5.1',
     'maya',
 
     # Third Party (Ethereum)
@@ -143,7 +142,7 @@ setup(name=ABOUT['__title__'],
       install_requires=INSTALL_REQUIRES,
       extras_require=EXTRAS_REQUIRE,
 
-      packages=[PACKAGE_NAME],
+      packages=[PACKAGE_NAME, 'cli'],
       package_data={PACKAGE_NAME: [
           'blockchain/eth/*', 'project/contracts/*',
           'blockchain/eth/sol_source/contracts/lib/*',
@@ -151,22 +150,18 @@ setup(name=ABOUT['__title__'],
           'blockchain/eth/sol_source/contracts/zepellin/ownership/*',
           'blockchain/eth/sol_source/contracts/zepellin/token/*']},
       include_package_data=True,
-      entry_points='''
-                   [console_scripts]
-                   {}=cli.main:cli
-                   '''.format(PACKAGE_NAME),
+      entry_points='[console_scripts]\n{}=cli.main:cli'.format(PACKAGE_NAME),
       cmdclass={'verify': VerifyVersionCommand},
       classifiers=[
           "Development Status :: 2 - Pre-Alpha",
           "Intended Audience :: Science/Research",
           "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
           "Natural Language :: English",
-          "Programming Language :: Python :: Implementation",
+          "Programming Language :: Python",
           "Programming Language :: Python :: 3 :: Only",
           "Programming Language :: Python :: 3.5",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
-          "Topic :: Scientific/Engineering",
-      ],
+          "Topic:: Security"],
       python_requires='>=3'
       )


### PR DESCRIPTION
##### Touch Ups
* Deprecate CLI Simulate Command
* Accept Load-Balanced Teacher URI's 
* Cleanup Simple Observer Output

##### Temporary Fixes
* Skip S3 Storage Tests (Recent Version Incompatibility with `boto`, `botocore`, `moto`) #527
* Include 'cli' as a top-level module.  #502 
* Pin `tzlocal==1.5.1` (Version Conflicts unresolved via Pipenv)