### PR TITLE
High-level TesterBlockchain network bootstrap method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,4 @@ variables*.yml
 *ansible/*.retry
 *ansible/inventory/*
 .env
-examples/heartbeat_demo/*.json
-examples/heartbeat_demo/*.msgpack
-examples/heartbeat_demo/doctor-files/
-examples/heartbeat_demo/alicia-files/
+/tests/metrics/results/

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ chains
 .ethash
 nucypher_cli/examples/examples-runtime-cruft/*
 nucypher_cli/examples/finnegans-wake.txt
+examples/heartbeat_demo/*.json
+examples/heartbeat_demo/*.msgpack
+examples/heartbeat_demo/doctor-files/
+examples/heartbeat_demo/alicia-files/
 mypy_reports/
 reports/
 test-*

--- a/nucypher/blockchain/eth/chains.py
+++ b/nucypher/blockchain/eth/chains.py
@@ -14,6 +14,8 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 from twisted.logger import Logger
 from web3.middleware import geth_poa_middleware
 

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -129,13 +129,13 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     # Setup
     #
 
-    if AnalyzeGas is None:
+    if analyzer is None:
         analyzer = AnalyzeGas()
 
     log = Logger(AnalyzeGas.LOG_NAME)
 
     # Blockchain
-    testerchain, accounts = TesterBlockchain.bootstrap_network()
+    testerchain, agents = TesterBlockchain.bootstrap_network()
     web3 = testerchain.interface.w3
 
     # Accounts

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -115,43 +115,6 @@ class AnalyzeGas:
         globalLogPublisher.addObserver(json_observer)
         globalLogPublisher.addObserver(self)
 
-    def connect_to_blockchain(self) -> TesterBlockchain:
-        print("Deploying Blockchain...")
-
-        solidity_compiler = SolidityCompiler(test_contract_dir=self.CONTRACT_DIR)
-        memory_registry = InMemoryEthereumContractRegistry()
-        interface = BlockchainDeployerInterface(provider_uri=self.PROVIDER_URI, compiler=solidity_compiler,
-                                                registry=memory_registry)
-
-        testerchain = TesterBlockchain(interface=interface, test_accounts=self.TEST_ACCOUNTS, airdrop=False)
-        return testerchain
-
-    @staticmethod
-    def deploy_contracts(testerchain: TesterBlockchain) -> None:
-        print("Deploying Contracts...")
-
-        origin = testerchain.interface.w3.eth.accounts[0]
-        deployer = Deployer(blockchain=testerchain, deployer_address=origin, bare=True)
-        _txhashes, _agents = deployer.deploy_network_contracts(miner_secret=os.urandom(DISPATCHER_SECRET_LENGTH),
-                                                               policy_secret=os.urandom(DISPATCHER_SECRET_LENGTH))
-
-    @staticmethod
-    def connect_to_contracts(testerchain: TesterBlockchain) -> Tuple[NucypherTokenAgent, MinerAgent, PolicyAgent]:
-        print("Connecting...")
-
-        token_agent = NucypherTokenAgent(blockchain=testerchain)
-        miner_agent = MinerAgent(blockchain=testerchain)
-        policy_agent = PolicyAgent(blockchain=testerchain)
-
-        return token_agent, miner_agent, policy_agent
-
-    def bootstrap_network(self) -> Tuple[TesterBlockchain, List[str]]:
-        print("Bootstrapping testing network...")
-
-        testerchain = self.connect_to_blockchain()
-        self.deploy_contracts(testerchain=testerchain)
-        return testerchain, testerchain.interface.w3.eth.accounts
-
 
 def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     """
@@ -165,24 +128,28 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     #
     # Setup
     #
+
     if AnalyzeGas is None:
         analyzer = AnalyzeGas()
 
-    # Logger
     log = Logger(AnalyzeGas.LOG_NAME)
 
     # Blockchain
-    testerchain, accounts = analyzer.bootstrap_network()
+    testerchain, accounts = TesterBlockchain.bootstrap_network()
     web3 = testerchain.interface.w3
-
-    # Contracts
-    token_agent, miner_agent, policy_agent = analyzer.connect_to_contracts(testerchain=testerchain)
-    token_functions = token_agent.contract.functions
-    miner_functions = miner_agent.contract.functions
-    policy_functions = policy_agent.contract.functions
 
     # Accounts
     origin, ursula1, ursula2, ursula3, alice1, *everyone_else = testerchain.interface.w3.eth.accounts
+
+    # Contracts
+    token_agent = NucypherTokenAgent(blockchain=testerchain)
+    miner_agent = MinerAgent(blockchain=testerchain)
+    policy_agent = PolicyAgent(blockchain=testerchain)
+
+    # Contract Callers
+    token_functions = token_agent.contract.functions
+    miner_functions = miner_agent.contract.functions
+    policy_functions = policy_agent.contract.functions
 
     analyzer.start_collection()
     print("********* Estimating Gas *********")


### PR DESCRIPTION
We have a growing need to run test or scripts within the context of an already deployed nucypher network.

##### Proposed Solution

Overrides `TesterBlockchain.connect`; Disregarding arguments, and redirecting to the default PyEVM configuration with an `InMemoryContractRegistry` and deployer options set on `BlockchainDeployerInterface`.

##### Usage
```
testerchain, accounts = TesterBlockchain.bootstrap_network()
```

Once the nucypher network is deployed, you can use the `Agents` API as usual:
```
token_agent = NucypherTokenAgent(blockchain=testerchain)
miner_agent = MinerAgent(blockchain=testerchain)
policy_agent = PolicyAgent(blockchain=testerchain)
```

Included in automated testing in `estimate_gas.py`