### PR TITLE
[Building] [Release] Bump version: 0.1.0-alpha.5 → 0.1.0-alpha.7

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-alpha.6
+current_version = 0.1.0-alpha.7
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -18,9 +18,6 @@ values =
 
 [bumpversion:part:devnum]
 
-[bumpversion:file:README.md]
-
 [bumpversion:file:nucypher/__about__.py]
 
 [bumpversion:file:docs/source/conf.py]
-

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-alpha.5
+current_version = 0.1.0-alpha.6
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
@@ -21,3 +21,4 @@ values =
 [bumpversion:file:nucypher/__about__.py]
 
 [bumpversion:file:docs/source/conf.py]
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,13 +3,6 @@ version: 2.1
 workflows:
   version: 2
   test_build_deploy:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - pipenv_install_36:
           filters:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.1.0-alpha.5'
+release = '0.1.0-alpha.6'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.1.0-alpha.6'
+release = '0.1.0-alpha.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "0.1.0-alpha.6"
+__version__ = "0.1.0-alpha.7"
 
 __author__ = "NuCypher"
 

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "0.1.0-alpha.5"
+__version__ = "0.1.0-alpha.6"
 
 __author__ = "NuCypher"
 


### PR DESCRIPTION
**Note: This tag has already been pushed to distributors - This PR is a follow-up to synchronize with `master`**