### PR TITLE
Short summary of NuCypher in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 *A proxy re-encryption network to empower privacy in decentralized systems*
 
+![](https://img.shields.io/pypi/v/nucypher.svg?style=flat)
 ![](https://img.shields.io/pypi/pyversions/nucypher.svg)
 ![](https://coveralls.io/repos/github/nucypher/nucypher/badge.svg?branch=master)
-![](https://circleci.com/gh/nucypher/nucypher/tree/master.svg?style=svg)
+[![](https://img.shields.io/circleci/project/github/nucypher/nucypher.svg?logo=circleci)](https://circleci.com/gh/nucypher/nucypher/tree/master)
 ![](https://img.shields.io/discord/411401661714792449.svg)
 [![Documentation Status](https://readthedocs.org/projects/nucypher/badge/?version=latest)](https://nucypher.readthedocs.io/en/latest/?badge=latest)
 ![](https://img.shields.io/pypi/l/nucypher.svg)
 
 ----
 
-![](https://img.shields.io/pypi/v/nucypher.svg?style=flat)
 
 - Documentation https://nucypher.readthedocs.io/en/latest/
 - Website https://www.nucypher.com/

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 *A proxy re-encryption network to empower privacy in decentralized systems*
 
-![](https://img.shields.io/pypi/v/nucypher.svg?style=flat)
-![](https://img.shields.io/pypi/pyversions/nucypher.svg)
-![](https://coveralls.io/repos/github/nucypher/nucypher/badge.svg?branch=master)
-[![](https://img.shields.io/circleci/project/github/nucypher/nucypher.svg?logo=circleci)](https://circleci.com/gh/nucypher/nucypher/tree/master)
-![](https://img.shields.io/discord/411401661714792449.svg)
-[![Documentation Status](https://readthedocs.org/projects/nucypher/badge/?version=latest)](https://nucypher.readthedocs.io/en/latest/?badge=latest)
-![](https://img.shields.io/pypi/l/nucypher.svg)
+[![pypi](https://img.shields.io/pypi/v/nucypher.svg?style=flat)](https://pypi.org/project/nucypher/)
+[![pyversions](https://img.shields.io/pypi/pyversions/nucypher.svg)](https://pypi.org/project/nucypher/)
+[![coveralls](https://coveralls.io/repos/github/nucypher/nucypher/badge.svg?branch=master)](https://coveralls.io/github/nucypher/nucypher?branch=master)
+[![circleci](https://img.shields.io/circleci/project/github/nucypher/nucypher.svg?logo=circleci)](https://circleci.com/gh/nucypher/nucypher/tree/master)
+[![discord](https://img.shields.io/discord/411401661714792449.svg)](https://discord.gg/7rmXa3S)
+[![Documentation Status](https://readthedocs.org/projects/nucypher/badge/?version=latest)](https://nucypher.readthedocs.io/en/latest/)
+[![license](https://img.shields.io/pypi/l/nucypher.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,15 @@
 
 ----
 
-The NuCypher network uses the [Umbral](https://github.com/nucypher/pyUmbral) threshold proxy re-encryption scheme to provide cryptographic access controls for distributed apps and protocols.
+The NuCypher network uses the [Umbral](https://github.com/nucypher/pyUmbral) 
+threshold proxy re-encryption scheme to provide cryptographic access control 
+for distributed apps and protocols. 
+Applications can use the NuCypher network to facilitate end-to-end encrypted 
+data sharing via sharing policies. Access permissions are baked into the 
+underlying encryption, and access can only be explicitly granted by the data owner. 
+Consequently, the data owner has ultimate control over access to their data. 
+At no point is the data decrypted nor can the underlying private keys be 
+determined by the NuCypher network.
 
 01. Alice, the data owner, grants access to her encrypted data to 
 anyone she wants by creating a policy and uploading it to 
@@ -25,11 +33,13 @@ or any other storage layer.
 03. Ursula, a miner, receives the access policy and stands ready to 
 re-encrypt data in exchange for payment in fees and block rewards. 
 Thanks to the use of proxy re-encryption, 
-Ursula and the storage layer never have access to Alice's plaintext data.
+Ursula and the storage layer never have access to Alice's 
+plaintext data nor her private key.
 
 04. Bob, a data recipient, sends an access request to the NuCypher network. 
-If the policy is satisfied, the data is re-encrypted to his public key 
-and he can decrypt it with his private key.
+If Bob was granted an access policy by Alice, 
+the data is re-encrypted for his public key, 
+and he can subsequently decrypt it with his private key.
 
 More detailed information:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@
 
 ----
 
+The NuCypher network uses the [Umbral](https://github.com/nucypher/pyUmbral) threshold proxy re-encryption scheme to provide cryptographic access controls for distributed apps and protocols.
+
+01. Alice, the data owner, grants access to her encrypted data to 
+anyone she wants by creating a policy and uploading it to 
+the NuCypher network.
+
+02. Anyone can encrypt data using Alice's policy public key. 
+The resulting encrypted data can be uploaded to IPFS, Swarm, S3, 
+or any other storage layer.
+
+03. Ursula, a miner, receives the access policy and stands ready to 
+re-encrypt data in exchange for payment in fees and block rewards. 
+Thanks to the use of proxy re-encryption, 
+Ursula and the storage layer never have access to Alice's plaintext data.
+
+04. Bob, a data recipient, sends an access request to the NuCypher network. 
+If the policy is satisfied, the data is re-encrypted to his public key 
+and he can decrypt it with his private key.
+
+More detailed information:
 
 - Documentation https://nucypher.readthedocs.io/en/latest/
 - Website https://www.nucypher.com/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -31,7 +31,6 @@ NuCypher
 
 
 - GitHub https://www.github.com/nucypher/nucypher
-- Documentation https://nucypher.readthedocs.io/en/latest/
 - Website https://www.nucypher.com/
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,8 +5,7 @@ NuCypher
 
 ----
 
-
-.. image:: https://img.shields.io/pypi/wheel/nucypher.svg
+.. image:: https://img.shields.io/pypi/v/nucypher.svg?style=flat
     :target: https://pypi.org/project/nucypher/
 
 .. image:: https://img.shields.io/pypi/pyversions/nucypher.svg
@@ -24,7 +23,7 @@ NuCypher
     :alt: Discord
 
 .. image:: https://readthedocs.org/projects/nucypher/badge/?version=latest
-    :target: https://nucypher.readthedocs.io/en/latest/?badge=latest
+    :target: https://nucypher.readthedocs.io/en/latest/
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/pypi/l/nucypher.svg

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,7 +51,7 @@ Ursula and the storage layer never have access to Alice's plaintext data.
 If the policy is satisfied, the data is re-encrypted to his public key
 and he can decrypt it with his private key.
 
-More information:
+More detailed information:
 
 - GitHub https://www.github.com/nucypher/nucypher
 - Website https://www.nucypher.com/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,6 +29,29 @@ NuCypher
 .. image:: https://img.shields.io/pypi/l/nucypher.svg
     :target: https://www.gnu.org/licenses/gpl-3.0.html
 
+.. _Umbral: https://github.com/nucypher/pyUmbral
+
+The NuCypher network uses the Umbral_ threshold proxy re-encryption scheme
+to provide cryptographic access controls for distributed apps and protocols.
+
+1. Alice, the data owner, grants access to her encrypted data to
+anyone she wants by creating a policy and uploading it to
+the NuCypher network.
+
+2. Anyone can encrypt data using Alice's policy public key.
+The resulting encrypted data can be uploaded to IPFS, Swarm, S3,
+or any other storage layer.
+
+3. Ursula, a miner, receives the access policy and stands ready to
+re-encrypt data in exchange for payment in fees and block rewards.
+Thanks to the use of proxy re-encryption,
+Ursula and the storage layer never have access to Alice's plaintext data.
+
+4. Bob, a data recipient, sends an access request to the NuCypher network.
+If the policy is satisfied, the data is re-encrypted to his public key
+and he can decrypt it with his private key.
+
+More information:
 
 - GitHub https://www.github.com/nucypher/nucypher
 - Website https://www.nucypher.com/

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(name=ABOUT['__title__'],
       description=ABOUT['__summary__'],
       license=ABOUT['__license__'],
       long_description=long_description,
+      long_description_content_type="text/markdown",
 
       setup_requires=['pytest-runner'],  # required for `setup.py test`
       tests_require=TESTS_REQUIRE,


### PR DESCRIPTION
This PR is just a basic UX improvement: Don't make people click on a secondary link (e.g., docs, whitepaper, website, etc) in order to learn about what is NuCypher. 

Other stuff in this PR:
- Fixes badges links and unify styles.
- Tries to fix bad render of Markdown text in pypi project description (see #794).