### PR TITLE
Bob handles failure cases with a bit more tact

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -561,40 +561,53 @@ class Bob(Character):
     def retrieve(self, message_kit, data_source, alice_verifying_key, label, cache=False):
 
         capsule = message_kit.capsule  # TODO: generalize for WorkOrders with more than one capsule
-        capsule.set_correctness_keys(
-            delegating=data_source.policy_pubkey,
-            receiving=self.public_keys(DecryptingPower),
-            verifying=alice_verifying_key)
 
         hrac, map_id = self.construct_hrac_and_map_id(alice_verifying_key, label)
         _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(map_id=map_id, block=True)
 
-        # TODO: Consider blocking until map is done being followed.
+        already_retrieved = len(message_kit.capsule._attached_cfrags) >= m
 
-        work_orders = self.generate_work_orders(map_id, capsule)
+        if already_retrieved:
+            if cache:
+                must_do_new_retrieval = False
+            else:
+                raise TypeError("Not using cached retrievals, but the MessageKit's capsule has attached CFrags.  Not sure what to do.")
+        else:
+            must_do_new_retrieval = True
 
         cleartexts = []
-        work_orders = work_orders.values()
-        for work_order in work_orders:
-            try:
-                cfrags = self.get_reencrypted_cfrags(work_order)
-            except requests.exceptions.ConnectTimeout:
-                continue
 
-            cfrag = cfrags[0]  # TODO: generalize for WorkOrders with more than one capsule
-            try:
-                message_kit.capsule.attach_cfrag(cfrag)
-                if len(message_kit.capsule._attached_cfrags) >= m:
-                    break
-            except UmbralCorrectnessError:
-                evidence = self.collect_evidence(capsule=capsule,
-                                                 cfrag=cfrag,
-                                                 ursula=work_order.ursula)
+        if must_do_new_retrieval:
+            capsule.set_correctness_keys(
+                delegating=data_source.policy_pubkey,
+                receiving=self.public_keys(DecryptingPower),
+                verifying=alice_verifying_key)
 
-                # TODO: Here's the evidence of Ursula misbehavior. Now what? #500
-                raise self.IncorrectCFragReceived(evidence)
-        else:
-            raise Ursula.NotEnoughUrsulas("Unable to snag m cfrags.")
+            # TODO: Consider blocking until map is done being followed.
+
+            work_orders = self.generate_work_orders(map_id, capsule, cache=cache)
+            work_orders = work_orders.values()  # TODO: A little pedantic, isn't it?
+
+            for work_order in work_orders:
+                try:
+                    cfrags = self.get_reencrypted_cfrags(work_order)
+                except (requests.exceptions.ConnectTimeout, NotFound):
+                    continue
+
+                cfrag = cfrags[0]  # TODO: generalize for WorkOrders with more than one capsule
+                try:
+                    message_kit.capsule.attach_cfrag(cfrag)
+                    if len(message_kit.capsule._attached_cfrags) >= m:
+                        break
+                except UmbralCorrectnessError:
+                    evidence = self.collect_evidence(capsule=capsule,
+                                                     cfrag=cfrag,
+                                                     ursula=work_order.ursula)
+
+                    # TODO: Here's the evidence of Ursula misbehavior. Now what? #500
+                    raise self.IncorrectCFragReceived(evidence)
+            else:
+                raise Ursula.NotEnoughUrsulas("Unable to snag m cfrags.")
 
         delivered_cleartext = self.verify_from(data_source, message_kit, decrypt=True)
         cleartexts.append(delivered_cleartext)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -527,9 +527,8 @@ class Bob(Character):
 
             capsules_to_include = []
             for capsule in capsules:
-                # if not capsule in self._saved_work_orders[node_id]:
-                # This means we'll overwrite the old work_order (see below).  TODO: Do we want to save it?
-                capsules_to_include.append(capsule)
+                if not capsule in self._saved_work_orders[node_id]:
+                    capsules_to_include.append(capsule)
 
             if capsules_to_include:
                 work_order = WorkOrder.construct_by_bob(

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -558,7 +558,7 @@ class Bob(Character):
         treasure_map = self.get_treasure_map(alice_pubkey_sig, label)
         self.follow_treasure_map(treasure_map=treasure_map, block=block)
 
-    def retrieve(self, message_kit, data_source, alice_verifying_key, label):
+    def retrieve(self, message_kit, data_source, alice_verifying_key, label, cache=False):
 
         capsule = message_kit.capsule  # TODO: generalize for WorkOrders with more than one capsule
         capsule.set_correctness_keys(

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -576,12 +576,12 @@ class Bob(Character):
 
         cleartexts = []
 
-        if must_do_new_retrieval:
-            capsule.set_correctness_keys(
-                delegating=data_source.policy_pubkey,
-                receiving=self.public_keys(DecryptingPower),
-                verifying=alice_verifying_key)
+        capsule.set_correctness_keys(
+            delegating=data_source.policy_pubkey,
+            receiving=self.public_keys(DecryptingPower),
+            verifying=alice_verifying_key)
 
+        if must_do_new_retrieval:
             # TODO: Consider blocking until map is done being followed.
 
             work_orders = self.generate_work_orders(map_id, capsule, cache=cache)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -506,7 +506,7 @@ class Bob(Character):
 
         return treasure_map
 
-    def generate_work_orders(self, map_id, *capsules, num_ursulas=None):
+    def generate_work_orders(self, map_id, *capsules, num_ursulas=None, cache=False):
         from nucypher.policy.models import WorkOrder  # Prevent circular import
 
         try:
@@ -536,7 +536,8 @@ class Bob(Character):
                     arrangement_id, capsules_to_include, ursula, self)
                 generated_work_orders[node_id] = work_order
                 # TODO: Fix this. It's always taking the last capsule
-                self._saved_work_orders[node_id][capsule] = work_order
+                if cache:
+                    self._saved_work_orders[node_id][capsule] = work_order
 
             if num_ursulas == len(generated_work_orders):
                 break

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -527,8 +527,9 @@ class Bob(Character):
 
             capsules_to_include = []
             for capsule in capsules:
-                if not capsule in self._saved_work_orders[node_id]:
-                    capsules_to_include.append(capsule)
+                # if not capsule in self._saved_work_orders[node_id]:
+                # This means we'll overwrite the old work_order (see below).  TODO: Do we want to save it?
+                capsules_to_include.append(capsule)
 
             if capsules_to_include:
                 work_order = WorkOrder.construct_by_bob(

--- a/tests/characters/conftest.py
+++ b/tests/characters/conftest.py
@@ -20,8 +20,7 @@ def bob_control_test_client(federated_bob):
 
 @pytest.fixture(scope='module')
 def enrico_control_test_client(capsule_side_channel):
-    _, data_source = capsule_side_channel
-    message_kit, enrico = capsule_side_channel
+    message_kit, enrico = capsule_side_channel()
     web_controller = enrico.make_web_controller(crash_on_error=True)
     yield web_controller._web_app.test_client()
 

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -290,6 +290,11 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
 
     number_left_to_collect = enacted_federated_policy.treasure_map.m - len(federated_bob._saved_work_orders)
 
+    the_message_kit.capsule.set_correctness_keys(
+        delegating=the_data_source.policy_pubkey,
+        receiving=federated_bob.public_keys(DecryptingPower),
+        verifying=federated_alice.stamp.as_umbral_pubkey())
+
     new_work_orders = federated_bob.generate_work_orders(enacted_federated_policy.treasure_map.public_id(),
                                                          the_message_kit.capsule,
                                                          num_ursulas=number_left_to_collect)
@@ -300,7 +305,8 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
 
     # Now.
     # At long last.
-    cleartext = federated_bob.verify_from(the_data_source, the_message_kit,
+    cleartext = federated_bob.verify_from(the_data_source,
+                                          the_message_kit,
                                           decrypt=True)
     assert cleartext == b'Welcome to the flippering.'
 

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -147,7 +147,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
 
     # We'll test against just a single Ursula - here, we make a WorkOrder for just one.
     # We can pass any number of capsules as args; here we pass just one.
-    capsule = capsule_side_channel[0].capsule
+    capsule = capsule_side_channel()[0].capsule
     capsule.set_correctness_keys(delegating=enacted_federated_policy.public_key,
                                  receiving=federated_bob.public_keys(DecryptingPower),
                                  verifying=federated_alice.stamp.as_umbral_pubkey())
@@ -247,14 +247,14 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_feder
     new_cfrag = cfrags[0]
 
     # Attach the CFrag to the Capsule.
-    capsule_side_channel[0].capsule.attach_cfrag(new_cfrag)
+    last_capsule_on_side_channel.attach_cfrag(new_cfrag)
 
 
 def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, federated_alice, capsule_side_channel):
     # The side channel delivers all that Bob needs at this point:
     # - A single MessageKit, containing a Capsule
     # - A representation of the data source
-    the_message_kit, the_data_source = capsule_side_channel
+    the_message_kit, the_data_source = capsule_side_channel.messages[-1]
 
     # Bob has saved two WorkOrders so far.
     assert len(federated_bob._saved_work_orders) == 2
@@ -292,7 +292,7 @@ def test_federated_bob_retrieves(federated_bob,
     # The side channel delivers all that Bob needs at this point:
     # - A single MessageKit, containing a Capsule
     # - A representation of the data source
-    the_message_kit, the_data_source = capsule_side_channel
+    the_message_kit, the_data_source = capsule_side_channel()
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -121,11 +121,24 @@ def test_bob_joins_policy_and_retrieves(federated_alice,
     failed_revocations = federated_alice.revoke(policy)
     assert len(failed_revocations) == 0
 
+    # One thing to note here is that Bob *can* still retrieve with the cached CFrags, even though this Policy has been revoked.  #892
+    _cleartexts = bob.retrieve(message_kit=message_kit,
+                               data_source=enrico,
+                               alice_verifying_key=alices_verifying_key,
+                               label=policy.label,
+                               cache=True,
+                               )
+    assert _cleartexts == delivered_cleartexts  # TODO: 892
+
+    # OK, but we imagine that the message_kit is fresh here.
+    message_kit.capsule._attached_cfrags = []
+
     with pytest.raises(Ursula.NotEnoughUrsulas):
         _cleartexts = bob.retrieve(message_kit=message_kit,
                                    data_source=enrico,
                                    alice_verifying_key=alices_verifying_key,
-                                   label=policy.label)
+                                   label=policy.label,
+                                   )
 
 
 def test_treasure_map_serialization(enacted_federated_policy, federated_bob):

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -29,7 +29,6 @@ def test_federated_bob_full_retrieve_flow(federated_ursulas,
     # - A single MessageKit, containing a Capsule
     # - A representation of the data source
     the_message_kit, the_data_source = capsule_side_channel()
-
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
     delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -1,7 +1,6 @@
-import os
-import time
-
 import datetime
+import os
+
 import maya
 import pytest
 
@@ -14,11 +13,11 @@ from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
 def test_federated_bob_full_retrieve_flow(federated_ursulas,
-                                 federated_bob,
-                                 federated_alice,
-                                 capsule_side_channel,
-                                 enacted_federated_policy
-                                 ):
+                                          federated_bob,
+                                          federated_alice,
+                                          capsule_side_channel,
+                                          enacted_federated_policy
+                                          ):
     # Assume for the moment that Bob has already received a TreasureMap.
     treasure_map = enacted_federated_policy.treasure_map
     federated_bob.treasure_maps[treasure_map.public_id()] = treasure_map
@@ -101,15 +100,24 @@ def test_bob_joins_policy_and_retrieves(federated_alice,
 
     assert plaintext == delivered_cleartexts[0]
 
-    # FIXME: Bob tries to retrieve again
-    # delivered_cleartexts = bob.retrieve(message_kit=message_kit,
-    #                                     data_source=enrico,
-    #                                     alice_verifying_key=alices_verifying_key,
-    #                                     label=policy.label)
-    #
-    # assert plaintext == delivered_cleartexts[0]
+    # Bob tries to retrieve again, but without using the cached CFrags, it fails.
+    with pytest.raises(TypeError):
+        delivered_cleartexts = bob.retrieve(message_kit=message_kit,
+                                            data_source=enrico,
+                                            alice_verifying_key=alices_verifying_key,
+                                            label=policy.label)
 
-    # # Let's try retrieve again, but Alice revoked the policy.
+    # Bob can retrieve again if he sets cache=True.
+    cleartexts_delivered_a_second_time = bob.retrieve(message_kit=message_kit,
+                                                      data_source=enrico,
+                                                      alice_verifying_key=alices_verifying_key,
+                                                      label=policy.label,
+                                                      cache=True)
+
+    # Indeed, they're the same cleartexts.
+    assert delivered_cleartexts == cleartexts_delivered_a_second_time
+
+    # Let's try retrieve again, but Alice revoked the policy.
     failed_revocations = federated_alice.revoke(policy)
     assert len(failed_revocations) == 0
 

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -28,7 +28,7 @@ def test_federated_bob_full_retrieve_flow(federated_ursulas,
     # The side channel delivers all that Bob needs at this point:
     # - A single MessageKit, containing a Capsule
     # - A representation of the data source
-    the_message_kit, the_data_source = capsule_side_channel
+    the_message_kit, the_data_source = capsule_side_channel()
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 

--- a/tests/characters/test_character_control.py
+++ b/tests/characters/test_character_control.py
@@ -159,7 +159,7 @@ def test_bob_character_control_join_policy(bob_control_test_client, enacted_fede
 
 
 def test_bob_character_control_retrieve(bob_control_test_client, enacted_federated_policy, capsule_side_channel):
-    message_kit, data_source = capsule_side_channel
+    message_kit, data_source = capsule_side_channel()
 
     request_data = {
         'label': enacted_federated_policy.label.decode(),

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -270,9 +270,19 @@ def enacted_blockchain_policy(idle_blockchain_policy, blockchain_ursulas):
 
 @pytest.fixture(scope="module")
 def capsule_side_channel(enacted_federated_policy):
-    enrico = Enrico(policy_encrypting_key=enacted_federated_policy.public_key)
-    message_kit, _signature = enrico.encrypt_message(b"Welcome to the flippering.")
-    return message_kit, enrico
+    class _CapsuleSideChannel:
+        def __init__(self):
+            self.messages = []
+            self()
+
+        def __call__(self):
+            enrico = Enrico(policy_encrypting_key=enacted_federated_policy.public_key)
+            message = "Welcome to the flippering.".format(len(self.messages)).encode()
+            message_kit, _signature = enrico.encrypt_message(message)
+            self.messages.append((message_kit, enrico))
+            return message_kit, enrico
+
+    return _CapsuleSideChannel()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Bob previously had trouble retrieving twice.  Ursula raised an error instead of 404'ing if a KFrag was `NotFound`.  Both of these are fixed, as well as smoothing out the retrieval flow and adding some test logic.

Fixes #833 
Fixes #851 

Opened #892 

**Note**: Presently, even though Bob *can* retrieve multiple times, he does not pass `cache=True` to `retrieve(...)` in any of the control APIs, so he will still fail in this case.  If we determine that this is the sane default, I'll add it in this PR.  If more discussion is in order, it can be added later or as an option for dapp developers.