### PR TITLE
Reworking middleware to share more logic.

### DIFF
--- a/deploy/templates/monitor.html
+++ b/deploy/templates/monitor.html
@@ -30,6 +30,7 @@
             text-align: center;
             box-shadow: 1px 1px black, -1px -1px black;
             width: 100px;
+            height: 100px;
         }
 
         .small {
@@ -73,11 +74,6 @@
             border-right: 3px solid black;
         }
 
-        #states .nucypher-nickname-icon {
-            height: 75px;
-            width: 75px;
-        }
-
         #states .single-symbol {
             font-size: 2em;
         }
@@ -105,11 +101,6 @@
             border-right: 3px solid black;
         }
 
-        #states .nucypher-nickname-icon {
-            height: 75px;
-            width: 75px;
-        }
-
         #states .single-symbol {
             font-size: 2em;
         }
@@ -122,15 +113,25 @@
     {% raw %}
     <script id="state-template" type="text/x-handlebars-template">
             <h5>{{nickname}}</h5>
-            <div class="body">
-                <div class="single-symbol">{{metadata.[0].[1]}}</div>
+            <div class="nucypher-nickname-icon" style="border-color:{{color_hex}};">
+                <div class="single-symbol">{{symbol}}</div>
                 <span>{{checksum}}</span>
-                {{updated}}
+                <span class="small">{{updated}}</span>
             </div>
     </script>
 
     <script id="node-template" type="text/x-handlebars-template">
-            <td>{{ nickname_icon }}</td>
+            <td>
+                <div class="nucypher-nickname-icon" style="border-top-color:{{icon_details.first_color}}; border-left-color:{{icon_details.first_color}}; border-bottom-color:{{icon_details.second_color}}; border-right-color:{{icon_details.second_color}};">
+                    <span class="small">{{icon_details.node_class}} v{{icon_details.version}}</span>
+                    <div class="symbols">
+                        <span class="single-symbol" style="color: {{icon_details.first_color}}">{{icon_details.first_symbol}}&#xFE0E;</span>
+                        <span class="single-symbol" style="color: {{icon_details.second_color}}">{{icon_details.second_symbol}}&#xFE0E;</span>
+                    </div>
+                    <br/>
+                    <span class="small-address">{{icon_details.address_first6}}</span>
+                </div>
+            </td>
                 <td>
                     <a href="https://{{rest_url}}/status">{{ nickname }}</a>
                     <br/><span class="small">{{ checksum_address }}</span>

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -42,7 +42,7 @@ class RestMiddleware:
     class _Client:
 
         def __init__(self, library, response_cleaner=None):
-            if self.response_cleaner is not None:
+            if response_cleaner is not None:
                 self.response_cleaner = response_cleaner
             else:
                 self.response_cleaner = lambda r: r
@@ -56,9 +56,9 @@ class RestMiddleware:
                 cleaned_response = self.response_cleaner(response)
                 if cleaned_response.status_code >= 300:
                     if cleaned_response.status_code == 404:
-                        raise NotFound("Server claims not to have found it: {}".format(cleaned_response.content))
+                        raise NotFound("While trying to {} {} ({}), server claims not to have found it.  Response: {}".format(item, args, kwargs, cleaned_response.content))
                     else:
-                        raise UnexpectedResponse("Unexpected response for {},{}: {}".format(args, kwargs, cleaned_response.content))
+                        raise UnexpectedResponse("Unexpected response while trying to {} {},{}: {} {}".format(item, args, kwargs, cleaned_response.status_code, cleaned_response.content))
                 return cleaned_response
             return method_wrapper
 

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -75,7 +75,7 @@ class RestMiddleware:
         ursula_rest_response = self.send_work_order_payload_to_ursula(work_order)
         # TODO: Check status code.
         splitter = BytestringSplitter((CapsuleFrag, VariableLengthBytestring), Signature)
-        cfrags_and_signatures = splitter.repeat(ursula_rest_response.data)
+        cfrags_and_signatures = splitter.repeat(ursula_rest_response.content)
         cfrags = work_order.complete(cfrags_and_signatures)
         return cfrags
 

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -58,7 +58,7 @@ class RestMiddleware:
                     if cleaned_response.status_code == 404:
                         raise NotFound("Server claims not to have found it: {}".format(cleaned_response.content))
                     else:
-                        raise UnexpectedResponse("Unexpected response: {}".format(cleaned_response.content))
+                        raise UnexpectedResponse("Unexpected response for {},{}: {}".format(args, kwargs, cleaned_response.content))
                 return cleaned_response
             return method_wrapper
 
@@ -115,14 +115,6 @@ class RestMiddleware:
                                                                 revocation.arrangement_id.hex()),
                                    bytes(revocation),
                                    verify=ursula.certificate_filepath)
-        if response.status_code == 200:
-            return response
-        elif response.status_code == 404:
-            raise RuntimeError("KFrag doesn't exist to revoke with id {}".format(revocation.arrangement_id),
-                               response.status_code)
-        else:
-            self.log.debug("Bad response during revocation: {}".format(response))
-            raise RuntimeError("Bad response: {}".format(response.content), response.status_code)
         return response
 
     def get_competitive_rate(self):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -46,6 +46,8 @@ class RestMiddleware:
                 method = getattr(self._library, item)
                 response = method(*args, **kwargs)
                 cleaned_response = self.response_cleaner(response)
+                if cleaned_response.status_code >= 300:
+                    raise RuntimeError("Unexpected response: {}".format(cleaned_response.content))
                 return cleaned_response
             return method_wrapper
 
@@ -79,9 +81,6 @@ class RestMiddleware:
         response = requests.post("https://{}/consider_arrangement".format(node.rest_interface),
                                  bytes(arrangement),
                                  verify=node.certificate_filepath, timeout=2)
-
-        if not response.status_code == 200:
-            raise RuntimeError("Bad response: {}".format(response.content))
         return response
 
     def enact_policy(self, ursula, id, payload):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -28,6 +28,14 @@ from umbral.signing import Signature
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 
 
+class UnexpectedResponse(Exception):
+    pass
+
+
+class NotFound(UnexpectedResponse):
+    pass
+
+
 class RestMiddleware:
     log = Logger()
 
@@ -47,7 +55,10 @@ class RestMiddleware:
                 response = method(*args, **kwargs)
                 cleaned_response = self.response_cleaner(response)
                 if cleaned_response.status_code >= 300:
-                    raise RuntimeError("Unexpected response: {}".format(cleaned_response.content))
+                    if cleaned_response.status_code == 404:
+                        raise NotFound("Server claims not to have found it: {}".format(cleaned_response.content))
+                    else:
+                        raise UnexpectedResponse("Unexpected response: {}".format(cleaned_response.content))
                 return cleaned_response
             return method_wrapper
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -215,8 +215,10 @@ class FleetStateTracker:
     @staticmethod
     def abridged_state_details(state):
         return {"nickname": state.nickname,
-                "metadata": state.metadata,
-                "updated": state.updated.iso8601()
+                "symbol": state.metadata[0][1],
+                "color_hex": state.metadata[0][0]['hex'],
+                "color_name": state.metadata[0][0]['color'],
+                "updated": state.updated.rfc2822()
                 }
 
     @staticmethod
@@ -224,8 +226,9 @@ class FleetStateTracker:
         try:
             last_seen = node.last_seen.iso8601()
         except AttributeError:  # TODO: This logic belongs somewhere - anywhere - else.
-            last_seen = str(node.last_seen)
-        return {"nickname_metadata": node.nickname_metadata,
+            last_seen = str(node.last_seen)  # In case it's the constant NEVER_SEEN
+        return {
+                "icon_details": node.nickname_icon_details(),  # TODO: Mix this in better.
                 "rest_url": node.rest_url(),
                 "nickname": node.nickname,
                 "checksum_address": node.checksum_public_address,
@@ -233,7 +236,6 @@ class FleetStateTracker:
                 "last_seen": last_seen,
                 "fleet_state_icon": node.fleet_state_icon,
                 }
-
 
 
 class Learner:
@@ -1053,7 +1055,10 @@ class Teacher:
         <span class="small-address">{address_first6}</span>
         </div>
         """.replace("  ", "").replace('\n', "")
-        return icon_template.format(
+        return icon_template.format(**self.nickname_icon_details)
+
+    def nickname_icon_details(self):
+        return dict(
             node_class=self.__class__.__name__,
             version=self.TEACHER_VERSION,
             first_color=self.nickname_metadata[0][0]['hex'],  # TODO: These index lookups are awful.

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -26,6 +26,10 @@ class MockRestMiddleware(RestMiddleware):
     class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
         pass
 
+    def response_cleaner(self, response):
+        response.content = response.data
+        return response
+
     def _get_mock_client_by_ursula(self, ursula):
         port = ursula.rest_information()[0].port
         return self._get_mock_client_by_port(port)
@@ -38,7 +42,7 @@ class MockRestMiddleware(RestMiddleware):
         ursula = self._get_ursula_by_port(port)
         rest_app = ursula.rest_app
         rest_app.testing = True
-        mock_client = rest_app.test_client()
+        mock_client = self._Client(rest_app.test_client(), response_cleaner=self.response_cleaner)
         return mock_client
 
     def _get_ursula_by_port(self, port):

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -57,13 +57,11 @@ class MockRestMiddleware(RestMiddleware):
         response = mock_client.post("http://localhost/consider_arrangement",
                                     data=bytes(arrangement),
                                     content_type='application/octet')
-        assert response.status_code == 200
         return response
 
     def enact_policy(self, ursula, id, payload):
         mock_client = self._get_mock_client_by_ursula(ursula)
         response = mock_client.post('http://localhost/kFrag/{}'.format(id.hex()), data=payload)
-        assert response.status_code == 200
         return True, ursula.stamp.as_umbral_pubkey()
 
     def send_work_order_payload_to_ursula(self, work_order):
@@ -75,19 +73,15 @@ class MockRestMiddleware(RestMiddleware):
     def get_treasure_map_from_node(self, node, map_id):
         mock_client = self._get_mock_client_by_ursula(node)
         response = mock_client.get("http://localhost/treasure_map/{}".format(map_id))
-        response.content = response.data
         return response
 
     def node_information(self, host, port, certificate_filepath):
         mock_client = self._get_mock_client_by_port(port)
         response = mock_client.get("http://localhost/public_information")
-        if not response.status_code == 200:
-            raise RuntimeError("Or something.")  # TODO: Raise an error here?  Or return False?  Or something?
-        return response.data
+        return response.content
 
     def get_nodes_via_rest(self, url, *args, **kwargs):
         response = super().get_nodes_via_rest(url, client=self._get_mock_client_by_url(url), *args, **kwargs)
-        response.content = response.data  # Little hack for compatibility.
         return response
 
     def put_treasure_map_on_node(self, node, map_id, map_payload):
@@ -101,10 +95,6 @@ class MockRestMiddleware(RestMiddleware):
         response = mock_client.delete('http://localhost/kFrag/{}'.format(
                                       revocation.arrangement_id.hex()),
                                       data=bytes(revocation))
-        
-        if response.status_code != 200:
-            if response.status_code != 404:
-                raise RuntimeError("Bad response: {}".format(response.status_code))
         return response
 
 

--- a/tests/learning/test_fault_tolerance.py
+++ b/tests/learning/test_fault_tolerance.py
@@ -1,7 +1,7 @@
+from collections import namedtuple
 from functools import partial
 
 import pytest
-from apistar.http import Response
 from eth_keys.datatypes import Signature as EthSignature
 from twisted.logger import globalLogPublisher, LogLevel
 
@@ -153,7 +153,7 @@ def test_emit_warning_upon_new_version(ursula_federated_test_config, caplog):
     # Now let's go a little further: make the version totally unrecognizable.
     crazy_bytes_representation = int(learner.LEARNER_VERSION + 1).to_bytes(2,
                                                                            byteorder="big") + b"totally unintelligible nonsense"
-
+    Response = namedtuple("MockResponse", ("content", "status_code"))
     response = Response(content=crazy_bytes_representation, status_code=200)
     learner.network_middleware.get_nodes_via_rest = lambda *args, **kwargs: response
     learner.learn_from_teacher_node()


### PR DESCRIPTION
* Creates new shared middleware `_Client`, which wraps all calls (production and test) to network library code (ie, requests and werkzeug). 
* "cleans" all returning responses, ensuring that `content` is an available attr in either case.
* Moved status-code checking up to the client so that it happens all in one place.
* Raises `NotFound` if an endpoint returns a 404, `UnexpectedResponse` for other > 300 responses.