### PR TITLE
[Post-Release] Bump version: 0.1.0-alpha.4 → 0.1.0-alpha.5

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-alpha.4
+current_version = 0.1.0-alpha.5
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ----
 
-v0.1.0-alpha.4
+v0.1.0-alpha.5
 
 ![](https://img.shields.io/pypi/wheel/nucypher.svg)
 ![](https://img.shields.io/pypi/pyversions/nucypher.svg)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.1.0-alpha.4'
+release = '0.1.0-alpha.5'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "0.1.0-alpha.4"
+__version__ = "0.1.0-alpha.5"
 
 __author__ = "NuCypher"
 


### PR DESCRIPTION
**Note: This Tag has already been pushed to distributors.  This PR is a follow up to update master with the tagged release commit**