### PR TITLE
Middleware unsuckified.

### DIFF
--- a/examples/heartbeat_demo/doctor.py
+++ b/examples/heartbeat_demo/doctor.py
@@ -1,11 +1,12 @@
 import json
 import os
-import sys
 import shutil
 import msgpack
 import maya
 import traceback
 from timeit import default_timer as timer
+
+from twisted.logger import globalLogPublisher
 
 from nucypher.characters.lawful import Bob, Ursula
 from nucypher.crypto.kits import UmbralMessageKit
@@ -16,6 +17,9 @@ from nucypher.network.middleware import RestMiddleware
 
 from umbral.keys import UmbralPublicKey
 
+from nucypher.utilities.logging import SimpleObserver
+
+globalLogPublisher.addObserver(SimpleObserver())
 
 ######################
 # Boring setup stuff #
@@ -35,6 +39,7 @@ ursula = Ursula.from_seed_and_stake_info(seed_uri=SEEDNODE_URL,
 
 # To create a Bob, we need the doctor's private keys previously generated.
 from doctor_keys import get_doctor_privkeys
+
 doctor_keys = get_doctor_privkeys()
 
 bob_enc_keypair = DecryptingKeypair(private_key=doctor_keys["enc"])
@@ -79,9 +84,9 @@ message_kits = (UmbralMessageKit.from_bytes(k) for k in data['kits'])
 
 # The doctor also needs to create a view of the Data Source from its public keys
 data_source = DataSource.from_public_keys(
-        policy_public_key=policy_pubkey,
-        datasource_public_key=data['data_source'],
-        label=label
+    policy_public_key=policy_pubkey,
+    datasource_public_key=data['data_source'],
+    label=label
 )
 
 # Now he can ask the NuCypher network to get a re-encrypted version of each MessageKit.
@@ -106,13 +111,12 @@ for message_kit in message_kits:
         terminal_size = shutil.get_terminal_size().columns
         max_width = min(terminal_size, 120)
         columns = max_width - 12 - 27
-        scale = columns/40
+        scale = columns / 40
         scaled_heart_rate = int(scale * (heart_rate - 60))
-        retrieval_time = "Retrieval time: {:8.2f} ms".format(1000*(end - start))
+        retrieval_time = "Retrieval time: {:8.2f} ms".format(1000 * (end - start))
         line = ("-" * scaled_heart_rate) + "❤︎ ({} BPM)".format(heart_rate)
         line = line.ljust(max_width - 27, " ") + retrieval_time
         print(line)
     except Exception as e:
         # We just want to know what went wrong and continue the demo
         traceback.print_exc()
-

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -741,6 +741,8 @@ class Ursula(Teacher, Character, Miner):
             *args,
             **kwargs)  # TODO: 466
 
+        potential_seed_node.certificate_filepath = certificate_filepath
+
         if checksum_address:
             # Ensure this is the specific node we expected
             if not checksum_address == potential_seed_node.checksum_public_address:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -49,7 +49,7 @@ from nucypher.config.constants import GLOBAL_DOMAIN
 from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.constants import PUBLIC_KEY_LENGTH, PUBLIC_ADDRESS_LENGTH
-from nucypher.crypto.powers import SigningPower, DecryptingPower, DelegatingPower, BlockchainPower
+from nucypher.crypto.powers import SigningPower, DecryptingPower, DelegatingPower, BlockchainPower, PowerUpError
 from nucypher.keystore.keypairs import HostingKeypair
 from nucypher.network.middleware import RestMiddleware, UnexpectedResponse, NotFound
 from nucypher.network.nicknames import nickname_from_seed
@@ -888,7 +888,7 @@ class Ursula(Teacher, Character, Miner):
 
         if rest_app_on_server is PUBLIC_ONLY or not rest_app_on_server:
             m = "This Ursula doesn't have a REST app attached. If you want one, init with is_me and attach_server."
-            raise AttributeError(m)
+            raise PowerUpError(m)
         else:
             return rest_app_on_server
 

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -15,7 +15,6 @@ You should have received a copy of the GNU General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
 import binascii
 import glob
 import os
@@ -40,7 +39,6 @@ from nucypher.utilities.decorators import validate_checksum_address
 
 
 class NodeStorage(ABC):
-
     _name = NotImplemented
     _TYPE_LABEL = 'storage_type'
     NODE_SERIALIZER = binascii.hexlify
@@ -110,7 +108,8 @@ class NodeStorage(ABC):
         # Validate
         # TODO: It's better for us to have checked this a while ago so that this situation is impossible.  #443
         if host and (host != common_name_on_certificate):
-            raise ValueError('You passed a hostname ("{}") that does not match the certificat\'s common name.'.format(host))
+            raise ValueError(
+                'You passed a hostname ("{}") that does not match the certificat\'s common name.'.format(host))
 
         certificate_filepath = self.generate_certificate_filepath(checksum_address=checksum_address)
         certificate_already_exists = os.path.isfile(certificate_filepath)
@@ -126,7 +125,6 @@ class NodeStorage(ABC):
         self.log.debug("Saved TLS certificate for {}: {}".format(self, certificate_filepath))
 
         return certificate_filepath
-
 
     @abstractmethod
     def store_node_certificate(self, certificate: Certificate) -> str:
@@ -178,7 +176,6 @@ class NodeStorage(ABC):
 
 
 class ForgetfulNodeStorage(NodeStorage):
-
     _name = ':memory:'
     __base_prefix = "nucypher-tmp-certs-"
 
@@ -231,7 +228,8 @@ class ForgetfulNodeStorage(NodeStorage):
             raise RuntimeError("Invalid certificate checksum_address encountered")  # TODO: More
         self.__certificates[checksum_address] = certificate
         self._write_tls_certificate(certificate=certificate)
-        return self.generate_certificate_filepath(checksum_address=checksum_address)
+        filepath = self.generate_certificate_filepath(checksum_address=checksum_address)
+        return filepath
 
     def store_node_metadata(self, node):
         self.__metadata[node.checksum_public_address] = node
@@ -282,7 +280,6 @@ class ForgetfulNodeStorage(NodeStorage):
 
 
 class LocalFileBasedNodeStorage(NodeStorage):
-
     _name = 'local'
     __METADATA_FILENAME_TEMPLATE = '{}.node'
 
@@ -348,7 +345,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
         return certificate_filepath
 
     @validate_checksum_address
-    def __read_tls_public_certificate(self, filepath: str = None, checksum_address: str=None) -> Certificate:
+    def __read_tls_public_certificate(self, filepath: str = None, checksum_address: str = None) -> Certificate:
         """Deserialize an X509 certificate from a filepath"""
         if not bool(filepath) ^ bool(checksum_address):
             raise ValueError("Either pass filepath or checksum_address; Not both.")
@@ -407,7 +404,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
             known_nodes = set()
             for filename in filenames:
                 metadata_path = os.path.join(self.metadata_dir, filename)
-                node = self.__read_metadata(filepath=metadata_path, federated_only=federated_only)   # TODO: 466
+                node = self.__read_metadata(filepath=metadata_path, federated_only=federated_only)  # TODO: 466
                 known_nodes.add(node)
             return known_nodes
 
@@ -417,7 +414,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
             certificate = self.__read_tls_public_certificate(checksum_address=checksum_address)
             return certificate
         metadata_path = self.__generate_metadata_filepath(checksum_address=checksum_address)
-        node = self.__read_metadata(filepath=metadata_path, federated_only=federated_only)   # TODO: 466
+        node = self.__read_metadata(filepath=metadata_path, federated_only=federated_only)  # TODO: 466
         return node
 
     def store_node_certificate(self, certificate: Certificate):
@@ -513,7 +510,6 @@ class TemporaryFileBasedNodeStorage(LocalFileBasedNodeStorage):
             shutil.rmtree(self.__temp_certificates_dir, ignore_errors=True)
 
     def initialize(self) -> bool:
-
         # Metadata
         self.__temp_metadata_dir = tempfile.mkdtemp(prefix="nucypher-tmp-nodes-")
         self.metadata_dir = self.__temp_metadata_dir
@@ -526,7 +522,6 @@ class TemporaryFileBasedNodeStorage(LocalFileBasedNodeStorage):
 
 
 class S3NodeStorage(NodeStorage):
-
     _name = 's3'
     S3_ACL = 'private'  # Canned S3 Permissions
 

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -109,8 +109,7 @@ class NodeStorage(ABC):
         # TODO: It's better for us to have checked this a while ago so that this situation is impossible.  #443
         if host and (host != common_name_on_certificate):
             raise ValueError(
-                'You passed a hostname ("{}") that does not match the certificat\'s common name.'.format(host))
-
+                f"You passed a hostname ('{host}') that does not match the certificate's common name.")
         certificate_filepath = self.generate_certificate_filepath(checksum_address=checksum_address)
         certificate_already_exists = os.path.isfile(certificate_filepath)
         if force is False and certificate_already_exists:
@@ -122,7 +121,7 @@ class NodeStorage(ABC):
             certificate_file.write(public_pem_bytes)
 
         self.certificate_filepath = certificate_filepath
-        self.log.debug("Saved TLS certificate for {}: {}".format(self, certificate_filepath))
+        self.log.debug(f"Saved TLS certificate for {self}: {certificate_filepath}")
 
         return certificate_filepath
 

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -123,7 +123,7 @@ class NodeStorage(ABC):
             certificate_file.write(public_pem_bytes)
 
         self.certificate_filepath = certificate_filepath
-        self.log.info("Saved TLS certificate for {}: {}".format(self, certificate_filepath))
+        self.log.debug("Saved TLS certificate for {}: {}".format(self, certificate_filepath))
 
         return certificate_filepath
 

--- a/nucypher/keystore/keypairs.py
+++ b/nucypher/keystore/keypairs.py
@@ -183,7 +183,7 @@ class HostingKeypair(Keypair):
             raise TypeError("You didn't provide a cert, but also told us not to generate keys.  Not sure what to do.")
 
         if not certificate_filepath:
-            certificate_filepath = constants.CERTIFICATE_NOT_SAVED.bool_value(False)
+            certificate_filepath = constants.CERTIFICATE_NOT_SAVED
 
         self.certificate = certificate
         self.certificate_filepath = certificate_filepath

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -48,20 +48,8 @@ class NucypherMiddlewareClient:
     def __getattr__(self, method_name):
         # Quick sanity check.
         if not method_name in ("post", "get", "put", "patch", "delete"):
-            raise TypeError("This client is for HTTP only - you need to use a real HTTP verb, not '{}'.".format(method_name))
-        def method_wrapper(node=None, host=None, port=None, *args, **kwargs):
-            if (not node and not all((host, port))) or (node and any(host, port)):
-                raise ValueError("Pass either node or host and port.")
-            if node:
-                if any((host, port)):
-                    raise ValueError("Don't pass host and port if you are passing the node.")
-            elif all((host, port)):
-                assert False
-            else:
-                raise ValueError("You need to pass either the node or a host and port.")
-            node = kwargs.pop('node')
-            self._node_selector(node)
-            response = method(*args, **kwargs)
+            raise TypeError(
+                "This client is for HTTP only - you need to use a real HTTP verb, not '{}'.".format(method_name))
 
 
             cleaned_response = self.response_cleaner(response)

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -24,6 +24,7 @@ from cryptography.hazmat.backends import default_backend
 from twisted.logger import Logger
 from umbral.cfrags import CapsuleFrag
 from umbral.signing import Signature
+from constant_sorrow.constants import CERTIFICATE_NOT_SAVED
 
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 
@@ -40,7 +41,18 @@ class NucypherMiddlewareClient:
     library = requests
 
     def parse_node_or_host_and_port(self, node, host, port):
-        raise NotImplementedError()
+        if node:
+            if any((host, port)):
+                raise ValueError("Don't pass host and port if you are passing the node.")
+            host = node.rest_url()
+            certificate_filepath = node.certificate_filepath
+        elif all((host, port)):
+            host = "{}:{}".format(host, port)
+            certificate_filepath = CERTIFICATE_NOT_SAVED
+        else:
+            raise ValueError("You need to pass either the node or a host and port.")
+
+        return host, certificate_filepath, self.library
 
     def invoke_method(self, method, url, *args, **kwargs):
         raise NotImplementedError()

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -83,9 +83,11 @@ class NucypherMiddlewareClient:
             host, node_certificate_filepath, http_client = self.parse_node_or_host_and_port(node, host, port)
 
             if certificate_filepath:
-                if node_certificate_filepath is not CERTIFICATE_NOT_SAVED:
+                filepaths_are_different = node_certificate_filepath != certificate_filepath
+                node_has_a_cert = node_certificate_filepath is not CERTIFICATE_NOT_SAVED
+                if node_has_a_cert and filepaths_are_different:
                     raise ValueError(
-                        "Don't try to pass a certificate_filepath while also passing a node with a certificate_filepath.  What do you even expect?")
+                        "Don't try to pass a node with a certificate_filepath while also passing a different certificate_filepath.  What do you even expect?")
             else:
                 certificate_filepath = node_certificate_filepath
 
@@ -194,7 +196,7 @@ class RestMiddleware:
             path=f"kFrag/{id_as_hex}/reencrypt",
             data=payload, timeout=2)
 
-    def node_information(self, host, port, certificate_filepath):
+    def node_information(self, host, port, certificate_filepath=None):
         response = self.client.get(host=host, port=port,
                                    path="public_information",
                                    timeout=2,

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -49,9 +49,12 @@ class RestMiddleware:
 
             self._library = library
 
-        def __getattr__(self, item):
+        def __getattr__(self, method_name):
+            # Quick sanity check.
+            if not method_name in ("post", "get", "put", "patch", "delete"):
+                raise TypeError("This client is for HTTP only - you need to use a real HTTP verb.")
             def method_wrapper(*args, **kwargs):
-                method = getattr(self._library, item)
+                method = getattr(self._library, method_name)
                 response = method(*args, **kwargs)
                 cleaned_response = self.response_cleaner(response)
                 if cleaned_response.status_code >= 300:

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -171,11 +171,9 @@ class RestMiddleware:
         return response.content
 
     def get_nodes_via_rest(self,
-                           url,
-                           certificate_filepath,
+                           node,
                            announce_nodes=None,
                            nodes_i_need=None,
-                           client=requests,
                            fleet_checksum=None):
         if nodes_i_need:
             # TODO: This needs to actually do something.
@@ -188,21 +186,16 @@ class RestMiddleware:
         else:
             params = {}
 
-        req_kwargs = {}
-
-        if client is requests:
-            req_kwargs["verify"] = certificate_filepath
-            req_kwargs["timeout"] = 2
-            req_kwargs["params"] = params
-        else:
-            req_kwargs["query_string"] = params
-
         if announce_nodes:
             payload = bytes().join(bytes(VariableLengthBytestring(n)) for n in announce_nodes)
-            response = client.post("https://{}/node_metadata".format(url),
-                                   data=payload,
-                                   **req_kwargs)
+            response = self.client.post(node=node,
+                                        path="node_metadata",
+                                        params=params,
+                                        data=payload,
+                                        )
         else:
-            response = client.get("https://{}/node_metadata".format(url), **req_kwargs)
+            response = self.client.get(node=node,
+                                       path="node_metadata",
+                                       params=params)
 
         return response

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -82,33 +82,7 @@ class NucypherMiddlewareClient:
 class RestMiddleware:
     log = Logger()
 
-    class _Client:
-
-        def __init__(self, library, response_cleaner=None):
-            if response_cleaner is not None:
-                self.response_cleaner = response_cleaner
-            else:
-                self.response_cleaner = lambda r: r
-
-            self._library = library
-
-        def __getattr__(self, method_name):
-            # Quick sanity check.
-            if not method_name in ("post", "get", "put", "patch", "delete"):
-                raise TypeError("This client is for HTTP only - you need to use a real HTTP verb.")
-            def method_wrapper(*args, **kwargs):
-                method = getattr(self._library, method_name)
-                response = method(*args, **kwargs)
-                cleaned_response = self.response_cleaner(response)
-                if cleaned_response.status_code >= 300:
-                    if cleaned_response.status_code == 404:
-                        raise NotFound("While trying to {} {} ({}), server claims not to have found it.  Response: {}".format(item, args, kwargs, cleaned_response.content))
-                    else:
-                        raise UnexpectedResponse("Unexpected response while trying to {} {},{}: {} {}".format(item, args, kwargs, cleaned_response.status_code, cleaned_response.content))
-                return cleaned_response
-            return method_wrapper
-
-    client = _Client(requests)
+    client = NucypherMiddlewareClient()
 
     def get_certificate(self, host, port, timeout=3, retry_attempts: int = 3, retry_rate: int = 2,
                         current_attempt: int = 0):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -40,6 +40,10 @@ class NotFound(UnexpectedResponse):
 class NucypherMiddlewareClient:
     library = requests
 
+    @staticmethod
+    def response_cleaner(response):
+        return response
+
     def parse_node_or_host_and_port(self, node, host, port):
         if node:
             if any((host, port)):
@@ -55,7 +59,14 @@ class NucypherMiddlewareClient:
         return host, certificate_filepath, self.library
 
     def invoke_method(self, method, url, *args, **kwargs):
-        raise NotImplementedError()
+        self.clean_params(kwargs)
+        response = method(url, *args, **kwargs)
+        return response
+
+    def clean_params(self, request_kwargs):
+        """
+        No cleaning needed.
+        """
 
     def __getattr__(self, method_name):
         # Quick sanity check.

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -52,7 +52,16 @@ class NucypherMiddlewareClient:
         # Quick sanity check.
         if not method_name in ("post", "get", "put", "patch", "delete"):
             raise TypeError("This client is for HTTP only - you need to use a real HTTP verb, not '{}'.".format(method_name))
-        def method_wrapper(*args, **kwargs):
+        def method_wrapper(node=None, host=None, port=None, *args, **kwargs):
+            if (not node and not all((host, port))) or (node and any(host, port)):
+                raise ValueError("Pass either node or host and port.")
+            if node:
+                if any((host, port)):
+                    raise ValueError("Don't pass host and port if you are passing the node.")
+            elif all((host, port)):
+                assert False
+            else:
+                raise ValueError("You need to pass either the node or a host and port.")
             node = kwargs.pop('node')
             self._node_selector(node)
             response = method(*args, **kwargs)

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -61,10 +61,11 @@ class NucypherMiddlewareClient:
             if cleaned_response.status_code >= 300:
                 if cleaned_response.status_code == 404:
                     raise NotFound(
-                        "While trying to {} {} ({}), server claims not to have found it.  Response: {}".format(item,
-                                                                                                               args,
-                                                                                                               kwargs,
-                                                                                                               cleaned_response.content))
+                        "While trying to {} {} ({}), server claims not to have found it.  Response: {}".format(
+                            method_name,
+                            args,
+                            kwargs,
+                            cleaned_response.content))
                 else:
                     raise UnexpectedResponse(
                         "Unexpected response while trying to {} {},{}: {} {}".format(item, args, kwargs,
@@ -132,18 +133,20 @@ class RestMiddleware:
 
     def revoke_arrangement(self, ursula, revocation):
         # TODO: Implement revocation confirmations
-        response = self.client.delete("https://{}/kFrag/{}".format(ursula.rest_interface,
-                                                                   revocation.arrangement_id.hex()),
-                                      bytes(revocation),
-                                      )
+        response = self.client.delete(
+            node=ursula,
+            path="kFrag/{}".format(revocation.arrangement_id.hex()),
+            data=bytes(revocation),
+        )
         return response
 
     def get_competitive_rate(self):
         return NotImplemented
 
     def get_treasure_map_from_node(self, node, map_id):
-        endpoint = "https://{}/treasure_map/{}".format(node.rest_interface, map_id)
-        response = self.client.get(endpoint, timeout=2)
+        response = self.client.get(node=node,
+                                   path="treasure_map/{}".format(map_id),
+                                   timeout=2)
         return response
 
     def put_treasure_map_on_node(self, node, map_id, map_payload):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -156,9 +156,8 @@ class RestMiddleware:
         return self.client.post(endpoint, payload, verify=work_order.ursula.certificate_filepath, timeout=2)
 
     def node_information(self, host, port, certificate_filepath):
-        endpoint = "https://{}:{}/public_information".format(host, port)
         response = self.client.get(host=host, port=port,
-                                   path=endpoint,
+                                   path="public_information",
                                    verify=certificate_filepath,
                                    timeout=2)
         return response.content

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -159,8 +159,10 @@ class RestMiddleware:
     def send_work_order_payload_to_ursula(self, work_order):
         payload = work_order.payload()
         id_as_hex = work_order.arrangement_id.hex()
-        endpoint = 'https://{}/kFrag/{}/reencrypt'.format(work_order.ursula.rest_interface, id_as_hex)
-        return self.client.post(endpoint, payload, timeout=2)
+        return self.client.post(
+            node=work_order.ursula,
+            path="kFrag/{}/reencrypt".format(id_as_hex),
+            data=payload, timeout=2)
 
     def node_information(self, host, port, certificate_filepath):
         response = self.client.get(host=host, port=port,

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -167,7 +167,10 @@ class RestMiddleware:
 
     def node_information(self, host, port, certificate_filepath):
         endpoint = "https://{}:{}/public_information".format(host, port)
-        response = self.client.get(endpoint, verify=certificate_filepath, timeout=2)
+        response = self.client.get(host=host, port=port,
+                                   path=endpoint,
+                                   verify=certificate_filepath,
+                                   timeout=2)
         return response.content
 
     def get_nodes_via_rest(self,

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -117,7 +117,7 @@ class RestMiddleware:
 
     def enact_policy(self, ursula, id, payload):
         response = self.client.post(node=ursula,
-                                    path='kFrag/{}'.format(ursula.rest_interface, id.hex()),
+                                    path='kFrag/{}'.format(id.hex()),
                                     data=payload,
                                     timeout=2)
         return True, ursula.stamp.as_umbral_pubkey()
@@ -147,8 +147,10 @@ class RestMiddleware:
         return response
 
     def put_treasure_map_on_node(self, node, map_id, map_payload):
-        endpoint = "https://{}/treasure_map/{}".format(node.rest_interface, map_id)
-        response = self.client.post(endpoint, data=map_payload, timeout=2)
+        response = self.client.post(node=node,
+                                    path="treasure_map/{}".format(map_id),
+                                    data=map_payload,
+                                    timeout=2)
         return response
 
     def send_work_order_payload_to_ursula(self, work_order):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -37,16 +37,13 @@ class NotFound(UnexpectedResponse):
 
 
 class NucypherMiddlewareClient:
-
     library = requests
 
-    def __init__(self,
-                 response_cleaner=None,
-                 ):
-        if response_cleaner is not None:
-            self.response_cleaner = response_cleaner
-        else:
-            self.response_cleaner = lambda r: r
+    def url_from_node_or_host_and_port(self, node, host, port):
+        raise NotImplementedError()
+
+    def invoke_method(self, method, url, *args, **kwargs):
+        raise NotImplementedError()
 
     def __getattr__(self, method_name):
         # Quick sanity check.

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -394,6 +394,7 @@ class Learner:
 
         # Store node's certificate - It has been seen.
         certificate_filepath = self.node_storage.store_node_certificate(certificate=node.certificate)
+        self.log.info("Saved TLS certificate for {}: {}".format(node.nickname, certificate_filepath))
 
         try:
             node.verify_node(force=force_verification_check,

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -394,6 +394,7 @@ class Learner:
 
         # Store node's certificate - It has been seen.
         certificate_filepath = self.node_storage.store_node_certificate(certificate=node.certificate)
+        node.certificate_filepath = certificate_filepath  # In some cases (seed nodes or other temp stored certs), this will update the filepath from the temp location to this one.
         self.log.info(f"Saved TLS certificate for {node.nickname}: {certificate_filepath}")
 
         try:
@@ -415,7 +416,6 @@ class Learner:
         self.known_nodes[address] = node
 
         if self.save_metadata:
-            node.certificate_filepath = certificate_filepath
             self.node_storage.store_node_metadata(node=node)
 
         self.log.info("Remembering {} ({}), popping {} listeners.".format(node.nickname, node.checksum_public_address, len(listeners)))

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -402,7 +402,7 @@ class Learner:
                              network_middleware=self.network_middleware,
                              accept_federated_only=self.federated_only,
                              # TODO: 466 - move federated-only up to Learner?
-                             certificate_filepath=certificate_filepath)
+                             )
         except SSLError:
             return False  # TODO: Bucket this node as having bad TLS info - maybe it's an update that hasn't fully propagated?
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -673,8 +673,6 @@ class Learner:
             self.log.warn("Can't learn right now: {}".format(e.args[0]))
             return
 
-        teacher_uri = current_teacher.rest_interface
-
         if Teacher in self.__class__.__bases__:
             announce_nodes = [self]
         else:
@@ -685,10 +683,9 @@ class Learner:
             # TODO: Streamline path generation
             certificate_filepath = self.node_storage.generate_certificate_filepath(
                 checksum_address=current_teacher.checksum_public_address)
-            response = self.network_middleware.get_nodes_via_rest(url=teacher_uri,
+            response = self.network_middleware.get_nodes_via_rest(node=current_teacher,
                                                                   nodes_i_need=self._node_ids_to_learn_about_immediately,
                                                                   announce_nodes=announce_nodes,
-                                                                  certificate_filepath=certificate_filepath,
                                                                   fleet_checksum=self.known_nodes.checksum)
         except requests.exceptions.ConnectionError as e:
             unresponsive_nodes.add(current_teacher)

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -418,7 +418,7 @@ class Learner:
             node.certificate_filepath = certificate_filepath
             self.node_storage.store_node_metadata(node=node)
 
-        self.log.info("Remembering {}, popping {} listeners.".format(node.checksum_public_address, len(listeners)))
+        self.log.info("Remembering {} ({}), popping {} listeners.".format(node.nickname, node.checksum_public_address, len(listeners)))
         for listener in listeners:
             listener.add(address)
         self._node_ids_to_learn_about_immediately.discard(address)

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -394,7 +394,7 @@ class Learner:
 
         # Store node's certificate - It has been seen.
         certificate_filepath = self.node_storage.store_node_certificate(certificate=node.certificate)
-        self.log.info("Saved TLS certificate for {}: {}".format(node.nickname, certificate_filepath))
+        self.log.info(f"Saved TLS certificate for {node.nickname}: {certificate_filepath}")
 
         try:
             node.verify_node(force=force_verification_check,

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -274,6 +274,7 @@ def make_rest_app(
         from nucypher.policy.models import Revocation
 
         revocation = Revocation.from_bytes(request.data)
+        # TODO: This line sometimes raises an error because it tries to log the bytes of the revocation, which can have a "{"  # 724
         log.info("Received revocation: {} -- for arrangement {}".format(bytes(revocation), id_as_hex))
         try:
             with ThreadedSession(db_engine) as session:

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -21,8 +21,11 @@ from nucypher.utilities.sandbox.constants import MOCK_KNOWN_URSULAS_CACHE
 
 
 class _TestMiddlewareClient(NucypherMiddlewareClient):
-    def node_selector(self, node):
-        assert False
+
+    @staticmethod
+    def response_cleaner(response):
+        response.content = response.data
+        return response
 
     def _get_mock_client_by_ursula(self, ursula):
         port = ursula.rest_information()[0].port

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -16,19 +16,27 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 from bytestring_splitter import VariableLengthBytestring
 from nucypher.characters.lawful import Ursula
-from nucypher.network.middleware import RestMiddleware
+from nucypher.network.middleware import RestMiddleware, NucypherMiddlewareClient
 from nucypher.utilities.sandbox.constants import MOCK_KNOWN_URSULAS_CACHE
+
+
+class _TestMiddlewareClient(NucypherMiddlewareClient):
+    def node_selector(self, node):
+        assert False
 
 
 class MockRestMiddleware(RestMiddleware):
     _ursulas = None
 
-    class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
-        pass
-
+    @staticmethod
     def response_cleaner(self, response):
         response.content = response.data
         return response
+
+    client = _TestMiddlewareClient(response_cleaner=response_cleaner)
+
+    class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
+        pass
 
     def _get_mock_client_by_ursula(self, ursula):
         port = ursula.rest_information()[0].port

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -42,18 +42,18 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
             raise RuntimeError(
                 "Can't find an Ursula with port {} - did you spin up the right test ursulas?".format(port))
 
-    def url_from_node_or_host_and_port(self, node, host, port):
+    def parse_node_or_host_and_port(self, node, host, port):
         if node:
             if any((host, port)):
                 raise ValueError("Don't pass host and port if you are passing the node.")
         elif all((host, port)):
             node = self._get_ursula_by_port(port)
-            rest_app = node.rest_app
-            rest_app.testing = True
-            mock_client = rest_app.test_client()
-            return node.rest_url(), mock_client
         else:
             raise ValueError("You need to pass either the node or a host and port.")
+        rest_app = node.rest_app
+        rest_app.testing = True
+        mock_client = rest_app.test_client()
+        return node.rest_url(), node.certificate_filepath, mock_client
 
     def invoke_method(self, method, url, *args, **kwargs):
         cert_location = kwargs.pop("verify")  # TODO: Is this something that can be meaningfully tested?

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -35,13 +35,6 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
         port = int(url.split(":")[1])
         return self._get_mock_client_by_port(port)
 
-    def _get_mock_client_by_port(self, port):
-        ursula = self._get_ursula_by_port(port)
-        rest_app = ursula.rest_app
-        rest_app.testing = True
-        mock_client = self._Client(rest_app.test_client(), response_cleaner=self.response_cleaner)
-        return mock_client
-
     def _get_ursula_by_port(self, port):
         try:
             return MOCK_KNOWN_URSULAS_CACHE[port]

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -18,6 +18,7 @@ from bytestring_splitter import VariableLengthBytestring
 from nucypher.characters.lawful import Ursula
 from nucypher.network.middleware import RestMiddleware, NucypherMiddlewareClient
 from nucypher.utilities.sandbox.constants import MOCK_KNOWN_URSULAS_CACHE
+from constant_sorrow.constants import CERTIFICATE_NOT_SAVED
 
 
 class _TestMiddlewareClient(NucypherMiddlewareClient):
@@ -60,7 +61,8 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
         else:
             raise ValueError("You need to pass either the node or a host and port.")
 
-        return node.rest_url(), node.certificate_filepath, mock_client
+        # We don't use certs in mock-style tests anyway.
+        return node.rest_url(), CERTIFICATE_NOT_SAVED, mock_client
 
     def invoke_method(self, method, url, *args, **kwargs):
         _cert_location = kwargs.pop("verify")  # TODO: Is this something that can be meaningfully tested?

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -24,20 +24,6 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
     def node_selector(self, node):
         assert False
 
-
-class MockRestMiddleware(RestMiddleware):
-    _ursulas = None
-
-    @staticmethod
-    def response_cleaner(self, response):
-        response.content = response.data
-        return response
-
-    client = _TestMiddlewareClient(response_cleaner=response_cleaner)
-
-    class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
-        pass
-
     def _get_mock_client_by_ursula(self, ursula):
         port = ursula.rest_information()[0].port
         return self._get_mock_client_by_port(port)
@@ -60,7 +46,22 @@ class MockRestMiddleware(RestMiddleware):
             raise RuntimeError(
                 "Can't find an Ursula with port {} - did you spin up the right test ursulas?".format(port))
 
-    def get_certificate(self, host, port, timeout=3, retry_attempts: int = 3, retry_rate: int = 2, current_attempt: int = 0):
+
+class MockRestMiddleware(RestMiddleware):
+    _ursulas = None
+
+    @staticmethod
+    def response_cleaner(self, response):
+        response.content = response.data
+        return response
+
+    client = _TestMiddlewareClient(response_cleaner=response_cleaner)
+
+    class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
+        pass
+
+    def get_certificate(self, host, port, timeout=3, retry_attempts: int = 3, retry_rate: int = 2,
+                        current_attempt: int = 0):
         ursula = self._get_ursula_by_port(port)
         return ursula.certificate
 
@@ -105,8 +106,8 @@ class MockRestMiddleware(RestMiddleware):
     def revoke_arrangement(self, ursula, revocation):
         mock_client = self._get_mock_client_by_ursula(ursula)
         response = mock_client.delete('http://localhost/kFrag/{}'.format(
-                                      revocation.arrangement_id.hex()),
-                                      data=bytes(revocation))
+            revocation.arrangement_id.hex()),
+            data=bytes(revocation))
         return response
 
 

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -65,12 +65,7 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
 class MockRestMiddleware(RestMiddleware):
     _ursulas = None
 
-    @staticmethod
-    def response_cleaner(self, response):
-        response.content = response.data
-        return response
-
-    client = _TestMiddlewareClient(response_cleaner=response_cleaner)
+    client = _TestMiddlewareClient()
 
     class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
         pass

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -53,13 +53,13 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
         if node:
             if any((host, port)):
                 raise ValueError("Don't pass host and port if you are passing the node.")
+            mock_client = self._get_mock_client_by_ursula(node)
         elif all((host, port)):
             node = self._get_ursula_by_port(port)
+            mock_client = self._get_mock_client_by_port(port)
         else:
             raise ValueError("You need to pass either the node or a host and port.")
-        rest_app = node.rest_app
-        rest_app.testing = True
-        mock_client = rest_app.test_client()
+
         return node.rest_url(), node.certificate_filepath, mock_client
 
     def invoke_method(self, method, url, *args, **kwargs):

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -65,8 +65,12 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
     def invoke_method(self, method, url, *args, **kwargs):
         cert_location = kwargs.pop("verify")  # TODO: Is this something that can be meaningfully tested?
         kwargs.pop("timeout", None)  # Just get rid of timeout; not needed for the test client.
+        self.clean_params(kwargs)
         response = method(url, *args, **kwargs)
         return response
+
+    def clean_params(self, request_kwargs):
+        request_kwargs["query_string"] = request_kwargs.pop("params", {})
 
 
 class MockRestMiddleware(RestMiddleware):

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -35,6 +35,13 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
         port = int(url.split(":")[1])
         return self._get_mock_client_by_port(port)
 
+    def _get_mock_client_by_port(self, port):
+        ursula = self._get_ursula_by_port(port)
+        rest_app = ursula.rest_app
+        rest_app.testing = True
+        mock_client = rest_app.test_client()
+        return mock_client
+
     def _get_ursula_by_port(self, port):
         try:
             return MOCK_KNOWN_URSULAS_CACHE[port]

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -96,8 +96,8 @@ class EvilMiddleWare(MockRestMiddleware):
         """
         Try to get Ursula to propagate a malicious (or otherwise shitty) interface ID.
         """
-        mock_client = self._get_mock_client_by_ursula(ursula)
-        response = mock_client.post("http://localhost/node_metadata".format(mock_client),
+        response = self.client.post(node=ursula,
+                                    path="node_metadata",
                                     data=bytes(VariableLengthBytestring(shitty_interface_id))
                                     )
         return response

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -75,28 +75,6 @@ class MockRestMiddleware(RestMiddleware):
         ursula = self._get_ursula_by_port(port)
         return ursula.certificate
 
-    def send_work_order_payload_to_ursula(self, work_order):
-        mock_client = self._get_mock_client_by_ursula(work_order.ursula)
-        payload = work_order.payload()
-        id_as_hex = work_order.arrangement_id.hex()
-        return mock_client.post('http://localhost/kFrag/{}/reencrypt'.format(id_as_hex), data=payload)
-
-    def get_treasure_map_from_node(self, node, map_id):
-        mock_client = self._get_mock_client_by_ursula(node)
-        response = mock_client.get("http://localhost/treasure_map/{}".format(map_id))
-        return response
-
-    def get_nodes_via_rest(self, url, *args, **kwargs):
-        response = super().get_nodes_via_rest(url, client=self._get_mock_client_by_url(url), *args, **kwargs)
-        return response
-
-    def revoke_arrangement(self, ursula, revocation):
-        mock_client = self._get_mock_client_by_ursula(ursula)
-        response = mock_client.delete('http://localhost/kFrag/{}'.format(
-            revocation.arrangement_id.hex()),
-            data=bytes(revocation))
-        return response
-
 
 class EvilMiddleWare(MockRestMiddleware):
     """

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -83,7 +83,7 @@ class MockRestMiddleware(RestMiddleware):
 
     def get_certificate(self, host, port, timeout=3, retry_attempts: int = 3, retry_rate: int = 2,
                         current_attempt: int = 0):
-        ursula = self._get_ursula_by_port(port)
+        ursula = self.client._get_ursula_by_port(port)
         return ursula.certificate
 
 

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -75,18 +75,6 @@ class MockRestMiddleware(RestMiddleware):
         ursula = self._get_ursula_by_port(port)
         return ursula.certificate
 
-    def consider_arrangement(self, arrangement):
-        mock_client = self._get_mock_client_by_ursula(arrangement.ursula)
-        response = mock_client.post("http://localhost/consider_arrangement",
-                                    data=bytes(arrangement),
-                                    content_type='application/octet')
-        return response
-
-    def enact_policy(self, ursula, id, payload):
-        mock_client = self._get_mock_client_by_ursula(ursula)
-        response = mock_client.post('http://localhost/kFrag/{}'.format(id.hex()), data=payload)
-        return True, ursula.stamp.as_umbral_pubkey()
-
     def send_work_order_payload_to_ursula(self, work_order):
         mock_client = self._get_mock_client_by_ursula(work_order.ursula)
         payload = work_order.payload()
@@ -100,12 +88,6 @@ class MockRestMiddleware(RestMiddleware):
 
     def get_nodes_via_rest(self, url, *args, **kwargs):
         response = super().get_nodes_via_rest(url, client=self._get_mock_client_by_url(url), *args, **kwargs)
-        return response
-
-    def put_treasure_map_on_node(self, node, map_id, map_payload):
-        mock_client = self._get_mock_client_by_ursula(node)
-        response = mock_client.post("http://localhost/treasure_map/{}".format(map_id),
-                                    data=map_payload)
         return response
 
     def revoke_arrangement(self, ursula, revocation):

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -98,11 +98,6 @@ class MockRestMiddleware(RestMiddleware):
         response = mock_client.get("http://localhost/treasure_map/{}".format(map_id))
         return response
 
-    def node_information(self, host, port, certificate_filepath):
-        mock_client = self._get_mock_client_by_port(port)
-        response = mock_client.get("http://localhost/public_information")
-        return response.content
-
     def get_nodes_via_rest(self, url, *args, **kwargs):
         response = super().get_nodes_via_rest(url, client=self._get_mock_client_by_url(url), *args, **kwargs)
         return response

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -63,10 +63,9 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
         return node.rest_url(), node.certificate_filepath, mock_client
 
     def invoke_method(self, method, url, *args, **kwargs):
-        cert_location = kwargs.pop("verify")  # TODO: Is this something that can be meaningfully tested?
+        _cert_location = kwargs.pop("verify")  # TODO: Is this something that can be meaningfully tested?
         kwargs.pop("timeout", None)  # Just get rid of timeout; not needed for the test client.
-        self.clean_params(kwargs)
-        response = method(url, *args, **kwargs)
+        response = super().invoke_method(method, url, *args, **kwargs)
         return response
 
     def clean_params(self, request_kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,8 +54,3 @@ def pytest_collection_modifyitems(config, items):
     log_level_name = config.getoption("--log-level", "info", skip=True)
     observer = SimpleObserver(log_level_name)
     globalLogPublisher.addObserver(observer)
-
-    # Timber!
-    log_level_name = config.getoption("--log-level", "info", skip=True)
-    observer = SimpleObserver(log_level_name)
-    globalLogPublisher.addObserver(observer)

--- a/tests/learning/test_fault_tolerance.py
+++ b/tests/learning/test_fault_tolerance.py
@@ -178,14 +178,12 @@ def test_node_posts_future_version(federated_ursulas):
     globalLogPublisher.addObserver(warning_trapper)
 
     crazy_node = b"invalid-node"
-    middleware.get_nodes_via_rest(ursula.rest_url(),
-                                  certificate_filepath=ursula.certificate_filepath,
+    middleware.get_nodes_via_rest(node=ursula,
                                   announce_nodes=(crazy_node,))
     assert len(warnings) == 1
     future_node = list(federated_ursulas)[1]
     future_node.TEACHER_VERSION = future_node.TEACHER_VERSION + 10
     future_node_bytes = bytes(future_node)
-    middleware.get_nodes_via_rest(ursula.rest_url(),
-                                  certificate_filepath=ursula.certificate_filepath,
+    middleware.get_nodes_via_rest(node=ursula,
                                   announce_nodes=(future_node_bytes,))
     assert len(warnings) == 2

--- a/tests/network/test_node_storage.py
+++ b/tests/network/test_node_storage.py
@@ -38,6 +38,7 @@ def test_one_node_stores_a_bunch_of_others(federated_ursulas, ursula_federated_t
     assert not newcomer.known_nodes
 
     newcomer.start_learning_loop(now=True)
+
     def start_lonely_learning_loop():
         newcomer.start_learning_loop()
         start = maya.now()


### PR DESCRIPTION
Our test suite has failed to detect and prevent mistakes related to middleware logic lately.  This is largely because the middleware we use for testing, `MockRestMiddleware`, has shared too little logic with `RestMiddleware`.

This PR changes that by smashing nearly all the logic down into the latter while only overriding small, surgical components needed for testing.

It also gives middleware more of an "onion" shape, by cleaning both requests and responses. 

There was no explicit Issue for these problems; this PR continues the work of #721.  During this work, three related issues were closed:

* Fixes #669 
* Fixes #727 
* Fixes #728 