### PR TITLE
Vodka aftertaste

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ jobs:
       - run:
           name: Blockchain Agent Tests
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/blockchain/eth/entities/agents/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/blockchain/eth/entities/agents/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   actors:
@@ -312,7 +312,7 @@ jobs:
       - run:
           name: Blockchain Actor Tests
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml  $(circleci tests glob "tests/blockchain/eth/entities/actors/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml  $(circleci tests glob "tests/blockchain/eth/entities/actors/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   deployers:
@@ -323,7 +323,7 @@ jobs:
       - run:
           name: Contract Deployer Tests
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/blockchain/eth/entities/deployers/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/blockchain/eth/entities/deployers/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   contracts:
@@ -334,7 +334,7 @@ jobs:
       - run:
           name: Ethereum Contract Unit Tests
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/blockchain/eth/contracts/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/blockchain/eth/contracts/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   basics:
@@ -345,7 +345,7 @@ jobs:
       - run:
           name: Tests for Blockhain interfaces, Crypto functions, Node Configuration and Keystore
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   network:
@@ -355,7 +355,7 @@ jobs:
       - run:
           name: Network Tests
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/network/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/network/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   character:
@@ -366,7 +366,7 @@ jobs:
       - run:
           name: Character Tests
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/characters/**/test_*.py" "tests/learning/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/characters/**/test_*.py" "tests/learning/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   cli:
@@ -377,7 +377,7 @@ jobs:
       - run:
           name: Nucypher CLI Tests
           command: |
-            pipenv run pytest --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/cli/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml $(circleci tests glob "tests/cli/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   tests_ok:

--- a/examples/finnegans_wake_demo/finnegans-wake-demo.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo.py
@@ -2,13 +2,11 @@ import os
 
 import datetime
 import maya
-import shutil
 from twisted.logger import globalLogPublisher
 from umbral.keys import UmbralPublicKey
 
 from nucypher.characters.lawful import Alice, Bob, Ursula
 from nucypher.characters.lawful import Enrico as Enrico
-from nucypher.crypto.powers import SigningPower
 from nucypher.network.middleware import RestMiddleware
 from nucypher.utilities.logging import SimpleObserver
 
@@ -128,7 +126,7 @@ for counter, plaintext in enumerate(finnegans_wake):
     ###############
 
     enrico_as_understood_by_bob = Enrico.from_public_keys(
-        {SigningPower: data_source_public_key},
+        verifying_key=data_source_public_key,
         policy_encrypting_key=policy_pubkey
     )
 

--- a/examples/heartbeat_demo/alicia.py
+++ b/examples/heartbeat_demo/alicia.py
@@ -96,13 +96,9 @@ heart_monitor.generate_heart_rate_samples(policy_pubkey,
 from doctor_keys import get_doctor_pubkeys
 doctor_pubkeys = get_doctor_pubkeys()
 
-powers_and_material = {
-    DecryptingPower: doctor_pubkeys['enc'],
-    SigningPower: doctor_pubkeys['sig']
-}
-
 # We create a view of the Bob who's going to be granted access.
-doctor_strange = Bob.from_public_keys(powers_and_material=powers_and_material,
+doctor_strange = Bob.from_public_keys(verifying_key=doctor_pubkeys['sig'],
+                                      encrypting_key=doctor_pubkeys['enc'],
                                       federated_only=True)
 
 # Here are our remaining Policy details, such as:

--- a/examples/heartbeat_demo/doctor.py
+++ b/examples/heartbeat_demo/doctor.py
@@ -83,7 +83,7 @@ message_kits = (UmbralMessageKit.from_bytes(k) for k in data['kits'])
 
 # The doctor also needs to create a view of the Data Source from its public keys
 data_source = Enrico.from_public_keys(
-    {SigningPower: data['data_source']},
+    verifying_key=data['data_source'],
     policy_encrypting_key=policy_pubkey
 )
 

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -45,7 +45,7 @@ class TokenEconomics:
 
     ...but also...
 
-    kappa = (small_stake_multiplier + (1 - small_stake_multiplier) * min(T, T1) / T1)
+    kappa = small_stake_multiplier + (1 - small_stake_multiplier) * min(T, T1) / T1
     where allLockedPeriods == min(T, T1)
 
     --------------------------

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -177,7 +177,8 @@ class SlashingEconomics:
     reward_coefficient = 2
 
     @property
-    def deployment_parameters(self):
+    def deployment_parameters(self) -> Tuple[int, ...]:
+        """Cast coefficient attributes to uint256 compatible type for solidity+EVM"""
 
         deployment_parameters = [
             self.algorithm_sha256,
@@ -187,4 +188,4 @@ class SlashingEconomics:
             self.reward_coefficient
         ]
 
-        return deployment_parameters
+        return tuple(map(int, deployment_parameters))

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -277,11 +277,11 @@ class Deployer(NucypherTokenActor):
                                      ) -> Dict[str, dict]:
         """
 
-        Example allocation dataset (one year is 31540000 seconds):
+        Example allocation dataset (one year is 31536000 seconds):
 
-        data = [{'address': '0xdeadbeef', 'amount': 100, 'duration': 31540000},
-                {'address': '0xabced120', 'amount': 133432, 'duration': 31540000*2},
-                {'address': '0xf7aefec2', 'amount': 999, 'duration': 31540000*3}]
+        data = [{'address': '0xdeadbeef', 'amount': 100, 'duration': 31536000},
+                {'address': '0xabced120', 'amount': 133432, 'duration': 31536000*2},
+                {'address': '0xf7aefec2', 'amount': 999, 'duration': 31536000*3}]
         """
         if allocation_registry and allocation_outfile:
             raise self.ActorError("Pass either allocation registry or allocation_outfile, not both.")

--- a/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
@@ -92,9 +92,9 @@ contract MiningAdjudicator is Upgradeable {
         public
     {
 
-        require(ReEncryptionValidator.check_serialized_coordinates(_minerPublicKey),
+        require(ReEncryptionValidator.checkSerializedCoordinates(_minerPublicKey),
                 "Miner's public key is invalid");
-        require(ReEncryptionValidator.check_serialized_coordinates(_requesterPublicKey),
+        require(ReEncryptionValidator.checkSerializedCoordinates(_requesterPublicKey),
                 "Requester's public key is invalid");
 
         // Check that CFrag is not evaluated yet

--- a/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
@@ -125,11 +125,24 @@ contract MiningAdjudicator is Upgradeable {
 
         // Verify that _taskSignature is bob's signature of the task specification.
         // A task specification is: capsule + ursula pubkey + alice address + blockhash
-        // TODO: Construct task specification?
-//        require(SignatureVerifier.verify(
-//                ?, _taskSignature, _requesterPublicKey, hashAlgorithm));
+        bytes32 miner_xcoord;
+        assembly {
+            miner_xcoord := mload(add(_minerPublicKey, 32))
+        }
+        require(SignatureVerifier.verify(
+                abi.encodePacked(_capsuleBytes,
+                                 precomp.lostBytes[4],
+                                 miner_xcoord,
+                                 precomp.alicesKeyAsAddress,
+                                 bytes32(0)),
+                abi.encodePacked(_taskSignature, precomp.lostBytes[3]),
+                _requesterPublicKey,
+                hashAlgorithm),
+                "Specification signature is invalid"
+        );
 
         // Extract miner's address and check that is real miner
+        // TODO: Rethink _minerPublicKeySignature, as we only need the miner's address...(I think?)
         address miner = SignatureVerifier.recover(
             SignatureVerifier.hash(_minerPublicKey, hashAlgorithm), _minerPublicKeySignature);
         // Check that miner can be slashed

--- a/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
@@ -142,7 +142,7 @@ contract MiningAdjudicator is Upgradeable {
         );
 
         // Extract miner's address and check that is real miner
-        // TODO: Rethink _minerPublicKeySignature, as we only need the miner's address...(I think?)
+        // TODO: This will depend on the outcome of #962
         address miner = SignatureVerifier.recover(
             SignatureVerifier.hash(_minerPublicKey, hashAlgorithm), _minerPublicKeySignature);
         // Check that miner can be slashed

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -343,6 +343,19 @@ library ReEncryptionValidator {
 		return correct_sign && is_on_curve(_pointX, _pointY);
 	}
 
+    /// @notice Tests if the given serialized coordinates represent a valid EC point
+    /// @param _coords The concatenation of serialized X and Y coordinates
+    /// @return true iff coordinates X and Y are a valid point
+    function check_serialized_coordinates(bytes memory _coords) internal pure returns(bool) {
+        require(_coords.length == 64, "Serialized coordinates should be 64 B");
+        uint256 coordX;
+        uint256 coordY;
+        assembly {
+            coordX := mload(add(_coords, 32))
+            coordY := mload(add(_coords, 64))
+        }
+		return is_on_curve(coordX, coordY);
+	}
 
     /// @notice Tests if a point is on the secp256k1 curve
     /// @param Px The X coordinate of an EC point in affine representation

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -63,7 +63,7 @@ library ReEncryptionValidator {
         require(alicesAddress == _precomputed.alicesKeyAsAddress, "Bad KFrag signature");
 
         // Compute proof's challenge scalar h, used in all ZKP verification equations
-        uint256 h = computeProofChallengeScalar(_capsuleBytes, _cFragBytes);
+        uint256 h = computeProofChallengeScalar(_capsule, _cFrag);
 
         //////
         // Verifying 1st equation: z*E == h*E_1 + E_2
@@ -257,13 +257,9 @@ library ReEncryptionValidator {
     }
 
     function computeProofChallengeScalar(
-        bytes memory _capsuleBytes,
-        bytes memory _cFragBytes
+        UmbralDeserializer.Capsule memory _capsule,
+        UmbralDeserializer.CapsuleFrag memory _cFrag
     ) internal pure returns (uint256) {
-
-        // TODO: Optimize this since they have already been parsed by the caller
-        UmbralDeserializer.Capsule memory _capsule = _capsuleBytes.toCapsule();
-        UmbralDeserializer.CapsuleFrag memory _cFrag = _cFragBytes.toCapsuleFrag();
 
         // Compute h = hash_to_bignum(e, e1, e2, v, v1, v2, u, u1, u2, metadata)
         bytes memory hashInput = abi.encodePacked(

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -307,29 +307,6 @@ library ReEncryptionValidator {
 
     }
 
-    // This function was introduced just to facilitate debugging and testing
-    // of Alice's address extraction from her signature
-    // TODO: Consider moving this somewhere else, or even removing it
-    function aliceAddress(
-        bytes memory _cFragBytes,
-        bytes memory _precomputedBytes
-    )
-        internal pure
-        returns (address)
-    {
-        UmbralDeserializer.CapsuleFrag memory _cFrag = _cFragBytes.toCapsuleFrag();
-        UmbralDeserializer.PreComputedData memory _precomputed = _precomputedBytes.toPreComputedData();
-
-        // Extract Alice's address and check that it corresponds to the one provided
-        address alicesAddress = SignatureVerifier.recover(
-            _precomputed.hashedKFragValidityMessage,
-            abi.encodePacked(_cFrag.proof.kFragSignature, _precomputed.kfragSignatureV)
-        );
-        return alicesAddress;
-    }
-
-    // TODO: Consider changing to internal
-    // TODO: Unit test wrt to Umbral implementation
     function extendedKeccakToBN (bytes memory _data) internal pure returns (uint256) {
 
         bytes32 upper;

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -70,7 +70,7 @@ library ReEncryptionValidator {
         //////
 
         // Input validation: E
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _capsule.pointE.sign,
             _capsule.pointE.xCoord,
             _precomputed.pointEyCoord),
@@ -78,7 +78,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: z*E
-        require(is_on_curve(_precomputed.pointEZxCoord, _precomputed.pointEZyCoord),
+        require(isOnCurve(_precomputed.pointEZxCoord, _precomputed.pointEZyCoord),
                 "Point zE is not a valid EC point"
         );
         require(ecmulVerify(
@@ -91,7 +91,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: E1
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _cFrag.pointE1.sign,          // E1_sign
             _cFrag.pointE1.xCoord,        // E1_x
             _precomputed.pointE1yCoord),  // E1_y
@@ -99,7 +99,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: h*E1
-        require(is_on_curve(_precomputed.pointE1HxCoord, _precomputed.pointE1HyCoord),
+        require(isOnCurve(_precomputed.pointE1HxCoord, _precomputed.pointE1HyCoord),
                 "Point h*E1 is not a valid EC point"
         );
         require(ecmulVerify(
@@ -112,7 +112,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: E2
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _cFrag.proof.pointE2.sign,        // E2_sign
             _cFrag.proof.pointE2.xCoord,      // E2_x
             _precomputed.pointE2yCoord),      // E2_y
@@ -136,7 +136,7 @@ library ReEncryptionValidator {
         //////
 
         // Input validation: V
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _capsule.pointV.sign,
             _capsule.pointV.xCoord,
             _precomputed.pointVyCoord),
@@ -144,7 +144,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: z*V
-        require(is_on_curve(_precomputed.pointVZxCoord, _precomputed.pointVZyCoord),
+        require(isOnCurve(_precomputed.pointVZxCoord, _precomputed.pointVZyCoord),
                 "Point zV is not a valid EC point"
         );
         require(ecmulVerify(
@@ -157,7 +157,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: V1
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _cFrag.pointV1.sign,         // V1_sign
             _cFrag.pointV1.xCoord,       // V1_x
             _precomputed.pointV1yCoord), // V1_y
@@ -165,7 +165,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: h*V1
-        require(is_on_curve(_precomputed.pointV1HxCoord, _precomputed.pointV1HyCoord),
+        require(isOnCurve(_precomputed.pointV1HxCoord, _precomputed.pointV1HyCoord),
             "Point h*V1 is not a valid EC point"
         );
         require(ecmulVerify(
@@ -178,7 +178,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: V2
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _cFrag.proof.pointV2.sign,        // V2_sign
             _cFrag.proof.pointV2.xCoord,      // V2_x
             _precomputed.pointV2yCoord),      // V2_y
@@ -204,7 +204,7 @@ library ReEncryptionValidator {
         // We don't have to validate U since it's fixed and hard-coded
 
         // Input validation: z*U
-        require(is_on_curve(_precomputed.pointUZxCoord, _precomputed.pointUZyCoord),
+        require(isOnCurve(_precomputed.pointUZxCoord, _precomputed.pointUZyCoord),
                 "Point z*U is not a valid EC point"
         );
         require(ecmulVerify(
@@ -217,7 +217,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: U1  (a.k.a. KFragCommitment)
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _cFrag.proof.pointKFragCommitment.sign,     // U1_sign
             _cFrag.proof.pointKFragCommitment.xCoord,   // U1_x
             _precomputed.pointU1yCoord),                // U1_y
@@ -225,7 +225,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: h*U1
-        require(is_on_curve(_precomputed.pointU1HxCoord, _precomputed.pointU1HyCoord),
+        require(isOnCurve(_precomputed.pointU1HxCoord, _precomputed.pointU1HyCoord),
                 "Point h*U1 is not a valid EC point"
         );
         require(ecmulVerify(
@@ -238,7 +238,7 @@ library ReEncryptionValidator {
         );
 
         // Input validation: U2  (a.k.a. KFragPok ("proof of knowledge"))
-        require(check_compressed_point(
+        require(checkCompressedPoint(
             _cFrag.proof.pointKFragPok.sign,    // U2_sign
             _cFrag.proof.pointKFragPok.xCoord,  // U2_x
             _precomputed.pointU2yCoord),        // U2_y
@@ -334,19 +334,19 @@ library ReEncryptionValidator {
     /// @param _pointX The X coordinate of an EC point in affine representation
     /// @param _pointY The Y coordinate of an EC point in affine representation
     /// @return true iff _pointSign and _pointX are the compressed representation of (_pointX, _pointY)
-	function check_compressed_point(
+	function checkCompressedPoint(
 		uint8 _pointSign,
 		uint256 _pointX,
 		uint256 _pointY
 	) internal pure returns(bool) {
 		bool correct_sign = _pointY % 2 == _pointSign - 2;
-		return correct_sign && is_on_curve(_pointX, _pointY);
+		return correct_sign && isOnCurve(_pointX, _pointY);
 	}
 
     /// @notice Tests if the given serialized coordinates represent a valid EC point
     /// @param _coords The concatenation of serialized X and Y coordinates
     /// @return true iff coordinates X and Y are a valid point
-    function check_serialized_coordinates(bytes memory _coords) internal pure returns(bool) {
+    function checkSerializedCoordinates(bytes memory _coords) internal pure returns(bool) {
         require(_coords.length == 64, "Serialized coordinates should be 64 B");
         uint256 coordX;
         uint256 coordY;
@@ -354,14 +354,14 @@ library ReEncryptionValidator {
             coordX := mload(add(_coords, 32))
             coordY := mload(add(_coords, 64))
         }
-		return is_on_curve(coordX, coordY);
+		return isOnCurve(coordX, coordY);
 	}
 
     /// @notice Tests if a point is on the secp256k1 curve
     /// @param Px The X coordinate of an EC point in affine representation
     /// @param Py The Y coordinate of an EC point in affine representation
     /// @return true if (Px, Py) is a valid secp256k1 point; false otherwise
-    function is_on_curve(uint256 Px, uint256 Py) internal pure returns (bool) {
+    function isOnCurve(uint256 Px, uint256 Py) internal pure returns (bool) {
         uint256 p = FIELD_ORDER;
 
         if (Px >= p || Py >= p){

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -58,7 +58,7 @@ library ReEncryptionValidator {
         // Extract Alice's address and check that it corresponds to the one provided
         address alicesAddress = SignatureVerifier.recover(
             _precomputed.hashedKFragValidityMessage,
-            abi.encodePacked(_cFrag.proof.kFragSignature, _precomputed.kfragSignatureV)
+            abi.encodePacked(_cFrag.proof.kFragSignature, _precomputed.lostBytes[0])
         );
         require(alicesAddress == _precomputed.alicesKeyAsAddress, "Bad KFrag signature");
 

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
@@ -70,7 +70,7 @@ library SignatureVerifier {
     * @dev Uses one of pre built hashing algorithm
     * @param _message Signed message
     * @param _signature Signature of message hash
-    * @param _publicKey secp256k1 public key
+    * @param _publicKey secp256k1 public key in uncompressed format without prefix byte (64 bytes)
     * @param _algorithm Hashing algorithm
     **/
     function verify(
@@ -83,6 +83,7 @@ library SignatureVerifier {
         pure
         returns (bool)
     {
+        require(_publicKey.length == 64);
         return toAddress(_publicKey) == recover(hash(_message, _algorithm), _signature);
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -58,7 +58,7 @@ library UmbralDeserializer {
         uint256 pointU2yCoord;
         bytes32 hashedKFragValidityMessage;
         address alicesKeyAsAddress;
-        byte kfragSignatureV;
+        bytes5  lostBytes;
     }
 
     uint256 constant BIGNUM_SIZE = 32;
@@ -68,7 +68,7 @@ library UmbralDeserializer {
     uint256 constant CORRECTNESS_PROOF_SIZE = 4 * POINT_SIZE + BIGNUM_SIZE + SIGNATURE_SIZE;
     uint256 constant CAPSULE_FRAG_SIZE = 3 * POINT_SIZE + BIGNUM_SIZE;
     uint256 constant FULL_CAPSULE_FRAG_SIZE = CAPSULE_FRAG_SIZE + CORRECTNESS_PROOF_SIZE;
-    uint256 constant PRECOMPUTED_DATA_SIZE = (20 * BIGNUM_SIZE) + 32 + 20 + 1;
+    uint256 constant PRECOMPUTED_DATA_SIZE = (20 * BIGNUM_SIZE) + 32 + 20 + 5;
 
     /**
     * @notice Deserialize to capsule (not activated)
@@ -214,8 +214,14 @@ library UmbralDeserializer {
         data.alicesKeyAsAddress = address(bytes20(getBytes32(pointer)));
         pointer += 20;
 
-        data.kfragSignatureV = getByte(pointer);
-        pointer += 1;
+        // Lost bytes: a bytes5 variable holding the following byte values:
+        //     0: kfrag signature recovery value v
+        //     1: cfrag signature recovery value v
+        //     2: metadata signature recovery value v
+        //     3: specification signature recovery value v
+        //     5: ursula pubkey sign byte
+        data.lostBytes = bytes5(getBytes32(pointer));
+        pointer += 5;
 
         require(pointer == initial_pointer + PRECOMPUTED_DATA_SIZE);
     }

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -21,16 +21,17 @@ from typing import Optional
 from typing import Union, List
 
 from constant_sorrow import default_constant_splitter
-from constant_sorrow.constants import NO_CONTROL_PROTOCOL, NO_WSGI_APP
 from constant_sorrow.constants import (
-    NO_NICKNAME,
-    NO_BLOCKCHAIN_CONNECTION,
-    STRANGER,
-    NO_SIGNING_POWER,
     DO_NOT_SIGN,
+    NO_BLOCKCHAIN_CONNECTION,
+    NO_CONTROL_PROTOCOL,
     NO_DECRYPTION_PERFORMED,
+    NO_NICKNAME,
+    NO_SIGNING_POWER,
+    NO_WSGI_APP,
     SIGNATURE_TO_FOLLOW,
-    SIGNATURE_IS_ON_CIPHERTEXT
+    SIGNATURE_IS_ON_CIPHERTEXT,
+    STRANGER,
 )
 from eth_keys import KeyAPI as EthKeyAPI
 from eth_utils import to_checksum_address, to_canonical_address
@@ -154,7 +155,7 @@ class Character(Learner):
         #
         else:  # Feel like a stranger
             if network_middleware is not None:
-                raise TypeError("Network middleware cannot be attached to a Stanger-Character.")
+                raise TypeError("Network middleware cannot be attached to a Stranger-Character.")
             self._stamp = StrangerStamp(self.public_keys(SigningPower))
             self.keyring_dir = STRANGER
             self.network_middleware = STRANGER
@@ -257,26 +258,38 @@ class Character(Learner):
         return config.produce(**overrides)
 
     @classmethod
-    def from_public_keys(cls, powers_and_material: Dict, federated_only=True, *args, **kwargs) -> 'Character':
+    def from_public_keys(cls,
+                         verifying_key : Union[bytes, UmbralPublicKey] = None,
+                         encrypting_key: Union[bytes, UmbralPublicKey] = None,
+                         powers_and_material: Dict = None,
+                         federated_only=True,
+                         *args, **kwargs) -> 'Character':
         """
         Sometimes we discover a Character and, at the same moment,
         learn the public parts of more of their powers. Here, we take a Dict
-        (powers_and_key_bytes) in the following format:
-        {CryptoPowerUp class: public_material_bytes}
+        (powers_and_material) in the format {CryptoPowerUp class: material},
+        where material can be bytes or UmbralPublicKey.
 
         Each item in the collection will have the CryptoPowerUp instantiated
-        with the public_material_bytes, and the resulting CryptoPowerUp instance
+        with the given material, and the resulting CryptoPowerUp instance
         consumed by the Character.
 
         # TODO: Need to be federated only until we figure out the best way to get the checksum_public_address in here.
-
         """
 
         crypto_power = CryptoPower()
 
+        if powers_and_material is None:
+            powers_and_material = dict()
+
+        if verifying_key:
+            powers_and_material[SigningPower] = verifying_key
+        if encrypting_key:
+            powers_and_material[DecryptingPower] = encrypting_key
+
         for power_up, public_key in powers_and_material.items():
             try:
-                umbral_key = UmbralPublicKey(public_key)
+                umbral_key = UmbralPublicKey.from_bytes(public_key)
             except TypeError:
                 umbral_key = public_key
 

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -259,10 +259,10 @@ class Character(Learner):
 
     @classmethod
     def from_public_keys(cls,
-                         verifying_key : Union[bytes, UmbralPublicKey] = None,
-                         encrypting_key: Union[bytes, UmbralPublicKey] = None,
                          powers_and_material: Dict = None,
                          federated_only=True,
+                         verifying_key: Union[bytes, UmbralPublicKey] = None,
+                         encrypting_key: Union[bytes, UmbralPublicKey] = None,
                          *args, **kwargs) -> 'Character':
         """
         Sometimes we discover a Character and, at the same moment,
@@ -273,6 +273,9 @@ class Character(Learner):
         Each item in the collection will have the CryptoPowerUp instantiated
         with the given material, and the resulting CryptoPowerUp instance
         consumed by the Character.
+
+        Alternatively, you can pass directly a verifying public key
+        (for SigningPower) and/or an encrypting public key (for DecryptionPower).
 
         # TODO: Need to be federated only until we figure out the best way to get the checksum_public_address in here.
         """

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -75,8 +75,9 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
 
         from nucypher.characters.lawful import Bob
 
-        crypto_powers = {DecryptingPower: bob_encrypting_key, SigningPower: bob_verifying_key}
-        bob = Bob.from_public_keys(crypto_powers, federated_only=federated_only)
+        bob = Bob.from_public_keys(encrypting_key=bob_encrypting_key,
+                                   verifying_key=bob_verifying_key,
+                                   federated_only=federated_only)
         new_policy = self.character.create_policy(bob, label, m, n, federated=federated_only)
         response_data = {'label': new_policy.label, 'policy_encrypting_key': new_policy.public_key}
         return response_data
@@ -98,8 +99,8 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
         from nucypher.characters.lawful import Bob
 
         # Operate
-        bob = Bob.from_public_keys({DecryptingPower: bob_encrypting_key,
-                                    SigningPower: bob_verifying_key},
+        bob = Bob.from_public_keys(encrypting_key=bob_encrypting_key,
+                                   verifying_key=bob_verifying_key,
                                    federated_only=federated_only)
 
         new_policy = self.character.grant(bob, label, m=m, n=n, expiration=expiration)
@@ -136,7 +137,7 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
         message_kit = UmbralMessageKit.from_bytes(message_kit)  # TODO #846: May raise UnknownOpenSSLError and InvalidTag.
 
         data_source = Enrico.from_public_keys(
-            {SigningPower: message_kit.sender_pubkey_sig},
+            verifying_key=message_kit.sender_pubkey_sig,
             policy_encrypting_key=policy_encrypting_key,
             label=label
         )
@@ -186,7 +187,7 @@ class BobInterface(CharacterPublicInterface, BobSpecification):
         alice_pubkey_sig = UmbralPublicKey.from_bytes(alice_verifying_key)
         message_kit = UmbralMessageKit.from_bytes(message_kit)  # TODO #846: May raise UnknownOpenSSLError and InvalidTag.
 
-        data_source = Enrico.from_public_keys({SigningPower: message_kit.sender_pubkey_sig},
+        data_source = Enrico.from_public_keys(verifying_key=message_kit.sender_pubkey_sig,
                                               policy_encrypting_key=policy_encrypting_key,
                                               label=label)
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -844,6 +844,8 @@ class Ursula(Teacher, Character, Miner):
                          timestamp=timestamp,
                          identity_evidence=identity_evidence,
                          substantiate_immediately=is_me and not federated_only,
+                         # FIXME: When is_me and not federated_only, the stamp is substantiated twice
+                         # See line 728 above.
                          )
 
         #

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -390,8 +390,8 @@ class Bob(Character):
         """
         Raised when Bob detects incorrect CFrags returned by some Ursulas
         """
-        def __init__(self, grievances):
-            self.grievances = grievances
+        def __init__(self, evidence: List):
+            self.evidence = evidence
 
     def __init__(self, controller=True, *args, **kwargs) -> None:
         Character.__init__(self, *args, **kwargs)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -20,11 +20,7 @@ from base64 import b64encode
 from collections import OrderedDict
 from functools import partial
 from json.decoder import JSONDecodeError
-from typing import Dict
-from typing import Iterable
-from typing import List
-from typing import Set
-from typing import Tuple
+from typing import Dict, Iterable, List, Set, Tuple
 
 import maya
 import requests
@@ -494,7 +490,7 @@ class Bob(Character):
         treasure_map = self.get_treasure_map_from_known_ursulas(self.network_middleware,
                                                                 map_id)
 
-        alice = Alice.from_public_keys({SigningPower: alice_verifying_key})
+        alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
         compass = self.make_compass_for_alice(alice)
         try:
             treasure_map.orient(compass)
@@ -1080,11 +1076,6 @@ class Ursula(Teacher, Character, Miner):
         # Version stuff checked out.  Moving on.
         node_info = cls.internal_splitter(payload)
 
-        powers_and_material = {
-            SigningPower: node_info.pop("verifying_key"),
-            DecryptingPower: node_info.pop("encrypting_key")
-        }
-
         interface_info = node_info.pop("rest_interface")
         node_info['rest_host'] = interface_info.host
         node_info['rest_port'] = interface_info.port
@@ -1095,7 +1086,7 @@ class Ursula(Teacher, Character, Miner):
         domains_vbytes = VariableLengthBytestring.dispense(node_info['domains'])
         node_info['domains'] = set(constant_or_bytes(d) for d in domains_vbytes)
 
-        ursula = cls.from_public_keys(powers_and_material, federated_only=federated_only, **node_info)
+        ursula = cls.from_public_keys(federated_only=federated_only, **node_info)
         return ursula
 
     @classmethod

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -778,18 +778,8 @@ class Ursula(Teacher, Character, Miner):
                 # REST Server (Ephemeral Self-Ursula)
                 #
                 rest_app, datastore = make_rest_app(
+                    this_node=self,
                     db_filepath=db_filepath,
-                    network_middleware=self.network_middleware,
-                    federated_only=self.federated_only,  # TODO: 466
-                    treasure_map_tracker=self.treasure_maps,
-                    node_tracker=self.known_nodes,
-                    node_bytes_caster=self.__bytes__,
-                    node_nickname=self.nickname,
-                    work_order_tracker=self._work_orders,
-                    node_recorder=self.remember_node,
-                    stamp=self.stamp,
-                    verifier=self.verify_from,
-                    suspicious_activity_tracker=self.suspicious_activities_witnessed,
                     serving_domains=domains,
                 )
 

--- a/nucypher/crypto/utils.py
+++ b/nucypher/crypto/utils.py
@@ -19,6 +19,7 @@ from coincurve import PublicKey
 from eth_keys import KeyAPI as EthKeyAPI
 from typing import Any, Union
 from umbral.keys import UmbralPublicKey
+from umbral.point import Point
 from umbral.signing import Signature
 
 from nucypher.crypto.api import keccak_digest
@@ -113,3 +114,16 @@ def get_signature_recovery_value(message: bytes,
     else:
         raise ValueError("Signature recovery failed. "
                          "Either the message, the signature or the public key is not correct")
+
+
+def get_coordinates_as_bytes(point: Union[Point, UmbralPublicKey], x_coord=True, y_coord=True) -> bytes:
+    coordinates_as_bytes = point.to_bytes(is_compressed=False)[1:]
+    middle = len(coordinates_as_bytes)//2
+    if x_coord and y_coord:
+        return coordinates_as_bytes
+    elif x_coord:
+        return coordinates_as_bytes[:middle]
+    elif y_coord:
+        return coordinates_as_bytes[middle:]
+    else:
+        raise ValueError("At least one coordinate must be set")

--- a/nucypher/crypto/utils.py
+++ b/nucypher/crypto/utils.py
@@ -44,7 +44,7 @@ def construct_policy_id(label: bytes, stamp: bytes) -> bytes:
 
 
 def canonical_address_from_umbral_key(public_key: UmbralPublicKey) -> bytes:
-    pubkey_raw_bytes = public_key.to_bytes(is_compressed=False)[1:]
+    pubkey_raw_bytes = get_coordinates_as_bytes(public_key)
     eth_pubkey = EthKeyAPI.PublicKey(pubkey_raw_bytes)
     canonical_address = eth_pubkey.to_canonical_address()
     return canonical_address
@@ -102,7 +102,7 @@ def get_signature_recovery_value(message: bytes,
 
     signature = bytes(signature)
     ecdsa_signature_size = Signature.expected_bytes_length()
-    if not len(signature) == ecdsa_signature_size:
+    if len(signature) != ecdsa_signature_size:
         raise ValueError(f"The signature size should be {ecdsa_signature_size} B.")
 
     kwargs = dict(hasher=None) if is_prehashed else {}
@@ -121,11 +121,9 @@ def get_signature_recovery_value(message: bytes,
 def get_coordinates_as_bytes(point: Union[Point, UmbralPublicKey, SignatureStamp],
                              x_coord=True,
                              y_coord=True) -> bytes:
-
-    try:
+    if isinstance(point, SignatureStamp):
         point = point.as_umbral_pubkey()
-    except AttributeError:
-        pass
+
     coordinates_as_bytes = point.to_bytes(is_compressed=False)[1:]
     middle = len(coordinates_as_bytes)//2
     if x_coord and y_coord:

--- a/nucypher/crypto/utils.py
+++ b/nucypher/crypto/utils.py
@@ -18,11 +18,13 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 from coincurve import PublicKey
 from eth_keys import KeyAPI as EthKeyAPI
 from typing import Any, Union
+
 from umbral.keys import UmbralPublicKey
 from umbral.point import Point
 from umbral.signing import Signature
 
 from nucypher.crypto.api import keccak_digest
+from nucypher.crypto.signing import SignatureStamp
 
 
 def fingerprint_from_key(public_key: Any):
@@ -116,7 +118,14 @@ def get_signature_recovery_value(message: bytes,
                          "Either the message, the signature or the public key is not correct")
 
 
-def get_coordinates_as_bytes(point: Union[Point, UmbralPublicKey], x_coord=True, y_coord=True) -> bytes:
+def get_coordinates_as_bytes(point: Union[Point, UmbralPublicKey, SignatureStamp],
+                             x_coord=True,
+                             y_coord=True) -> bytes:
+
+    try:
+        point = point.as_umbral_pubkey()
+    except AttributeError:
+        pass
     coordinates_as_bytes = point.to_bytes(is_compressed=False)[1:]
     middle = len(coordinates_as_bytes)//2
     if x_coord and y_coord:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -22,7 +22,6 @@ from collections import deque
 from collections import namedtuple
 from contextlib import suppress
 
-from twisted.python.threadpool import ThreadPool
 from typing import Set, Tuple
 
 import maya
@@ -911,8 +910,8 @@ class Teacher:
         signature_bytes = self._evidence_of_decentralized_identity
         if signature_bytes is NOT_SIGNED:
             return False
-        else:
-            signature = EthSignature(signature_bytes)
+
+        signature = EthSignature(signature_bytes)
         proper_pubkey = signature.recover_public_key_from_msg(bytes(self.stamp))
         proper_address = proper_pubkey.to_checksum_address()
         return proper_address == self.checksum_public_address

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -37,15 +37,15 @@ from nucypher.config.constants import GLOBAL_DOMAIN
 from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.kits import UmbralMessageKit
-from nucypher.crypto.powers import SigningPower, KeyPairBasedPower, PowerUpError
-from nucypher.crypto.signing import InvalidSignature, SignatureStamp, Signature
+from nucypher.crypto.powers import KeyPairBasedPower, PowerUpError
+from nucypher.crypto.signing import InvalidSignature, SignatureStamp
 from nucypher.crypto.utils import canonical_address_from_umbral_key
 from nucypher.keystore.keypairs import HostingKeypair
 from nucypher.keystore.keystore import NotFound
 from nucypher.keystore.threading import ThreadedSession
 from nucypher.network import LEARNING_LOOP_VERSION
 from nucypher.network.middleware import RestMiddleware
-from nucypher.network.protocols import InterfaceInfo, SuspiciousActivity
+from nucypher.network.protocols import InterfaceInfo
 
 HERE = BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 TEMPLATES_DIR = os.path.join(HERE, "templates")
@@ -246,7 +246,7 @@ def make_rest_app(
         policy_message_kit = UmbralMessageKit.from_bytes(request.data)
 
         alices_verifying_key = policy_message_kit.sender_pubkey_sig
-        alice = _alice_class.from_public_keys({SigningPower: alices_verifying_key})
+        alice = _alice_class.from_public_keys(verifying_key=alices_verifying_key)
 
         try:
             cleartext = verifier(alice, policy_message_kit, decrypt=True)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -294,6 +294,10 @@ def make_rest_app(
 
     @rest_app.route('/kFrag/<id_as_hex>/reencrypt', methods=["POST"])
     def reencrypt_via_rest(id_as_hex):
+
+        # TODO: How to pass Ursula's identity evidence to Bob? #962
+        # 'Identity evidence' is a signature of her stamp with the checksum address
+
         from nucypher.policy.models import WorkOrder  # Avoid circular import
         arrangement_id = binascii.unhexlify(id_as_hex)
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -127,7 +127,7 @@ def make_rest_app(
     @rest_app.route("/public_information")
     def public_information():
         """
-        REST endpoint for public keys and address..
+        REST endpoint for public keys and address.
         """
         response = Response(
             response=node_bytes_caster(),

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -30,9 +30,11 @@ from umbral.kfrags import KFrag
 
 from bytestring_splitter import VariableLengthBytestring
 from constant_sorrow import constants
-from constant_sorrow.constants import FLEET_STATES_MATCH
-from constant_sorrow.constants import GLOBAL_DOMAIN, NO_KNOWN_NODES
+from constant_sorrow.constants import (FLEET_STATES_MATCH,
+                                       GLOBAL_DOMAIN,
+                                       NO_KNOWN_NODES)
 from hendrix.experience import crosstown_traffic
+
 from nucypher.config.constants import GLOBAL_DOMAIN
 from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest
@@ -83,22 +85,12 @@ class ProxyRESTServer:
 
 def make_rest_app(
         db_filepath: str,
-        network_middleware: RestMiddleware,
-        federated_only: bool,
-        treasure_map_tracker: dict,
-        node_tracker: 'FleetStateTracker',
-        node_bytes_caster: Callable,
-        work_order_tracker: list,
-        node_nickname: str,
-        node_recorder: Callable,
-        stamp: SignatureStamp,
-        verifier: Callable,
-        suspicious_activity_tracker: dict,
+        this_node,
         serving_domains,
         log=Logger("http-application-layer")
         ) -> Tuple:
 
-    forgetful_node_storage = ForgetfulNodeStorage(federated_only=federated_only)
+    forgetful_node_storage = ForgetfulNodeStorage(federated_only=this_node.federated_only)
 
     from nucypher.keystore import keystore
     from nucypher.keystore.db import Base
@@ -130,7 +122,7 @@ def make_rest_app(
         REST endpoint for public keys and address.
         """
         response = Response(
-            response=node_bytes_caster(),
+            response=bytes(this_node),
             mimetype='application/octet-stream')
 
         return response
@@ -139,17 +131,17 @@ def make_rest_app(
     def all_known_nodes():
         headers = {'Content-Type': 'application/octet-stream'}
 
-        if node_tracker.checksum is NO_KNOWN_NODES:
+        if this_node.known_nodes.checksum is NO_KNOWN_NODES:
             return Response(b"", headers=headers, status=204)
 
-        payload = node_tracker.snapshot()
+        payload = this_node.known_nodes.snapshot()
 
-        ursulas_as_vbytes = (VariableLengthBytestring(n) for n in node_tracker)
+        ursulas_as_vbytes = (VariableLengthBytestring(n) for n in this_node.known_nodes)
         ursulas_as_bytes = bytes().join(bytes(u) for u in ursulas_as_vbytes)
-        ursulas_as_bytes += VariableLengthBytestring(node_bytes_caster())
+        ursulas_as_bytes += VariableLengthBytestring(bytes(this_node))
 
         payload += ursulas_as_bytes
-        signature = stamp(payload)
+        signature = this_node.stamp(payload)
         return Response(bytes(signature) + payload, headers=headers)
 
     @rest_app.route('/node_metadata', methods=["POST"])
@@ -157,14 +149,14 @@ def make_rest_app(
         # If these nodes already have the same fleet state, no exchange is necessary.
 
         learner_fleet_state = request.args.get('fleet')
-        if learner_fleet_state == node_tracker.checksum:
+        if learner_fleet_state == this_node.known_nodes.checksum:
             log.debug("Learner already knew fleet state {}; doing nothing.".format(learner_fleet_state))
             headers = {'Content-Type': 'application/octet-stream'}
-            payload = node_tracker.snapshot() + bytes(FLEET_STATES_MATCH)
-            signature = stamp(payload)
+            payload = this_node.known_nodes.snapshot() + bytes(FLEET_STATES_MATCH)
+            signature = this_node.stamp(payload)
             return Response(bytes(signature) + payload, headers=headers)
 
-        nodes = _node_class.batch_from_bytes(request.data, federated_only=federated_only)  # TODO: 466
+        nodes = _node_class.batch_from_bytes(request.data, federated_only=this_node.federated_only)  # TODO: 466
 
         # TODO: This logic is basically repeated in learn_from_teacher_node and remember_node.
         # Let's find a better way.  #555
@@ -173,8 +165,8 @@ def make_rest_app(
                 if not set(serving_domains).intersection(set(node.serving_domains)):
                     continue  # This node is not serving any of our domains.
 
-            if node in node_tracker:
-                if node.timestamp <= node_tracker[node.checksum_public_address].timestamp:
+            if node in this_node.known_nodes:
+                if node.timestamp <= this_node.known_nodes[node.checksum_public_address].timestamp:
                     continue
 
             @crosstown_traffic()
@@ -184,8 +176,8 @@ def make_rest_app(
                     certificate_filepath = forgetful_node_storage.store_node_certificate(
                         certificate=node.certificate)
 
-                    node.verify_node(network_middleware,
-                                     accept_federated_only=federated_only,  # TODO: 466
+                    node.verify_node(this_node.network_middleware,
+                                     accept_federated_only=this_node.federated_only,  # TODO: 466
                                      certificate_filepath=certificate_filepath)
 
                 # Suspicion
@@ -195,7 +187,7 @@ def make_rest_app(
                     # TODO: Maybe also record the bytes representation separately to disk?
                     message = f"Suspicious Activity: Discovered node with bad signature: {node}.  Announced via REST."
                     log.warn(message)
-                    suspicious_activity_tracker['vladimirs'].append(node)
+                    this_node.suspicious_activities_witnessed['vladimirs'].append(node)
 
                 # Async Sentinel
                 except Exception as e:
@@ -205,7 +197,7 @@ def make_rest_app(
                 # Believable
                 else:
                     log.info("Learned about previously unknown node: {}".format(node))
-                    node_recorder(node)
+                    this_node.remember_node(node)
                     # TODO: Record new fleet state
 
                 # Cleanup
@@ -249,7 +241,7 @@ def make_rest_app(
         alice = _alice_class.from_public_keys(verifying_key=alices_verifying_key)
 
         try:
-            cleartext = verifier(alice, policy_message_kit, decrypt=True)
+            cleartext = this_node.verify_from(alice, policy_message_kit, decrypt=True)
         except InvalidSignature:
             # TODO: Perhaps we log this?
             return Response(status_code=400)
@@ -318,7 +310,7 @@ def make_rest_app(
 
         work_order = WorkOrder.from_rest_payload(arrangement_id=arrangement_id,
                                                  rest_payload=request.data,
-                                                 ursula_pubkey_bytes=bytes(stamp),
+                                                 ursula_pubkey_bytes=bytes(this_node.stamp),
                                                  alice_address=alices_address)
 
         log.info(f"Work Order from {work_order.bob}, signed {work_order.receipt_signature}")
@@ -328,7 +320,7 @@ def make_rest_app(
         for task in work_order.tasks:
             # Ursula signs on top of Bob's signature of each task.
             # Now both are committed to the same task.  See #259.
-            reencryption_metadata = bytes(stamp(bytes(task.signature)))
+            reencryption_metadata = bytes(this_node.stamp(bytes(task.signature)))
 
             capsule = task.capsule
             capsule.set_correctness_keys(verifying=alices_verifying_key)
@@ -336,11 +328,11 @@ def make_rest_app(
             log.info(f"Re-encrypting for {capsule}, made {cfrag}.")
 
             # Finally, Ursula commits to her result
-            reencryption_signature = stamp(bytes(cfrag))
+            reencryption_signature = this_node.stamp(bytes(cfrag))
             cfrag_byte_stream += VariableLengthBytestring(cfrag) + reencryption_signature
 
         # TODO: Put this in Ursula's datastore
-        work_order_tracker.append(work_order)
+        this_node._work_orders.append(work_order)
 
         headers = {'Content-Type': 'application/octet-stream'}
 
@@ -354,12 +346,12 @@ def make_rest_app(
 
         try:
 
-            treasure_map = treasure_map_tracker[treasure_map_bytes]
+            treasure_map = this_node.treasure_maps[treasure_map_bytes]
             response = Response(bytes(treasure_map), headers=headers)
-            log.info("{} providing TreasureMap {}".format(node_nickname, treasure_map_id))
+            log.info("{} providing TreasureMap {}".format(this_node.nickname, treasure_map_id))
 
         except KeyError:
-            log.info("{} doesn't have requested TreasureMap {}".format(stamp, treasure_map_id))
+            log.info("{} doesn't have requested TreasureMap {}".format(this_node.stamp, treasure_map_id))
             response = Response("No Treasure Map with ID {}".format(treasure_map_id),
                                 status=404, headers=headers)
 
@@ -379,16 +371,9 @@ def make_rest_app(
             do_store = treasure_map.public_id() == treasure_map_id
 
         if do_store:
-            log.info("{} storing TreasureMap {}".format(stamp, treasure_map_id))
-
-            # # # #
-            # TODO: Now that the DHT is retired, let's do this another way.
-            # self.dht_server.set_now(binascii.unhexlify(treasure_map_id),
-            #                         constants.BYTESTRING_IS_TREASURE_MAP + bytes(treasure_map))
-            # # # #
-
+            log.info("{} storing TreasureMap {}".format(this_node.stamp, treasure_map_id))
             # TODO 341 - what if we already have this TreasureMap?
-            treasure_map_tracker[keccak_digest(binascii.unhexlify(treasure_map_id))] = treasure_map
+            this_node.treasure_maps[keccak_digest(binascii.unhexlify(treasure_map_id))] = treasure_map
             return Response(bytes(treasure_map), status=202)
         else:
             # TODO: Make this a proper 500 or whatever.
@@ -397,17 +382,12 @@ def make_rest_app(
 
     @rest_app.route('/status')
     def status():
-        # TODO: Seems very strange to deserialize *this node* when we can just pass it in.
-        #       Might be a sign that we need to rethnk this composition.
-
         headers = {"Content-Type": "text/html", "charset": "utf-8"}
-        this_node = _node_class.from_bytes(node_bytes_caster(), federated_only=federated_only)
-
-        previous_states = list(reversed(node_tracker.states.values()))[:5]
+        previous_states = list(reversed(this_node.known_nodes.states.values()))[:5]
 
         try:
             content = status_template.render(this_node=this_node,
-                                             known_nodes=node_tracker,
+                                             known_nodes=this_node.known_nodes,
                                              previous_states=previous_states)
         except Exception as e:
             log.debug("Template Rendering Exception: ".format(str(e)))

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -810,6 +810,8 @@ class IndisputableEvidence:
             raise ValueError("All correctness keys are required to compute evidence.  "
                              "Either pass them as arguments or in the capsule.")
 
+        # TODO: check that the metadata is correct.
+
     def get_proof_challenge_scalar(self) -> CurveBN:
         umbral_params = default_params()
         e, v, _ = self.capsule.components()

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -945,6 +945,6 @@ class IndisputableEvidence:
                 bytes(self.task.signature),
                 get_coordinates_as_bytes(self.bob_pubkey),
                 get_coordinates_as_bytes(self.ursula_pubkey),
-                None,   # FIXME: bytes memory _minerPublicKeySignature,
+                None,   # FIXME: bytes memory _minerPublicKeySignature #962
                 self.precompute_values()
                 )

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -90,7 +90,7 @@ class Arrangement:
         # Still unclear how to arrive at the correct number of bytes to represent a deposit.  See #148.
         alice_pubkey_sig, arrangement_id, expiration_bytes = cls.splitter(arrangement_as_bytes)
         expiration = maya.parse(expiration_bytes.decode())
-        alice = Alice.from_public_keys({SigningPower: alice_pubkey_sig})
+        alice = Alice.from_public_keys(verifying_key=alice_pubkey_sig)
         return cls(alice=alice, arrangement_id=arrangement_id, expiration=expiration)
 
     def encrypt_payload_for_ursula(self):
@@ -661,7 +661,7 @@ class WorkOrder:
             if not task.signature.verify(specification, bob_pubkey_sig):
                 raise InvalidSignature()
 
-        bob = Bob.from_public_keys({SigningPower: bob_pubkey_sig})
+        bob = Bob.from_public_keys(verifying_key=bob_pubkey_sig)
         return cls(bob=bob,
                    arrangement_id=arrangement_id,
                    tasks=tasks,

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -937,3 +937,14 @@ class IndisputableEvidence:
             ursula_pubkey_prefix_byte,
         )
         return b''.join(pieces)
+
+    def evaluation_arguments(self) -> Tuple:
+        return (bytes(self.task.capsule),
+                bytes(self.task.cfrag),
+                bytes(self.task.cfrag_signature),
+                bytes(self.task.signature),
+                get_coordinates_as_bytes(self.bob_pubkey),
+                get_coordinates_as_bytes(self.ursula_pubkey),
+                None,   # FIXME: bytes memory _minerPublicKeySignature,
+                self.precompute_values()
+                )

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -593,7 +593,7 @@ class WorkOrder:
         self.tasks = tasks
         self.receipt_signature = receipt_signature
         self.ursula = ursula  # TODO: We may still need a more elegant system for ID'ing Ursula.  See #136.
-        self.blockhash = blockhash or b'\x00' * 32  # TODO
+        self.blockhash = blockhash or b'\x00' * 32  # TODO: #259
         self.completed = False
 
     def __repr__(self):
@@ -688,14 +688,14 @@ class WorkOrder:
             metadata_as_signature = Signature.from_bytes(cfrag.proof.metadata)
             if not metadata_as_signature.verify(metadata_input, ursula_verifying_key):
                 raise InvalidSignature(f"Invalid metadata for {cfrag}.")
-                # TODO: Instead of raising, we should do something
+                # TODO: Instead of raising, we should do something (#957)
 
             # Validate re-encryption signatures
             if reencryption_signature.verify(bytes(cfrag), ursula_verifying_key):
                 good_cfrags.append(cfrag)
             else:
                 raise InvalidSignature(f"{cfrag} is not properly signed by Ursula.")
-                # TODO: Instead of raising, we should do something
+                # TODO: Instead of raising, we should do something (#957)
 
         for task, (cfrag, reencryption_signature) in zip(self.tasks, cfrags_and_signatures):
             task.attach_work_result(cfrag, reencryption_signature)
@@ -784,6 +784,7 @@ class Revocation:
         return True
 
 
+# TODO: Change name to EvaluationEvidence
 class IndisputableEvidence:
 
     def __init__(self,

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -125,4 +125,4 @@ MOCK_IP_ADDRESS_2 = '10.10.10.10'
 
 MOCK_URSULA_DB_FILEPATH = ':memory:'
 
-PYEVM_GAS_LIMIT = 8000000  # TODO: move elsewhere (used to set pyevm gas limit in tests)?
+PYEVM_GAS_LIMIT = 8_000_000  # TODO: move elsewhere (used to set pyevm gas limit in tests)?

--- a/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
@@ -185,7 +185,9 @@ contract ReEncryptionValidatorMock {
     )
         public pure returns (uint256)
     {
-        return ReEncryptionValidator.computeProofChallengeScalar(_capsuleBytes, _cFragBytes);
+        UmbralDeserializer.Capsule memory _capsule = _capsuleBytes.toCapsule();
+        UmbralDeserializer.CapsuleFrag memory _cFrag = _cFragBytes.toCapsuleFrag();
+        return ReEncryptionValidator.computeProofChallengeScalar(_capsule, _cFrag);
     }
 
     function aliceAddress(

--- a/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
@@ -190,15 +190,6 @@ contract ReEncryptionValidatorMock {
         return ReEncryptionValidator.computeProofChallengeScalar(_capsule, _cFrag);
     }
 
-    function aliceAddress(
-        bytes memory _cFragBytes,
-        bytes memory _precomputedBytes
-    )
-        public pure returns (address)
-    {
-        return ReEncryptionValidator.aliceAddress(_cFragBytes, _precomputedBytes);
-    }
-
     function extendedKeccakToBN (bytes memory _data) public pure returns (uint256) {
         return ReEncryptionValidator.extendedKeccakToBN(_data);
     }

--- a/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
@@ -202,6 +202,10 @@ contract ReEncryptionValidatorMock {
         return ReEncryptionValidator.check_compressed_point(_pointSign, _pointX, _pointY);
 	}
 
+    function check_serialized_coordinates(bytes memory _coords) public pure returns(bool) {
+		return ReEncryptionValidator.check_serialized_coordinates(_coords);
+	}
+
     function is_on_curve(uint256 Px, uint256 Py) public pure returns (bool) {
         return ReEncryptionValidator.is_on_curve(Px, Py);
     }

--- a/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
@@ -159,6 +159,8 @@ contract ReEncryptionValidatorMock {
 
     using UmbralDeserializer for bytes;
 
+//    TODO: Test constants when https://github.com/ethereum/solidity/issues/1290 is solved
+
 //    uint8 public constant UMBRAL_PARAMETER_U_SIGN = ReEncryptionValidator.UMBRAL_PARAMETER_U_SIGN();
 //    uint256 public constant UMBRAL_PARAMETER_U_XCOORD = ReEncryptionValidator.UMBRAL_PARAMETER_U_XCOORD();
 //    uint256 public constant UMBRAL_PARAMETER_U_YCOORD = ReEncryptionValidator.UMBRAL_PARAMETER_U_YCOORD();
@@ -235,7 +237,7 @@ contract ReEncryptionValidatorMock {
         return ReEncryptionValidator.addAffineJacobian(P, Q);
     }
 
-    function doubleJacobian(uint[3] memory P) internal pure returns (uint[3] memory) {
+    function doubleJacobian(uint[3] memory P) public pure returns (uint[3] memory) {
         return ReEncryptionValidator.doubleJacobian(P);
     }
 }

--- a/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
@@ -194,20 +194,20 @@ contract ReEncryptionValidatorMock {
         return ReEncryptionValidator.extendedKeccakToBN(_data);
     }
 
-	function check_compressed_point(
+	function checkCompressedPoint(
 		uint8 _pointSign,
 		uint256 _pointX,
 		uint256 _pointY
 	) public pure returns(bool) {
-        return ReEncryptionValidator.check_compressed_point(_pointSign, _pointX, _pointY);
+        return ReEncryptionValidator.checkCompressedPoint(_pointSign, _pointX, _pointY);
 	}
 
-    function check_serialized_coordinates(bytes memory _coords) public pure returns(bool) {
-		return ReEncryptionValidator.check_serialized_coordinates(_coords);
+    function checkSerializedCoordinates(bytes memory _coords) public pure returns(bool) {
+		return ReEncryptionValidator.checkSerializedCoordinates(_coords);
 	}
 
-    function is_on_curve(uint256 Px, uint256 Py) public pure returns (bool) {
-        return ReEncryptionValidator.is_on_curve(Px, Py);
+    function isOnCurve(uint256 Px, uint256 Py) public pure returns (bool) {
+        return ReEncryptionValidator.isOnCurve(Px, Py);
     }
 
     function ecmulVerify(

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -160,7 +160,7 @@ def generate_args_for_slashing(testerchain, mock_ursula_reencrypts, ursula, acco
     signed_miner_umbral_public_key = bytes(sig_key.sign_msg_hash(miner_umbral_public_key_hash))
 
     args = list(evidence.evaluation_arguments())
-    args[-2] = signed_miner_umbral_public_key  # FIXME
+    args[-2] = signed_miner_umbral_public_key  # FIXME  #962
 
     data_hash = sha256_hash(bytes(evidence.task.capsule) + bytes(evidence.task.cfrag))
     return data_hash, args

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -109,11 +109,16 @@ def adjudicator(testerchain, escrow, slashing_economics):
 
     secret_hash = testerchain.interface.w3.keccak(adjudicator_secret)
 
+    deployment_parameters = list(slashing_economics.deployment_parameters)
+    # TODO: For some reason this test used non-stadard slashing parameters (#354)
+    deployment_parameters[1] = 300
+    deployment_parameters[3] = 2
+
     # Creator deploys the contract
     contract, _ = testerchain.interface.deploy_contract(
         'MiningAdjudicator',
         escrow.address,
-        *slashing_economics.deployment_parameters)
+        *deployment_parameters)
 
     dispatcher, _ = testerchain.interface.deploy_contract('Dispatcher', contract.address, secret_hash)
 
@@ -771,7 +776,12 @@ def test_all(testerchain, token, escrow, policy_manager, adjudicator, user_escro
     total_lock = escrow.functions.lockedPerPeriod(period).call()
     alice1_balance = token.functions.balanceOf(alice1).call()
 
-    algorithm_sha256, base_penalty, *coefficients = slashing_economics.deployment_parameters
+    deployment_parameters = list(slashing_economics.deployment_parameters)
+    # TODO: For some reason this test used non-stadard slashing parameters (#354)
+    deployment_parameters[1] = 300
+    deployment_parameters[3] = 2
+
+    algorithm_sha256, base_penalty, *coefficients = deployment_parameters
     penalty_history_coefficient, percentage_penalty_coefficient, reward_coefficient = coefficients
 
     data_hash, slashing_args = generate_args_for_slashing(testerchain, ursula1)

--- a/tests/blockchain/eth/contracts/lib/test_reencryption_validator.py
+++ b/tests/blockchain/eth/contracts/lib/test_reencryption_validator.py
@@ -92,3 +92,14 @@ def test_ec_point_operations(testerchain, reencryption_validator):
 
     P_plus_P = reencryption_validator.functions.addAffineJacobian(P.to_affine(), P.to_affine()).call()
     assert reencryption_validator.functions.eqAffineJacobian((P + P).to_affine(), P_plus_P).call()
+
+
+# TODO: See https://github.com/nucypher/nucypher/issues/626#issuecomment-486186171
+@pytest.mark.skip(reason="no way of testing library constants for the moment")
+def test_umbral_constants(testerchain, reencryption_validator):
+    umbral_params = default_params()
+    u_xcoord, u_ycoord = umbral_params.u.to_affine()
+    u_sign = 2 + (u_ycoord % 2)
+    assert u_sign == reencryption_validator.functions.UMBRAL_PARAMETER_U_SIGN().call()
+    assert u_xcoord == reencryption_validator.functions.UMBRAL_PARAMETER_U_XCOORD().call()
+    assert u_ycoord == reencryption_validator.functions.UMBRAL_PARAMETER_U_YCOORD().call()

--- a/tests/blockchain/eth/contracts/lib/test_reencryption_validator.py
+++ b/tests/blockchain/eth/contracts/lib/test_reencryption_validator.py
@@ -80,6 +80,13 @@ def test_ec_point_operations(testerchain, reencryption_validator):
     bad_sign = 3 - (y % 2)
     assert not reencryption_validator.functions.check_compressed_point(bad_sign, x, y).call()
 
+    # Test check_serialized_coordinates
+    coords = valid_point.to_bytes(is_compressed=False)[1:]
+    assert reencryption_validator.functions.check_serialized_coordinates(coords).call()
+
+    coords = coords[:-1] + ((coords[-1] + 42) % 256).to_bytes(1, 'big')
+    assert not reencryption_validator.functions.check_serialized_coordinates(coords).call()
+
     # Test ecmulVerify
     P = valid_point
     scalar = CurveBN.gen_rand()
@@ -119,7 +126,7 @@ def test_ec_point_operations(testerchain, reencryption_validator):
     assert reencryption_validator.functions.eqAffineJacobian((P + P).to_affine(), P_plus_P).call()
 
 
-# TODO: See https://github.com/nucypher/nucypher/issues/626#issuecomment-486186171
+# TODO: Find a non-intrusive way of testing constants of a Solidity library #954
 @pytest.mark.skip(reason="no way of testing library constants for the moment")
 def test_umbral_constants(testerchain, reencryption_validator):
     umbral_params = default_params()

--- a/tests/blockchain/eth/contracts/lib/test_reencryption_validator.py
+++ b/tests/blockchain/eth/contracts/lib/test_reencryption_validator.py
@@ -49,25 +49,25 @@ def test_ec_point_operations(testerchain, reencryption_validator):
     valid_point = Point.gen_rand()
     x, y = valid_point.to_affine()
 
-    # Test is_on_curve
-    assert reencryption_validator.functions.is_on_curve(x, y).call()
+    # Test isOnCurve
+    assert reencryption_validator.functions.isOnCurve(x, y).call()
 
     bad_y = y - 1
-    assert not reencryption_validator.functions.is_on_curve(x, bad_y).call()
+    assert not reencryption_validator.functions.isOnCurve(x, bad_y).call()
 
-    # Test check_compressed_point
+    # Test checkCompressedPoint
     sign = 2 + (y % 2)
-    assert reencryption_validator.functions.check_compressed_point(sign, x, y).call()
+    assert reencryption_validator.functions.checkCompressedPoint(sign, x, y).call()
 
     bad_sign = 3 - (y % 2)
-    assert not reencryption_validator.functions.check_compressed_point(bad_sign, x, y).call()
+    assert not reencryption_validator.functions.checkCompressedPoint(bad_sign, x, y).call()
 
-    # Test check_serialized_coordinates
+    # Test checkSerializedCoordinates
     coords = valid_point.to_bytes(is_compressed=False)[1:]
-    assert reencryption_validator.functions.check_serialized_coordinates(coords).call()
+    assert reencryption_validator.functions.checkSerializedCoordinates(coords).call()
 
     coords = coords[:-1] + ((coords[-1] + 42) % 256).to_bytes(1, 'big')
-    assert not reencryption_validator.functions.check_serialized_coordinates(coords).call()
+    assert not reencryption_validator.functions.checkSerializedCoordinates(coords).call()
 
     # Test ecmulVerify
     P = valid_point

--- a/tests/blockchain/eth/contracts/lib/test_signature_verifier.py
+++ b/tests/blockchain/eth/contracts/lib/test_signature_verifier.py
@@ -18,17 +18,17 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 
-import coincurve
 import pytest
+from coincurve import PublicKey
 from cryptography.hazmat.backends.openssl import backend
 from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives.asymmetric import ec
 from eth_tester.exceptions import TransactionFailed
 from eth_utils import to_normalized_address
 
 from umbral.keys import UmbralPrivateKey
-from umbral.signing import Signature
+from umbral.signing import Signer
 
+from nucypher.crypto.api import keccak_digest
 
 ALGORITHM_KECCAK256 = 0
 ALGORITHM_SHA256 = 1
@@ -53,26 +53,25 @@ def test_recover(testerchain, signature_verifier):
     # Generate Umbral key and extract "address" from the public key
     umbral_privkey = UmbralPrivateKey.gen_key()
     umbral_pubkey_bytes = umbral_privkey.get_pubkey().to_bytes(is_compressed=False)
-    signer_address = bytearray(testerchain.interface.w3.solidityKeccak(['bytes32'], [umbral_pubkey_bytes[1:]]))
+    signer_address = keccak_digest(umbral_pubkey_bytes[1:])
     signer_address = to_normalized_address(signer_address[12:])
 
-    # Sign message using SHA-256 hash (because only 32 bytes hash can be used in the `ecrecover` method)
-    cryptography_priv_key = umbral_privkey.to_cryptography_privkey()
-    signature_der_bytes = cryptography_priv_key.sign(message, ec.ECDSA(hashes.SHA256()))
-    signature = Signature.from_bytes(signature_der_bytes, der_encoded=True)
+    # Sign message
+    signer = Signer(umbral_privkey)
+    signature = signer(message)
 
     # Get recovery id (v) before using contract
     # If we don't have recovery id while signing than we should try to recover public key with different v
     # Only the correct v will match the correct public key
     # First try v = 0
     recoverable_signature = bytes(signature) + bytes([0])
-    pubkey_bytes = coincurve.PublicKey.from_signature_and_message(recoverable_signature, message_hash, hasher=None)\
-        .format(compressed=False)
+    pubkey = PublicKey.from_signature_and_message(recoverable_signature, message_hash, hasher=None)
+    pubkey_bytes = pubkey.format(compressed=False)
     if pubkey_bytes != umbral_pubkey_bytes:
         # Extracted public key is not ours, that means v = 1
         recoverable_signature = bytes(signature) + bytes([1])
-        pubkey_bytes = coincurve.PublicKey.from_signature_and_message(recoverable_signature, message_hash, hasher=None)\
-            .format(compressed=False)
+        pubkey = PublicKey.from_signature_and_message(recoverable_signature, message_hash, hasher=None)
+        pubkey_bytes = pubkey.format(compressed=False)
 
     # Check that recovery was ok
     assert umbral_pubkey_bytes == pubkey_bytes
@@ -81,7 +80,7 @@ def test_recover(testerchain, signature_verifier):
         signature_verifier.functions.recover(message_hash, recoverable_signature).call())
 
     # Also numbers 27 and 28 can be used for v
-    recoverable_signature = recoverable_signature[0:-1] + bytes([recoverable_signature[-1] + 27])
+    recoverable_signature = recoverable_signature[:-1] + bytes([recoverable_signature[-1] + 27])
     assert signer_address == to_normalized_address(
         signature_verifier.functions.recover(message_hash, recoverable_signature).call())
 
@@ -100,12 +99,12 @@ def test_recover(testerchain, signature_verifier):
 def test_address(testerchain, signature_verifier):
     # Generate Umbral key and extract "address" from the public key
     umbral_privkey = UmbralPrivateKey.gen_key()
-    umbral_pubkey_bytes = umbral_privkey.get_pubkey().to_bytes(is_compressed=False)
-    signer_address = bytearray(testerchain.interface.w3.solidityKeccak(['bytes32'], [umbral_pubkey_bytes[1:]]))
+    umbral_pubkey_bytes = umbral_privkey.get_pubkey().to_bytes(is_compressed=False)[1:]
+    signer_address = keccak_digest(umbral_pubkey_bytes)
     signer_address = to_normalized_address(signer_address[12:])
 
     # Check extracting address in library
-    result_address = signature_verifier.functions.toAddress(umbral_pubkey_bytes[1:]).call()
+    result_address = signature_verifier.functions.toAddress(umbral_pubkey_bytes).call()
     assert signer_address == to_normalized_address(result_address)
 
 
@@ -131,9 +130,8 @@ def test_verify(testerchain, signature_verifier):
     umbral_pubkey_bytes = umbral_privkey.get_pubkey().to_bytes(is_compressed=False)
 
     # Sign message using SHA-256 hash
-    cryptography_priv_key = umbral_privkey.to_cryptography_privkey()
-    signature_der_bytes = cryptography_priv_key.sign(message, ec.ECDSA(hashes.SHA256()))
-    signature = Signature.from_bytes(signature_der_bytes, der_encoded=True)
+    signer = Signer(umbral_privkey)
+    signature = signer(message)
 
     # Prepare message hash
     hash_ctx = hashes.Hash(hashes.SHA256(), backend=backend)
@@ -143,18 +141,22 @@ def test_verify(testerchain, signature_verifier):
     # Get recovery id (v) before using contract
     # First try v = 0
     recoverable_signature = bytes(signature) + bytes([0])
-    pubkey_bytes = coincurve.PublicKey.from_signature_and_message(recoverable_signature, message_hash, hasher=None) \
-        .format(compressed=False)
+    pubkey = PublicKey.from_signature_and_message(recoverable_signature, message_hash, hasher=None)
+    pubkey_bytes = pubkey.format(compressed=False)
     if pubkey_bytes != umbral_pubkey_bytes:
         # Extracted public key is not ours, that means v = 1
         recoverable_signature = bytes(signature) + bytes([1])
 
     # Verify signature
-    assert signature_verifier.functions.\
-        verify(message, recoverable_signature, umbral_pubkey_bytes[1:], ALGORITHM_SHA256).call()
+    assert signature_verifier.functions.verify(message,
+                                               recoverable_signature,
+                                               umbral_pubkey_bytes[1:],
+                                               ALGORITHM_SHA256).call()
 
     # Verify signature using wrong key
     umbral_privkey = UmbralPrivateKey.gen_key()
     umbral_pubkey_bytes = umbral_privkey.get_pubkey().to_bytes(is_compressed=False)
-    assert not signature_verifier.functions.\
-        verify(message, recoverable_signature, umbral_pubkey_bytes[1:], ALGORITHM_SHA256).call()
+    assert not signature_verifier.functions.verify(message,
+                                                   recoverable_signature,
+                                                   umbral_pubkey_bytes[1:],
+                                                   ALGORITHM_SHA256).call()

--- a/tests/blockchain/eth/contracts/lib/test_umbral_deserializer.py
+++ b/tests/blockchain/eth/contracts/lib/test_umbral_deserializer.py
@@ -143,3 +143,5 @@ def test_cfrag(testerchain, deserializer, fragments):
     assert proof.bn_sig.to_bytes() == result[8]
     assert bytes(proof.kfrag_signature) == result[9]
     assert bytes(proof.metadata) == result[10]
+
+# TODO: Missing test for precomputed_data

--- a/tests/blockchain/eth/contracts/main/mining_adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/mining_adjudicator/conftest.py
@@ -34,11 +34,7 @@ def adjudicator_contract(testerchain, escrow, request, slashing_economics):
     contract, _ = testerchain.interface.deploy_contract(
         'MiningAdjudicator',
         escrow.address,
-        slashing_economics.algorithm_sha256,
-        slashing_economics.base_penalty,
-        slashing_economics.penalty_history_coefficient,
-        slashing_economics.percentage_penalty_coefficient,
-        slashing_economics.reward_coefficient)
+        *slashing_economics.deployment_parameters)
 
     if request.param:
         secret = os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH)

--- a/tests/blockchain/eth/contracts/main/mining_adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/mining_adjudicator/conftest.py
@@ -22,8 +22,6 @@ from web3.contract import Contract
 
 from nucypher.blockchain.eth.deployers import DispatcherDeployer
 
-secret = os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH)
-
 
 @pytest.fixture()
 def escrow(testerchain):
@@ -43,6 +41,7 @@ def adjudicator_contract(testerchain, escrow, request, slashing_economics):
         slashing_economics.reward_coefficient)
 
     if request.param:
+        secret = os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH)
         secret_hash = testerchain.interface.w3.keccak(secret)
         dispatcher, _ = testerchain.interface.deploy_contract('Dispatcher', contract.address, secret_hash)
 

--- a/tests/blockchain/eth/contracts/main/mining_adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/mining_adjudicator/conftest.py
@@ -15,18 +15,14 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import os
 
 import pytest
 from web3.contract import Contract
 
+from nucypher.blockchain.eth.deployers import DispatcherDeployer
 
-ALGORITHM_SHA256 = 1
-BASE_PENALTY = 100
-PENALTY_HISTORY_COEFFICIENT = 10
-PERCENTAGE_PENALTY_COEFFICIENT = 8
-REWARD_COEFFICIENT = 2
-
-secret = (123456).to_bytes(32, byteorder='big')
+secret = os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH)
 
 
 @pytest.fixture()
@@ -36,15 +32,15 @@ def escrow(testerchain):
 
 
 @pytest.fixture(params=[False, True])
-def adjudicator_contract(testerchain, escrow, request):
+def adjudicator_contract(testerchain, escrow, request, slashing_economics):
     contract, _ = testerchain.interface.deploy_contract(
         'MiningAdjudicator',
         escrow.address,
-        ALGORITHM_SHA256,
-        BASE_PENALTY,
-        PENALTY_HISTORY_COEFFICIENT,
-        PERCENTAGE_PENALTY_COEFFICIENT,
-        REWARD_COEFFICIENT)
+        slashing_economics.algorithm_sha256,
+        slashing_economics.base_penalty,
+        slashing_economics.penalty_history_coefficient,
+        slashing_economics.percentage_penalty_coefficient,
+        slashing_economics.reward_coefficient)
 
     if request.param:
         secret_hash = testerchain.interface.w3.keccak(secret)

--- a/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
+++ b/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
@@ -139,16 +139,6 @@ def test_evaluate_cfrag(testerchain, escrow, adjudicator_contract, slashing_econ
     evidence_data = evidence.precompute_values()
     assert len(evidence_data) == 20 * 32 + 32 + 20 + 1
 
-    # This check is a workaround in order to test the signature validation is correct.
-    # In reality, this check should be part of the isCapsuleFragCorrect logic,
-    # but we're facing with "Stack too deep" errors at the moment.
-    # address = adjudicator_contract.functions.aliceAddress(cfrag_bytes, evidence_data).call()
-    # assert address == to_checksum_address(evidence_data[-21:-1].hex())
-
-    proof_challenge_scalar = int(evidence.get_proof_challenge_scalar())
-    # computeProofChallengeScalar = adjudicator_contract.functions.computeProofChallengeScalar
-    # assert proof_challenge_scalar == computeProofChallengeScalar(capsule_bytes, cfrag_bytes).call()
-
     hash_ctx = hashes.Hash(hashes.SHA256(), backend=backend)
     hash_ctx.update(capsule_bytes + cfrag_bytes)
     data_hash = hash_ctx.finalize()

--- a/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
+++ b/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
@@ -102,7 +102,7 @@ def test_evaluate_cfrag(testerchain,
     assert not adjudicator_contract.functions.evaluatedCFrags(data_hash).call()
 
     args = list(evidence.evaluation_arguments())
-    args[-2] = signed_miner_umbral_public_key  # FIXME
+    args[-2] = signed_miner_umbral_public_key  # FIXME  #962  #962
 
     # Challenge using good data
     assert worker_stake == escrow.functions.minerInfo(miner).call()[0]
@@ -139,7 +139,7 @@ def test_evaluate_cfrag(testerchain,
     assert not cfrag.verify_correctness(capsule)
 
     args = list(evidence.evaluation_arguments())
-    args[-2] = signed_miner_umbral_public_key  # FIXME
+    args[-2] = signed_miner_umbral_public_key  # FIXME  #962
 
     data_hash = evaluation_hash(capsule, cfrag)
     assert not adjudicator_contract.functions.evaluatedCFrags(data_hash).call()
@@ -184,7 +184,7 @@ def test_evaluate_cfrag(testerchain,
     evidence_data = bytes(evidence_data)
 
     args = list(evidence.evaluation_arguments())
-    args[-2] = signed_miner_umbral_public_key  # FIXME
+    args[-2] = signed_miner_umbral_public_key  # FIXME  #962
     args[-1] = evidence_data
 
     data_hash = evaluation_hash(capsule, cfrag)
@@ -205,7 +205,7 @@ def test_evaluate_cfrag(testerchain,
     assert not cfrag.verify_correctness(capsule)
 
     args = list(evidence.evaluation_arguments())
-    args[-2] = signed_miner_umbral_public_key  # FIXME
+    args[-2] = signed_miner_umbral_public_key  # FIXME  #962  #962
 
     data_hash = evaluation_hash(capsule, cfrag)
     assert not adjudicator_contract.functions.evaluatedCFrags(data_hash).call()
@@ -249,7 +249,7 @@ def test_evaluate_cfrag(testerchain,
     assert not cfrag.verify_correctness(capsule)
 
     args = list(evidence.evaluation_arguments())
-    args[-2] = signed_miner_umbral_public_key  # FIXME
+    args[-2] = signed_miner_umbral_public_key  # FIXME  #962  #962
 
     data_hash = evaluation_hash(capsule, cfrag)
     assert not adjudicator_contract.functions.evaluatedCFrags(data_hash).call()

--- a/tests/blockchain/eth/entities/deployers/test_economics.py
+++ b/tests/blockchain/eth/entities/deployers/test_economics.py
@@ -33,7 +33,7 @@ def test_rough_economics():
     if allLockedPeriods > awarded_periods then allLockedPeriods = awarded_periods
     kappa * log(2) / halving_delay === (k1 + allLockedPeriods) / k2
 
-    kappa = (small_stake_multiplier + (1 - small_stake_multiplier) * min(T, T1) / T1)
+    kappa = small_stake_multiplier + (1 - small_stake_multiplier) * min(T, T1) / T1
     where allLockedPeriods == min(T, T1)
     """
 
@@ -56,6 +56,9 @@ def test_rough_economics():
     assert int(LOG2 / (e.token_halving * 365) * (e.erc20_total_supply - e.initial_supply)) == int(initial_rate)
     assert int(e.reward_supply) == int(e.erc20_total_supply - Decimal(int(1e9)))
 
+    # Sanity check for locked_periods_coefficient (k1) and staking_coefficient (k2)
+    assert e.locked_periods_coefficient * e.token_halving == e.staking_coefficient * LOG2 * e.small_stake_multiplier / 365
+
 
 def test_exact_economics():
     """
@@ -68,7 +71,7 @@ def test_exact_economics():
     if allLockedPeriods > awarded_periods then allLockedPeriods = awarded_periods
     kappa * log(2) / halving_delay === (k1 + allLockedPeriods) / k2
 
-    kappa = (small_stake_multiplier + (1 - small_stake_multiplier) * min(T, T1) / T1)
+    kappa = small_stake_multiplier + (1 - small_stake_multiplier) * min(T, T1) / T1
     where allLockedPeriods == min(T, T1)
     """
 
@@ -90,6 +93,8 @@ def test_exact_economics():
     multiplier = 0.5
     expected_locked_periods_coefficient = 365
     expected_staking_coefficient = 768812
+
+    assert expected_locked_periods_coefficient * halving == round(expected_staking_coefficient * log(2) * multiplier / 365)
 
     #
     # Sanity

--- a/tests/blockchain/eth/entities/deployers/test_economics.py
+++ b/tests/blockchain/eth/entities/deployers/test_economics.py
@@ -117,7 +117,7 @@ def test_exact_economics():
         # Sanity check expected testing outputs
         assert Decimal(expected_total_supply) / expected_initial_supply == expected_supply_ratio
         assert expected_reward_supply == expected_total_supply - expected_initial_supply
-        assert reward_saturation * 365 == expected_locked_periods_coefficient
+        assert reward_saturation * 365 * multiplier == expected_locked_periods_coefficient * (1 - multiplier)
         assert int(365 ** 2 * reward_saturation * halving / log(2) / (1-multiplier)) == expected_staking_coefficient
 
     # After sanity checking, assemble expected test deployment parameters

--- a/tests/blockchain/eth/entities/deployers/test_economics.py
+++ b/tests/blockchain/eth/entities/deployers/test_economics.py
@@ -156,6 +156,8 @@ def test_exact_economics():
 
         # Check deployment parameters
         assert e.staking_deployment_parameters == expected_deployment_parameters
+        assert e.erc20_initial_supply == expected_initial_supply
+        assert e.erc20_reward_supply == expected_reward_supply
 
 
 def test_economic_parameter_aliases():

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -1,5 +1,4 @@
 import os
-import time
 
 import datetime
 import maya
@@ -14,11 +13,10 @@ from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
 def test_federated_bob_full_retrieve_flow(federated_ursulas,
-                                 federated_bob,
-                                 federated_alice,
-                                 capsule_side_channel,
-                                 enacted_federated_policy
-                                 ):
+                                          federated_bob,
+                                          federated_alice,
+                                          capsule_side_channel,
+                                          enacted_federated_policy):
     # Assume for the moment that Bob has already received a TreasureMap.
     treasure_map = enacted_federated_policy.treasure_map
     federated_bob.treasure_maps[treasure_map.public_id()] = treasure_map

--- a/tests/characters/test_character_control.py
+++ b/tests/characters/test_character_control.py
@@ -6,15 +6,9 @@ import maya
 import pytest
 
 import nucypher
-from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.policy.models import TreasureMap
-from nucypher.utilities.sandbox.policy import generate_random_label
-
-from click.testing import CliRunner
-from nucypher.cli.main import nucypher_cli
-click_runner = CliRunner()
 
 
 def test_alice_character_control_create_policy(alice_control_test_client, federated_bob):
@@ -115,11 +109,13 @@ def test_alice_character_control_revoke(alice_control_test_client, federated_bob
     assert response_data['result']['failed_revocations'] == 0
 
 
-def test_alice_character_control_decrypt(mocker, alice_federated_test_config, alice_control_test_client, enacted_federated_policy, capsule_side_channel):
+def test_alice_character_control_decrypt(alice_control_test_client,
+                                         enacted_federated_policy,
+                                         capsule_side_channel):
+
     message_kit, data_source = capsule_side_channel
 
     label = enacted_federated_policy.label.decode()
-    policy_encrypting_key = bytes(enacted_federated_policy.public_key).hex()
     message_kit = b64encode(message_kit.to_bytes()).decode()
 
     request_data = {

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -21,8 +21,12 @@ from constant_sorrow import constants
 from nucypher.characters.lawful import Alice, Character, Bob
 from nucypher.characters.lawful import Enrico
 from nucypher.crypto import api
-from nucypher.crypto.powers import CryptoPower, SigningPower, NoSigningPower, \
-    BlockchainPower, PowerUpError
+from nucypher.crypto.powers import (CryptoPower,
+                                    SigningPower,
+                                    NoSigningPower,
+                                    BlockchainPower,
+                                    PowerUpError)
+from nucypher.crypto.signing import InvalidSignature
 
 """
 Chapter 1: SIGNING
@@ -89,6 +93,24 @@ def test_anybody_can_verify():
 
     # Our everyman can verify it.
     cleartext = somebody.verify_from(alice, message, signature, decrypt=False)
+    assert cleartext is constants.NO_DECRYPTION_PERFORMED
+
+    # Of course, verification fails with any fake message
+    with pytest.raises(InvalidSignature):
+        fake = b"McLovin      892 Momona St.  Honolulu, HI 96820"
+        _ = somebody.verify_from(alice, fake, signature, decrypt=False)
+
+    # Signature verification also works when Alice is not living with our
+    # everyman in the same process, and he only knows her by her public key
+    alice_pubkey_bytes = bytes(alice.stamp)
+    hearsay_alice = Character.from_public_keys({SigningPower: alice_pubkey_bytes})
+
+    cleartext = somebody.verify_from(hearsay_alice, message, signature, decrypt=False)
+    assert cleartext is constants.NO_DECRYPTION_PERFORMED
+
+    hearsay_alice = Character.from_public_keys(verifying_key=alice_pubkey_bytes)
+
+    cleartext = somebody.verify_from(hearsay_alice, message, signature, decrypt=False)
     assert cleartext is constants.NO_DECRYPTION_PERFORMED
 
 

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -74,7 +74,7 @@ def test_cli_lifecycle(click_runner,
                        custom_filepath_2):
     """
     This is an end to end integration test that runs each cli call
-    in it's own process using only CLI chatacter control entry points,
+    in it's own process using only CLI character control entry points,
     and a mock side channel that runs in the control process
     """
 

--- a/tests/cli/ursula/test_blockchain_ursula.py
+++ b/tests/cli/ursula/test_blockchain_ursula.py
@@ -31,13 +31,13 @@ def configuration_file_location(custom_filepath):
 
 
 @pytest.fixture(scope='module')
-def mock_registry_filepath(deployed_blockchain):
+def mock_registry_filepath(testerchain):
 
-    _blockchain, _deployer_address, _registry = deployed_blockchain
+    registry = testerchain.interface.registry
 
     # Fake the source contract registry
     with open(MOCK_REGISTRY_FILEPATH, 'w') as file:
-        file.write(json.dumps(_registry.read()))
+        file.write(json.dumps(registry.read()))
 
     yield MOCK_REGISTRY_FILEPATH
 

--- a/tests/cli/ursula/test_blockchain_ursula.py
+++ b/tests/cli/ursula/test_blockchain_ursula.py
@@ -7,79 +7,26 @@ import maya
 import pytest
 
 from nucypher.blockchain.eth.actors import Miner
-from nucypher.blockchain.eth.agents import NucypherTokenAgent, MinerAgent
+from nucypher.blockchain.eth.agents import MinerAgent
 from nucypher.blockchain.eth.token import NU
 from nucypher.characters.lawful import Enrico
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
-from nucypher.utilities.sandbox import constants
-from nucypher.utilities.sandbox.blockchain import token_airdrop
 from nucypher.utilities.sandbox.constants import (
+    MOCK_CUSTOM_INSTALLATION_PATH,
     MOCK_IP_ADDRESS,
     TEST_PROVIDER_URI,
     MOCK_URSULA_STARTING_PORT,
     INSECURE_DEVELOPMENT_PASSWORD,
     MOCK_REGISTRY_FILEPATH,
     TEMPORARY_DOMAIN,
-    DEVELOPMENT_ETH_AIRDROP_AMOUNT)
+)
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
-from nucypher.utilities.sandbox.ursula import start_pytest_ursula_services
-
-from web3 import Web3
-
-
-@pytest.fixture(scope='module')
-def stake_value(token_economics):
-    value = NU(token_economics.minimum_allowed_locked * 2, 'NuNit')
-    return value
-
-
-@pytest.fixture(scope='module')
-def policy_rate():
-    rate = Web3.toWei(21, 'gwei')
-    return rate
-
-
-@pytest.fixture(scope='module')
-def policy_value(token_economics, policy_rate):
-    value = policy_rate * token_economics.minimum_locked_periods  # * len(ursula)
-    return value
-
-
-@pytest.fixture(autouse=True, scope='module')
-def funded_blockchain(deployed_blockchain, token_economics):
-
-    # Who are ya'?
-    blockchain, _deployer_address, registry = deployed_blockchain
-    deployer_address, *everyone_else, staking_participant = blockchain.interface.w3.eth.accounts
-
-    # Free ETH!!!
-    blockchain.ether_airdrop(amount=DEVELOPMENT_ETH_AIRDROP_AMOUNT)
-
-    # Free Tokens!!!
-    token_airdrop(token_agent=NucypherTokenAgent(blockchain=blockchain),
-                  origin=_deployer_address,
-                  addresses=everyone_else,
-                  amount=token_economics.minimum_allowed_locked*5)
-
-    # HERE YOU GO
-    yield blockchain, _deployer_address
-
-
-@pytest.fixture(scope='module')
-def staking_participant(funded_blockchain, blockchain_ursulas):
-    # Start up the local fleet
-    for teacher in blockchain_ursulas:
-        start_pytest_ursula_services(ursula=teacher)
-
-    teachers = list(blockchain_ursulas)
-    staking_participant = teachers[-1]
-    return staking_participant
 
 
 @pytest.fixture(scope='module')
 def configuration_file_location(custom_filepath):
-    _configuration_file_location = os.path.join(constants.MOCK_CUSTOM_INSTALLATION_PATH, 'ursula.config')
+    _configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH, 'ursula.config')
     return _configuration_file_location
 
 

--- a/tests/crypto/test_utils.py
+++ b/tests/crypto/test_utils.py
@@ -19,18 +19,20 @@ import pytest
 
 from umbral.keys import UmbralPrivateKey
 
+from nucypher.crypto.signing import SignatureStamp
 from nucypher.crypto.utils import get_coordinates_as_bytes
 
 
 def test_coordinates_as_bytes():
     pubkey = UmbralPrivateKey.gen_key().pubkey
     point = pubkey.point_key
+    stamp = SignatureStamp(verifying_key=pubkey)
 
     x, y = point.to_affine()
     x = x.to_bytes(32, 'big')
     y = y.to_bytes(32, 'big')
 
-    for p in (point, pubkey):
+    for p in (point, pubkey, stamp):
         assert get_coordinates_as_bytes(p) == x + y
         assert get_coordinates_as_bytes(p, x_coord=False) == y
         assert get_coordinates_as_bytes(p, y_coord=False) == x

--- a/tests/crypto/test_utils.py
+++ b/tests/crypto/test_utils.py
@@ -1,0 +1,38 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+
+from umbral.keys import UmbralPrivateKey
+
+from nucypher.crypto.utils import get_coordinates_as_bytes
+
+
+def test_coordinates_as_bytes():
+    pubkey = UmbralPrivateKey.gen_key().pubkey
+    point = pubkey.point_key
+
+    x, y = point.to_affine()
+    x = x.to_bytes(32, 'big')
+    y = y.to_bytes(32, 'big')
+
+    for p in (point, pubkey):
+        assert get_coordinates_as_bytes(p) == x + y
+        assert get_coordinates_as_bytes(p, x_coord=False) == y
+        assert get_coordinates_as_bytes(p, y_coord=False) == x
+        with pytest.raises(ValueError):
+            _ = get_coordinates_as_bytes(p, x_coord=False, y_coord=False)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -24,7 +24,7 @@ import pytest
 from constant_sorrow.constants import NON_PAYMENT
 from sqlalchemy.engine import create_engine
 
-from nucypher.blockchain.economics import TokenEconomics
+from nucypher.blockchain.economics import TokenEconomics, SlashingEconomics
 from nucypher.blockchain.eth.deployers import NucypherTokenDeployer, MinerEscrowDeployer, PolicyManagerDeployer, \
     DispatcherDeployer
 from nucypher.blockchain.eth.interfaces import BlockchainDeployerInterface
@@ -319,6 +319,12 @@ def federated_ursulas(ursula_federated_test_config):
 @pytest.fixture(scope='session')
 def token_economics():
     economics = TokenEconomics()
+    return economics
+
+
+@pytest.fixture(scope='session')
+def slashing_economics():
+    economics = SlashingEconomics()
     return economics
 
 @pytest.fixture(scope='session')

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -147,7 +147,7 @@ def generate_args_for_slashing(testerchain, ursula, account, corrupt_cfrag: bool
     signed_miner_umbral_public_key = bytes(sig_key.sign_msg_hash(miner_umbral_public_key_hash))
 
     args = list(evidence.evaluation_arguments())
-    args[-2] = signed_miner_umbral_public_key  # FIXME
+    args[-2] = signed_miner_umbral_public_key  # FIXME  #962
     return args
 
 


### PR DESCRIPTION
This PR gets us very close to having real slashing, fully-compatible with Ursulas' work. Mainly, it crystallizes the re-encryption metadata format (#259) into something actually useful for `MiningAdjudicator`. There are, however, some small missing pieces in order to finish the integration of slashing (e.g., #962, #931, #855, #500)

It also completes the testing framework for `MiningAdjudicator` and `ReEncryptionValidator` (Close #626)

Other:
* Improvement and simplification of some fixtures
* Improved API for `Character.from_public_bytes()` (f078026eb8166276626893458595a50bbe10f65e)
* Adds missing commits to #866 that were lost after a rebase. Closes #831.
* References #354