### PR TITLE
Pin umbral==0.1.1a3 before new API-breaking release

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ python_version = "3"
 #
 # NuCypher
 #
-umbral = "*"
+umbral = "==0.1.1a3"
 constant-sorrow = "*"
 bytestringSplitter = "*"
 hendrix = ">=3.1.0"

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ class VerifyVersionCommand(install):
 INSTALL_REQUIRES = [
 
     # NuCypher
-    'umbral',
+    'umbral==0.1.1a3',
     'constant-sorrow',
     'bytestringSplitter',
     'hendrix>=3.1.0',


### PR DESCRIPTION
Umbral will have soon a new non-backwards-compatible release. Let's pin umbral to current release (v0.1.1a3) for the moment. `vodka` will fix everything (it always does, right?).