### PR TITLE
Adapt NuCypher to umbral==0.1.2a1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ python_version = "3"
 #
 # NuCypher
 #
-umbral = "==0.1.1a3"
+umbral = "==0.1.2a1"
 constant-sorrow = "*"
 bytestringSplitter = "*"
 hendrix = ">=3.1.0"

--- a/nucypher/keystore/keystore.py
+++ b/nucypher/keystore/keystore.py
@@ -17,7 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 from bytestring_splitter import BytestringSplitter
 from sqlalchemy.orm import sessionmaker
 from typing import Union
-from umbral.fragments import KFrag
+from umbral.kfrags import KFrag
 from umbral.keys import UmbralPublicKey
 
 from nucypher.crypto.signing import Signature

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -23,7 +23,7 @@ from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from twisted.logger import Logger
-from umbral.fragments import CapsuleFrag
+from umbral.cfrags import CapsuleFrag
 from umbral.signing import Signature
 
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -31,7 +31,7 @@ from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.signing import SignatureStamp
 from nucypher.network.middleware import RestMiddleware
 from umbral import pre
-from umbral.fragments import KFrag
+from umbral.kfrags import KFrag
 from umbral.keys import UmbralPublicKey
 
 from nucypher.crypto.api import keccak_digest

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -27,7 +27,6 @@ from constant_sorrow import constants
 from eth_utils import to_canonical_address, to_checksum_address
 from typing import Generator, List, Set
 from umbral.config import default_params
-from umbral.fragments import KFrag
 from umbral.pre import Capsule
 
 from nucypher.characters.lawful import Alice

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ trie==1.3.8
 twisted==18.9.0
 txaio==18.8.1
 tzlocal==1.5.1
-umbral==0.1.1a3
+umbral==0.1.2a1
 urllib3==1.24.1 ; python_version >= '3.4'
 watchdog==0.9.0
 web3==4.8.2

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -22,6 +22,8 @@ import datetime
 import maya
 import pytest
 
+from umbral.kfrags import KFrag
+
 from nucypher.characters.lawful import Bob
 from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.api import keccak_digest
@@ -30,7 +32,6 @@ from nucypher.policy.models import Revocation
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 from nucypher.utilities.sandbox.policy import MockPolicyCreation
-from umbral.fragments import KFrag
 
 
 @pytest.mark.skip(reason="to be implemented")  # TODO

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -22,7 +22,8 @@ from tempfile import TemporaryDirectory
 from twisted.internet import threads
 
 from umbral import pre
-from umbral.fragments import KFrag, CapsuleFrag
+from umbral.kfrags import KFrag
+from umbral.cfrags import CapsuleFrag
 
 from nucypher.crypto.powers import EncryptingPower
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware


### PR DESCRIPTION
Just adapts NuCypher to latest umbral release (0.1.2a1)

**Cute animal picture**: Baby Aceituno!
![image](https://user-images.githubusercontent.com/2564234/49760582-1a9c2e00-fcc5-11e8-9ba7-b0994db8a4db.png)
