### PR TITLE
[Federated] Split Ansible playbooks; Use network names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,7 @@ reports/
 test-*
 *.sqlite3
 *variables.yml
+variables*.yml
 *ansible/*.retry
 *ansible/inventory/*
+.env

--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ python_version = "3"
 #
 # NuCypher
 #
-umbral = "*"
+umbral = "==0.1.1a3"
 constant-sorrow = "*"
 bytestringSplitter = "*"
 hendrix = ">=3.1.0"

--- a/deploy/ansible/provision.yml
+++ b/deploy/ansible/provision.yml
@@ -3,9 +3,11 @@
   gather_facts: false
   user: ubuntu
   pre_tasks:
-    - include_vars: variables.yml
+    - include_vars: "{{ lookup('env', 'ANSIBLE_SEEDNODE_VARIABLES') }}"
+  vars:
+    nucypher_network_name: "{{ lookup('env', 'NUCYPHER_NETWORK_NAME') }}"
   tasks:
-    - name: Provision {{ ec2_count }} instances with tag {{ ec2_tag_Role }}
+    - name: "Provision {{ ec2_count }} instances on the {{ ec2_region }} region"
       local_action:
         module: ec2
         key_name: "{{ ec2_keypair }}"
@@ -14,159 +16,30 @@
         image: "{{ ec2_image }}"
         vpc_subnet_id: "{{ ec2_subnet_id }}"
         region: "{{ ec2_region }}"
-        instance_tags: '{"Type":"{{ec2_instance_type}}", "Role":"{{ec2_tag_Role}}"}'
+        instance_tags: '{"Type":"{{ec2_instance_type}}", "Role":"{{nucypher_network_name}}"}'
         assign_public_ip: yes
         wait: true
         exact_count: "{{ ec2_count }}"
         count_tag:
-          Role: "{{ ec2_tag_Role }}"
+          Role: "{{ nucypher_network_name }}"
         volumes:
           - device_name: /dev/xvda
             volume_type: gp2
             volume_size: "{{ ec2_volume_size }}"
             delete_on_termination: true
-      register: ec2
+      register: nucypher_swarm
 
     - name: "Add Provisioned Servers as Hosts"
       add_host:
         name: "{{ item.public_ip }}"
-        groups: seednodes
+        groups: "{{ nucypher_network_name }}"
         ec2_region: "{{ ec2_region }}"
         ec2_tag_Type: "{{ ec2_tag_Type}}"
-        ec2_tag_Role: "{{ ec2_tag_Role }}"
+        ec2_tag_Role: "{{ nucypher_network_name }}"
         ec2_ip_address: "{{ item.public_ip }}"
-      with_items: "{{ ec2.instances }}"
+      with_items: "{{ nucypher_swarm.instances }}"
 
     - name: Wait for the instances to boot by checking the ssh port
       wait_for: host={{item.public_ip}} port=22 delay=15 timeout=300 state=started
-      with_items: "{{ ec2.instances }}"
+      with_items: "{{ nucypher_swarm.instances }}"
 
-#
-#  Spin-Up Seednode Services
-#
-- name: "Start Ursulas"
-  hosts: seednodes
-  user: ubuntu
-  gather_facts: false
-
-  pre_tasks:
-    - name: "Install Python2.7 for Ansible Control"
-      raw: sudo apt -y update && sudo apt install -y python2.7-minimal python2.7-setuptools
-    - include_vars: variables.yml
-
-  tasks:
-    - name: "Install System Dependencies"
-      become: yes
-      become_flags: "-H -S"
-      apt:
-        name: "{{ packages }}"
-        update_cache: yes
-      vars:
-        packages:
-        - python-pip
-        - python3
-        - python3-pip
-        - python3-dev
-        - python3-setuptools
-        - libffi-dev
-
-    - pip:
-        name: docker
-
-    - name: "Install Pipenv"
-      become: yes
-      become_flags: "-H -S"
-      shell: pip3 install pipenv
-
-    - name: "Create custom fact directory"
-      become: yes
-      become_flags: "-H -S"
-      file:
-        path: "/etc/ansible/facts.d"
-        state: "directory"
-        mode: 0755
-
-    - git:
-        repo: "{{ git_repo }}"
-        dest: ./code
-        version: "{{ git_version }}"
-
-    - name: "Install Python Dependencies via Pipenv"
-      shell: "pipenv install --dev --skip-lock --pre"
-      args:
-        chdir: ./code
-      environment:
-        LC_ALL: C.UTF-8
-        LANG: C.UTF-8
-
-    - name: "Generate Ursula passphrase"
-      shell: head -c 32 /dev/urandom | sha256sum
-      register: ursula_passphrase
-
-    - name: "Configure Ursula"
-      shell: "pipenv run nucypher configure install --rest-host {{inventory_hostname}}"
-      args:
-        chdir: ./code
-      vars:
-        ansible_python_interpreter: /usr/bin/python3
-      environment:
-        NUCYPHER_KEYRING_PASSPHRASE: "{{ ursula_passphrase.stdout }}"
-        LC_ALL: C.UTF-8
-        LANG: C.UTF-8
-      ignore_errors: yes
-      register: configure_ursula_output
-
-    - name: "Get Ursula Seed Node Config (and more)"
-      slurp:
-        src: "~/.local/share/nucypher/ursula.config"
-      register: ursula_seed_node_config
-      run_once: true
-
-    - name: "Set Ursula Seed Node Fact"
-      set_fact:
-        seed_node_metadata: "{{ ursula_seed_node_config['content'] | b64decode }}"
-
-    - name: "Get Ursula env dir"
-      shell: "pipenv --venv"
-      args:
-        chdir: ./code
-      environment:
-        LC_ALL: C.UTF-8
-        LANG: C.UTF-8
-      register: env_dir
-
-    - name: "Open Ursula node port"
-      become: yes
-      become_flags: "-H -S"
-      shell: 'iptables -A INPUT -p tcp -m conntrack --dport {{ seed_node_metadata.rest_port }} --ctstate NEW,ESTABLISHED -j ACCEPT'
-
-    - name: "Register Firstula Service"
-      become: yes
-      become_flags: "-H -S"
-      template:
-        src: ../services/firstula_node.j2
-        dest: /etc/systemd/system/ursula_node.service
-        mode: 0755
-      when: '"existing" not in configure_ursula_output.stdout'
-      run_once: true
-
-    - name: "Register Subsequent Ursulas"
-      become: yes
-      become_flags: "-H -S"
-      template:
-        src: ../services/ursula_node.j2
-        dest: /etc/systemd/system/ursula_node.service
-        mode: 0755
-      when:
-        - '"existing" not in configure_ursula_output.stdout'
-        - inventory_hostname != seed_node_metadata.rest_host
-
-    - name: "Enable and Start Ursula Service"
-      become: yes
-      become_flags: "-H -S"
-      systemd:
-        daemon_reload: yes
-        no_block: yes
-        enabled: yes
-        state: restarted
-        name: "ursula_node"

--- a/deploy/ansible/provision.yml
+++ b/deploy/ansible/provision.yml
@@ -27,7 +27,7 @@
             volume_type: gp2
             volume_size: "{{ ec2_volume_size }}"
             delete_on_termination: true
-      register: nucypher_swarm
+      register: nucypher_fleet
 
     - name: "Add Provisioned Servers as Hosts"
       add_host:
@@ -37,9 +37,9 @@
         ec2_tag_Type: "{{ ec2_tag_Type}}"
         ec2_tag_Role: "{{ nucypher_network_name }}"
         ec2_ip_address: "{{ item.public_ip }}"
-      with_items: "{{ nucypher_swarm.instances }}"
+      with_items: "{{ nucypher_fleet.instances }}"
 
     - name: Wait for the instances to boot by checking the ssh port
       wait_for: host={{item.public_ip}} port=22 delay=15 timeout=300 state=started
-      with_items: "{{ nucypher_swarm.instances }}"
+      with_items: "{{ nucypher_fleet.instances }}"
 

--- a/deploy/ansible/restart_all.yml
+++ b/deploy/ansible/restart_all.yml
@@ -1,5 +1,5 @@
 - name: "Restart Ursulas"
-  hosts: seednodes
+  hosts: "{{ 'tag_Role_' + lookup('env', 'NUCYPHER_NETWORK_NAME') }}"
   user: ubuntu
   gather_facts: false
   tasks:

--- a/deploy/ansible/run_seednodes.yml
+++ b/deploy/ansible/run_seednodes.yml
@@ -51,8 +51,8 @@
         LANG: C.UTF-8
 
     - name: "Generate Ursula passphrase"
-      shell: head -c 32 /dev/urandom | sha256sum
-      register: ursula_passphrase
+      shell: head -c 32 /dev/urandom | sha256sum | awk '{print $1}'
+      register: ursula_password
 
     - name: "Configure Ursula"
       shell: "pipenv run nucypher configure install --rest-host {{inventory_hostname}}"
@@ -61,7 +61,7 @@
       vars:
         ansible_python_interpreter: /usr/bin/python3
       environment:
-        NUCYPHER_KEYRING_PASSPHRASE: "{{ ursula_passphrase.stdout }}"
+        NUCYPHER_KEYRING_PASSPHRASE: "{{ ursula_password.stdout }}"
         LC_ALL: C.UTF-8
         LANG: C.UTF-8
       ignore_errors: yes

--- a/deploy/ansible/run_seednodes.yml
+++ b/deploy/ansible/run_seednodes.yml
@@ -1,0 +1,123 @@
+- name: "Start Ursulas"
+  hosts: "{{ 'tag_Role_' + lookup('env', 'NUCYPHER_NETWORK_NAME') }}"
+  user: ubuntu
+  gather_facts: false
+
+  pre_tasks:
+    - name: "Install Python2.7 for Ansible Control"
+      raw: sudo apt -y update && sudo apt install -y python2.7-minimal python2.7-setuptools
+    - include_vars: "{{ lookup('env', 'ANSIBLE_SEEDNODE_VARIABLES') }}"
+
+  tasks:
+    - name: "Install System Dependencies"
+      become: yes
+      become_flags: "-H -S"
+      apt:
+        name: "{{ packages }}"
+        update_cache: yes
+      vars:
+        packages:
+        - python-pip
+        - python3
+        - python3-pip
+        - python3-dev
+        - python3-setuptools
+        - libffi-dev
+
+    - name: "Install Pipenv"
+      become: yes
+      become_flags: "-H -S"
+      shell: pip3 install pipenv
+
+    - name: "Create custom fact directory"
+      become: yes
+      become_flags: "-H -S"
+      file:
+        path: "/etc/ansible/facts.d"
+        state: "directory"
+        mode: 0755
+
+    - git:
+        repo: "{{ git_repo }}"
+        dest: ./code
+        version: "{{ git_version }}"
+
+    - name: "Install Python Dependencies via Pipenv"
+      shell: "pipenv install --three --dev --pre --skip-lock"
+      args:
+        chdir: ./code
+      environment:
+        LC_ALL: C.UTF-8
+        LANG: C.UTF-8
+
+    - name: "Generate Ursula passphrase"
+      shell: head -c 32 /dev/urandom | sha256sum
+      register: ursula_passphrase
+
+    - name: "Configure Ursula"
+      shell: "pipenv run nucypher configure install --rest-host {{inventory_hostname}}"
+      args:
+        chdir: ./code
+      vars:
+        ansible_python_interpreter: /usr/bin/python3
+      environment:
+        NUCYPHER_KEYRING_PASSPHRASE: "{{ ursula_passphrase.stdout }}"
+        LC_ALL: C.UTF-8
+        LANG: C.UTF-8
+      ignore_errors: yes
+      register: configure_ursula_output
+
+    - name: "Get Ursula Seed Node Config (and more)"
+      slurp:
+        src: "~/.local/share/nucypher/ursula.config"
+      register: ursula_seed_node_config
+      run_once: true
+
+    - name: "Set Ursula Seed Node Fact"
+      set_fact:
+        seed_node_metadata: "{{ ursula_seed_node_config['content'] | b64decode }}"
+
+    - name: "Get Ursula env dir"
+      shell: "pipenv --venv"
+      args:
+        chdir: ./code
+      environment:
+        LC_ALL: C.UTF-8
+        LANG: C.UTF-8
+      register: env_dir
+
+    - name: "Open Ursula node port"
+      become: yes
+      become_flags: "-H -S"
+      shell: 'iptables -A INPUT -p tcp -m conntrack --dport {{ seed_node_metadata.rest_port }} --ctstate NEW,ESTABLISHED -j ACCEPT'
+
+    - name: "Register Firstula Service"
+      become: yes
+      become_flags: "-H -S"
+      template:
+        src: ../services/firstula_node.j2
+        dest: /etc/systemd/system/ursula_node.service
+        mode: 0755
+      when: '"existing" not in configure_ursula_output.stdout'
+      run_once: true
+
+    - name: "Register Subsequent Ursulas"
+      become: yes
+      become_flags: "-H -S"
+      template:
+        src: ../services/ursula_node.j2
+        dest: /etc/systemd/system/ursula_node.service
+        mode: 0755
+      when:
+        - '"existing" not in configure_ursula_output.stdout'
+        - inventory_hostname != seed_node_metadata.rest_host
+
+    - name: "Enable and Start Ursula Service"
+      become: yes
+      become_flags: "-H -S"
+      systemd:
+        daemon_reload: yes
+        no_block: yes
+        enabled: yes
+        state: restarted
+        name: "ursula_node"

--- a/deploy/ansible/terminate.yml
+++ b/deploy/ansible/terminate.yml
@@ -3,14 +3,16 @@
   gather_facts: false
   user: root
   pre_tasks:
-    - include_vars: variables.yml
+    - include_vars: "{{ lookup('env', 'ANSIBLE_SEEDNODE_VARIABLES') }}"
+  vars:
+    nucypher_network_name: "{{ lookup('env', 'NUCYPHER_NETWORK_NAME') }}"
   tasks:
-    - name: Get EC2 instance IDs
+    - name: Get EC2 instance IDs for {{ nucypher_network_name }}
       run_once: true
       ec2_remote_facts:
         filters:
           "tag:Type": "{{ ec2_tag_Type }}"
-          "tag:Role": "{{ ec2_tag_Role }}"
+          "tag:Role": "{{ nucypher_network_name }}"
         region: "{{ ec2_region }}"
       register: instances
 

--- a/deploy/ansible/update.yml
+++ b/deploy/ansible/update.yml
@@ -1,9 +1,9 @@
 - name: "Update Application Code on Seednodes"
-  hosts: seednodes
+  hosts: "{{ 'tag_Role_' + lookup('env', 'NUCYPHER_NETWORK_NAME') }}"
   user: ubuntu
   gather_facts: false
   pre_tasks:
-    - include_vars: variables.yml
+    - include_vars: "{{ lookup('env', 'ANSIBLE_SEEDNODE_VARIABLES') }}"
   tasks:
 
     - git:

--- a/deploy/ansible/wipe_ursula_config.yml
+++ b/deploy/ansible/wipe_ursula_config.yml
@@ -1,5 +1,5 @@
 - name: "Start Ursulas"
-  hosts: ec2
+  hosts: "{{ 'tag_Role_' + lookup('env', 'NUCYPHER_NETWORK_NAME') }}"
   user: ubuntu
   gather_facts: false
 


### PR DESCRIPTION
- Separates server provisioning from Ursula network services configuration
- Uses `NUCYPHER_NETWORK_NAME` envvar as dynamic inventory tag
- Updates .gitignore with Ansible variables 