### PR TITLE
Check KFrag signature as part of on-chain ZKP verification

### DIFF
--- a/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
@@ -162,6 +162,26 @@ contract MiningAdjudicator is Upgradeable {
         }
     }
 
+
+
+    function aliceAddress(
+        bytes memory _cFragBytes,
+        bytes memory _precomputedBytes
+    )
+        public pure
+        returns (address)
+    {
+        UmbralDeserializer.CapsuleFrag memory _cFrag = _cFragBytes.toCapsuleFrag();
+        UmbralDeserializer.PreComputedData memory _precomputed = _precomputedBytes.toPreComputedData();
+
+        // Extract Alice's address and check that it corresponds to the one provided
+        address alicesAddress = SignatureVerifier.recover(
+            _precomputed.hashedKFragValidityMessage,
+            abi.encodePacked(_cFrag.proof.kFragSignature, _precomputed.kfragSignatureV)
+        );
+        return alicesAddress;
+    }
+
     /**
     * @notice Check correctness of re-encryption
     * @param _capsuleBytes Capsule
@@ -179,7 +199,13 @@ contract MiningAdjudicator is Upgradeable {
         UmbralDeserializer.CapsuleFrag memory _cFrag = _cFragBytes.toCapsuleFrag();
         UmbralDeserializer.PreComputedData memory _precomputed = _precomputedBytes.toPreComputedData();
 
-        // TODO: Check KFrag signature by Alice. Depends on using ECDSA+SHA256 in umbral and nucypher
+        // TODO: Check ECDSA signature. Getting 'Stack too deep' error.
+        // Extract Alice's address and check that it corresponds to the one provided
+//        address alicesAddress = SignatureVerifier.recover(
+//            _precomputed.hashedKFragValidityMessage,
+//            _cFrag.proof.kFragSignature
+//        );
+//        require(alicesAddress == _precomputed.alicesKeyAsAddress, "JARL!");
 
         uint256 h = computeProofChallengeScalar(_capsuleBytes, _cFragBytes);
 

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -58,6 +58,7 @@ library UmbralDeserializer {
         uint256 pointU2yCoord;
         bytes32 hashedKFragValidityMessage;
         address alicesKeyAsAddress;
+        byte kfragSignatureV;
     }
 
     uint256 constant BIGNUM_SIZE = 32;
@@ -67,7 +68,7 @@ library UmbralDeserializer {
     uint256 constant CORRECTNESS_PROOF_SIZE = 4 * POINT_SIZE + BIGNUM_SIZE + SIGNATURE_SIZE;
     uint256 constant CAPSULE_FRAG_SIZE = 3 * POINT_SIZE + BIGNUM_SIZE;
     uint256 constant FULL_CAPSULE_FRAG_SIZE = CAPSULE_FRAG_SIZE + CORRECTNESS_PROOF_SIZE;
-    uint256 constant PRECOMPUTED_DATA_SIZE = (20 * BIGNUM_SIZE) + 32 + 20;
+    uint256 constant PRECOMPUTED_DATA_SIZE = (20 * BIGNUM_SIZE) + 32 + 20 + 1;
 
     /**
     * @notice Deserialize to capsule (not activated)
@@ -211,6 +212,11 @@ library UmbralDeserializer {
 
         data.alicesKeyAsAddress = address(bytes20(getBytes32(pointer)));
         pointer += 20;
+
+        data.kfragSignatureV = getByte(pointer);
+        pointer += 1;
+
+        // TODO: add require as post-condition to check that the pointer has advanced exactly what is intended
 
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -252,9 +252,12 @@ library UmbralDeserializer {
     * @notice Read 1 byte from memory in the pointer position
     **/
     function getByte(uint256 _pointer) internal pure returns (byte result) {
+        bytes32 word;
         assembly {
-            result := byte(0, _pointer)
+            word := mload(_pointer)
         }
+        result = word[0];
+        return result;
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -145,7 +145,8 @@ library UmbralDeserializer {
         internal pure returns (PreComputedData memory data)
     {
         require(_preComputedData.length == PRECOMPUTED_DATA_SIZE);
-        uint256 pointer = getPointer(_preComputedData);
+        uint256 initial_pointer = getPointer(_preComputedData);
+        uint256 pointer = initial_pointer;
 
         data.pointEyCoord = uint256(getBytes32(pointer));
         pointer += BIGNUM_SIZE;
@@ -216,8 +217,7 @@ library UmbralDeserializer {
         data.kfragSignatureV = getByte(pointer);
         pointer += 1;
 
-        // TODO: add require as post-condition to check that the pointer has advanced exactly what is intended
-
+        require(pointer == initial_pointer + PRECOMPUTED_DATA_SIZE);
     }
 
     // TODO extract to external library if needed

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -56,6 +56,8 @@ library UmbralDeserializer {
         uint256 pointU1HxCoord;
         uint256 pointU1HyCoord;
         uint256 pointU2yCoord;
+        bytes32 hashedKFragValidityMessage;
+        address alicesKeyAsAddress;
     }
 
     uint256 constant BIGNUM_SIZE = 32;
@@ -65,7 +67,7 @@ library UmbralDeserializer {
     uint256 constant CORRECTNESS_PROOF_SIZE = 4 * POINT_SIZE + BIGNUM_SIZE + SIGNATURE_SIZE;
     uint256 constant CAPSULE_FRAG_SIZE = 3 * POINT_SIZE + BIGNUM_SIZE;
     uint256 constant FULL_CAPSULE_FRAG_SIZE = CAPSULE_FRAG_SIZE + CORRECTNESS_PROOF_SIZE;
-    uint256 constant PRECOMPUTED_DATA_SIZE = 20 * BIGNUM_SIZE;
+    uint256 constant PRECOMPUTED_DATA_SIZE = (20 * BIGNUM_SIZE) + 32 + 20;
 
     /**
     * @notice Deserialize to capsule (not activated)
@@ -202,6 +204,14 @@ library UmbralDeserializer {
         pointer += BIGNUM_SIZE;
 
         data.pointU2yCoord = uint256(getBytes32(pointer));
+        pointer += BIGNUM_SIZE;
+
+        data.hashedKFragValidityMessage = getBytes32(pointer);
+        pointer += 32;
+
+        data.alicesKeyAsAddress = address(bytes20(getBytes32(pointer)));
+        pointer += 20;
+
     }
 
     // TODO extract to external library if needed

--- a/nucypher/crypto/utils.py
+++ b/nucypher/crypto/utils.py
@@ -15,6 +15,8 @@ You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 from typing import Any
+from eth_keys import KeyAPI as EthKeyAPI
+from umbral.keys import UmbralPublicKey
 
 from nucypher.crypto.api import keccak_digest
 
@@ -25,3 +27,10 @@ def fingerprint_from_key(public_key: Any):
     :return: Hexdigest fingerprint of key (keccak-256) in bytes
     """
     return keccak_digest(bytes(public_key)).hex().encode()
+
+
+def canonical_address_from_umbral_key(public_key: UmbralPublicKey) -> bytes:
+    pubkey_raw_bytes = public_key.to_bytes(is_compressed=False)[1:]
+    eth_pubkey = EthKeyAPI.PublicKey(pubkey_raw_bytes)
+    canonical_address = eth_pubkey.to_canonical_address()
+    return canonical_address

--- a/nucypher/crypto/utils.py
+++ b/nucypher/crypto/utils.py
@@ -14,9 +14,12 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-from typing import Any
+
+from coincurve import PublicKey
 from eth_keys import KeyAPI as EthKeyAPI
+from typing import Any
 from umbral.keys import UmbralPublicKey
+from umbral.signing import Signature
 
 from nucypher.crypto.api import keccak_digest
 
@@ -34,3 +37,41 @@ def canonical_address_from_umbral_key(public_key: UmbralPublicKey) -> bytes:
     eth_pubkey = EthKeyAPI.PublicKey(pubkey_raw_bytes)
     canonical_address = eth_pubkey.to_canonical_address()
     return canonical_address
+
+
+def recover_pubkey_from_signature(prehashed_message, signature, v_value_to_try=None) -> bytes:
+    """
+    Recovers a serialized, compressed public key from a signature.
+    It allows to specify a potential v value, in which case it assumes the signature
+    has the traditional (r,s) raw format. If a v value is not present, it assumes
+    the signature has the recoverable format (r, s, v).
+
+    :param prehashed_message: Prehashed message
+    :param signature: The signature from which the pubkey is recovered
+    :param v_value_to_try: A potential v value to try
+    :return: The compressed byte-serialized representation of the recovered public key
+    """
+
+    signature = bytes(signature)
+    ecdsa_signature_size = Signature.expected_bytes_length()
+
+    if not v_value_to_try:
+        expected_signature_size = ecdsa_signature_size + 1
+        if not len(signature) == expected_signature_size:
+            raise ValueError(f"When not passing a v value, "
+                             f"the signature size should be {expected_signature_size} B.")
+    elif v_value_to_try in (0, 1, 27, 28):
+        expected_signature_size = ecdsa_signature_size
+        if not len(signature) == expected_signature_size:
+            raise ValueError(f"When passing a v value, "
+                             f"the signature size should be {expected_signature_size} B.")
+        if v_value_to_try >= 27:
+            v_value_to_try -= 27
+        signature = signature + v_value_to_try.to_bytes(1, 'big')
+    else:
+        raise ValueError("Wrong v value. It should be 0, 1, 27 or 28.")
+
+    pubkey = PublicKey.from_signature_and_message(serialized_sig=signature,
+                                                  message=prehashed_message,
+                                                  hasher=None)
+    return pubkey.format(compressed=True)

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -594,7 +594,7 @@ class WorkOrder:
             (self.receipt_bytes,
              msgpack.dumps(capsules_as_bytes),
              msgpack.dumps(capsule_signatures_as_bytes),
-             self.alice_address,
+             self.alice_address,  # TODO: if Ursula computes ETH address, we can remove this
              self.alice_address_signature,
              )
         )
@@ -603,13 +603,27 @@ class WorkOrder:
     def complete(self, cfrags_and_signatures):
         good_cfrags = []
         if not len(self) == len(cfrags_and_signatures):
-            raise ValueError("Ursula gave back the wrong number of cfrags.  She's up to something.")
+            raise ValueError("Ursula gave back the wrong number of cfrags.  "
+                             "She's up to something.")
+
+        alice_address_signature = bytes(self.alice_address_signature)
+        ursula_verifying_key = self.ursula.stamp.as_umbral_pubkey()
+
         for counter, capsule in enumerate(self.capsules):
             cfrag, signature = cfrags_and_signatures[counter]
-            if signature.verify(bytes(cfrag) + bytes(capsule), self.ursula.stamp.as_umbral_pubkey()):
+
+            # Validate CFrag metadata
+            capsule_signature = bytes(self.capsule_signatures[counter])
+            metadata_input = capsule_signature + alice_address_signature
+            metadata_as_signature = Signature.from_bytes(cfrag.proof.metadata)
+            if not metadata_as_signature.verify(metadata_input, ursula_verifying_key):
+                raise InvalidSignature("Invalid metadata for {}.".format(cfrag))
+
+            # Validate work order response signatures
+            if signature.verify(bytes(cfrag) + bytes(capsule), ursula_verifying_key):
                 good_cfrags.append(cfrag)
             else:
-                raise self.ursula.InvalidSignature("This CFrag is not properly signed by Ursula.")
+                raise InvalidSignature("{} is not properly signed by Ursula.".format(cfrag))
         else:
             self.completed = maya.now()
             return good_cfrags

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -25,7 +25,7 @@ from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import UNKNOWN_KFRAG, NO_DECRYPTION_PERFORMED, NOT_SIGNED
 from eth_utils import to_canonical_address, to_checksum_address
 from typing import Generator, List, Set, Optional
-from eth_keys import KeyAPI as EthKeyAPI
+
 from umbral.config import default_params
 from umbral.kfrags import KFrag
 from umbral.cfrags import CapsuleFrag
@@ -543,9 +543,7 @@ class WorkOrder:
             capsules_bytes.append(capsule_bytes)
             capsule_signatures.append(bob.stamp(capsule_bytes))
 
-        pubkey_raw_bytes = alice_verifying_key.to_bytes(is_compressed=False)[1:]
-        verifying_key_as_eth_key = EthKeyAPI.PublicKey(pubkey_raw_bytes)
-        alice_address = verifying_key_as_eth_key.to_canonical_address()
+        alice_address = canonical_address_from_umbral_key(alice_verifying_key)
         alice_address_signature = bytes(bob.stamp(alice_address))
 
         receipt_bytes = b"wo:" + ursula.canonical_public_address

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -500,13 +500,13 @@ class WorkOrder:
             super().__init__("This doesn't appear to be from Bob.")
 
     def __init__(self,
-                 bob,
+                 bob: Bob,
                  arrangement_id,
-                 capsules,
-                 capsule_signatures,
-                 alice_address,
-                 alice_address_signature,
-                 receipt_bytes,
+                 capsules: List[Capsule],
+                 capsule_signatures: List[Signature],
+                 alice_address: bytes,
+                 alice_address_signature: bytes,
+                 receipt_bytes: bytes,
                  receipt_signature,
                  ursula=None,
                  ) -> None:
@@ -596,7 +596,7 @@ class WorkOrder:
             (self.receipt_bytes,
              msgpack.dumps(capsules_as_bytes),
              msgpack.dumps(capsule_signatures_as_bytes),
-             self.alice_address,  # TODO: if Ursula computes ETH address, we can remove this
+             self.alice_address,
              self.alice_address_signature,
              )
         )

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -23,6 +23,8 @@ import msgpack
 import uuid
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import UNKNOWN_KFRAG, NO_DECRYPTION_PERFORMED, NOT_SIGNED
+from cryptography.hazmat.backends.openssl import backend
+from cryptography.hazmat.primitives import hashes
 from eth_utils import to_canonical_address, to_checksum_address
 from typing import Generator, List, Set, Optional
 
@@ -41,6 +43,7 @@ from nucypher.crypto.kits import UmbralMessageKit, RevocationKit
 from nucypher.crypto.powers import SigningPower, DecryptingPower
 from nucypher.crypto.signing import Signature, InvalidSignature
 from nucypher.crypto.splitters import key_splitter
+from nucypher.crypto.utils import canonical_address_from_umbral_key
 from nucypher.network.middleware import RestMiddleware
 
 
@@ -783,11 +786,12 @@ class IndisputableEvidence:
         uz = z * u
 
         def raw_bytes_from_point(point: Point, only_y_coord=False) -> bytes:
+            uncompressed_point_bytes = point.to_bytes(is_compressed=False)
             if only_y_coord:
                 y_coord_start = (1 + Point.expected_bytes_length(is_compressed=False)) // 2
-                return point.to_bytes(is_compressed=False)[y_coord_start:]
+                return uncompressed_point_bytes[y_coord_start:]
             else:
-                return point.to_bytes(is_compressed=False)[1:]
+                return uncompressed_point_bytes[1:]
 
         # E points
         e_y = raw_bytes_from_point(e, only_y_coord=True)
@@ -807,9 +811,28 @@ class IndisputableEvidence:
         u1h_xy = raw_bytes_from_point(u1h)
         u2_y = raw_bytes_from_point(u2, only_y_coord=True)
 
+        # Get hashed KFrag validity message
+        hash_function = hashes.Hash(hashes.SHA256(), backend=backend)
+
+        kfrag_id = self.cfrag.kfrag_id
+        precursor = self.cfrag.point_precursor
+        delegating_pubkey = self.delegating_pubkey
+        receiving_pubkey = self.receiving_pubkey
+
+        validity_input = (kfrag_id, delegating_pubkey, receiving_pubkey, u1, precursor)
+        kfrag_validity_message = bytes().join(bytes(item) for item in validity_input)
+        hash_function.update(kfrag_validity_message)
+        hashed_kfrag_validity_message = hash_function.finalize()
+
+        # Get Alice's verifying pubkey as ETH address
+        alice_address = canonical_address_from_umbral_key(self.verifying_pubkey)
+
+        # Bundle everything together
         pieces = (
             e_y, ez_xy, e1_y, e1h_xy, e2_y,
             v_y, vz_xy, v1_y, v1h_xy, v2_y,
             uz_xy, u1_y, u1h_xy, u2_y,
+            hashed_kfrag_validity_message,
+            alice_address,
         )
         return b''.join(pieces)

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -26,12 +26,13 @@ from constant_sorrow.constants import UNKNOWN_KFRAG, NO_DECRYPTION_PERFORMED, NO
 from eth_utils import to_canonical_address, to_checksum_address
 from typing import Generator, List, Set, Optional
 
-from umbral.config import default_params
-from umbral.kfrags import KFrag
 from umbral.cfrags import CapsuleFrag
-from umbral.pre import Capsule
-from umbral.point import Point
+from umbral.config import default_params
 from umbral.curvebn import CurveBN
+from umbral.keys import UmbralPublicKey
+from umbral.kfrags import KFrag
+from umbral.point import Point
+from umbral.pre import Capsule
 
 from nucypher.characters.lawful import Alice, Bob, Ursula, Character
 from nucypher.crypto.api import keccak_digest, encrypt_and_sign, secure_random
@@ -708,10 +709,32 @@ class Revocation:
 
 class IndisputableEvidence:
 
-    def __init__(self, capsule: Capsule, cfrag: CapsuleFrag, ursula) -> None:
+    def __init__(self,
+                 capsule: Capsule,
+                 cfrag: CapsuleFrag,
+                 ursula,
+                 delegating_pubkey: UmbralPublicKey = None,
+                 receiving_pubkey: UmbralPublicKey = None,
+                 verifying_pubkey: UmbralPublicKey = None,
+                 ) -> None:
         self.capsule = capsule
         self.cfrag = cfrag
         self.ursula = ursula
+
+        keys = capsule.get_correctness_keys()
+        key_types = ("delegating", "receiving", "verifying")
+        if all(keys[key_type] for key_type in key_types):
+            self.delegating_pubkey = keys["delegating"]
+            self.receiving_pubkey = keys["receiving"]
+            self.verifying_pubkey = keys["verifying"]
+        elif all((delegating_pubkey, receiving_pubkey, verifying_pubkey)):
+            self.delegating_pubkey = delegating_pubkey
+            self.receiving_pubkey = receiving_pubkey
+            self.verifying_pubkey = verifying_pubkey
+        else:
+            raise ValueError("All correctness keys are required to compute evidence.  "
+                             "Either pass them as arguments or in the capsule.")
+
 
     def get_proof_challenge_scalar(self) -> CurveBN:
         umbral_params = default_params()

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -43,7 +43,7 @@ from nucypher.crypto.kits import UmbralMessageKit, RevocationKit
 from nucypher.crypto.powers import SigningPower, DecryptingPower
 from nucypher.crypto.signing import Signature, InvalidSignature
 from nucypher.crypto.splitters import key_splitter
-from nucypher.crypto.utils import canonical_address_from_umbral_key
+from nucypher.crypto.utils import canonical_address_from_umbral_key, recover_pubkey_from_signature
 from nucypher.network.middleware import RestMiddleware
 
 
@@ -827,6 +827,19 @@ class IndisputableEvidence:
         # Get Alice's verifying pubkey as ETH address
         alice_address = canonical_address_from_umbral_key(self.verifying_pubkey)
 
+        # Get KFrag signature's v value
+        v_value = 27
+        pubkey_bytes = recover_pubkey_from_signature(prehashed_message=hashed_kfrag_validity_message,
+                                                     signature=self.cfrag.proof.kfrag_signature,
+                                                     v_value_to_try=v_value)
+        if not pubkey_bytes == self.verifying_pubkey.to_bytes():
+            v_value = 28
+            pubkey_bytes = recover_pubkey_from_signature(prehashed_message=hashed_kfrag_validity_message,
+                                                         signature=self.cfrag.proof.kfrag_signature,
+                                                         v_value_to_try=v_value)
+        if not pubkey_bytes == self.verifying_pubkey.to_bytes():
+            raise InvalidSignature("Bad signature: Not possible to recover public key from it.")
+
         # Bundle everything together
         pieces = (
             e_y, ez_xy, e1_y, e1h_xy, e2_y,
@@ -834,5 +847,6 @@ class IndisputableEvidence:
             uz_xy, u1_y, u1h_xy, u2_y,
             hashed_kfrag_validity_message,
             alice_address,
+            v_value.to_bytes(1, 'big'),
         )
         return b''.join(pieces)

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -25,6 +25,7 @@ from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import UNKNOWN_KFRAG, NO_DECRYPTION_PERFORMED, NOT_SIGNED
 from eth_utils import to_canonical_address, to_checksum_address
 from typing import Generator, List, Set, Optional
+from eth_keys import KeyAPI as EthKeyAPI
 from umbral.config import default_params
 from umbral.kfrags import KFrag
 from umbral.cfrags import CapsuleFrag
@@ -489,11 +490,18 @@ class TreasureMap:
 
 
 class WorkOrder:
+
+    class NotFromBob(InvalidSignature):
+        def __init__(self):
+            super().__init__("This doesn't appear to be from Bob.")
+
     def __init__(self,
                  bob,
                  arrangement_id,
                  capsules,
                  capsule_signatures,
+                 alice_address,
+                 alice_address_signature,
                  receipt_bytes,
                  receipt_signature,
                  ursula=None,
@@ -502,6 +510,8 @@ class WorkOrder:
         self.arrangement_id = arrangement_id
         self.capsules = capsules
         self.capsule_signatures = capsule_signatures
+        self.alice_address = alice_address
+        self.alice_address_signature = alice_address_signature
         self.receipt_bytes = receipt_bytes
         self.receipt_signature = receipt_signature
         self.ursula = ursula  # TODO: We may still need a more elegant system for ID'ing Ursula.  See #136.
@@ -522,39 +532,72 @@ class WorkOrder:
 
     @classmethod
     def construct_by_bob(cls, arrangement_id, capsules, ursula, bob):
-        capsules_bytes = [bytes(c) for c in capsules]
+        alice_verifying_key = capsules[0].get_correctness_keys()["verifying"]
+
+        capsules_bytes = []
+        capsule_signatures = []
+        for capsule in capsules:
+            if alice_verifying_key != capsule.get_correctness_keys()["verifying"]:
+                raise ValueError("Capsules in this work order are inconsistent.")
+            capsule_bytes = bytes(capsule)
+            capsules_bytes.append(capsule_bytes)
+            capsule_signatures.append(bob.stamp(capsule_bytes))
+
+        pubkey_raw_bytes = alice_verifying_key.to_bytes(is_compressed=False)[1:]
+        verifying_key_as_eth_key = EthKeyAPI.PublicKey(pubkey_raw_bytes)
+        alice_address = verifying_key_as_eth_key.to_canonical_address()
+        alice_address_signature = bytes(bob.stamp(alice_address))
+
         receipt_bytes = b"wo:" + ursula.canonical_public_address
         receipt_bytes += msgpack.dumps(capsules_bytes)
         receipt_signature = bob.stamp(receipt_bytes)
-        capsule_signatures = [bob.stamp(c) for c in capsules_bytes]
-        return cls(bob, arrangement_id, capsules, capsule_signatures, receipt_bytes, receipt_signature,
-                   ursula)
+
+        return cls(bob, arrangement_id, capsules, capsule_signatures,
+                   alice_address, alice_address_signature,
+                   receipt_bytes, receipt_signature, ursula)
 
     @classmethod
     def from_rest_payload(cls, arrangement_id, rest_payload):
+
+        # TODO: Use JSON instead? This is a mess.
         payload_splitter = BytestringSplitter(Signature) + key_splitter
-        signature, bob_pubkey_sig, \
-            (receipt_bytes, packed_capsules, packed_signatures) = payload_splitter(rest_payload,
-                                                                                   msgpack_remainder=True)
+        signature, bob_pubkey_sig, remainder = payload_splitter(rest_payload,
+                                                                msgpack_remainder=True)
+
+        receipt_bytes, *remainder = remainder
+        packed_capsules, packed_signatures, *remainder = remainder
+        alice_address, alice_address_signature = remainder
+        alice_address_signature = Signature.from_bytes(alice_address_signature)
+        if not alice_address_signature.verify(alice_address, bob_pubkey_sig):
+            raise cls.NotFromBob()
+
         capsules, capsule_signatures = list(), list()
-        for capsule_bytes, signed_capsule in zip(msgpack.loads(packed_capsules), msgpack.loads(packed_signatures)):
+        for capsule_bytes, capsule_signature in zip(msgpack.loads(packed_capsules), msgpack.loads(packed_signatures)):
             capsules.append(Capsule.from_bytes(capsule_bytes, params=default_params()))
-            signed_capsule = Signature.from_bytes(signed_capsule)
-            capsule_signatures.append(signed_capsule)
-            if not signed_capsule.verify(capsule_bytes, bob_pubkey_sig):
-                raise ValueError("This doesn't appear to be from Bob.")
+            capsule_signature = Signature.from_bytes(capsule_signature)
+            capsule_signatures.append(capsule_signature)
+            if not capsule_signature.verify(capsule_bytes, bob_pubkey_sig):
+                raise cls.NotFromBob()
 
         verified = signature.verify(receipt_bytes, bob_pubkey_sig)
         if not verified:
-            raise ValueError("This doesn't appear to be from Bob.")
+            raise cls.NotFromBob()
         bob = Bob.from_public_keys({SigningPower: bob_pubkey_sig})
-        return cls(bob, arrangement_id, capsules, capsule_signatures, receipt_bytes, signature)
+        return cls(bob, arrangement_id, capsules, capsule_signatures,
+                   alice_address, alice_address_signature,
+                   receipt_bytes, signature)
 
     def payload(self):
         capsules_as_bytes = [bytes(p) for p in self.capsules]
         capsule_signatures_as_bytes = [bytes(s) for s in self.capsule_signatures]
         packed_receipt_and_capsules = msgpack.dumps(
-            (self.receipt_bytes, msgpack.dumps(capsules_as_bytes), msgpack.dumps(capsule_signatures_as_bytes)))
+            (self.receipt_bytes,
+             msgpack.dumps(capsules_as_bytes),
+             msgpack.dumps(capsule_signatures_as_bytes),
+             self.alice_address,
+             self.alice_address_signature,
+             )
+        )
         return bytes(self.receipt_signature) + self.bob.stamp + packed_receipt_and_capsules
 
     def complete(self, cfrags_and_signatures):

--- a/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
+++ b/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
@@ -142,7 +142,7 @@ def test_evaluate_cfrag(testerchain, escrow, adjudicator_contract):
     evidence = IndisputableEvidence(capsule, cfrag, ursula=None)
 
     evidence_data = evidence.precompute_values()
-    assert len(evidence_data) == 20 * 32
+    assert len(evidence_data) == 20 * 32 + 32 + 20
 
     proof_signature = int(evidence.get_proof_challenge_scalar())
     assert proof_signature == \
@@ -173,6 +173,7 @@ def test_evaluate_cfrag(testerchain, escrow, adjudicator_contract):
             miner_umbral_public_key_bytes,
             signed_miner_umbral_public_key,
             evidence_data)
+
     value = escrow.functions.minerInfo(miner).call()[0]
     tx = adjudicator_contract.functions.evaluateCFrag(*args).transact({'from': investigator})
     testerchain.wait_for_receipt(tx)

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -149,7 +149,11 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
 
     # We'll test against just a single Ursula - here, we make a WorkOrder for just one.
     # We can pass any number of capsules as args; here we pass just one.
-    work_orders = federated_bob.generate_work_orders(map_id, capsule_side_channel[0].capsule, num_ursulas=1)
+    capsule = capsule_side_channel[0].capsule
+    capsule.set_correctness_keys(delegating=enacted_federated_policy.public_key,
+                                 receiving=federated_bob.public_keys(DecryptingPower),
+                                 verifying=federated_alice.stamp.as_umbral_pubkey())
+    work_orders = federated_bob.generate_work_orders(map_id, capsule, num_ursulas=1)
 
     # Again: one Ursula, one work_order.
     assert len(work_orders) == 1
@@ -175,10 +179,6 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     assert work_order.completed
 
     # Attach the CFrag to the Capsule.
-    capsule = capsule_side_channel[0].capsule
-    capsule.set_correctness_keys(delegating=enacted_federated_policy.public_key,
-                                 receiving=federated_bob.public_keys(DecryptingPower),
-                                 verifying=federated_alice.stamp.as_umbral_pubkey())
     capsule.attach_cfrag(the_cfrag)
 
     # Having received the cFrag, Bob also saved the WorkOrder as complete.


### PR DESCRIPTION
The goal of this PR is to validate the KFrag signature on-chain, as part of the ZKP verification.
This was pending from #509. Specifically:

- It precomputes the necessary data to validate the signature, namely:
    - The pre-hashed message. Pre-hashing has several benefits here: (1) reduced computations, (2) reduce space costs, (3) some data anonymity (we don't need to disclose `delegating_pubkey` and `receiving_pubkey`, which are part of the message).
    - the `v` value that allows to recover a public key from a ECDSA signature.
    - the signing public key (from Alice) as ETH address (since that's what the EVM's `ecrecover` actually recovers). This also prevents disclosing Alice's verifying public key directly, just the corresponding ETH address.
- Alice's ETH address now is signed by Bob and Ursula, as a commitment from both of them.
- Checks the KFrag signature on-chain using the `ecrecover` method.
