### PR TITLE
Another small step with a few small fixes.

### DIFF
--- a/deploy/templates/monitor.html
+++ b/deploy/templates/monitor.html
@@ -30,6 +30,7 @@
             text-align: center;
             box-shadow: 1px 1px black, -1px -1px black;
             width: 100px;
+            height: 100px;
         }
 
         .small {
@@ -73,11 +74,6 @@
             border-right: 3px solid black;
         }
 
-        #states .nucypher-nickname-icon {
-            height: 75px;
-            width: 75px;
-        }
-
         #states .single-symbol {
             font-size: 2em;
         }
@@ -105,11 +101,6 @@
             border-right: 3px solid black;
         }
 
-        #states .nucypher-nickname-icon {
-            height: 75px;
-            width: 75px;
-        }
-
         #states .single-symbol {
             font-size: 2em;
         }
@@ -122,15 +113,25 @@
     {% raw %}
     <script id="state-template" type="text/x-handlebars-template">
             <h5>{{nickname}}</h5>
-            <div class="body">
-                <div class="single-symbol">{{metadata.[0].[1]}}</div>
+            <div class="nucypher-nickname-icon" style="border-color:{{color_hex}};">
+                <div class="single-symbol">{{symbol}}</div>
                 <span>{{checksum}}</span>
-                {{updated}}
+                <span class="small">{{updated}}</span>
             </div>
     </script>
 
     <script id="node-template" type="text/x-handlebars-template">
-            <td>{{ nickname_icon }}</td>
+            <td>
+                <div class="nucypher-nickname-icon" style="border-top-color:{{icon_details.first_color}}; border-left-color:{{icon_details.first_color}}; border-bottom-color:{{icon_details.second_color}}; border-right-color:{{icon_details.second_color}};">
+                    <span class="small">{{icon_details.node_class}} v{{icon_details.version}}</span>
+                    <div class="symbols">
+                        <span class="single-symbol" style="color: {{icon_details.first_color}}">{{icon_details.first_symbol}}&#xFE0E;</span>
+                        <span class="single-symbol" style="color: {{icon_details.second_color}}">{{icon_details.second_symbol}}&#xFE0E;</span>
+                    </div>
+                    <br/>
+                    <span class="small-address">{{icon_details.address_first6}}</span>
+                </div>
+            </td>
                 <td>
                     <a href="https://{{rest_url}}/status">{{ nickname }}</a>
                     <br/><span class="small">{{ checksum_address }}</span>

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -75,7 +75,7 @@ class RestMiddleware:
         ursula_rest_response = self.send_work_order_payload_to_ursula(work_order)
         # TODO: Check status code.
         splitter = BytestringSplitter((CapsuleFrag, VariableLengthBytestring), Signature)
-        cfrags_and_signatures = splitter.repeat(ursula_rest_response.data)
+        cfrags_and_signatures = splitter.repeat(ursula_rest_response.content)
         cfrags = work_order.complete(cfrags_and_signatures)
         return cfrags
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -215,8 +215,10 @@ class FleetStateTracker:
     @staticmethod
     def abridged_state_details(state):
         return {"nickname": state.nickname,
-                "metadata": state.metadata,
-                "updated": state.updated.iso8601()
+                "symbol": state.metadata[0][1],
+                "color_hex": state.metadata[0][0]['hex'],
+                "color_name": state.metadata[0][0]['color'],
+                "updated": state.updated.rfc2822()
                 }
 
     @staticmethod
@@ -224,8 +226,9 @@ class FleetStateTracker:
         try:
             last_seen = node.last_seen.iso8601()
         except AttributeError:  # TODO: This logic belongs somewhere - anywhere - else.
-            last_seen = str(node.last_seen)
-        return {"nickname_metadata": node.nickname_metadata,
+            last_seen = str(node.last_seen)  # In case it's the constant NEVER_SEEN
+        return {
+                "icon_details": node.nickname_icon_details(),  # TODO: Mix this in better.
                 "rest_url": node.rest_url(),
                 "nickname": node.nickname,
                 "checksum_address": node.checksum_public_address,
@@ -233,7 +236,6 @@ class FleetStateTracker:
                 "last_seen": last_seen,
                 "fleet_state_icon": node.fleet_state_icon,
                 }
-
 
 
 class Learner:
@@ -1053,7 +1055,10 @@ class Teacher:
         <span class="small-address">{address_first6}</span>
         </div>
         """.replace("  ", "").replace('\n', "")
-        return icon_template.format(
+        return icon_template.format(**self.nickname_icon_details)
+
+    def nickname_icon_details(self):
+        return dict(
             node_class=self.__class__.__name__,
             version=self.TEACHER_VERSION,
             first_color=self.nickname_metadata[0][0]['hex'],  # TODO: These index lookups are awful.

--- a/tests/learning/test_fault_tolerance.py
+++ b/tests/learning/test_fault_tolerance.py
@@ -1,7 +1,7 @@
+from collections import namedtuple
 from functools import partial
 
 import pytest
-from apistar.http import Response
 from eth_keys.datatypes import Signature as EthSignature
 from twisted.logger import globalLogPublisher, LogLevel
 
@@ -153,7 +153,7 @@ def test_emit_warning_upon_new_version(ursula_federated_test_config, caplog):
     # Now let's go a little further: make the version totally unrecognizable.
     crazy_bytes_representation = int(learner.LEARNER_VERSION + 1).to_bytes(2,
                                                                            byteorder="big") + b"totally unintelligible nonsense"
-
+    Response = namedtuple("MockResponse", ("content", "status_code"))
     response = Response(content=crazy_bytes_representation, status_code=200)
     learner.network_middleware.get_nodes_via_rest = lambda *args, **kwargs: response
     learner.learn_from_teacher_node()


### PR DESCRIPTION
* Displays node icons on `Moe` monitor
* Displays better status icons on `Moe` monitor
* Fixes `test_emit_warning_upon_new_version`, which previously relied on an apistar `Response` object