### PR TITLE
Bump version: 0.1.0-alpha.20 → 0.1.0-alpha.21

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-alpha.20
+current_version = 0.1.0-alpha.21
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.1.0-alpha.20'
+release = '0.1.0-alpha.21'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "0.1.0-alpha.20"
+__version__ = "0.1.0-alpha.21"
 
 __author__ = "NuCypher"
 


### PR DESCRIPTION
- Alice revoke interface and HTTP character control endpoint
- Token denomination management with `NU` and "NuNit"
- Stake management with `Stake` class
- Testnet token faucet (Felix)
- Initial "Slashing Protocol" documentation
- New banner art "NU" and "NuCypher"
- Updates to Web3 5.0.0a8