### PR TITLE
Maintain non-federated CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__
 *.pyc
 /.venv
+.eggs
 /*.egg-info
 /build
 /.cache

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -14,6 +14,7 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
 import json
 from collections import OrderedDict
 from json import JSONDecodeError
@@ -125,10 +126,10 @@ class Deployer(NucypherTokenActor):
         self.user_escrow_deployers = dict()
 
         self.deployers = {
-            NucypherTokenDeployer._contract_name: self.deploy_token_contract,
-            MinerEscrowDeployer._contract_name: self.deploy_miner_contract,
-            PolicyManagerDeployer._contract_name: self.deploy_policy_contract,
-            UserEscrowProxyDeployer._contract_name: self.deploy_escrow_proxy,
+            NucypherTokenDeployer.contract_name: self.deploy_token_contract,
+            MinerEscrowDeployer.contract_name: self.deploy_miner_contract,
+            PolicyManagerDeployer.contract_name: self.deploy_policy_contract,
+            UserEscrowProxyDeployer.contract_name: self.deploy_escrow_proxy,
         }
 
     def __repr__(self):
@@ -214,15 +215,15 @@ class Deployer(NucypherTokenActor):
         policy_txhashes = self.deploy_policy_contract(secret=policy_secret)
 
         txhashes = {
-            NucypherTokenDeployer._contract_name: token_txhashes,
-            MinerEscrowDeployer._contract_name: miner_txhashes,
-            PolicyManagerDeployer._contract_name: policy_txhashes
+            NucypherTokenDeployer.contract_name: token_txhashes,
+            MinerEscrowDeployer.contract_name: miner_txhashes,
+            PolicyManagerDeployer.contract_name: policy_txhashes
         }
 
         agents = {
-            NucypherTokenDeployer._contract_name: self.token_agent,
-            MinerEscrowDeployer._contract_name: self.miner_agent,
-            PolicyManagerDeployer._contract_name: self.policy_agent
+            NucypherTokenDeployer.contract_name: self.token_agent,
+            MinerEscrowDeployer.contract_name: self.miner_agent,
+            PolicyManagerDeployer.contract_name: self.policy_agent
         }
 
         return txhashes, agents

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -168,7 +168,8 @@ class Deployer(NucypherTokenActor):
 
     def deploy_miner_contract(self, secret: bytes):
 
-        miner_escrow_deployer = MinerEscrowDeployer(deployer_address=self.deployer_address,
+        miner_escrow_deployer = MinerEscrowDeployer(blockchain=self.blockchain,
+                                                    deployer_address=self.deployer_address,
                                                     secret_hash=secret)
 
         txhashes = miner_escrow_deployer.deploy()
@@ -177,7 +178,8 @@ class Deployer(NucypherTokenActor):
 
     def deploy_policy_contract(self, secret: bytes):
 
-        policy_manager_deployer = PolicyManagerDeployer(deployer_address=self.deployer_address,
+        policy_manager_deployer = PolicyManagerDeployer(blockchain=self.blockchain,
+                                                        deployer_address=self.deployer_address,
                                                         secret_hash=secret)
 
         txhashes = policy_manager_deployer.deploy()
@@ -186,14 +188,16 @@ class Deployer(NucypherTokenActor):
 
     def deploy_escrow_proxy(self, secret: bytes):
 
-        escrow_proxy_deployer = UserEscrowProxyDeployer(deployer_address=self.deployer_address,
+        escrow_proxy_deployer = UserEscrowProxyDeployer(blockchain=self.blockchain,
+                                                        deployer_address=self.deployer_address,
                                                         secret_hash=secret)
 
         txhashes = escrow_proxy_deployer.deploy()
         return txhashes
 
     def deploy_user_escrow(self):
-        user_escrow_deployer = UserEscrowDeployer(deployer_address=self.deployer_address,
+        user_escrow_deployer = UserEscrowDeployer(blockchain=self.blockchain,
+                                                  deployer_address=self.deployer_address,
                                                   allocation_registry=self.allocation_registy)
 
         user_escrow_deployer.deploy()

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -29,7 +29,7 @@ from typing import Tuple, List, Dict, Union
 from nucypher.blockchain.eth.agents import NucypherTokenAgent, MinerAgent, PolicyAgent
 from nucypher.blockchain.eth.chains import Blockchain
 from nucypher.blockchain.eth.deployers import NucypherTokenDeployer, MinerEscrowDeployer, PolicyManagerDeployer, \
-    UserEscrowProxyDeployer, UserEscrowDeployer
+    UserEscrowProxyDeployer, UserEscrowDeployer, DispatcherDeployer
 from nucypher.blockchain.eth.interfaces import BlockchainDeployerInterface
 from nucypher.blockchain.eth.registry import EthereumContractRegistry, AllocationRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
@@ -124,6 +124,19 @@ class Deployer(NucypherTokenActor):
         self.allocation_registy = allocation_registry
         self.user_escrow_deployers = dict()
 
+        self.deployers = {
+            NucypherTokenDeployer._contract_name: self.deploy_token_contract,
+            MinerEscrowDeployer._contract_name: self.deploy_miner_contract,
+            PolicyManagerDeployer._contract_name: self.deploy_policy_contract,
+            UserEscrowProxyDeployer._contract_name: self.deploy_escrow_proxy,
+        }
+
+    def __repr__(self):
+        r = '{name}({blockchain}, {deployer_address})'.format(name=self.__class__.__name__,
+                                                              blockchain=self.blockchain,
+                                                              deployer_address=self.deployer_address)
+        return r
+
     @classmethod
     def from_blockchain(cls, provider_uri: str, registry=None, *args, **kwargs):
         blockchain = Blockchain.connect(provider_uri=provider_uri, registry=registry)
@@ -149,32 +162,35 @@ class Deployer(NucypherTokenActor):
 
         token_deployer = NucypherTokenDeployer(blockchain=self.blockchain, deployer_address=self.deployer_address)
 
-        token_deployer.deploy()
+        txhashes = token_deployer.deploy()
         self.token_agent = token_deployer.make_agent()
+        return txhashes
 
-    def deploy_miner_contract(self, secret):
+    def deploy_miner_contract(self, secret: bytes):
 
         miner_escrow_deployer = MinerEscrowDeployer(deployer_address=self.deployer_address,
                                                     secret_hash=secret)
 
-        miner_escrow_deployer.deploy()
+        txhashes = miner_escrow_deployer.deploy()
         self.miner_agent = miner_escrow_deployer.make_agent()
+        return txhashes
 
-    def deploy_policy_contract(self, secret):
+    def deploy_policy_contract(self, secret: bytes):
 
         policy_manager_deployer = PolicyManagerDeployer(deployer_address=self.deployer_address,
                                                         secret_hash=secret)
 
-        policy_manager_deployer.deploy()
+        txhashes = policy_manager_deployer.deploy()
         self.policy_agent = policy_manager_deployer.make_agent()
+        return txhashes
 
-    def deploy_escrow_proxy(self, secret):
+    def deploy_escrow_proxy(self, secret: bytes):
 
         escrow_proxy_deployer = UserEscrowProxyDeployer(deployer_address=self.deployer_address,
                                                         secret_hash=secret)
 
-        escrow_proxy_deployer.deploy()
-        return escrow_proxy_deployer
+        txhashes = escrow_proxy_deployer.deploy()
+        return txhashes
 
     def deploy_user_escrow(self):
         user_escrow_deployer = UserEscrowDeployer(deployer_address=self.deployer_address,
@@ -185,13 +201,27 @@ class Deployer(NucypherTokenActor):
         self.user_escrow_deployers[principal_address] = user_escrow_deployer
         return user_escrow_deployer
 
-    def deploy_network_contracts(self, miner_secret, policy_secret):
+    def deploy_network_contracts(self, miner_secret: bytes, policy_secret: bytes) -> Tuple[dict, dict]:
         """
         Musketeers, if you will; Deploy the "big three" contracts to the blockchain.
         """
-        self.deploy_token_contract()
-        self.deploy_miner_contract(secret=miner_secret)
-        self.deploy_policy_contract(secret=policy_secret)
+        token_txhashes = self.deploy_token_contract()
+        miner_txhashes = self.deploy_miner_contract(secret=miner_secret)
+        policy_txhashes = self.deploy_policy_contract(secret=policy_secret)
+
+        txhashes = {
+            NucypherTokenDeployer._contract_name: token_txhashes,
+            MinerEscrowDeployer._contract_name: miner_txhashes,
+            PolicyManagerDeployer._contract_name: policy_txhashes
+        }
+
+        agents = {
+            NucypherTokenDeployer._contract_name: self.token_agent,
+            MinerEscrowDeployer._contract_name: self.miner_agent,
+            PolicyManagerDeployer._contract_name: self.policy_agent
+        }
+
+        return txhashes, agents
 
     def deploy_beneficiary_contracts(self, allocations: List[Dict[str, Union[str, int]]]) -> None:
         """

--- a/nucypher/blockchain/eth/chains.py
+++ b/nucypher/blockchain/eth/chains.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 from twisted.logger import Logger
+from web3.middleware import geth_poa_middleware
 
 from constant_sorrow.constants import NO_BLOCKCHAIN_AVAILABLE
 from typing import Union
@@ -64,6 +65,7 @@ class Blockchain:
                 registry: EthereumContractRegistry = None,
                 deployer: bool = False,
                 compile: bool = False,
+                poa: bool = False
                 ) -> 'Blockchain':
 
         if cls._instance is NO_BLOCKCHAIN_AVAILABLE:
@@ -71,6 +73,10 @@ class Blockchain:
             compiler = SolidityCompiler() if compile is True else None
             InterfaceClass = BlockchainDeployerInterface if deployer is True else BlockchainInterface
             interface = InterfaceClass(provider_uri=provider_uri, registry=registry, compiler=compiler)
+
+            if poa is True:
+                interface.w3.middleware_stack.inject(geth_poa_middleware, layer=0)
+
             cls._instance = cls(interface=interface)
         else:
             if provider_uri is not None:

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -239,14 +239,8 @@ class BlockchainInterface:
                     provider = EthereumTesterProvider(ethereum_tester=eth_tester)
 
                 elif uri_breakdown.netloc == 'geth':
-                    # TODO: Auto gethdev
-                    # https://web3py.readthedocs.io/en/stable/providers.html  # geth-dev-proof-of-authority
-                    # from web3.auto.gethdev import w3
-
                     # Hardcoded gethdev IPC provider
                     provider = IPCProvider(ipc_path='/tmp/geth.ipc', timeout=timeout)
-                    # w3 = Web3(providers=(provider))
-                    # w3.middleware_stack.inject(geth_poa_middleware, layer=0)
 
                 else:
                     raise ValueError("{} is an invalid or unsupported blockchain provider URI".format(provider_uri))

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -14,19 +14,26 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-from twisted.logger import Logger
+
+
 from urllib.parse import urlparse
 
-from constant_sorrow import constants
 from eth_keys.datatypes import PublicKey, Signature
-from eth_tester import EthereumTester
-from eth_tester import PyEVMBackend
 from eth_utils import to_canonical_address
+from twisted.logger import Logger
 from typing import Tuple, Union
 from web3 import Web3, WebsocketProvider, HTTPProvider, IPCProvider
 from web3.contract import Contract
 from web3.providers.eth_tester.main import EthereumTesterProvider
 
+from constant_sorrow.constants import (
+    NO_BLOCKCHAIN_CONNECTION,
+    NO_COMPILATION_PERFORMED,
+    MANUAL_PROVIDERS_SET,
+    NO_DEPLOYER_CONFIGURED
+)
+from eth_tester import EthereumTester
+from eth_tester import PyEVMBackend
 from nucypher.blockchain.eth.constants import NUCYPHER_GAS_LIMIT
 from nucypher.blockchain.eth.registry import EthereumContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
@@ -130,9 +137,9 @@ class BlockchainInterface:
         # Providers
         #
 
-        self.w3 = constants.NO_BLOCKCHAIN_CONNECTION
-        self.__providers = providers or constants.NO_BLOCKCHAIN_CONNECTION
-        self.provider_uri = constants.NO_BLOCKCHAIN_CONNECTION
+        self.w3 = NO_BLOCKCHAIN_CONNECTION
+        self.__providers = providers or NO_BLOCKCHAIN_CONNECTION
+        self.provider_uri = NO_BLOCKCHAIN_CONNECTION
         self.timeout = timeout if timeout is not None else self.__default_timeout
 
         if provider_uri and providers:
@@ -141,7 +148,7 @@ class BlockchainInterface:
             self.provider_uri = provider_uri
             self.add_provider(provider_uri=provider_uri)
         elif providers:
-            self.provider_uri = constants.MANUAL_PROVIDERS_SET
+            self.provider_uri = MANUAL_PROVIDERS_SET
             for provider in providers:
                 self.add_provider(provider)
         else:
@@ -163,7 +170,7 @@ class BlockchainInterface:
             interfaces = self.__sol_compiler.compile()
             __raw_contract_cache = interfaces
         else:
-            __raw_contract_cache = constants.NO_COMPILATION_PERFORMED
+            __raw_contract_cache = NO_COMPILATION_PERFORMED
         self.__raw_contract_cache = __raw_contract_cache
 
         # Auto-connect
@@ -171,10 +178,14 @@ class BlockchainInterface:
         if self.autoconnect is True:
             self.connect()
 
+    def __repr__(self):
+        r = '{name}({uri})'.format(name=self.__class__.__name__, uri=self.provider_uri)
+        return r
+
     def connect(self):
         self.log.info("Connecting to {}".format(self.provider_uri))
 
-        if self.__providers is constants.NO_BLOCKCHAIN_CONNECTION:
+        if self.__providers is NO_BLOCKCHAIN_CONNECTION:
             raise self.NoProvider("There are no configured blockchain providers")
 
         # Connect
@@ -256,7 +267,7 @@ class BlockchainInterface:
                 raise self.InterfaceError("'{}' is not a blockchain provider protocol".format(uri_breakdown.scheme))
 
             # lazy
-            if self.__providers is constants.NO_BLOCKCHAIN_CONNECTION:
+            if self.__providers is NO_BLOCKCHAIN_CONNECTION:
                 self.__providers = list()
             self.__providers.append(provider)
 
@@ -267,7 +278,7 @@ class BlockchainInterface:
         except KeyError:
             raise self.UnknownContract('{} is not a locally compiled contract.'.format(contract_name))
         except TypeError:
-            if self.__raw_contract_cache is constants.NO_COMPILATION_PERFORMED:
+            if self.__raw_contract_cache is NO_COMPILATION_PERFORMED:
                 message = "The local contract compiler cache is empty because no compilation was performed."
                 raise self.InterfaceError(message)
         else:
@@ -399,7 +410,7 @@ class BlockchainDeployerInterface(BlockchainInterface):
 
     def __init__(self, deployer_address: str=None, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)  # Depends on web3 instance
-        self.__deployer_address = deployer_address if deployer_address is not None else constants.NO_DEPLOYER_CONFIGURED
+        self.__deployer_address = deployer_address if deployer_address is not None else NO_DEPLOYER_CONFIGURED
 
     @property
     def deployer_address(self):
@@ -407,7 +418,7 @@ class BlockchainDeployerInterface(BlockchainInterface):
 
     @deployer_address.setter
     def deployer_address(self, checksum_address: str) -> None:
-        if self.deployer_address is not constants.NO_DEPLOYER_CONFIGURED:
+        if self.deployer_address is not NO_DEPLOYER_CONFIGURED:
             raise RuntimeError("{} already has a deployer address set: {}.".format(self.__class__.__name__, self.deployer_address))
         self.__deployer_address = checksum_address
 
@@ -416,7 +427,7 @@ class BlockchainDeployerInterface(BlockchainInterface):
         Retrieve compiled interface data from the cache and
         return an instantiated deployed contract
         """
-        if self.__deployer_address is constants.NO_DEPLOYER_CONFIGURED:
+        if self.__deployer_address is NO_DEPLOYER_CONFIGURED:
             raise self.NoDeployerAddress
 
         #

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -275,6 +275,7 @@ class BlockchainInterface:
             if self.__raw_contract_cache is NO_COMPILATION_PERFORMED:
                 message = "The local contract compiler cache is empty because no compilation was performed."
                 raise self.InterfaceError(message)
+            raise
         else:
             contract = self.w3.eth.contract(abi=interface['abi'],
                                             bytecode=interface['bin'],

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -71,6 +71,9 @@ class EthereumContractRegistry:
         self.__filepath = filepath
         return True
 
+    def _destroy(self) -> None:
+        os.remove(self.filepath)
+
     def write(self, registry_data: list) -> None:
         """
         Writes the registry data list as JSON to the registry file. If no

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -95,7 +95,7 @@ nucypher_deployer_config = click.make_pass_decorator(NucypherDeployerClickConfig
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
 @click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)
 @click.option('--deployer-address', help="Deployer's checksum address", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--allocation-infile', help="Input path for allocation JSON file", type=EXISTING_READABLE_FILE)
+@click.option('--allocation-infile', help="Input path for token allocation JSON file", type=EXISTING_READABLE_FILE)
 @nucypher_deployer_config
 def deploy(click_config,
            action,

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -139,7 +139,7 @@ def deploy(click_config,
             deployer.blockchain.interface.registry._destroy()
 
         try:
-            txhashes, agents = deployer.deploy_network_contracts(miner_secret=bytes(secrets.miner_secret, encoding='utf=8'),
+            txhashes, agents = deployer.deploy_network_contracts(miner_secret=bytes(secrets.miner_secret, encoding='utf-8'),
                                                                  policy_secret=bytes(secrets.policy_secret, encoding='utf-8'))
         except BlockchainInterface.InterfaceError:
             raise  # TODO: Handle registry management here (it may already exists)

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -55,7 +55,7 @@ class NucypherDeployerClickConfig:
     Secrets = collections.namedtuple('Secrets', ('miner_secret', 'policy_secret', 'escrow_proxy_secret'))
 
     def __init__(self):
-        if self.log_to_file is True:
+        if self.log_to_file:
             globalLogPublisher.addObserver(getTextFileObserver())
         self.log = Logger(self.__class__.__name__)
 
@@ -91,7 +91,7 @@ nucypher_deployer_config = click.make_pass_decorator(NucypherDeployerClickConfig
 @click.argument('action')
 @click.option('--force', is_flag=True)
 @click.option('--poa', help="Inject POA middleware", is_flag=True)
-@click.option('--no-compile', help="Inject POA middleware", is_flag=True)
+@click.option('--no-compile', help="Disables solidity contract compilation", is_flag=True)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
 @click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)
 @click.option('--deployer-address', help="Deployer's checksum address", type=EIP55_CHECKSUM_ADDRESS)

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -46,6 +46,9 @@ from nucypher.utilities.logging import (
     SimpleObserver)
 
 
+FEDERATED_ONLY = False
+
+
 #
 # Click CLI Config
 #
@@ -144,7 +147,7 @@ def status(click_config, config_file):
 @click.option('--rest-port', help="The host port to run Ursula network services on", type=UNREGISTERED_PORT)
 @click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
 @click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--federated-only', help="Connect only to federated nodes", is_flag=True, default=True)
+@click.option('--federated-only', help="Connect only to federated nodes", is_flag=True, default=FEDERATED_ONLY)
 @click.option('--poa', help="Inject POA middleware", is_flag=True)
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
@@ -234,7 +237,8 @@ def ursula(click_config,
                                                      checksum_public_address=checksum_address,
                                                      no_registry=federated_only or no_registry,
                                                      registry_filepath=registry_filepath,
-                                                     provider_uri=provider_uri)
+                                                     provider_uri=provider_uri,
+                                                     poa=poa)
 
         click.secho("Generated keyring {}".format(ursula_config.keyring_dir), fg='green')
         click.secho("Saved configuration file {}".format(ursula_config.config_file_location), fg='green')

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -286,7 +286,7 @@ def ursula(click_config,
         except CryptoError:
             raise ursula_config.keyring.AuthenticationFailed
 
-    if not federated_only:
+    if not ursula_config.federated_only:
         ursula_config.connect_to_blockchain(recompile_contracts=False)
         ursula_config.connect_to_contracts()
 

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -31,7 +31,7 @@ from nucypher.cli.painting import BANNER, paint_configuration, paint_known_nodes
 from nucypher.cli.protocol import UrsulaCommandProtocol
 from nucypher.cli.types import (
     EIP55_CHECKSUM_ADDRESS,
-    UNREGISTERED_PORT,
+    NETWORK_PORT,
     EXISTING_READABLE_FILE,
     EXISTING_WRITABLE_DIRECTORY,
     STAKE_VALUE,
@@ -144,7 +144,7 @@ def status(click_config, config_file):
 @click.option('--teacher-uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @click.option('--rest-host', help="The host IP address to run Ursula network services on", type=click.STRING)
-@click.option('--rest-port', help="The host port to run Ursula network services on", type=UNREGISTERED_PORT)
+@click.option('--rest-port', help="The host port to run Ursula network services on", type=NETWORK_PORT)
 @click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
 @click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--federated-only', help="Connect only to federated nodes", is_flag=True, default=FEDERATED_ONLY)

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -282,6 +282,10 @@ def ursula(click_config,
         except CryptoError:
             raise ursula_config.keyring.AuthenticationFailed
 
+    if not federated_only:
+        ursula_config.connect_to_blockchain(recompile_contracts=False)
+        ursula_config.connect_to_contracts()
+
     click_config.ursula_config = ursula_config  # Pass Ursula's config onto staking sub-command
 
     #

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -49,6 +49,6 @@ STAKE_DURATION = click.IntRange(min=MIN_LOCKED_PERIODS, max=MAX_MINTING_PERIODS,
 STAKE_VALUE = click.IntRange(min=MIN_ALLOWED_LOCKED, max=MAX_ALLOWED_LOCKED, clamp=False)
 EXISTING_WRITABLE_DIRECTORY = click.Path(exists=True, dir_okay=True, file_okay=False, writable=True)
 EXISTING_READABLE_FILE = click.Path(exists=True, dir_okay=False, file_okay=True, readable=True)
-UNREGISTERED_PORT = click.IntRange(min=49151, max=65535, clamp=False)
+NETWORK_PORT = click.IntRange(min=0, max=65535, clamp=False)
 IPV4_ADDRESS = IPv4Address()
 EIP55_CHECKSUM_ADDRESS = ChecksumAddress()

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -363,7 +363,10 @@ class NodeConfiguration(ABC):
                                                   deserializer=cls.NODE_DESERIALIZER)
 
         payload.update(dict(node_storage=node_storage))
-        return cls(**{**payload, **overrides})
+
+        # Instantiate from merged params
+        node_configuration = cls(**{**payload, **overrides})
+        return node_configuration
 
     def to_configuration_file(self, filepath: str = None) -> str:
         """Write the static_payload to a JSON file."""
@@ -436,7 +439,7 @@ class NodeConfiguration(ABC):
                        node_storage=self.node_storage,
                        crypto_power_ups=self.derive_node_power_ups() or None)
 
-        if self.federated_only is False:
+        if not self.federated_only:
             self.connect_to_blockchain(recompile_contracts=False)
             payload.update(blockchain=self.blockchain)
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -70,10 +70,10 @@ class NodeConfiguration(ABC):
     # Configuration
     __CONFIG_FILE_EXT = '.config'
     __CONFIG_FILE_DESERIALIZER = json.loads
-    __TEMP_CONFIGURATION_DIR_PREFIX = "nucypher-tmp-"
+    TEMP_CONFIGURATION_DIR_PREFIX = "nucypher-tmp-"
 
     # Blockchain
-    __DEFAULT_PROVIDER_URI = 'tester://pyevm'  # FIXME: Needs to be updated in tandem with manual providers for interface.connect
+    DEFAULT_PROVIDER_URI = 'tester://pyevm'  # FIXME: Needs to be updated in tandem with manual providers for interface.connect
 
     # Registry
     __REGISTRY_NAME = 'contract_registry.json'
@@ -235,7 +235,7 @@ class NodeConfiguration(ABC):
         # Blockchain
         #
         self.poa = poa
-        self.provider_uri = provider_uri or self.__DEFAULT_PROVIDER_URI
+        self.provider_uri = provider_uri or self.DEFAULT_PROVIDER_URI
 
         self.blockchain = NO_BLOCKCHAIN_CONNECTION
         self.accounts = NO_BLOCKCHAIN_CONNECTION
@@ -487,7 +487,7 @@ class NodeConfiguration(ABC):
         # Create Config Root
         #
         if self.__dev_mode:
-            self.__temp_dir = TemporaryDirectory(prefix=self.__TEMP_CONFIGURATION_DIR_PREFIX)
+            self.__temp_dir = TemporaryDirectory(prefix=self.TEMP_CONFIGURATION_DIR_PREFIX)
             self.config_root = self.__temp_dir.name
         else:
             try:

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -73,7 +73,7 @@ class NodeConfiguration(ABC):
     __TEMP_CONFIGURATION_DIR_PREFIX = "nucypher-tmp-"
 
     # Blockchain
-    __DEFAULT_PROVIDER_URI = 'tester://geth'
+    __DEFAULT_PROVIDER_URI = 'tester://pyevm'  # FIXME: Needs to be updated in tandem with manual providers for interface.connect
 
     # Registry
     __REGISTRY_NAME = 'contract_registry.json'

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -89,7 +89,7 @@ class TesterBlockchain(Blockchain):
 
             umbral_priv_key = UmbralPrivateKey.gen_key()
             address = self.interface.w3.personal.importRawKey(private_key=umbral_priv_key.to_bytes(),
-                                                              password=insecure_password)
+                                                              passphrase=insecure_password)
 
             assert self.interface.unlock_account(address, password=insecure_password, duration=None), 'Failed to unlock {}'.format(address)
             addresses.append(address)

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -15,13 +15,39 @@ You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
+import contextlib
 import os
 
+import socket
+
 from nucypher.blockchain.eth.constants import DISPATCHER_SECRET_LENGTH, M
+from nucypher.config.characters import UrsulaConfiguration
+
+
+def select_test_port() -> int:
+    """
+    Search for a network port that is open at the time of the call;
+    Verify that the port is not the same as the default Ursula running port.
+
+    Note: There is no guarantee that the returned port will still be available later.
+    """
+
+    closed_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    with contextlib.closing(closed_socket) as open_socket:
+        open_socket.bind(('localhost', 0))
+        port = open_socket.getsockname()[1]
+
+        if port == UrsulaConfiguration.DEFAULT_REST_PORT:
+            return select_test_port()
+
+        open_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return port
+
+
+MOCK_URSULA_STARTING_PORT = select_test_port()
 
 MOCK_KNOWN_URSULAS_CACHE = {}
-
-MOCK_URSULA_STARTING_PORT = 49152
 
 NUMBER_OF_URSULAS_IN_DEVELOPMENT_NETWORK = 10
 

--- a/tests/blockchain/eth/interfaces/test_solidity_compiler.py
+++ b/tests/blockchain/eth/interfaces/test_solidity_compiler.py
@@ -14,6 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 from nucypher.blockchain.eth.deployers import NucypherTokenDeployer
 
 
@@ -21,5 +23,5 @@ def test_nucypher_contract_compiled(testerchain):
     # Ensure that solidity smart contacts are available, post-compile.
     origin, *everybody_else = testerchain.interface.w3.eth.accounts
 
-    token_contract_identifier = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)._contract_name
+    token_contract_identifier = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin).contract_name
     assert token_contract_identifier in testerchain.interface._BlockchainInterface__raw_contract_cache

--- a/tests/cli/commands/test_federated_ursula.py
+++ b/tests/cli/commands/test_federated_ursula.py
@@ -83,7 +83,7 @@ def test_initialize_custom_configuration_root(custom_filepath, click_runner):
     assert 'Repeat for confirmation:' in result.output, 'User was not prompted to confirm password'
 
 
-def test_configuration_file_contents(custom_filepath, nominal_configuration_fields):
+def test_configuration_file_contents(custom_filepath, nominal_federated_configuration_fields):
     custom_config_filepath = os.path.join(custom_filepath, UrsulaConfiguration.CONFIG_FILENAME)
     assert os.path.isfile(custom_config_filepath), 'Configuration file does not exist'
 
@@ -96,7 +96,7 @@ def test_configuration_file_contents(custom_filepath, nominal_configuration_fiel
         except JSONDecodeError:
             raise pytest.fail(msg="Invalid JSON configuration file {}".format(custom_config_filepath))
 
-        for field in nominal_configuration_fields:
+        for field in nominal_federated_configuration_fields:
             assert field in data, "Missing field '{}' from configuration file."
             if any(keyword in field for keyword in ('path', 'dir')):
                 path = data[field]
@@ -126,7 +126,7 @@ def test_password_prompt(click_runner, custom_filepath):
     assert result.exit_code == 0
 
 
-def test_ursula_view_configuration(custom_filepath, click_runner, nominal_configuration_fields):
+def test_ursula_view_configuration(custom_filepath, click_runner, nominal_federated_configuration_fields):
 
     # Ensure the configuration file still exists
     custom_config_filepath = os.path.join(custom_filepath, UrsulaConfiguration.CONFIG_FILENAME)
@@ -142,7 +142,7 @@ def test_ursula_view_configuration(custom_filepath, click_runner, nominal_config
     # CLI Output
     assert 'password' in result.output, 'WARNING: User was not prompted for password'
     assert MOCK_CUSTOM_INSTALLATION_PATH in result.output
-    for field in nominal_configuration_fields:
+    for field in nominal_federated_configuration_fields:
         assert field in result.output, "Missing field '{}' from configuration file."
 
     # Make sure nothing crazy is happening...

--- a/tests/cli/commands/test_federated_ursula.py
+++ b/tests/cli/commands/test_federated_ursula.py
@@ -39,7 +39,7 @@ def test_initialize_ursula_defaults(click_runner, mocker):
     mocker.patch.object(UrsulaConfiguration, 'to_configuration_file', autospec=True)
 
     # Use default ursula init args
-    init_args = ('ursula', 'init')
+    init_args = ('ursula', 'init', '--federated-only')
     user_input = '{ip}\n{password}\n{password}\n'.format(password=INSECURE_DEVELOPMENT_PASSWORD, ip=MOCK_IP_ADDRESS)
     result = click_runner.invoke(nucypher_cli, init_args, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
@@ -56,6 +56,7 @@ def test_initialize_custom_configuration_root(custom_filepath, click_runner):
 
     # Use a custom local filepath for configuration
     init_args = ('ursula', 'init',
+                 '--federated-only',
                  '--config-root', custom_filepath,
                  '--rest-host', MOCK_IP_ADDRESS,
                  '--rest-port', MOCK_URSULA_STARTING_PORT)

--- a/tests/cli/commands/test_status.py
+++ b/tests/cli/commands/test_status.py
@@ -24,7 +24,7 @@ from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, 
 
 
 def test_initialize_configuration_files_and_directories(custom_filepath, click_runner):
-    init_args = ('ursula', 'init', '--config-root', custom_filepath)
+    init_args = ('ursula', 'init', '--federated-only', '--config-root', custom_filepath)
 
     # Use a custom local filepath for configuration
     user_input = '{ip}\n{password}\n{password}\n'.format(password=INSECURE_DEVELOPMENT_PASSWORD, ip=MOCK_IP_ADDRESS_2)

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -33,8 +33,8 @@ def click_runner():
 
 
 @pytest.fixture(scope='module')
-def nominal_configuration_fields():
-    config = UrsulaConfiguration(dev_mode=True)
+def nominal_federated_configuration_fields():
+    config = UrsulaConfiguration(dev_mode=True, federated_only=True)
     config_fields = config.static_payload
     del config_fields['is_me']
     yield tuple(config_fields.keys())

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -14,6 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 import contextlib
 import shutil
 

--- a/tests/config/test_firstula_circumstances.py
+++ b/tests/config/test_firstula_circumstances.py
@@ -19,7 +19,7 @@ from functools import partial
 
 import maya
 import pytest
-import pytest_twisted
+import pytest_twisted as pt
 from twisted.internet.threads import deferToThread
 
 from nucypher.network.middleware import RestMiddleware
@@ -41,7 +41,7 @@ def test_proper_seed_node_instantiation(ursula_federated_test_config):
     assert firstula in any_other_ursula.known_nodes
 
 
-@pytest_twisted.inlineCallbacks
+@pt.inlineCallbacks
 def test_get_cert_from_running_seed_node(ursula_federated_test_config):
     lonely_ursula_maker = partial(make_federated_ursulas,
                                   ursula_config=ursula_federated_test_config,

--- a/tests/config/test_storages.py
+++ b/tests/config/test_storages.py
@@ -15,10 +15,6 @@ You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
-import contextlib
-import os
-
 import boto3
 import pytest
 import requests
@@ -31,7 +27,7 @@ from nucypher.config.storages import (
     TemporaryFileBasedNodeStorage,
     NodeStorage
 )
-from nucypher.utilities.sandbox.constants import MOCK_URSULA_DB_FILEPATH
+from nucypher.utilities.sandbox.constants import MOCK_URSULA_DB_FILEPATH, MOCK_URSULA_STARTING_PORT
 
 MOCK_S3_BUCKET_NAME = 'mock-seednodes'
 S3_DOMAIN_NAME = 's3.amazonaws.com'
@@ -41,17 +37,11 @@ class BaseTestNodeStorageBackends:
 
     @pytest.fixture(scope='class')
     def light_ursula(temp_dir_path):
-        db_filepath = 'ursula-{}.db'.format(10151)
-        try:
-            node = Ursula(rest_host='127.0.0.1',
-                          rest_port=10151,
-                          db_filepath=MOCK_URSULA_DB_FILEPATH,
-                          federated_only=True)
-
-            yield node
-        finally:
-            with contextlib.suppress(Exception):
-                os.remove(db_filepath)
+        node = Ursula(rest_host='127.0.0.1',
+                      rest_port=MOCK_URSULA_STARTING_PORT,
+                      db_filepath=MOCK_URSULA_DB_FILEPATH,
+                      federated_only=True)
+        yield node
 
     character_class = Ursula
     federated_only = True
@@ -68,7 +58,7 @@ class BaseTestNodeStorageBackends:
 
         # Save more nodes
         all_known_nodes = set()
-        for port in range(10152, 10251):
+        for port in range(MOCK_URSULA_STARTING_PORT, MOCK_URSULA_STARTING_PORT+100):
             node = Ursula(rest_host='127.0.0.1', db_filepath=MOCK_URSULA_DB_FILEPATH, rest_port=port, federated_only=True)
             node_storage.store_node_metadata(node=node)
             all_known_nodes.add(node)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -43,7 +43,7 @@ from nucypher.keystore.db import Base
 from nucypher.keystore.keypairs import SigningKeypair
 from nucypher.utilities.sandbox.blockchain import TesterBlockchain, token_airdrop
 from nucypher.utilities.sandbox.constants import (NUMBER_OF_URSULAS_IN_DEVELOPMENT_NETWORK,
-                                                  DEVELOPMENT_TOKEN_AIRDROP_AMOUNT)
+                                                  DEVELOPMENT_TOKEN_AIRDROP_AMOUNT, MOCK_URSULA_STARTING_PORT)
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 from nucypher.utilities.sandbox.ursula import make_federated_ursulas, make_decentralized_ursulas
 
@@ -122,6 +122,7 @@ def certificates_tempdir():
 def ursula_federated_test_config():
 
     ursula_config = UrsulaConfiguration(dev_mode=True,
+                                        rest_port=MOCK_URSULA_STARTING_PORT,
                                         is_me=True,
                                         start_learning_now=False,
                                         abort_on_learning_error=True,
@@ -140,6 +141,7 @@ def ursula_decentralized_test_config(three_agents):
     ursula_config = UrsulaConfiguration(dev_mode=True,
                                         is_me=True,
                                         provider_uri="tester://pyevm",
+                                        rest_port=MOCK_URSULA_STARTING_PORT,
                                         start_learning_now=False,
                                         abort_on_learning_error=True,
                                         federated_only=False,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -139,6 +139,7 @@ def ursula_decentralized_test_config(three_agents):
 
     ursula_config = UrsulaConfiguration(dev_mode=True,
                                         is_me=True,
+                                        provider_uri="tester://pyevm",
                                         start_learning_now=False,
                                         abort_on_learning_error=True,
                                         federated_only=False,
@@ -171,6 +172,7 @@ def alice_blockchain_test_config(blockchain_ursulas, three_agents):
 
     config = AliceConfiguration(dev_mode=True,
                                 is_me=True,
+                                provider_uri="tester://pyevm",
                                 checksum_public_address=alice_address,
                                 network_middleware=MockRestMiddleware(),
                                 known_nodes=blockchain_ursulas,
@@ -201,6 +203,7 @@ def bob_blockchain_test_config(blockchain_ursulas, three_agents):
     etherbase, alice_address, bob_address, *everyone_else = token_agent.blockchain.interface.w3.eth.accounts
 
     config = BobConfiguration(dev_mode=True,
+                              provider_uri="tester://pyevm",
                               checksum_public_address=bob_address,
                               network_middleware=MockRestMiddleware(),
                               known_nodes=blockchain_ursulas,

--- a/tests/network/test_node_storage.py
+++ b/tests/network/test_node_storage.py
@@ -15,9 +15,15 @@ You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import maya
+import pytest
+import pytest_twisted as pt
+from twisted.internet.threads import deferToThread
+
 from nucypher.utilities.sandbox.ursula import make_federated_ursulas
 
 
+@pt.inlineCallbacks
 def test_one_node_stores_a_bunch_of_others(federated_ursulas, ursula_federated_test_config):
     the_chosen_seednode = list(federated_ursulas)[2]  # ...neo?
     seed_node = the_chosen_seednode.seed_node_metadata()
@@ -32,6 +38,16 @@ def test_one_node_stores_a_bunch_of_others(federated_ursulas, ursula_federated_t
     assert not newcomer.known_nodes
 
     newcomer.start_learning_loop(now=True)
+    def start_lonely_learning_loop():
+        newcomer.start_learning_loop()
+        start = maya.now()
+        # Loop until the_chosen_seednode is in storage.
+        while the_chosen_seednode not in newcomer.node_storage.all(federated_only=True):
+            passed = maya.now() - start
+            if passed.seconds > 2:
+                pytest.fail("Didn't find the seed node.")
+
+    yield deferToThread(start_lonely_learning_loop)
 
     assert list(newcomer.known_nodes)
     assert len(list(newcomer.known_nodes)) == len(list(newcomer.node_storage.all(True)))


### PR DESCRIPTION
The recent work to build a federated network, left this code on the back-burner for a while.  This PR updates reestablishes decentralisation as the primary and default operating mode.

- Restore nucypher contract deployment CLI (`nucypher-deploy`;  Implements `Deployer` actor)
- Sets `--federated-only` False by default (Fixes #600)
- Select a (possibly) open network port for test runs (Fixes #566 )
- Ensure deployer uses it's internal blockchain reference to produce entities.
- Allow CLI to accept any port number when passed via `--rest-port` (Fixes #601)
- Separates configuration parameter generation and character production
- Ensure federating operating mode is determined by configuration, not always by flag.
