### PR TITLE
Rename EncryptingKeypair/EncryptingPower to DecryptingKeypair/DecryptingPower

### DIFF
--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -44,7 +44,7 @@ from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import (
     CryptoPower,
     SigningPower,
-    EncryptingPower,
+    DecryptingPower,
     NoSigningPower,
     CryptoPowerUp,
     DelegatingPower
@@ -293,7 +293,7 @@ class Character(Learner):
         """
         signer = self.stamp if sign else DO_NOT_SIGN
 
-        message_kit, signature = encrypt_and_sign(recipient_pubkey_enc=recipient.public_keys(EncryptingPower),
+        message_kit, signature = encrypt_and_sign(recipient_pubkey_enc=recipient.public_keys(DecryptingPower),
                                                   plaintext=plaintext,
                                                   signer=signer,
                                                   sign_plaintext=sign_plaintext
@@ -377,10 +377,10 @@ class Character(Learner):
                 label: Optional[bytes] = None) -> bytes:
         if label and DelegatingPower in self._default_crypto_powerups:
             delegating_power = self._crypto_power.power_ups(DelegatingPower)
-            encrypting_power = delegating_power.get_encrypting_power_from_label(label)
+            decrypting_power = delegating_power.get_decrypting_power_from_label(label)
         else:
-            encrypting_power = self._crypto_power.power_ups(EncryptingPower)
-        return encrypting_power.decrypt(message_kit)
+            decrypting_power = self._crypto_power.power_ups(DecryptingPower)
+        return decrypting_power.decrypt(message_kit)
 
     def sign(self, message):
         return self._crypto_power.power_ups(SigningPower).sign(message)
@@ -391,7 +391,7 @@ class Character(Learner):
         class - whatever type of object that may be.
 
         If the Character doesn't have the power corresponding to that class, raises the
-        appropriate PowerUpError (ie, NoSigningPower or NoEncryptingPower).
+        appropriate PowerUpError (ie, NoSigningPower or NoDecryptingPower).
         """
         power_up = self._crypto_power.power_ups(power_up_class)
         return power_up.public_key()

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -46,7 +46,7 @@ from nucypher.characters.base import Character, Learner
 from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.constants import PUBLIC_KEY_LENGTH, PUBLIC_ADDRESS_LENGTH
-from nucypher.crypto.powers import SigningPower, EncryptingPower, DelegatingPower, BlockchainPower
+from nucypher.crypto.powers import SigningPower, DecryptingPower, DelegatingPower, BlockchainPower
 from nucypher.keystore.keypairs import HostingKeypair
 from nucypher.network.middleware import RestMiddleware
 from nucypher.network.nicknames import nickname_from_seed
@@ -57,7 +57,7 @@ from nucypher.utilities.decorators import validate_checksum_address
 
 
 class Alice(Character, PolicyAuthor):
-    _default_crypto_powerups = [SigningPower, EncryptingPower, DelegatingPower]
+    _default_crypto_powerups = [SigningPower, DecryptingPower, DelegatingPower]
 
     def __init__(self, is_me=True, federated_only=False, network_middleware=None, *args, **kwargs) -> None:
 
@@ -85,7 +85,7 @@ class Alice(Character, PolicyAuthor):
         :param n: Total number of kfrags to generate
         """
 
-        bob_pubkey_enc = bob.public_keys(EncryptingPower)
+        bob_pubkey_enc = bob.public_keys(DecryptingPower)
         delegating_power = self._crypto_power.power_ups(DelegatingPower)
         return delegating_power.generate_kfrags(bob_pubkey_enc, self.stamp, label, m, n)
 
@@ -198,7 +198,7 @@ class Alice(Character, PolicyAuthor):
 
 
 class Bob(Character):
-    _default_crypto_powerups = [SigningPower, EncryptingPower]
+    _default_crypto_powerups = [SigningPower, DecryptingPower]
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -395,7 +395,7 @@ class Bob(Character):
 
         message_kit.capsule.set_correctness_keys(
             delegating=data_source.policy_pubkey,
-            receiving=self.public_keys(EncryptingPower),
+            receiving=self.public_keys(DecryptingPower),
             verifying=alice_verifying_key)
 
         hrac, map_id = self.construct_hrac_and_map_id(alice_verifying_key, data_source.label)
@@ -430,7 +430,7 @@ class Ursula(Teacher, Character, Miner):
 
     # TODO: Maybe this wants to be a registry, so that, for example,
     # TLSHostingPower still can enjoy default status, but on a different class
-    _default_crypto_powerups = [SigningPower, EncryptingPower]
+    _default_crypto_powerups = [SigningPower, DecryptingPower]
 
     class NotEnoughUrsulas(Learner.NotEnoughTeachers, MinerAgent.NotEnoughMiners):
         """
@@ -628,7 +628,7 @@ class Ursula(Teacher, Character, Miner):
                                  bytes(self._interface_signature),
                                  bytes(identity_evidence),
                                  bytes(self.public_keys(SigningPower)),
-                                 bytes(self.public_keys(EncryptingPower)),
+                                 bytes(self.public_keys(DecryptingPower)),
                                  bytes(cert_vbytes),
                                  bytes(interface_info))
                                 )
@@ -804,7 +804,7 @@ class Ursula(Teacher, Character, Miner):
 
         powers_and_material = {
             SigningPower: node_info.pop("verifying_key"),
-            EncryptingPower: node_info.pop("encrypting_key")
+            DecryptingPower: node_info.pop("encrypting_key")
         }
 
         interface_info = node_info.pop("rest_interface")

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -43,7 +43,7 @@ from umbral.keys import UmbralPrivateKey, UmbralPublicKey, UmbralKeyingMaterial
 
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.api import generate_self_signed_certificate
-from nucypher.crypto.powers import SigningPower, EncryptingPower, KeyPairBasedPower, DerivedKeyBasedPower
+from nucypher.crypto.powers import SigningPower, DecryptingPower, KeyPairBasedPower, DerivedKeyBasedPower
 from nucypher.network.server import TLSHostingPower
 
 FILE_ENCODING = 'utf-8'
@@ -526,8 +526,8 @@ class NucypherKeyring:
     @unlock_required
     def derive_crypto_power(self, power_class: ClassVar) -> Union[KeyPairBasedPower, DerivedKeyBasedPower]:
         """
-        Takes either a SigningPower or an EncryptingPower and returns
-        either a SigningPower or EncryptingPower with the coinciding
+        Takes either a SigningPower or an DecryptingPower and returns
+        either a SigningPower or DecryptingPower with the coinciding
         private key.
 
         TODO: Derive a key from the root_key.
@@ -536,7 +536,7 @@ class NucypherKeyring:
         if issubclass(power_class, KeyPairBasedPower):
 
             codex = {SigningPower: self.__signing_keypath,
-                     EncryptingPower: self.__root_keypath,
+                     DecryptingPower: self.__root_keypath,
                      TLSHostingPower: self.__tls_keypath,    # TODO
                      # BlockchainPower: self.__wallet_path,    # TODO
                     }

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -23,7 +23,7 @@ from umbral import pre
 from umbral.keys import UmbralPublicKey, UmbralPrivateKey, UmbralKeyingMaterial
 
 from nucypher.keystore import keypairs
-from nucypher.keystore.keypairs import SigningKeypair, EncryptingKeypair
+from nucypher.keystore.keypairs import SigningKeypair, DecryptingKeypair
 
 
 class PowerUpError(TypeError):
@@ -34,7 +34,7 @@ class NoSigningPower(PowerUpError):
     pass
 
 
-class NoEncryptingPower(PowerUpError):
+class NoDecryptingPower(PowerUpError):
     pass
 
 
@@ -196,9 +196,9 @@ class SigningPower(KeyPairBasedPower):
     provides = ("sign", "get_signature_stamp")
 
 
-class EncryptingPower(KeyPairBasedPower):
-    _keypair_class = EncryptingKeypair
-    not_found_error = NoEncryptingPower
+class DecryptingPower(KeyPairBasedPower):
+    _keypair_class = DecryptingKeypair
+    not_found_error = NoDecryptingPower
     provides = ("decrypt",)
 
 
@@ -249,8 +249,8 @@ class DelegatingPower(DerivedKeyBasedPower):
                                      )
         return __private_key.get_pubkey(), kfrags
 
-    def get_encrypting_power_from_label(self, label):
+    def get_decrypting_power_from_label(self, label):
         label_privkey = self._get_privkey_from_label(label)
-        label_keypair = keypairs.EncryptingKeypair(private_key=label_privkey)
-        encrypting_power = EncryptingPower(keypair=label_keypair)
-        return encrypting_power
+        label_keypair = keypairs.DecryptingKeypair(private_key=label_privkey)
+        decrypting_power = DecryptingPower(keypair=label_keypair)
+        return decrypting_power

--- a/nucypher/keystore/keypairs.py
+++ b/nucypher/keystore/keypairs.py
@@ -85,7 +85,7 @@ class Keypair(object):
         return sha3.keccak_256(bytes(self.pubkey)).hexdigest().encode()
 
 
-class EncryptingKeypair(Keypair):
+class DecryptingKeypair(Keypair):
     """
     A keypair for Umbral
     """

--- a/nucypher/keystore/keystore.py
+++ b/nucypher/keystore/keystore.py
@@ -68,7 +68,7 @@ class KeyStore(object):
 
         return new_key
 
-    def get_key(self, fingerprint: bytes, session=None) -> Union[keypairs.EncryptingKeypair, keypairs.SigningKeypair]:
+    def get_key(self, fingerprint: bytes, session=None) -> Union[keypairs.DecryptingKeypair, keypairs.SigningKeypair]:
         """
         Returns a key from the KeyStore.
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -42,7 +42,7 @@ from constant_sorrow.constants import GLOBAL_DOMAIN
 from nucypher.config.constants import SeednodeMetadata
 from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
-from nucypher.crypto.powers import BlockchainPower, SigningPower, EncryptingPower, NoSigningPower
+from nucypher.crypto.powers import BlockchainPower, SigningPower, DecryptingPower, NoSigningPower
 from nucypher.crypto.signing import signature_splitter
 from nucypher.network import LEARNING_LOOP_VERSION
 from nucypher.network.middleware import RestMiddleware
@@ -889,7 +889,7 @@ class Teacher:
         # TODO check timestamp here.  589
 
         verifying_keys_match = node_details['verifying_key'] == self.public_keys(SigningPower)
-        encrypting_keys_match = node_details['encrypting_key'] == self.public_keys(EncryptingPower)
+        encrypting_keys_match = node_details['encrypting_key'] == self.public_keys(DecryptingPower)
         addresses_match = node_details['public_address'] == self.canonical_public_address
         evidence_matches = node_details['identity_evidence'] == self._evidence_of_decentralized_identity
 

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -34,7 +34,7 @@ from nucypher.characters.lawful import Bob, Ursula, Character
 from nucypher.crypto.api import keccak_digest, encrypt_and_sign, secure_random
 from nucypher.crypto.constants import PUBLIC_ADDRESS_LENGTH, KECCAK_DIGEST_LENGTH
 from nucypher.crypto.kits import UmbralMessageKit, RevocationKit
-from nucypher.crypto.powers import SigningPower, EncryptingPower
+from nucypher.crypto.powers import SigningPower, DecryptingPower
 from nucypher.crypto.signing import Signature, InvalidSignature
 from nucypher.crypto.splitters import key_splitter
 from nucypher.network.middleware import RestMiddleware
@@ -178,7 +178,7 @@ class Policy:
         return keccak_digest(bytes(self.alice.stamp) + bytes(self.bob.stamp) + self.label)
 
     def publish_treasure_map(self, network_middleware: RestMiddleware) -> dict:
-        self.treasure_map.prepare_for_publication(self.bob.public_keys(EncryptingPower),
+        self.treasure_map.prepare_for_publication(self.bob.public_keys(DecryptingPower),
                                                   self.bob.public_keys(SigningPower),
                                                   self.alice.stamp,
                                                   self.label

--- a/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
@@ -22,7 +22,7 @@ from eth_utils import is_checksum_address
 
 from nucypher.blockchain.eth.constants import MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS
 
-TestPolicyMetadata = collections.namedtuple('TestPolicyMetadata', 'policy_id author addresses')
+MockPolicyMetadata = collections.namedtuple('MockPolicyMetadata', 'policy_id author addresses')
 
 
 @pytest.fixture(scope='function')
@@ -41,7 +41,7 @@ def policy_meta(testerchain, three_agents):
                                   initial_reward=20,
                                   node_addresses=node_addresses)
 
-    return TestPolicyMetadata(_policy_id, someone, node_addresses)
+    return MockPolicyMetadata(_policy_id, someone, node_addresses)
 
 
 @pytest.mark.slow()

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -27,7 +27,7 @@ from umbral.kfrags import KFrag
 from nucypher.characters.lawful import Bob
 from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.api import keccak_digest
-from nucypher.crypto.powers import SigningPower, EncryptingPower
+from nucypher.crypto.powers import SigningPower, DecryptingPower
 from nucypher.policy.models import Revocation
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
@@ -157,7 +157,7 @@ def test_alices_powers_are_persistent(federated_ursulas, tmpdir):
 
     # Let's save Alice's public keys too to check they are correctly restored later
     alices_verifying_key = alice.public_keys(SigningPower)
-    alices_receiving_key = alice.public_keys(EncryptingPower)
+    alices_receiving_key = alice.public_keys(DecryptingPower)
 
     # Next, let's fix a label for all the policies we will create later.
     label = b"this_is_the_path_to_which_access_is_being_granted"
@@ -204,7 +204,7 @@ def test_alices_powers_are_persistent(federated_ursulas, tmpdir):
 
     # First, we check that her public keys are correctly restored
     assert alices_verifying_key == new_alice.public_keys(SigningPower)
-    assert alices_receiving_key == new_alice.public_keys(EncryptingPower)
+    assert alices_receiving_key == new_alice.public_keys(DecryptingPower)
 
     # Bob's eldest brother, Roberto, appears too
     roberto = Bob(federated_only=True,

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -25,7 +25,7 @@ from umbral import pre
 from umbral.kfrags import KFrag
 from umbral.cfrags import CapsuleFrag
 
-from nucypher.crypto.powers import EncryptingPower
+from nucypher.crypto.powers import DecryptingPower 
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
@@ -177,7 +177,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     # Attach the CFrag to the Capsule.
     capsule = capsule_side_channel[0].capsule
     capsule.set_correctness_keys(delegating=enacted_federated_policy.public_key,
-                                 receiving=federated_bob.public_keys(EncryptingPower),
+                                 receiving=federated_bob.public_keys(DecryptingPower),
                                  verifying=federated_alice.stamp.as_umbral_pubkey())
     capsule.attach_cfrag(the_cfrag)
 

--- a/tests/config/test_keyring.py
+++ b/tests/config/test_keyring.py
@@ -4,7 +4,7 @@ from umbral.keys import UmbralPrivateKey
 from umbral.signing import Signer
 
 from nucypher.config.keyring import NucypherKeyring
-from nucypher.crypto.powers import DelegatingPower, EncryptingPower
+from nucypher.crypto.powers import DelegatingPower, DecryptingPower
 
 
 @pytest.mark.skip("Redacted and refactored for sensitive info leakage")
@@ -34,12 +34,12 @@ def test_generate_alice_keyring(tmpdir):
     assert enc_pubkey is not None
 
     with pytest.raises(NucypherKeyring.KeyringLocked):
-        _enc_keypair = keyring.derive_crypto_power(EncryptingPower).keypair
+        _dec_keypair = keyring.derive_crypto_power(DecryptingPower).keypair
 
     keyring.unlock(password)
-    enc_keypair = keyring.derive_crypto_power(EncryptingPower).keypair
+    dec_keypair = keyring.derive_crypto_power(DecryptingPower).keypair
 
-    assert enc_pubkey == enc_keypair.pubkey
+    assert enc_pubkey == dec_keypair.pubkey
 
     label = b'test'
 

--- a/tests/keystore/test_keypairs.py
+++ b/tests/keystore/test_keypairs.py
@@ -23,10 +23,10 @@ from nucypher.keystore import keypairs
 
 
 def test_gen_keypair_if_needed():
-    new_enc_keypair = keypairs.EncryptingKeypair()
-    assert new_enc_keypair._privkey is not None
-    assert new_enc_keypair.pubkey is not None
-    assert new_enc_keypair.pubkey == new_enc_keypair._privkey.get_pubkey()
+    new_dec_keypair = keypairs.DecryptingKeypair()
+    assert new_dec_keypair._privkey is not None
+    assert new_dec_keypair.pubkey is not None
+    assert new_dec_keypair.pubkey == new_dec_keypair._privkey.get_pubkey()
 
     new_sig_keypair = keypairs.SigningKeypair()
     assert new_sig_keypair._privkey is not None
@@ -81,4 +81,4 @@ def test_signing():
     assert not signature.verify(bad_msg, sig_keypair.pubkey)
 
 
-# TODO: Add test for EncryptingKeypair.decrypt
+# TODO: Add test for DecryptingKeypair.decrypt

--- a/tests/keystore/test_keystore.py
+++ b/tests/keystore/test_keystore.py
@@ -38,7 +38,7 @@ def test_key_sqlite_keystore(test_keystore, federated_bob):
 
 def test_policy_arrangement_sqlite_keystore(test_keystore):
     alice_keypair_sig = keypairs.SigningKeypair(generate_keys_if_needed=True)
-    alice_keypair_enc = keypairs.EncryptingKeypair(generate_keys_if_needed=True)
+    alice_keypair_dec = keypairs.DecryptingKeypair(generate_keys_if_needed=True)
     bob_keypair_sig = keypairs.SigningKeypair(generate_keys_if_needed=True)
 
     arrangement_id = b'test'


### PR DESCRIPTION
### What this does:
1. Renames `EncryptingKeypair` and `EncryptingPower` to `DecryptingKeypair` and `DecryptingPower` respectively. Resolves #597 
2. Renames `TestPolicyMetadata` to `MockPolicyData` as per pytest warnings.