### PR TITLE
CLI bug fixes and enhancements

### DIFF
--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -26,6 +26,7 @@ from twisted.logger import globalLogPublisher
 
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION, NO_PASSWORD
 from nucypher.blockchain.eth.constants import MIN_LOCKED_PERIODS, MAX_MINTING_PERIODS
+from nucypher.blockchain.eth.registry import EthereumContractRegistry
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.painting import BANNER, paint_configuration, paint_known_nodes, paint_contract_status
 from nucypher.cli.protocol import UrsulaCommandProtocol
@@ -289,8 +290,11 @@ def ursula(click_config,
             raise ursula_config.keyring.AuthenticationFailed
 
     if not ursula_config.federated_only:
-        ursula_config.connect_to_blockchain(recompile_contracts=False)
-        ursula_config.connect_to_contracts()
+        try:
+            ursula_config.connect_to_blockchain(recompile_contracts=False)
+            ursula_config.connect_to_contracts()
+        except EthereumContractRegistry.NoRegistry:
+            raise EthereumContractRegistry.NoRegistry("No contract registry found.  Did you mean to pass --federated-only?")
 
     click_config.ursula_config = ursula_config  # Pass Ursula's config onto staking sub-command
 

--- a/nucypher/cli/protocol.py
+++ b/nucypher/cli/protocol.py
@@ -22,6 +22,7 @@ from collections import deque
 import click
 import maya
 from twisted.internet import reactor
+from twisted.internet.protocol import connectionDone
 from twisted.protocols.basic import LineReceiver
 
 from nucypher.cli.painting import build_fleet_state_status
@@ -33,6 +34,8 @@ class UrsulaCommandProtocol(LineReceiver):
     delimiter = os.linesep.encode(encoding=encoding)
 
     def __init__(self, ursula):
+        super().__init__()
+
         self.ursula = ursula
         self.start_time = maya.now()
 
@@ -56,8 +59,6 @@ class UrsulaCommandProtocol(LineReceiver):
             'stop': reactor.stop,
 
         }
-
-        super().__init__()
 
     @property
     def commands(self):
@@ -86,6 +87,9 @@ class UrsulaCommandProtocol(LineReceiver):
 
         click.secho("\nType 'help' or '?' for help")
         self.transport.write(self.prompt)
+
+    def connectionLost(self, reason=connectionDone) -> None:
+        self.ursula.stop_learning_loop(reason=reason)
 
     def lineReceived(self, line):
         """Ursula Console REPL"""

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -396,7 +396,9 @@ class NodeConfiguration(ABC):
 
         for field, path in filepaths.items():
             if not os.path.exists(path):
-                message = 'Missing configuration directory {}.'
+                message = 'Missing configuration file or directory: {}.'
+                if 'registry' in path:
+                    message += ' Did you mean to pass --federated-only?'                    
                 raise NodeConfiguration.InvalidConfiguration(message.format(path))
         return True
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -21,18 +21,11 @@ import json
 import os
 import secrets
 import string
-from abc import ABC, abstractmethod
+from abc import ABC
 from json import JSONDecodeError
 from tempfile import TemporaryDirectory
 
 import shutil
-from cryptography.hazmat.primitives.asymmetric import ec
-from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
-from cryptography.x509 import Certificate
-from twisted.logger import Logger
-from typing import List
-from web3.middleware import geth_poa_middleware
-
 from constant_sorrow.constants import (
     UNINITIALIZED_CONFIGURATION,
     STRANGER_CONFIGURATION,
@@ -40,6 +33,13 @@ from constant_sorrow.constants import (
     LIVE_CONFIGURATION,
     NO_KEYRING_ATTACHED
 )
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
+from cryptography.x509 import Certificate
+from twisted.logger import Logger
+from typing import List
+from umbral.signing import Signature
+
 from nucypher.blockchain.eth.agents import PolicyAgent, MinerAgent, NucypherTokenAgent
 from nucypher.blockchain.eth.chains import Blockchain
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, BASE_DIR, USER_LOG_DIR
@@ -48,7 +48,6 @@ from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage, LocalFil
 from nucypher.crypto.powers import CryptoPowerUp, CryptoPower
 from nucypher.network.middleware import RestMiddleware
 from nucypher.network.nodes import FleetStateTracker
-from umbral.signing import Signature
 
 
 class NodeConfiguration(ABC):
@@ -82,6 +81,7 @@ class NodeConfiguration(ABC):
     # Rest + TLS
     DEFAULT_REST_HOST = '127.0.0.1'
     DEFAULT_REST_PORT = 9151
+    DEFAULT_DEVELOPMENT_REST_PORT = 10151
     __DEFAULT_TLS_CURVE = ec.SECP384R1
     __DEFAULT_NETWORK_MIDDLEWARE_CLASS = RestMiddleware
 
@@ -151,7 +151,8 @@ class NodeConfiguration(ABC):
         # REST + TLS (Ursula)
         #
         self.rest_host = rest_host or self.DEFAULT_REST_HOST
-        self.rest_port = rest_port or self.DEFAULT_REST_PORT
+        default_port = (self.DEFAULT_DEVELOPMENT_REST_PORT if dev_mode else self.DEFAULT_REST_PORT)
+        self.rest_port = rest_port or default_port
         self.tls_curve = tls_curve or self.__DEFAULT_TLS_CURVE
         self.certificate = certificate
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -497,14 +497,14 @@ class NodeConfiguration(ABC):
         else:
             try:
                 os.mkdir(self.config_root, mode=0o755)
+
             except FileExistsError:
-                # Check for existing files
                 if os.listdir(self.config_root):
                     message = "There are existing files located at {}".format(self.config_root)
                     raise self.ConfigurationError(message)
+
             except FileNotFoundError:
-                message = "Cannot write configuration files because the directory {} does not exist.".format(self.config_root)
-                raise self.ConfigurationError(message)
+                os.makedirs(self.config_root, mode=0o755)
 
         #
         # Create Config Subdirectories

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -414,10 +414,11 @@ class Learner:
             self.learning_deferred = defer.DeferredList([seeder_deferred, learner_deferred])
             return self.learning_deferred
 
-    def stop_learning_loop(self):
+    def stop_learning_loop(self, reason=None):
         """
         Only for tests at this point.  Maybe some day for graceful shutdowns.
         """
+        self._learning_task.stop()
 
     def handle_learning_errors(self, *args, **kwargs):
         failure = args[0]

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -18,6 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import contextlib
 import os
+import time
 
 import socket
 
@@ -69,4 +70,4 @@ MOCK_IP_ADDRESS_2 = '10.10.10.10'
 
 MOCK_URSULA_DB_FILEPATH = ':memory:'
 
-MOCK_CUSTOM_INSTALLATION_PATH = '/tmp/nucypher-tmp-test-custom'
+MOCK_CUSTOM_INSTALLATION_PATH = '/tmp/nucypher-tmp-test-custom-{}'.format(time.time())

--- a/tests/cli/commands/test_run_ursula.py
+++ b/tests/cli/commands/test_run_ursula.py
@@ -21,6 +21,7 @@ from twisted.internet import threads
 
 from nucypher.characters.base import Learner
 from nucypher.cli.main import nucypher_cli
+from nucypher.config.node import NodeConfiguration
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, MOCK_URSULA_STARTING_PORT
 
 
@@ -43,3 +44,6 @@ def test_run_lone_federated_default_development_ursula(click_runner):
     assert result.exit_code == 0
     assert ":memory:" in result.output
     assert "Running Ursula on 127.0.0.1:{}".format(MOCK_URSULA_STARTING_PORT)
+
+    reserved_ports = (NodeConfiguration.DEFAULT_REST_PORT, NodeConfiguration.DEFAULT_DEVELOPMENT_REST_PORT)
+    assert MOCK_URSULA_STARTING_PORT not in reserved_ports

--- a/tests/cli/commands/test_run_ursula.py
+++ b/tests/cli/commands/test_run_ursula.py
@@ -15,32 +15,31 @@ You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import pytest
 import pytest_twisted as pt
 import time
 from twisted.internet import threads
-from twisted.internet.error import CannotListenError
 
 from nucypher.characters.base import Learner
 from nucypher.cli.main import nucypher_cli
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, MOCK_URSULA_STARTING_PORT
 
 
-@pytest.mark.skip('Results in exception "ReactorAlreadyRunning"')
 @pt.inlineCallbacks
 def test_run_lone_federated_default_development_ursula(click_runner):
-    args = ('ursula', 'run', '--rest-port', MOCK_URSULA_STARTING_PORT, '--dev')
+    args = ('ursula', 'run',
+            '--federated-only',                         # Operating Mode
+            '--rest-port', MOCK_URSULA_STARTING_PORT,   # Network Port
+            '--dev',                                    # Run in development mode (ephemeral node)
+            '--debug',                                  # Display log output; Do not attach console
+            '--dry-run'                                 # Disable twisted reactor
+            )
 
     result = yield threads.deferToThread(click_runner.invoke,
                                          nucypher_cli, args,
                                          catch_exceptions=False,
                                          input=INSECURE_DEVELOPMENT_PASSWORD + '\n')
 
-    alone = "WARNING - Can't learn right now: Need some nodes to start learning from."
     time.sleep(Learner._SHORT_LEARNING_DELAY)
-    assert alone in result.output
     assert result.exit_code == 0
-
-    # Cannot start another Ursula on the same REST port
-    with pytest.raises(CannotListenError):
-        _result = click_runner.invoke(nucypher_cli, args, catch_exceptions=False, input=INSECURE_DEVELOPMENT_PASSWORD)
+    assert ":memory:" in result.output
+    assert "Running Ursula on 127.0.0.1:{}".format(MOCK_URSULA_STARTING_PORT)

--- a/tests/config/test_ursula_config.py
+++ b/tests/config/test_ursula_config.py
@@ -23,6 +23,8 @@ def test_ursula_development_configuration(federated_only=True):
     assert ursula_one.federated_only is federated_only
 
     # A Temporary Ursula
+    port = ursula_one.rest_information()[0].port
+    assert port == UrsulaConfiguration.DEFAULT_DEVELOPMENT_REST_PORT
     assert ursula_one.datastore.engine.url.database == ":memory:"
     assert ursula_one.certificate_filepath is CERTIFICATE_NOT_SAVED
     assert UrsulaConfiguration.TEMP_CONFIGURATION_DIR_PREFIX in ursula_one.keyring_dir

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -54,23 +54,6 @@ TEST_CONTRACTS_DIR = os.path.join(BASE_DIR, 'tests', 'blockchain', 'eth', 'contr
 # Temporary
 #
 
-
-@pytest.fixture(scope="session", autouse=True)
-def cleanup():
-    yield  # we've got a lot of men and women here...
-
-    # Database teardown
-    for f in glob.glob("**/*.db"):  # TODO: Needs cleanup
-        os.remove(f)
-
-    # Temp Storage Teardown
-    for f in os.listdir(tempfile.tempdir):
-        if re.search(r'nucypher-*', f):
-            with contextlib.suppress(FileNotFoundError, TypeError):
-                shutil.rmtree(os.path.join(tempfile.tempdir, f),
-                              ignore_errors=True)
-
-
 @pytest.fixture(scope="function")
 def tempfile_path():
     fd, path = tempfile.mkstemp()


### PR DESCRIPTION
##### Fixes Issues
- #614 - Question: Do we want this condition to `raise`?
- #634 - Unskip `nucypher ursula run` CLI test (Reactor / Pytest Issue)
- #610 - Timestamp temp system filepaths
- #551 - Auto-generate configuration root directory if it does not exist.
- #578 (Half) - Disable logging via CLI (`--quiet` / `-Q`)
- #583 - Allow destruction of invalid system configurations

Also attempts to address #582 

 ##### Shorthand CLI usage:

| Option | Shorthand |
-----------|----------------|
| `--dev` | `-d` |
| `--federated-only` | `-F` |
| `--debug` | `-D` |
| `--quiet` | `-Q` |
| `--force` | - |
| `--dry-run` | `-x` |

##### Other 
- Remove `cleanup` pytest fixture