### PR TITLE
Touch-ups to CLI and status page

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -376,7 +376,7 @@ class Bob(Character):
             try:
                 cfrags = self.get_reencrypted_cfrags(work_order)
                 message_kit.capsule.attach_cfrag(cfrags[0])
-                if len(message_kit.capsule._attached_cfrags) > m:
+                if len(message_kit.capsule._attached_cfrags) >= m:
                     break
             except requests.exceptions.ConnectTimeout:
                 continue

--- a/nucypher/cli.py
+++ b/nucypher/cli.py
@@ -511,6 +511,10 @@ def accounts(config,
         keyring._export_wallet_to_node(blockchain=config.blockchain, passphrase=passphrase)
 
     elif action == 'list':
+        if config.accounts == NO_BLOCKCHAIN_CONNECTION:
+            click.echo('No account found.')
+            return
+
         for index, checksum_address in enumerate(config.accounts):
             token_balance = config.token_agent.get_balance(address=checksum_address)
             eth_balance = config.blockchain.interface.w3.eth.getBalance(checksum_address)
@@ -599,6 +603,10 @@ def stake(config,
         config.connect_to_contracts()
 
     if not checksum_address:
+
+        if config.accounts == NO_BLOCKCHAIN_CONNECTION:
+            click.echo('No account found.')
+            return
 
         for index, address in enumerate(config.accounts):
             if index == 0:

--- a/nucypher/cli.py
+++ b/nucypher/cli.py
@@ -524,7 +524,7 @@ def accounts(config,
     elif action == 'list':
         if config.accounts == NO_BLOCKCHAIN_CONNECTION:
             click.echo('No account found.')
-            return
+            raise click.Abort()
 
         for index, checksum_address in enumerate(config.accounts):
             token_balance = config.token_agent.get_balance(address=checksum_address)
@@ -606,7 +606,7 @@ collect-reward    Withdraw staking reward
 
         if config.accounts == NO_BLOCKCHAIN_CONNECTION:
             click.echo('No account found.')
-            return
+            raise click.Abort()
 
         for index, address in enumerate(config.accounts):
             if index == 0:

--- a/nucypher/cli.py
+++ b/nucypher/cli.py
@@ -427,7 +427,17 @@ def configure(config,
               rest_host,
               no_registry,
               force):
-    """Manage Ursula node system configuration"""
+    """Manage Ursula node system configuration
+
+
+Actions:
+
+install     Create a new Ursula node configuration
+view        View the configuration of Ursula node
+forget      Remove all stored known nodes' metadata and certificates
+reset       Delete current Ursula node configuration and create a new one
+destroy     Delete current Ursula node configuration
+    """
 
     # Fetch Existing Configuration
     config.get_node_configuration(configuration_class=UrsulaConfiguration, rest_host=rest_host)
@@ -571,26 +581,15 @@ def stake(config,
     Manage token staking.
 
 
-    Arguments
-    ==========
+Actions:
 
     action - Which action to perform; The choices are:
-
-        - list: List all stakes for this node
-        - info: Display info about a specific stake
-        - start: Start the staking daemon
-        - confirm-activity: Manually confirm-activity for the current period
-        - divide-stake: Divide an existing stake
-
-    value - The quantity of tokens to stake.
-
-    periods - The duration (in periods) of the stake.
-
-    Options
-    ========
-
-    --wallet-address - A valid ethereum checksum address to use instead of the default
-    --stake-index - The zero-based stake index, or stake tag for this wallet-address
+list              List all stakes for this node
+init              Stage a new stake
+start             Start the staking daemon
+confirm-activity  Manually confirm-activity for the current period
+divide            Divide an existing stake
+collect-reward    Withdraw staking reward
 
     """
 

--- a/nucypher/cli.py
+++ b/nucypher/cli.py
@@ -432,6 +432,7 @@ def configure(config,
 
 Actions:
 
+\b
 install     Create a new Ursula node configuration
 view        View the configuration of Ursula node
 forget      Remove all stored known nodes' metadata and certificates
@@ -583,7 +584,7 @@ def stake(config,
 
 Actions:
 
-    action - Which action to perform; The choices are:
+\b
 list              List all stakes for this node
 init              Stage a new stake
 start             Start the staking daemon
@@ -987,6 +988,7 @@ def ursula(config,
 
     Here is the procedure to "spin-up" an Ursula node.
 
+    \b
         0. Validate CLI Input
         1. Initialize UrsulaConfiguration (from configuration file or inline)
         2. Initialize Ursula with Passphrase

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -93,12 +93,12 @@ class NodeStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def payload(self) -> str:
+    def payload(self) -> dict:
         raise NotImplementedError
 
     @classmethod
     @abstractmethod
-    def from_payload(self, data: str, *args, **kwargs) -> 'NodeStorage':
+    def from_payload(self, data: dict, *args, **kwargs) -> 'NodeStorage':
         """Instantiate a storage object from a dictionary"""
         raise NotImplementedError
 
@@ -141,7 +141,7 @@ class InMemoryNodeStorage(NodeStorage):
         return payload
 
     @classmethod
-    def from_payload(cls, payload: str, *args, **kwargs) -> 'InMemoryNodeStorage':
+    def from_payload(cls, payload: dict, *args, **kwargs) -> 'InMemoryNodeStorage':
         if payload[cls._TYPE_LABEL] != cls._name:
             raise cls.NodeStorageError
         return cls(*args, **kwargs)
@@ -219,7 +219,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
     def clear(self):
         self.__known_nodes = dict()
 
-    def payload(self) -> str:
+    def payload(self) -> dict:
         payload = {
             'storage_type': self._name,
             'known_metadata_dir': self.known_metadata_dir
@@ -321,7 +321,7 @@ class S3NodeStorage(NodeStorage):
             raise self.NodeStorageError("S3 Storage failed to delete node {}".format(checksum_address))
         return True
 
-    def payload(self) -> str:
+    def payload(self) -> dict:
         payload = {
             self._TYPE_LABEL: self._name,
             'bucket_name': self.__bucket_name
@@ -329,7 +329,7 @@ class S3NodeStorage(NodeStorage):
         return payload
 
     @classmethod
-    def from_payload(cls, payload: str, *args, **kwargs):
+    def from_payload(cls, payload: dict, *args, **kwargs):
         return cls(bucket_name=payload['bucket_name'], *args, **kwargs)
 
     def initialize(self):

--- a/nucypher/network/templates/basic_status.j2
+++ b/nucypher/network/templates/basic_status.j2
@@ -2,19 +2,22 @@
 <html>
 <head>
      <meta charset="UTF-8">
+     <link rel="icon" type="image/x-icon" href="https://www.nucypher.com/favicon-32x32.png"/>
 </head>
 
 <style type="text/css">
+    html {
+        font-family: sans-serif;
+    }
     table, th, td {
         border: 1px solid black;
-}
+    }
     .nucypher-nickname-icon {
         border-width: 10px;
         border-style: solid;
         margin: 3px;
         padding: 3px;
         text-align: center;
-        text-shadow: 1px 1px black, -1px -1px black;
         box-shadow: 1px 1px black, -1px -1px black;
     }
     #this-node .nucypher-nickname-icon {
@@ -23,6 +26,10 @@
     .symbol {
         font-size: 3em;
         color: black;
+        text-shadow: 1px 1px black, -1px -1px black;
+    }
+    .address, .small-address {
+        font-family: monospace;
     }
 </style>
 
@@ -50,7 +57,8 @@
             <td>{{ node.nickname_icon() }}</td>
             <td>
                 <a href="https://{{ node.rest_url()}}/status">{{ node.nickname }}</a>
-                <br/>{{ node.checksum_public_address }}
+                <br/>
+                <span class="address">{{ node.checksum_public_address }}</span>
             </td>
             <td>{{ node.timestamp }}</td>
             <td>{{ node.last_seen }}</td>


### PR DESCRIPTION
- Fixes CLI errors when `nucypher stake` and `nucypher accounts` are called with no arguments.
- Adds docs to CLI commands `nucypher configure` and `nucypher stake`
- Shallow changes to the node status page (favicon, sans-serif font, removes text shadow which reads badly, etc)