### PR TITLE
Adapt NuCypher to umbral==0.1.2a0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ python_version = "3"
 #
 # NuCypher
 #
-umbral = "==0.1.1a3"
+umbral = "==0.1.2a0"
 constant-sorrow = "*"
 bytestringSplitter = "*"
 hendrix = ">=3.1.0"

--- a/Pipfile
+++ b/Pipfile
@@ -27,6 +27,7 @@ maya = "*"
 #
 # Third-Party Ethereum
 #
+coincurve = "==9.0.0"
 eth-hash = {version = "==0.2.0", extras = ["pysha3"]}
 eth-utils = "==1.2.1"
 eth-keys="*"

--- a/nucypher/keystore/keystore.py
+++ b/nucypher/keystore/keystore.py
@@ -17,7 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 from bytestring_splitter import BytestringSplitter
 from sqlalchemy.orm import sessionmaker
 from typing import Union
-from umbral.fragments import KFrag
+from umbral.kfrags import KFrag
 from umbral.keys import UmbralPublicKey
 
 from nucypher.crypto.signing import Signature

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -23,7 +23,7 @@ from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from twisted.logger import Logger
-from umbral.fragments import CapsuleFrag
+from umbral.cfrags import CapsuleFrag
 from umbral.signing import Signature
 
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -24,7 +24,7 @@ from bytestring_splitter import VariableLengthBytestring
 from constant_sorrow import constants
 from hendrix.experience import crosstown_traffic
 from umbral import pre
-from umbral.fragments import KFrag
+from umbral.kfrags import KFrag
 from umbral.keys import UmbralPublicKey
 
 from nucypher.crypto.api import keccak_digest

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -27,7 +27,6 @@ from constant_sorrow import constants
 from eth_utils import to_canonical_address, to_checksum_address
 from typing import Generator, List, Set
 from umbral.config import default_params
-from umbral.fragments import KFrag
 from umbral.pre import Capsule
 
 from nucypher.characters.lawful import Alice

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ trie==1.3.8
 twisted==18.9.0
 txaio==18.8.1
 tzlocal==1.5.1
-umbral==0.1.1a3
+umbral==0.1.2a0
 urllib3==1.24.1 ; python_version >= '3.4'
 watchdog==0.9.0
 web3==4.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ certifi==2018.10.15
 cffi==1.11.5
 chardet==3.0.4
 click==7.0
+coincurve==9.0.0
 colorama==0.4.1
 constant-sorrow==0.1.0a4
 constantly==15.1.0

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -18,7 +18,7 @@ import datetime
 import maya
 import os
 import pytest
-from umbral.fragments import KFrag
+from umbral.kfrags import KFrag
 
 from nucypher.characters.lawful import Bob, Ursula
 from nucypher.config.characters import AliceConfiguration

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -22,7 +22,8 @@ from tempfile import TemporaryDirectory
 from twisted.internet import threads
 
 from umbral import pre
-from umbral.fragments import KFrag, CapsuleFrag
+from umbral.kfrags import KFrag
+from umbral.cfrags import CapsuleFrag
 
 from nucypher.crypto.powers import EncryptingPower
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware


### PR DESCRIPTION
This is for the `vodka` branch.

- Adapts NuCypher to `umbral==0.1.2a0`
- Brings back `coincurve` (pinned to v9.0.0)