### PR TITLE
Make domain constants bytestrings

### DIFF
--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -39,6 +39,7 @@ from constant_sorrow.constants import (
     SIGNATURE_IS_ON_CIPHERTEXT
 )
 from nucypher.blockchain.eth.chains import Blockchain
+from nucypher.config.constants import GLOBAL_DOMAIN
 from nucypher.crypto.api import encrypt_and_sign
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import (
@@ -68,7 +69,7 @@ class Character(Learner):
     from nucypher.crypto.signing import InvalidSignature
 
     def __init__(self,
-                 domains: Set = (constants.GLOBAL_DOMAIN,),
+                 domains: Set = (GLOBAL_DOMAIN,),
                  is_me: bool = True,
                  federated_only: bool = False,
                  blockchain: Blockchain = None,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -45,6 +45,7 @@ from constant_sorrow.constants import INCLUDED_IN_BYTESTRING, PUBLIC_ONLY
 from nucypher.blockchain.eth.actors import PolicyAuthor, Miner
 from nucypher.blockchain.eth.agents import MinerAgent
 from nucypher.characters.base import Character, Learner
+from nucypher.config.constants import GLOBAL_DOMAIN
 from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.constants import PUBLIC_KEY_LENGTH, PUBLIC_ADDRESS_LENGTH
@@ -449,7 +450,7 @@ class Ursula(Teacher, Character, Miner):
                  # Ursula
                  rest_host: str,
                  rest_port: int,
-                 domains: Set = (constants.GLOBAL_DOMAIN,),  # For now, serving and learning domains will be the same.
+                 domains: Set = (GLOBAL_DOMAIN,),  # For now, serving and learning domains will be the same.
                  certificate: Certificate = None,
                  certificate_filepath: str = None,
                  db_filepath: str = None,

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -25,16 +25,26 @@ from appdirs import AppDirs
 import nucypher
 from nucypher.blockchain.eth import sol
 
+
 # Base Filepaths
 BASE_DIR = abspath(dirname(dirname(nucypher.__file__)))
 PROJECT_ROOT = abspath(dirname(nucypher.__file__))
 CONTRACT_ROOT = os.path.join(abspath(dirname(sol.__file__)), 'source', 'contracts')
+
 
 # User Application Filepaths
 APP_DIR = AppDirs(nucypher.__title__, nucypher.__author__)
 DEFAULT_CONFIG_ROOT = APP_DIR.user_data_dir
 USER_LOG_DIR = APP_DIR.user_log_dir
 
+
 # Static Seednodes
 SeednodeMetadata = namedtuple('seednode', ['checksum_public_address', 'rest_host', 'rest_port'])
 SEEDNODES = tuple()
+
+
+# Domains
+#If this domain is among those being learned or served, then domain checking is skipped.
+#A Learner learning about the GLOBAL_DOMAIN will learn about all nodes.
+#A Teacher serving the GLOBAL_DOMAIN will teach about all nodes.
+GLOBAL_DOMAIN = b'GLOBAL_DOMAIN'

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -33,8 +33,6 @@ from cryptography.x509 import Certificate
 from twisted.logger import Logger
 from umbral.signing import Signature
 
-from constant_sorrow import constants
-from constant_sorrow.constants import GLOBAL_DOMAIN
 from constant_sorrow.constants import (
     UNINITIALIZED_CONFIGURATION,
     STRANGER_CONFIGURATION,
@@ -44,7 +42,7 @@ from constant_sorrow.constants import (
 )
 from nucypher.blockchain.eth.agents import PolicyAgent, MinerAgent, NucypherTokenAgent
 from nucypher.blockchain.eth.chains import Blockchain
-from nucypher.config.constants import DEFAULT_CONFIG_ROOT, BASE_DIR, USER_LOG_DIR
+from nucypher.config.constants import DEFAULT_CONFIG_ROOT, BASE_DIR, USER_LOG_DIR, GLOBAL_DOMAIN
 from nucypher.config.keyring import NucypherKeyring
 from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage, LocalFileBasedNodeStorage
 from nucypher.crypto.powers import CryptoPowerUp, CryptoPower
@@ -374,8 +372,8 @@ class NodeConfiguration(ABC):
                                                   serializer=cls.NODE_SERIALIZER,
                                                   deserializer=cls.NODE_DESERIALIZER)
 
-        # Deserialize domains to Constants vis Constant Sorrow
-        domains = set(getattr(constants, domain.upper()) for domain in payload['domains'])
+        # Deserialize domains to UTF-8 bytestrings
+        domains = list(domain.encode() for domain in payload['domains'])
 
         payload.update(dict(node_storage=node_storage, domains=domains))
 
@@ -397,7 +395,7 @@ class NodeConfiguration(ABC):
         del payload['is_me']  # TODO
 
         # Serialize domains
-        domains = list(str(domain) for domain in self.domains)
+        domains = list(domain.decode() for domain in self.domains)
 
         # Save node connection data
         payload.update(dict(node_storage=self.node_storage.payload(), domains=domains))

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -52,14 +52,6 @@ from nucypher.network.protocols import SuspiciousActivity
 from nucypher.network.server import TLSHostingPower
 
 
-GLOBAL_DOMAIN.set_constant_documentation(
-    """
-    If this domain is among those being learned or served, then domain checking is skipped.
-    A Learner learning about the GLOBAL_DOMAIN will learn about all nodes.
-    A Teacher serving the GLOBAL_DOMAIN will teach about all nodes.
-    """)
-
-
 def icon_from_checksum(checksum,
                        nickname_metadata,
                        number_of_nodes="Unknown number of "):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -30,7 +30,7 @@ import time
 from bytestring_splitter import BytestringSplitter
 from bytestring_splitter import VariableLengthBytestring, BytestringSplittingError
 from constant_sorrow import constant_or_bytes
-from constant_sorrow.constants import GLOBAL_DOMAIN, NO_KNOWN_NODES, NOT_SIGNED, NEVER_SEEN, NO_STORAGE_AVAILIBLE, FLEET_STATES_MATCH
+from constant_sorrow.constants import NO_KNOWN_NODES, NOT_SIGNED, NEVER_SEEN, NO_STORAGE_AVAILIBLE, FLEET_STATES_MATCH
 from cryptography.x509 import Certificate
 from eth_keys.datatypes import Signature as EthSignature
 from requests.exceptions import SSLError
@@ -40,7 +40,7 @@ from twisted.internet.threads import deferToThread
 from twisted.logger import Logger
 from typing import Set, Tuple
 
-from nucypher.config.constants import SeednodeMetadata
+from nucypher.config.constants import SeednodeMetadata, GLOBAL_DOMAIN
 from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.powers import BlockchainPower, SigningPower, DecryptingPower, NoSigningPower

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -22,7 +22,6 @@ from collections import defaultdict, OrderedDict
 from collections import deque
 from collections import namedtuple
 from contextlib import suppress
-from logging import Logger
 
 import maya
 import requests

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -29,8 +29,9 @@ from umbral.keys import UmbralPublicKey
 
 from bytestring_splitter import VariableLengthBytestring
 from constant_sorrow import constants
-from constant_sorrow.constants import GLOBAL_DOMAIN, NO_KNOWN_NODES
+from constant_sorrow.constants import NO_KNOWN_NODES
 from hendrix.experience import crosstown_traffic
+from nucypher.config.constants import GLOBAL_DOMAIN
 from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.kits import UmbralMessageKit


### PR DESCRIPTION
### What this does:
1. Deserializes domain constants from config files as UTF-8 bytestrings.
    - They get serialized as strings.
2. Moves `GLOBAL_DOMAIN` definition to `config.constants`
3. Removes an unused `logging.Logger` import that shadows a `twisted.Logger` import.
4. Resolves #671 