### PR TITLE
[WIP] Hash secrets correctly for nucypher-deploy

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -168,7 +168,7 @@ class Deployer(NucypherTokenActor):
         return txhashes
 
     def deploy_miner_contract(self, secret: bytes):
-
+        secret = self.blockchain.interface.w3.keccak(secret)
         miner_escrow_deployer = MinerEscrowDeployer(blockchain=self.blockchain,
                                                     deployer_address=self.deployer_address,
                                                     secret_hash=secret)
@@ -178,7 +178,7 @@ class Deployer(NucypherTokenActor):
         return txhashes
 
     def deploy_policy_contract(self, secret: bytes):
-
+        secret = self.blockchain.interface.w3.keccak(secret)
         policy_manager_deployer = PolicyManagerDeployer(blockchain=self.blockchain,
                                                         deployer_address=self.deployer_address,
                                                         secret_hash=secret)
@@ -188,7 +188,7 @@ class Deployer(NucypherTokenActor):
         return txhashes
 
     def deploy_escrow_proxy(self, secret: bytes):
-
+        secret = self.blockchain.interface.w3.keccak(secret)
         escrow_proxy_deployer = UserEscrowProxyDeployer(blockchain=self.blockchain,
                                                         deployer_address=self.deployer_address,
                                                         secret_hash=secret)

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -147,7 +147,7 @@ def deploy(click_config,
             __deployment_transactions.update(txhashes)
 
         # User Escrow Proxy
-        deployer.deploy_escrow_proxy(secret=secrets.escrow_proxy_secret)
+        deployer.deploy_escrow_proxy(secret=bytes(secrets.escrow_proxy_secret, encoding='utf-8'))
         click.secho("Deployed!", fg='green', bold=True)
 
         #


### PR DESCRIPTION
### What this does:
1. Uses keccak hashing on the deploy secrets so that the contracts can deploy correctly via `nucypher-deploy`.
2. More to come...