### PR TITLE
Store active policies via a policy ID

### DIFF
--- a/nucypher/characters/control/controllers.py
+++ b/nucypher/characters/control/controllers.py
@@ -72,8 +72,8 @@ class AliceJSONController(AliceInterface, CharacterController):
         return response_data
 
     @character_control_interface
-    def revoke(self, policy_encrypting_key, request):
-        result = super().revoke(policy_encrypting_key)
+    def revoke(self, request):
+        result = super().revoke(**self.serializer.parse_revoke_input(request=request))
         response_data = result
         return response_data
 

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -109,8 +109,9 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
                          'alice_verifying_key': new_policy.alice.stamp}
         return response_data
 
-    def revoke(self, policy_encrypting_key):
-        policy = self.character.active_policies[policy_encrypting_key]
+    def revoke(self, label: bytes, bob_verifying_key: bytes):
+        policy_id = construct_policy_id(label, bob_verifying_key)
+        policy = self.character.active_policies[policy_id]
 
         failed_revocations = self.character.revoke(policy)
         if len(failed_revocations) > 0:
@@ -119,7 +120,7 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
                 if fail_reason == NotFound:
                     del(failed_revocations[node_id])
         if len(failed_revocations) <= (policy.n - policy.treasure_map.m + 1):
-            del(self.character.active_policies[policy_encrypting_key])
+            del(self.character.active_policies[policy_id])
 
         response_data = {'failed_revocations': len(failed_revocations)}
         return response_data

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -6,6 +6,7 @@ from umbral.keys import UmbralPublicKey
 from nucypher.characters.control.specifications import AliceSpecification, BobSpecification, EnricoSpecification
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import DecryptingPower, SigningPower
+from nucypher.crypto.utils import construct_policy_id
 from nucypher.network.middleware import NotFound
 
 

--- a/nucypher/characters/control/serializers.py
+++ b/nucypher/characters/control/serializers.py
@@ -109,8 +109,11 @@ class AliceControlJSONSerializer(CharacterControlJSONSerializer):
 
         return response_data
 
-    # The revoke endpoint only uses a URL-param; ergo, we have no need for
-    # a de/serialization method.
+    @staticmethod
+    def parse_revoke_input(request: dict):
+        parsed_input = dict(label=request['label'].encode(),
+                            bob_verifying_key=bytes.fromhex(request['bob_verifying_key']))
+        return parsed_input
 
     @staticmethod
     def dump_public_keys_output(response: dict):

--- a/nucypher/characters/control/specifications.py
+++ b/nucypher/characters/control/specifications.py
@@ -70,7 +70,7 @@ class AliceSpecification(CharacterSpecification):
     __grant = (('bob_encrypting_key', 'bob_verifying_key', 'm', 'n', 'label', 'expiration'),  # In
                ('treasure_map', 'policy_encrypting_key', 'alice_verifying_key'))              # Out
 
-    __revoke = (('policy_encrypting_key', ),  # In
+    __revoke = (('label', 'bob_verifying_key', ),  # In
                 ('failed_revocations',))     # Out
 
     __public_keys = ((),

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -16,7 +16,6 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 import json
 import random
-import secrets
 from base64 import b64encode
 from collections import OrderedDict
 from functools import partial
@@ -102,6 +101,16 @@ class Alice(Character, PolicyAuthor):
         self.log.info(self.banner)
 
         self.active_policies = dict()
+
+    def add_active_policy(self, active_policy):
+        """
+        Adds a Policy object that is active on the NuCypher network to Alice's
+        `active_policies` dictionary by the policy ID.
+        The policy ID is a Keccak hash of the policy label and Bob's stamp bytes
+        """
+        if active_policy.id in self.active_policies:
+            raise KeyError("Policy already exists in active_policies.")
+        self.active_policies[active_policy.id] = active_policy
 
     def generate_kfrags(self, bob: 'Bob', label: bytes, m: int, n: int) -> List:
         """

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -325,14 +325,13 @@ class Alice(Character, PolicyAuthor):
             response = controller(interface=controller._internal_controller.grant, control_request=request)
             return response
 
-        @alice_control.route("/revoke/<policy_encrypting_key>", methods=['DELETE'])
-        def revoke(policy_encrypting_key):
+        @alice_control.route("/revoke", methods=['DELETE'])
+        def revoke():
             """
             Character control endpoint for policy revocation.
             """
             response = controller(interface=controller._internal_controller.revoke,
-                                  control_request=request,
-                                  policy_encrypting_key=policy_encrypting_key)
+                                  control_request=request)
             return response
 
         return controller

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -29,7 +29,6 @@ from nucypher.config.constants import GLOBAL_DOMAIN
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--bob-encrypting-key', help="Bob's encrypting key as a hexideicmal string", type=click.STRING)
 @click.option('--bob-verifying-key', help="Bob's verifying key as a hexideicmal string", type=click.STRING)
-@click.option('--policy-encrypting-key', help="The Policy encrypting key derived from a label", type=click.STRING)
 @click.option('--label', help="The label for a policy", type=click.STRING)
 @click.option('--m', help="M-Threshold KFrags", type=click.INT)
 @click.option('--n', help="N-Total KFrags", type=click.INT)
@@ -56,7 +55,6 @@ def alice(click_config,
           dry_run,
           bob_encrypting_key,
           bob_verifying_key,
-          policy_encrypting_key,
           label,
           m,
           n):
@@ -181,7 +179,11 @@ def alice(click_config,
         return ALICE.controller.grant(request=grant_request)
 
     elif action == "revoke":
-        return ALICE.controller.revoke(policy_encrypting_key=policy_encrypting_key)
+        revoke_request = {
+            'label': label,
+            'bob_verifying_key': bob_verifying_key
+        }
+        return ALICE.controller.revoke(request=revoke_request)
 
     elif action == "destroy":
         """Delete all configuration files from the disk"""

--- a/nucypher/crypto/utils.py
+++ b/nucypher/crypto/utils.py
@@ -32,6 +32,14 @@ def fingerprint_from_key(public_key: Any):
     return keccak_digest(bytes(public_key)).hex().encode()
 
 
+def construct_policy_id(label: bytes, stamp: bytes) -> bytes:
+    """
+    Forms an ID unique to the policy per label and Bob's signing pubkey via
+    a keccak hash of the two.
+    """
+    return keccak_digest(label + stamp)
+
+
 def canonical_address_from_umbral_key(public_key: UmbralPublicKey) -> bytes:
     pubkey_raw_bytes = public_key.to_bytes(is_compressed=False)[1:]
     eth_pubkey = EthKeyAPI.PublicKey(pubkey_raw_bytes)

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -163,6 +163,14 @@ class Policy:
     def n(self) -> int:
         return len(self.kfrags)
 
+    @property
+    def id(self) -> bytes:
+        """
+        Forms an ID unique to the policy per label and Bob via a hash of the
+        label + bob's encrypting pubkey.
+        """
+        return keccak_digest(self.label + bytes(self.bob.stamp))
+
     def hrac(self) -> bytes:
         """
         This function is hanging on for dear life.  After 180 is closed, it can be completely deprecated.

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -267,7 +267,7 @@ class Policy:
         else:  # ...After *all* the policies are enacted
             # Create Alice's revocation kit
             self.revocation_kit = RevocationKit(self, self.alice.stamp)
-            self.alice.active_policies[self.id] = self
+            self.alice.add_active_policy(self)
 
             if publish is True:
                 return self.publish(network_middleware=network_middleware)

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -41,8 +41,8 @@ from nucypher.crypto.api import keccak_digest, encrypt_and_sign, secure_random
 from nucypher.crypto.constants import PUBLIC_ADDRESS_LENGTH, KECCAK_DIGEST_LENGTH
 from nucypher.crypto.kits import UmbralMessageKit, RevocationKit
 from nucypher.crypto.powers import SigningPower, DecryptingPower
-from nucypher.crypto.signing import Signature, InvalidSignature
-from nucypher.crypto.splitters import key_splitter
+from nucypher.crypto.signing import Signature, InvalidSignature, signature_splitter
+from nucypher.crypto.splitters import key_splitter, capsule_splitter
 from nucypher.crypto.utils import canonical_address_from_umbral_key, recover_pubkey_from_signature, construct_policy_id
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware, NotFound

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -26,6 +26,7 @@ from umbral.kfrags import KFrag
 
 from nucypher.characters.lawful import Bob
 from nucypher.config.characters import AliceConfiguration
+from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.powers import SigningPower, DecryptingPower
 from nucypher.policy.models import Revocation
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
@@ -49,6 +50,10 @@ def test_mocked_decentralized_grant(blockchain_alice, blockchain_bob, three_agen
 
     # Create the Policy, Granting access to Bob
     policy = blockchain_alice.grant(blockchain_bob, label, m=2, n=n, expiration=policy_end_datetime)
+
+    # Check the policy ID
+    policy_id = keccak_digest(policy.label + bytes(policy.bob.stamp))
+    assert policy_id == policy.id
 
     # The number of accepted arrangements at least the number of Ursulas we're using (n)
     assert len(policy._accepted_arrangements) >= n
@@ -77,6 +82,10 @@ def test_federated_grant(federated_alice, federated_bob):
 
     # Create the Policy, granting access to Bob
     policy = federated_alice.grant(federated_bob, label, m=m, n=n, expiration=policy_end_datetime)
+
+    # Check the policy ID
+    policy_id = keccak_digest(policy.label + bytes(policy.bob.stamp))
+    assert policy_id == policy.id
 
     # The number of accepted arrangements at least the number of Ursulas we're using (n)
     assert len(policy._accepted_arrangements) >= n

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -87,6 +87,10 @@ def test_federated_grant(federated_alice, federated_bob):
     policy_id = keccak_digest(policy.label + bytes(policy.bob.stamp))
     assert policy_id == policy.id
 
+    # Check Alice's active policies
+    assert policy_id in federated_alice.active_policies
+    assert federated_alice.active_policies[policy_id] == policy
+
     # The number of accepted arrangements at least the number of Ursulas we're using (n)
     assert len(policy._accepted_arrangements) >= n
 

--- a/tests/characters/test_character_control.py
+++ b/tests/characters/test_character_control.py
@@ -89,7 +89,7 @@ def test_alice_character_control_revoke(alice_control_test_client, federated_bob
     grant_request_data = {
         'bob_encrypting_key': bytes(bob_pubkey_enc).hex(),
         'bob_verifying_key': bytes(federated_bob.stamp).hex(),
-        'label': 'test',
+        'label': 'test-revoke',
         'm': 2,
         'n': 3,
         'expiration': (maya.now() + datetime.timedelta(days=3)).iso8601(),

--- a/tests/characters/test_character_control.py
+++ b/tests/characters/test_character_control.py
@@ -86,7 +86,7 @@ def test_alice_character_control_grant(alice_control_test_client, federated_bob)
 def test_alice_character_control_revoke(alice_control_test_client, federated_bob):
     bob_pubkey_enc = federated_bob.public_keys(DecryptingPower)
 
-    request_data = {
+    grant_request_data = {
         'bob_encrypting_key': bytes(bob_pubkey_enc).hex(),
         'bob_verifying_key': bytes(federated_bob.stamp).hex(),
         'label': 'test',
@@ -94,13 +94,15 @@ def test_alice_character_control_revoke(alice_control_test_client, federated_bob
         'n': 3,
         'expiration': (maya.now() + datetime.timedelta(days=3)).iso8601(),
     }
-    response = alice_control_test_client.put('/grant', data=json.dumps(request_data))
+    response = alice_control_test_client.put('/grant', data=json.dumps(grant_request_data))
     assert response.status_code == 200
 
-    response_data = json.loads(response.data)
-    policy_pubkey = response_data['result']['policy_encrypting_key']
+    revoke_request_data = {
+        'label': 'test',
+        'bob_verifying_key': bytes(federated_bob.stamp).hex()
+    }
 
-    response = alice_control_test_client.delete(f'/revoke/{policy_pubkey}')
+    response = alice_control_test_client.delete(f'/revoke', data=json.dumps(revoke_request_data))
     assert response.status_code == 200
 
     response_data = json.loads(response.data)


### PR DESCRIPTION
### What this does:
1. Adds a function `construct_policy_id` in `nucypher.crypto.utils` to form a "policy ID".
    - This is a Keccak hash of `label || bob_verifying_key`.
2. Modifies Alice's `active_policies` by having policies stored under the policy ID as a key.
3. Fixes controller endpoints to use label and bob's verifying key.

Please release after merging.

![](https://cloudfront.crimethinc.com/assets/posters/your-life-is-your-life/your-life-is-your-life_front_color.jpg)