### PR TITLE
Persistent DelegatingPower

### DIFF
--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -665,7 +665,6 @@ class Character(Learner):
         return int.from_bytes(bytes(self.stamp), byteorder="big")
 
     def __repr__(self):
-        class_name = self.__class__.__name__
         r = "⇀{}↽ ({})"
         r = r.format(self.nickname, self.checksum_public_address)
         return r

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -105,7 +105,7 @@ class Alice(Character, PolicyAuthor):
 
         return policy
 
-    def grant(self, bob, label, m=None, n=None, expiration=None, deposit=None, handpicked_ursulas=None):
+    def grant(self, bob: "Bob", label: bytes, m=None, n=None, expiration=None, deposit=None, handpicked_ursulas=None):
         if not m:
             # TODO: get m from config  #176
             raise NotImplementedError
@@ -157,6 +157,11 @@ class Alice(Character, PolicyAuthor):
         # REST call happens here, as does population of TreasureMap.
         policy.enact(network_middleware=self.network_middleware)
         return policy  # Now with TreasureMap affixed!
+
+    def get_policy_pubkey_from_label(self, label: bytes) -> UmbralPublicKey:
+        alice_delegating_power = self._crypto_power.power_ups(DelegatingPower)
+        policy_pubkey = alice_delegating_power.get_pubkey_from_label(label)
+        return policy_pubkey
 
 
 class Bob(Character):

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -209,19 +209,20 @@ def _derive_key_material_from_passphrase(salt: bytes,
 
 
 def _derive_wrapping_key_from_key_material(salt: bytes,
-                                           key_material: bytes
+                                           key_material: bytes,
                                            ) -> bytes:
     """
     Uses HKDF to derive a 32 byte wrapping key to encrypt key material with.
     """
+
     wrapping_key = HKDF(
         algorithm=__HKDF_HASH_ALGORITHM(__HKDF_HASH_LENGTH),
-        length=__HKDF_HASH_LENGTH,
+        length=__WRAPPING_KEY_LENGTH,
         salt=salt,
         info=__WRAPPING_KEY_INFO,
         backend=default_backend()
     ).derive(key_material)
-    return wrapping_key[:__WRAPPING_KEY_LENGTH]
+    return wrapping_key
 
 
 def _encrypt_umbral_key(wrapping_key: bytes,

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -260,10 +260,6 @@ def _generate_encryption_keys() -> Tuple[UmbralPrivateKey, UmbralPublicKey]:
     return privkey, pubkey
 
 
-def _generate_umbral_keying_material() -> UmbralKeyingMaterial:
-    return UmbralKeyingMaterial()
-
-
 def _generate_signing_keys() -> Tuple[UmbralPrivateKey, UmbralPublicKey]:
     """
     TODO: Do we really want to use Umbral keys for signing? Perhaps we can use Curve25519/EdDSA for signatures?
@@ -543,7 +539,6 @@ class NucypherKeyring:
 
         # Derived
         elif issubclass(power_class, DerivedKeyBasedPower):
-            # TODO
             key_data = _read_keyfile(self.__delegating_keypath, deserializer=self._private_key_serializer)
             wrap_key = _derive_wrapping_key_from_key_material(salt=key_data['wrap_salt'],
                                                               key_material=self.__derived_key_material)
@@ -617,7 +612,7 @@ class NucypherKeyring:
                                                       public_key_dir=_public_key_dir)
         if encrypting is True:
             encrypting_private_key, encrypting_public_key = _generate_encryption_keys()
-            delegating_keying_material = _generate_umbral_keying_material().to_bytes()
+            delegating_keying_material = UmbralKeyingMaterial().to_bytes()
 
             # Derive Wrapping Keys
             passphrase_salt, encrypting_salt, signing_salt, delegating_salt = (os.urandom(32) for _ in range(4))

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -193,7 +193,7 @@ def _derive_key_material_from_passphrase(salt: bytes,
                                          passphrase: str
                                          ) -> bytes:
     """
-    Uses Scrypt derivation to derive a  key for encrypting key material.
+    Uses Scrypt derivation to derive a key for encrypting key material.
     See RFC 7914 for n, r, and p value selections.
     This takes around ~5 seconds to perform.
     """
@@ -515,7 +515,7 @@ class NucypherKeyring:
     def derive_crypto_power(self, power_class: ClassVar) -> Union[KeyPairBasedPower, DerivedKeyBasedPower]:
         """
         Takes either a SigningPower or an EncryptingPower and returns
-        a either a SigningPower or EncryptingPower with the coinciding
+        either a SigningPower or EncryptingPower with the coinciding
         private key.
 
         TODO: Derive a key from the root_key.
@@ -630,7 +630,7 @@ class NucypherKeyring:
 
             # Write Public Keys
             root_keypath = _write_public_keyfile(__key_filepaths['root_pub'], encrypting_public_key.to_bytes())
-            siging_keypath = _write_public_keyfile(__key_filepaths['signing_pub'], signing_public_key.to_bytes())
+            signing_keypath = _write_public_keyfile(__key_filepaths['signing_pub'], signing_public_key.to_bytes())
 
             # Commit
             keyring_args.update(
@@ -638,7 +638,7 @@ class NucypherKeyring:
                 root_key_path=rootkey_path,
                 pub_root_key_path=root_keypath,
                 signing_key_path=sigkey_path,
-                pub_signing_key_path=siging_keypath
+                pub_signing_key_path=signing_keypath,
             )
 
         if tls is True:

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -21,6 +21,7 @@ from json import JSONDecodeError
 from twisted.logger import Logger
 from tempfile import TemporaryDirectory
 from typing import List
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 
 from constant_sorrow import constants
 
@@ -391,7 +392,7 @@ class NodeConfiguration:
                       wallet: bool,
                       tls: bool,
                       host: str,
-                      tls_curve,
+                      tls_curve: EllipticCurve = None,
                       ) -> NucypherKeyring:
 
         self.keyring = NucypherKeyring.generate(passphrase=passphrase,

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -202,7 +202,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
         self.log.debug("Delted {} from the filesystem".format(checksum_address))
         return os.remove(filepath)
 
-    def payload(self) -> str:
+    def payload(self) -> dict:
         payload = {
             'storage_type': self._name,
             'known_metadata_dir': self.known_metadata_dir
@@ -210,7 +210,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
         return payload
 
     @classmethod
-    def from_payload(cls, payload: str, *args, **kwargs) -> 'LocalFileBasedNodeStorage':
+    def from_payload(cls, payload: dict, *args, **kwargs) -> 'LocalFileBasedNodeStorage':
         storage_type = payload[cls._TYPE_LABEL]
         if not storage_type == cls._name:
             raise cls.NodeStorageError("Wrong storage type. got {}".format(storage_type))

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -212,7 +212,7 @@ class EncryptingPower(KeyPairBasedPower):
 class DelegatingPower(DerivedKeyBasedPower):
 
     def __init__(self) -> None:
-        self.umbral_keying_material = UmbralKeyingMaterial()
+        self.__umbral_keying_material = UmbralKeyingMaterial()
 
     def generate_kfrags(self, bob_pubkey_enc, signer, label, m, n) -> Tuple[UmbralPublicKey, List]:
         """
@@ -222,11 +222,11 @@ class DelegatingPower(DerivedKeyBasedPower):
         that he can activate the Capsule.
         :param bob_pubkey_enc: Bob's public key
         :param m: Minimum number of KFrags needed to rebuild ciphertext
-        :param n: Total number of rekey shares to generate
+        :param n: Total number of KFrags to generate
         """
         # TODO: salt?  #265
 
-        __private_key = self.umbral_keying_material.derive_privkey_by_label(label)
+        __private_key = self.__umbral_keying_material.derive_privkey_by_label(label)
         kfrags = pre.generate_kfrags(delegating_privkey=__private_key,
                                      receiving_pubkey=bob_pubkey_enc,
                                      threshold=m,

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -207,7 +207,6 @@ class DerivedKeyBasedPower(CryptoPowerUp):
     Rather than rely on an established KeyPair, this type of power
     derives a key at moments defined by the user.
     """
-    pass
 
 
 class DelegatingPower(DerivedKeyBasedPower):

--- a/nucypher/keystore/keypairs.py
+++ b/nucypher/keystore/keypairs.py
@@ -22,6 +22,8 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from hendrix.deploy.tls import HendrixDeployTLS
 from hendrix.facilities.services import ExistingKeyTLSContextFactory
 from typing import Union
+import base64
+
 from umbral import pre
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
 from umbral.signing import Signature, Signer
@@ -68,12 +70,11 @@ class Keypair(object):
         Serializes the pubkey for storage/transport in either urlsafe base64
         or as a bytestring.
 
-        :param as_bytes: Return the pubkey as bytes?
+        :param as_b64: Return the pubkey as urlsafe base64 byte string
         :return: The serialized pubkey in bytes
         """
-        if as_b64:
-            return self.pubkey.to_bytes()
-        return bytes(self.pubkey)
+        encoder = base64.urlsafe_b64encode if as_b64 else None
+        return self.pubkey.to_bytes(encoder=encoder)
 
     def fingerprint(self):
         """

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -63,12 +63,12 @@ def test_mocked_decentralized_grant(blockchain_alice, blockchain_bob, three_agen
 def test_federated_grant(federated_alice, federated_bob):
 
     # Setup the policy details
-    n = 3
+    m, n = 2, 3
     policy_end_datetime = maya.now() + datetime.timedelta(days=5)
     label = b"this_is_the_path_to_which_access_is_being_granted"
 
-    # Create the Policy, Grating access to Bob
-    policy = federated_alice.grant(federated_bob, label, m=2, n=n, expiration=policy_end_datetime)
+    # Create the Policy, granting access to Bob
+    policy = federated_alice.grant(federated_bob, label, m=m, n=n, expiration=policy_end_datetime)
 
     # The number of accepted arrangements at least the number of Ursulas we're using (n)
     assert len(policy._accepted_arrangements) >= n

--- a/tests/config/test_firstula_circumstances.py
+++ b/tests/config/test_firstula_circumstances.py
@@ -23,7 +23,6 @@ from twisted.internet.threads import deferToThread
 
 from nucypher.network.middleware import RestMiddleware
 from nucypher.utilities.sandbox.ursula import make_federated_ursulas
-from cryptography.hazmat.primitives import serialization
 
 
 def test_proper_seed_node_instantiation(ursula_federated_test_config):

--- a/tests/config/test_keyring.py
+++ b/tests/config/test_keyring.py
@@ -1,0 +1,59 @@
+import pytest
+
+from umbral.keys import UmbralPrivateKey
+from umbral.signing import Signer
+
+from nucypher.config.keyring import NucypherKeyring
+from nucypher.crypto.powers import DelegatingPower, EncryptingPower
+
+
+def test_validate_passphrase():
+    # Passphrase too short
+    passphrase = 'x' * 5
+    with pytest.raises(ValueError):
+        _keyring = NucypherKeyring.generate(passphrase=passphrase)
+
+    # Empty passphrase is provided
+    with pytest.raises(ValueError):
+        _keyring = NucypherKeyring.generate(passphrase="")
+
+
+def test_generate_alice_keyring(tmpdir):
+    passphrase = 'x' * 16
+
+    keyring = NucypherKeyring.generate(
+        passphrase=passphrase,
+        encrypting=True,
+        wallet=False,
+        tls=False,
+        keyring_root=tmpdir
+    )
+
+    enc_pubkey = keyring.encrypting_public_key
+    assert enc_pubkey is not None
+
+    with pytest.raises(NucypherKeyring.KeyringLocked):
+        _enc_keypair = keyring.derive_crypto_power(EncryptingPower).keypair
+
+    keyring.unlock(passphrase)
+    enc_keypair = keyring.derive_crypto_power(EncryptingPower).keypair
+
+    assert enc_pubkey == enc_keypair.pubkey
+
+    label = b'test'
+
+    delegating_power = keyring.derive_crypto_power(DelegatingPower)
+    delegating_pubkey = delegating_power.get_pubkey_from_label(label)
+
+    bob_pubkey = UmbralPrivateKey.gen_key().get_pubkey()
+    signer = Signer(UmbralPrivateKey.gen_key())
+    delegating_pubkey_again, _kfrags = delegating_power.generate_kfrags(
+        bob_pubkey, signer, label, m=2, n=3
+    )
+
+    assert delegating_pubkey == delegating_pubkey_again
+
+    another_delegating_power = keyring.derive_crypto_power(DelegatingPower)
+    another_delegating_pubkey = another_delegating_power.get_pubkey_from_label(label)
+
+    assert delegating_pubkey == another_delegating_pubkey

--- a/tests/keystore/test_keypairs.py
+++ b/tests/keystore/test_keypairs.py
@@ -14,6 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+import base64
 import sha3
 from constant_sorrow.constants import PUBLIC_ONLY
 from umbral.keys import UmbralPrivateKey
@@ -54,7 +55,7 @@ def test_keypair_serialization():
     assert pubkey_bytes == bytes(umbral_pubkey)
 
     pubkey_b64 = new_keypair.serialize_pubkey(as_b64=True)
-    assert pubkey_b64 == umbral_pubkey.to_bytes()
+    assert pubkey_b64 == base64.urlsafe_b64encode(umbral_pubkey.to_bytes())
 
 
 def test_keypair_fingerprint():

--- a/tests/keystore/test_keypairs.py
+++ b/tests/keystore/test_keypairs.py
@@ -23,12 +23,14 @@ from nucypher.keystore import keypairs
 
 def test_gen_keypair_if_needed():
     new_enc_keypair = keypairs.EncryptingKeypair()
-    assert new_enc_keypair._privkey != None
-    assert new_enc_keypair.pubkey != None
+    assert new_enc_keypair._privkey is not None
+    assert new_enc_keypair.pubkey is not None
+    assert new_enc_keypair.pubkey == new_enc_keypair._privkey.get_pubkey()
 
     new_sig_keypair = keypairs.SigningKeypair()
-    assert new_sig_keypair._privkey != None
-    assert new_sig_keypair.pubkey != None
+    assert new_sig_keypair._privkey is not None
+    assert new_sig_keypair.pubkey is not None
+    assert new_sig_keypair.pubkey == new_sig_keypair._privkey.get_pubkey()
 
 
 def test_keypair_with_umbral_keys():
@@ -60,7 +62,7 @@ def test_keypair_fingerprint():
     new_keypair = keypairs.Keypair(public_key=umbral_pubkey)
 
     fingerprint = new_keypair.fingerprint()
-    assert fingerprint != None
+    assert fingerprint is not None
 
     umbral_fingerprint = sha3.keccak_256(bytes(umbral_pubkey)).hexdigest().encode()
     assert fingerprint == umbral_fingerprint
@@ -70,12 +72,12 @@ def test_signing():
     umbral_privkey = UmbralPrivateKey.gen_key()
     sig_keypair = keypairs.SigningKeypair(umbral_privkey)
 
-    msg = b'attack at dawn'
+    msg = b'peace at dawn'
     signature = sig_keypair.sign(msg)
-    assert signature.verify(msg, sig_keypair.pubkey) == True
+    assert signature.verify(msg, sig_keypair.pubkey)
 
     bad_msg = b'bad message'
-    assert signature.verify(bad_msg, sig_keypair.pubkey) == False
+    assert not signature.verify(bad_msg, sig_keypair.pubkey)
 
 
 # TODO: Add test for EncryptingKeypair.decrypt


### PR DESCRIPTION
Currently, DelegatingPower is not persistent, which means that Alice can only grant access to Bobs while her DelegatingPower is in memory; when restored through the Keyring, a new DelegatingPower is created, and due to its random nature, it cannot recreate the same policies.

This PR extends the Keyring to store the state of the DelegatingPower so it can be restored for later use. 

Additionally, it provides a convenience method `Alice.get_policy_pubkey_from_label()` to derive policy public keys independently of policy creation. This supports one of the use case we mention often, where Enricos can encrypt for a policy _even before_ Alice has started to grant access to it. 