### PR TITLE
Testing heartbeat demo in CircleCI + some build performance optimization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,15 +86,15 @@ workflows:
               only: /.*/
           requires:
             - blockchain
-            - contracts
+            # - contracts  (Removed dependency to speed up overall workflow execution)
       - actors:
           context: "NuCypher Tests"
           filters:
             tags:
               only: /.*/
           requires:
-            - blockchain
-            - contracts
+            # - blockchain (Removed dependency to speed up overall workflow execution)
+            # - contracts  (Removed dependency to speed up overall workflow execution)
       - deployers:
           context: "NuCypher Tests"
           filters:
@@ -102,7 +102,7 @@ workflows:
               only: /.*/
           requires:
             - blockchain
-            - contracts
+            # - contracts  (Removed dependency to speed up overall workflow execution)
       - config:
           context: "NuCypher Tests"
           filters:
@@ -339,7 +339,7 @@ jobs:
 
   agents:
     <<: *python_36_base
-    parallelism: 2
+    parallelism: 4
     steps:
       - prepare_environment
       - run:
@@ -445,7 +445,7 @@ jobs:
 
   cli:
     <<: *python_36_base
-    parallelism: 4
+    parallelism: 6
     steps:
       - prepare_environment
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,13 @@ workflows:
           filters:
             tags:
               only: /.*/
-          requires:
-            # - blockchain (Removed dependency to speed up overall workflow execution)
-            # - contracts  (Removed dependency to speed up overall workflow execution)
+          requires:   #  (Prioritizing this task given that it's awfully slow)
+              - pip_install_36
+              - pipenv_install_36
+              - pip_install_37
+              - pipenv_install_37
+            # - blockchain
+            # - contracts
       - deployers:
           context: "NuCypher Tests"
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-          requires:
-          - pip_install_36
-          - pipenv_install_36
-          - pip_install_37
-          - pipenv_install_37
       - contracts:
           context: "NuCypher Tests"
           filters:
@@ -460,17 +455,20 @@ jobs:
   heartbeat_demo:
     <<: *python_36_base
     steps:
-    - prepare_environment
+    - checkout
+    - pip_install
     - run:
         name: Run demo Ursula fleet, Alicia and the Doctor
         command: |
           mkdir /tmp/ursulas-logs
-          pipenv run python examples/run_lonely_demo_ursula.py > /tmp/ursulas-logs/lonely.log.txt 2>&1 &
+          export PATH=~/.local/bin:$PATH
+          source ~/.bashrc
+          python3 examples/run_lonely_demo_ursula.py > /tmp/ursulas-logs/lonely.log.txt 2>&1 &
           sleep 25
-          pipenv run python examples/run_demo_ursula_fleet.py > /tmp/ursulas-logs/fleet.log.txt 2>&1 &
+          python3 examples/run_demo_ursula_fleet.py > /tmp/ursulas-logs/fleet.log.txt 2>&1 &
           sleep 60
-          pipenv run python examples/heartbeat_demo/alicia.py
-          pipenv run python examples/heartbeat_demo/doctor.py
+          python3 examples/heartbeat_demo/alicia.py
+          python3 examples/heartbeat_demo/doctor.py
     - store_artifacts:
           path: /tmp/ursulas-logs
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -464,12 +464,15 @@ jobs:
     - run:
         name: Run demo Ursula fleet, Alicia and the Doctor
         command: |
-          pipenv run python examples/run_lonely_demo_ursula.py > /dev/null 2>&1 &
+          mkdir /tmp/ursulas-logs
+          pipenv run python examples/run_lonely_demo_ursula.py > /tmp/ursulas-logs/lonely.log.txt 2>&1 &
           sleep 25
-          pipenv run python examples/run_demo_ursula_fleet.py > /dev/null 2>&1 &
+          pipenv run python examples/run_demo_ursula_fleet.py > /tmp/ursulas-logs/fleet.log.txt 2>&1 &
           sleep 60
           pipenv run python examples/heartbeat_demo/alicia.py
           pipenv run python examples/heartbeat_demo/doctor.py
+    - store_artifacts:
+          path: /tmp/ursulas-logs
 
   cli:
     <<: *python_36_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,16 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - heartbeat_demo:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+          - pip_install_36
+          - pipenv_install_36
+          - pip_install_37
+          - pipenv_install_37
       - contracts:
           context: "NuCypher Tests"
           filters:
@@ -446,6 +456,20 @@ jobs:
           name: Learner Tests
           command: pipenv run pytest tests/learning
       - capture_test_results
+
+  heartbeat_demo:
+    <<: *python_36_base
+    steps:
+    - prepare_environment
+    - run:
+        name: Run demo Ursula fleet, Alicia and the Doctor
+        command: |
+          pipenv run python examples/run_lonely_demo_ursula.py > /dev/null 2>&1 &
+          sleep 25
+          pipenv run python examples/run_demo_ursula_fleet.py > /dev/null 2>&1 &
+          sleep 60
+          pipenv run python examples/heartbeat_demo/alicia.py
+          pipenv run python examples/heartbeat_demo/doctor.py
 
   cli:
     <<: *python_36_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - heartbeat_demo:
-          context: "NuCypher Tests"
-          filters:
-            tags:
-              only: /.*/
       - contracts:
           context: "NuCypher Tests"
           filters:
@@ -144,6 +139,14 @@ workflows:
             - deployers
             - config
             - character
+      - heartbeat_demo:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+          - cli
+          - ursula_command
       - mypy:
           context: "NuCypher Tests"
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -500,7 +500,8 @@ jobs:
     <<: *python_36_base
     steps:
       - checkout
-      - pip_install
+      - attach_workspace:
+          at: ~/.local/share/virtualenvs/
       - run:
           name: Install Documentation Build Dependencies
           command: pip3 install --user sphinx recommonmark sphinx-rtd-theme

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -463,10 +463,14 @@ jobs:
           mkdir /tmp/ursulas-logs
           export PATH=~/.local/bin:$PATH
           source ~/.bashrc
-          python3 examples/run_lonely_demo_ursula.py > /tmp/ursulas-logs/lonely.log.txt 2>&1 &
-          sleep 25
-          python3 examples/run_demo_ursula_fleet.py > /tmp/ursulas-logs/fleet.log.txt 2>&1 &
-          sleep 60
+          export NUCYPHER_SENTRY_LOGS=0
+          export NUCYPHER_FILE_LOGS=0
+          python3 examples/run_lonely_demo_ursula.py > /tmp/ursulas-logs/ursula-11500.txt 2>&1 &
+          sleep 15
+          nucypher ursula run --dev --debug --federated-only --teacher-uri localhost:11500 --rest-port 11501 > /tmp/ursulas-logs/ursula-11501.txt 2>&1 &
+          sleep 15
+          nucypher ursula run --dev --debug --federated-only --teacher-uri localhost:11500 --rest-port 11502 > /tmp/ursulas-logs/ursula-11502.txt 2>&1 &
+          sleep 15
           python3 examples/heartbeat_demo/alicia.py
           python3 examples/heartbeat_demo/doctor.py
     - store_artifacts:

--- a/docs/source/demos/heartbeat_demo.md
+++ b/docs/source/demos/heartbeat_demo.md
@@ -10,7 +10,7 @@ Since Alicia knows that she may want to share this data in the future, she uses 
 a _policy public key_ for her Heart Monitor to use, so she can read and delegate access to the encrypted
 data as she sees fit.
 
-The Heart Monitor uses this public key to produce a file with some amount of encrypted heart rate measurements;
+The Heart Monitor uses this public key to produce a file with some amount of encrypted heart rate measurements. 
 This file is uploaded to a storage layer (e.g., IPFS, S3, or whatever you choose).
 
 At some future point, she wants to share this information with other people, such as her Doctor.
@@ -29,12 +29,13 @@ This simple example showcases many interesting and distinctive aspects of NuCyph
 
 ## Install Nucypher
 
-Acquire the nucypher application code and install the dependencies.
-For a full installation guide see the [NuCypher Installation Guide](/guides/installation_guide).
+Acquire the `nucypher` application code and install the dependencies.
+For a full installation guide see the [NuCypher Installation Guide](../guides/installation_guide).
 
 ## Run the Demo
 
-Assuming you already have `nucypher` installed with the `demos` extra, running the Heartbeat demo only involves running the `alicia.py` and `doctor.py` scripts; Run `alicia.py` first:
+Assuming you already have `nucypher` installed with the `demos` extra and a [local fleet of Ursulas running](local_fleet_demo), running the Heartbeat demo only involves executing the `alicia.py` and `doctor.py` scripts, contained in the `examples/heartbeat_demo` directory. 
+Run `alicia.py` first:
 
 ```bash
 (nucypher)$ python alicia.py

--- a/examples/heartbeat_demo/alicia.py
+++ b/examples/heartbeat_demo/alicia.py
@@ -99,6 +99,7 @@ print("The policy public key for "
 import heart_monitor
 heart_monitor.generate_heart_rate_samples(policy_pubkey,
                                           label=label,
+                                          samples=50,
                                           save_as_file=True)
 
 
@@ -122,7 +123,7 @@ doctor_strange = Bob.from_public_keys(powers_and_material=powers_and_material,
 policy_end_datetime = maya.now() + datetime.timedelta(days=5)
 # - m-out-of-n: This means Alicia splits the re-encryption key in 5 pieces and
 #               she requires Bob to seek collaboration of at least 3 Ursulas
-m, n = 3, 5
+m, n = 2, 3
 
 
 # With this information, Alicia creates a policy granting access to Bob.

--- a/examples/heartbeat_demo/heartbeat_demo.md
+++ b/examples/heartbeat_demo/heartbeat_demo.md
@@ -15,15 +15,15 @@ This simple use case showcases many interesting and distinctive aspects of NuCyp
   - The Doctor never interacts with Alicia or the Heart Monitor: he only needs the encrypted data and some policy metadata.
 
 ### How to run the demo 
-Assuming you already have `nucypher` installed (specifically, the `federated` branch), running the demo only involves running the `alicia.py` and `doctor.py` scripts. You should run `alicia.py` first:
+Assuming you already have `nucypher` installed and a local demo fleet of Ursulas deployed, running the demo only involves running the `alicia.py` and `doctor.py` scripts. You should run `alicia.py` first:
 
 ```sh
-(nucypher)$ python alicia.py <seednode_url>
+(nucypher)$ python examples/heartbeat_demo/alicia.py
 ```
 This will create a temporal directory called `alicia-files` that contains the data for making Alicia persistent (i.e., her private keys). Apart from that, it will also generate data and keys for the demo. What's left is running the `doctor.py` script:
 
 ```sh
-(nucypher)$ python doctor.py <seednode_url>
+(nucypher)$ python examples/heartbeat_demo/doctor.py
 ```
 This script will read the data generated in the previous step and retrieve re-encrypted ciphertexts by means of the NuCypher network. The result is printed in the console:
 


### PR DESCRIPTION
This PR aims at two different things, both related to CircleCI:
1) A naive test of the currently official heartbeat demo (i.e., the command-line one):
    - Adds a `heartbeat_demo` task that deploys a local fleet and tests the demo (#599).
    - I've run into problems for using the fleet script in CircleCI. I ended up spinning a few nodes individually.
2) A simple, not-at-all-elegant way to speed up the running time of our builds by ~25%:
    - Increases the parallelism in a few tasks where there was still some room for improvement.
    - Reuses the pipenv workspace for building the docs. (Saved almost 2 minutes here. Yay!)
    - This is the "ugly" part: some tasks are being "re-organized" by removing logical dependencies that were making the overall execution too slow (e.g., slow tasks that were chained). The most critical example is the `actors` task, which is impossible to speed up with CircleCI alone.

Including the heartbeat testing, the workflow can run in 9 minutes (see https://circleci.com/workflow-run/92605882-751e-417b-a4a1-57b2ec4f1e5f), which is more than 3 minutes faster than previous builds on master, which were approximately 12-13 minutes (e.g., see https://circleci.com/workflow-run/f71fd3a8-635d-4963-91e4-4164c3313c55).
