### PR TITLE
Separate worker role from miner/staker

### DIFF
--- a/docs/source/architecture/contracts.md
+++ b/docs/source/architecture/contracts.md
@@ -83,30 +83,35 @@ When calculating locked tokens using the `MinersEscrow.getLockedTokens(address, 
 ### Ursula Confirms Activity
 
 In order to confirm activity every period, miners call `MinersEscrow.confirmActivity()` wherein activities for the next period are registered.
-The method `MinersEscrow.confirmActivity` is called every time the methods `MinersEscrow.deposit(uint256, uint16)` or `MinersEscrow.lock(uint256, uint16)` is called.
 The miner gets a reward for every confirmed period.
 
 ### Ursula Generates Staking Rewards
 After the period of activity has passed, the miner may call `MinersEscrow.mint()` method which computes and transfers tokens to the miner's account.
-Also note that calls to `MinersEscrow.lock(uint256, uint16)` and `MinersEscrow.confirmActivity()` are included the `MinersEscrow.mint()` method.
+Also note that calls to `MinersEscrow.confirmActivity()` are included the `MinersEscrow.mint()` method.
 
 The reward value depends on the fraction of locked tokens for the period (only those who confirmed activity are accounted for).
 Also, the reward depends on the number of periods during which the tokens will be locked: if the tokens will be locked for half a year, the coefficient is 1.5.
 The minimum coefficient is 1 (when tokens will get unlocked in the next period), and the maximum is 2 (when the time is 1 year or more).
 The reward is calculated separately for each stake that is active during the mining period and all rewards are summed up.
-The order of calling `mint` by miners (e.g. who calls first, second etc) doesn't matter.
-Miners can claim their rewards by using the `withdraw(uint256)` method. Only non-locked tokens can be withdrawn.
+The order of calling `MinersEscrow.mint()` by miners (e.g. who calls first, second etc) doesn't matter.
+Miners can claim their rewards by using the `MinersEscrow.withdraw(uint256)` method. Only non-locked tokens can be withdrawn.
 
 
 ### Ursula Generates Policy Rewards
 Also the miner gets rewards for policies deployed.
-Computation of a policy reward happens every time `mint()` is called by the `updateReward(address, uint16)` method.
+Computation of a policy reward happens every time `MinersEscrow.mint()` is called by the `PolicyManager.updateReward(address, uint16)` method.
 In order to take the reward, the miner needs to call method `withdraw()` of the contract `PolicyManager`.
-The miner can set a minimum reward rate for a policy. For that, the miner should call the `setMinRewardRate(uint256)` method.
+The miner can set a minimum reward rate for a policy. For that, the miner should call the `PolicyManager.setMinRewardRate(uint256)` method.
 
 
 ### NuCypher Partner Ursula Staking
 Some users will have locked but not staked tokens.
-In that case, an instance of the `UserEscrow` contract will hold their tokens (method `initialDeposit(uint256, uint256)`).
-All tokens will be unlocked after a specified time and the user can retrieve them using the `withdraw(uint256)` method.
+In that case, an instance of the `UserEscrow` contract will hold their tokens (method `UserEscrow.initialDeposit(uint256, uint256)`).
+All tokens will be unlocked after a specified time and the user can retrieve them using the `UserEscrow.withdraw(uint256)` method.
 When the user wants to become a miner - he uses the `UserEscrow` contract as a proxy for the `MinersEscrow` and `PolicyManager` contracts.
+
+
+### Ursula's Worker
+In the case when Ursula uses an intermediary contract to lock tokens (for example, `UserEscrow`), the staker must specify a worker who will confirm the activity and sign on behalf of this staker by calling the `MinersEscrow.setWorker(address)` method.
+Changing a worker is allowed no more than 1 time in `MinersEscrow.minWorkerPeriods()`.
+Only the worker can confirm activity (by default, the worker is the staker).

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -69,6 +69,7 @@ class TokenEconomics:
     seconds_per_period = hours_per_period * 60 * 60  # Seconds in single period
 
     # Time Constraints
+    minimum_worker_periods = 2
     minimum_locked_periods = 30  # 720 Hours minimum
 
     # Value Constraints
@@ -163,7 +164,8 @@ class TokenEconomics:
             # Constraints
             self.minimum_locked_periods,      # Min amount of periods during which tokens can be locked
             self.minimum_allowed_locked,      # Min amount of tokens that can be locked
-            self.maximum_allowed_locked       # Max amount of tokens that can be locked
+            self.maximum_allowed_locked,      # Max amount of tokens that can be locked
+            self.minimum_worker_periods       # Min amount of periods while a worker can't be changed
         )
         return tuple(map(int, deploy_parameters))
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -636,6 +636,12 @@ class Miner(NucypherTokenActor):
     #
 
     @only_me
+    def set_worker(self, worker_address: str) -> str:
+        txhash = self.miner_agent.set_worker(node_address=self.checksum_public_address, worker_address=worker_address)
+        self._transaction_cache.append((datetime.utcnow(), txhash))
+        return txhash
+
+    @only_me
     def confirm_activity(self) -> str:
         """Miner rewarded for every confirmed period"""
         txhash = self.miner_agent.confirm_activity(node_address=self.checksum_public_address)

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -443,6 +443,11 @@ class UserEscrowAgent(EthereumContractAgent):
         self.blockchain.wait_for_receipt(txhash)
         return txhash
 
+    def set_worker(self, worker: str) -> str:
+        txhash = self.__proxy_contract.functions.setWorker(worker).transact({'from': self.__beneficiary})
+        self.blockchain.wait_for_receipt(txhash)
+        return txhash
+
     def confirm_activity(self) -> str:
         txhash = self.__proxy_contract.functions.confirmActivity().transact({'from': self.__beneficiary})
         self.blockchain.wait_for_receipt(txhash)

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -184,6 +184,11 @@ class MinerAgent(EthereumContractAgent):
         period = self.contract.functions.getLastActivePeriod(address).call()
         return int(period)
 
+    def set_worker(self, node_address: str, worker_address: str) -> str:
+        txhash = self.contract.functions.setWorker(worker_address).transact({'from': node_address})
+        self.blockchain.wait_for_receipt(txhash)
+        return txhash
+
     def confirm_activity(self, node_address: str) -> str:
         """Miner rewarded for every confirmed period"""
 
@@ -443,8 +448,8 @@ class UserEscrowAgent(EthereumContractAgent):
         self.blockchain.wait_for_receipt(txhash)
         return txhash
 
-    def set_worker(self, worker: str) -> str:
-        txhash = self.__proxy_contract.functions.setWorker(worker).transact({'from': self.__beneficiary})
+    def set_worker(self, worker_address: str) -> str:
+        txhash = self.__proxy_contract.functions.setWorker(worker_address).transact({'from': self.__beneficiary})
         self.blockchain.wait_for_receipt(txhash)
         return txhash
 

--- a/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
@@ -5,7 +5,7 @@ import "contracts/NuCypherToken.sol";
 import "zeppelin/math/SafeMath.sol";
 import "zeppelin/math/Math.sol";
 import "contracts/proxy/Upgradeable.sol";
-import "./lib/AdditionalMath.sol";
+import "contracts/lib/AdditionalMath.sol";
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MiningAdjudicator.sol
@@ -146,7 +146,7 @@ contract MiningAdjudicator is Upgradeable {
         address miner = SignatureVerifier.recover(
             SignatureVerifier.hash(_minerPublicKey, hashAlgorithm), _minerPublicKeySignature);
         // Check that miner can be slashed
-        (uint256 minerValue,,,,,) = escrow.minerInfo(miner);
+        uint256 minerValue = escrow.getAllTokens(miner);
         require(minerValue > 0);
 
         // Verify correctness of re-encryption

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.3;
 import "zeppelin/token/ERC20/SafeERC20.sol";
 import "zeppelin/math/SafeMath.sol";
 import "zeppelin/math/Math.sol";
-import "./lib/AdditionalMath.sol";
+import "contracts/lib/AdditionalMath.sol";
 import "contracts/MinersEscrow.sol";
 import "contracts/NuCypherToken.sol";
 import "contracts/proxy/Upgradeable.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
@@ -63,7 +63,7 @@ contract UserEscrowProxy {
 
     /**
     * @notice Set `worker` parameter in the miners escrow
-    * @param _worker Worker address. Use zero address to set miner as worker
+    * @param _worker Worker address
     **/
     function setWorker(address _worker) public {
         getStateContract().escrow().setWorker(_worker);

--- a/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.3;
 
 
-import "./UserEscrow.sol";
+import "contracts/UserEscrow.sol";
 import "contracts/NuCypherToken.sol";
 import "contracts/MinersEscrow.sol";
 import "contracts/PolicyManager.sol";
@@ -14,16 +14,17 @@ import "contracts/PolicyManager.sol";
 **/
 contract UserEscrowProxy {
 
-    event DepositedAsMiner(address indexed owner, uint256 value, uint16 periods);
-    event WithdrawnAsMiner(address indexed owner, uint256 value);
-    event Locked(address indexed owner, uint256 value, uint16 periods);
-    event Divided(address indexed owner, uint256 index, uint256 newValue, uint16 periods);
-    event ActivityConfirmed(address indexed owner);
-    event Mined(address indexed owner);
-    event PolicyRewardWithdrawn(address indexed owner, uint256 value);
-    event MinRewardRateSet(address indexed owner, uint256 value);
-    event ReStakeSet(address indexed owner, bool reStake);
-    event ReStakeLocked(address indexed owner, uint16 lockUntilPeriod);
+    event DepositedAsMiner(address indexed sender, uint256 value, uint16 periods);
+    event WithdrawnAsMiner(address indexed sender, uint256 value);
+    event Locked(address indexed sender, uint256 value, uint16 periods);
+    event Divided(address indexed sender, uint256 index, uint256 newValue, uint16 periods);
+    event ActivityConfirmed(address indexed sender);
+    event Mined(address indexed sender);
+    event PolicyRewardWithdrawn(address indexed sender, uint256 value);
+    event MinRewardRateSet(address indexed sender, uint256 value);
+    event ReStakeSet(address indexed sender, bool reStake);
+    event ReStakeLocked(address indexed sender, uint16 lockUntilPeriod);
+    event WorkerSet(address indexed sender, address worker);
 
     NuCypherToken public token;
     MinersEscrow public escrow;
@@ -58,6 +59,15 @@ contract UserEscrowProxy {
         address payable userEscrowAddress = address(bytes20(address(this)));
         UserEscrowLibraryLinker linker = UserEscrow(userEscrowAddress).linker();
         return UserEscrowProxy(linker.target());
+    }
+
+    /**
+    * @notice Set `worker` parameter in the miners escrow
+    * @param _worker Worker address. Use zero address to set miner as worker
+    **/
+    function setWorker(address _worker) public {
+        getStateContract().escrow().setWorker(_worker);
+        emit WorkerSet(msg.sender, _worker);
     }
 
     /**

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -422,6 +422,8 @@ def ursula(click_config,
             click.confirm("Publish staged stake to the blockchain?", abort=True)
 
         stake = URSULA.initialize_stake(amount=int(value), lock_periods=duration)
+        # TODO temporary fix to not break backward compatibility
+        URSULA.set_worker(worker_address=URSULA.checksum_public_address)
         painting.paint_staking_confirmation(ursula=URSULA, transactions=stake.transactions)
         return
 

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -125,4 +125,4 @@ MOCK_IP_ADDRESS_2 = '10.10.10.10'
 
 MOCK_URSULA_DB_FILEPATH = ':memory:'
 
-PYEVM_GAS_LIMIT = 8_000_000  # TODO: move elsewhere (used to set pyevm gas limit in tests)?
+PYEVM_GAS_LIMIT = 8_200_000  # TODO: move elsewhere (used to set pyevm gas limit in tests)?

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -125,4 +125,4 @@ MOCK_IP_ADDRESS_2 = '10.10.10.10'
 
 MOCK_URSULA_DB_FILEPATH = ':memory:'
 
-PYEVM_GAS_LIMIT = 8_200_000  # TODO: move elsewhere (used to set pyevm gas limit in tests)?
+PYEVM_GAS_LIMIT = 8_500_000  # TODO: move elsewhere (used to set pyevm gas limit in tests)?

--- a/nucypher/utilities/sandbox/ursula.py
+++ b/nucypher/utilities/sandbox/ursula.py
@@ -102,7 +102,7 @@ def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
             periods = random.randint(min_locktime, max_locktime)
 
             ursula.initialize_stake(amount=amount, lock_periods=periods)
-            # TODO change to real worker
+            # TODO temporary fix to not break backward compatibility
             ursula.set_worker(worker_address=ursula.checksum_public_address)
             ursula.confirm_activity()
 

--- a/nucypher/utilities/sandbox/ursula.py
+++ b/nucypher/utilities/sandbox/ursula.py
@@ -102,6 +102,8 @@ def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
             periods = random.randint(min_locktime, max_locktime)
 
             ursula.initialize_stake(amount=amount, lock_periods=periods)
+            # TODO change to real worker
+            ursula.set_worker(worker_address=ursula.checksum_public_address)
             ursula.confirm_activity()
 
         ursulas.append(ursula)

--- a/nucypher/utilities/sandbox/ursula.py
+++ b/nucypher/utilities/sandbox/ursula.py
@@ -102,6 +102,7 @@ def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
             periods = random.randint(min_locktime, max_locktime)
 
             ursula.initialize_stake(amount=amount, lock_periods=periods)
+            ursula.confirm_activity()
 
         ursulas.append(ursula)
         # Store this Ursula in our global cache.

--- a/tests/blockchain/eth/contracts/contracts/MinersEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/MinersEscrowTestSet.sol
@@ -18,7 +18,8 @@ contract MinersEscrowBad is MinersEscrow {
         uint16 _rewardedPeriods,
         uint16 _minLockedPeriods,
         uint256 _minAllowableLockedTokens,
-        uint256 _maxAllowableLockedTokens
+        uint256 _maxAllowableLockedTokens,
+        uint16 _minWorkerPeriods
     )
         public
         MinersEscrow(
@@ -29,7 +30,8 @@ contract MinersEscrowBad is MinersEscrow {
             _rewardedPeriods,
             _minLockedPeriods,
             _minAllowableLockedTokens,
-            _maxAllowableLockedTokens
+            _maxAllowableLockedTokens,
+            _minWorkerPeriods
         )
     {
     }
@@ -57,6 +59,7 @@ contract MinersEscrowV2Mock is MinersEscrow {
         uint16 _minLockedPeriods,
         uint256 _minAllowableLockedTokens,
         uint256 _maxAllowableLockedTokens,
+        uint16 _minWorkerPeriods,
         uint256 _valueToCheck
     )
         public
@@ -68,7 +71,8 @@ contract MinersEscrowV2Mock is MinersEscrow {
             _rewardedPeriods,
             _minLockedPeriods,
             _minAllowableLockedTokens,
-            _maxAllowableLockedTokens
+            _maxAllowableLockedTokens,
+            _minWorkerPeriods
         )
     {
         valueToCheck = _valueToCheck;

--- a/tests/blockchain/eth/contracts/contracts/MinersEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/MinersEscrowTestSet.sol
@@ -153,3 +153,31 @@ contract MiningAdjudicatorForMinersEscrowMock {
         escrow.slashMiner(_miner, _penalty, _investigator, _reward);
     }
 }
+
+/**
+* @notice Intermediary contract for testing worker
+**/
+contract Intermediary {
+
+    NuCypherToken token;
+    MinersEscrow escrow;
+
+    constructor(NuCypherToken _token, MinersEscrow _escrow) public {
+        token = _token;
+        escrow = _escrow;
+    }
+
+    function setWorker(address _worker) public {
+        escrow.setWorker(_worker);
+    }
+
+    function deposit(uint256 _value, uint16 _periods) public {
+        token.approve(address(escrow), _value);
+        escrow.deposit(_value, _periods);
+    }
+
+    function confirmActivity() public {
+        escrow.confirmActivity();
+    }
+
+}

--- a/tests/blockchain/eth/contracts/contracts/MiningAdjudicatorTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/MiningAdjudicatorTestSet.sol
@@ -15,13 +15,22 @@ contract MinersEscrowForMiningAdjudicatorMock {
     uint32 public secondsPerPeriod = 1;
     mapping (address => uint256) public minerInfo;
     mapping (address => uint256) public rewardInfo;
+    mapping (address => address) public workerToMiner;
 
-    function setMinerInfo(address _miner, uint256 _amount) public {
+    function setMinerInfo(address _miner, uint256 _amount, address _worker) public {
         minerInfo[_miner] = _amount;
+        if (_worker == address(0)) {
+            _worker = _miner;
+        }
+        workerToMiner[_worker] = _miner;
     }
 
     function getAllTokens(address _miner) public view returns (uint256) {
         return minerInfo[_miner];
+    }
+
+    function getMinerByWorker(address _worker) public view returns (address) {
+        return workerToMiner[_worker];
     }
 
     function slashMiner(

--- a/tests/blockchain/eth/contracts/contracts/MiningAdjudicatorTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/MiningAdjudicatorTestSet.sol
@@ -12,21 +12,16 @@ import "contracts/proxy/Upgradeable.sol";
 **/
 contract MinersEscrowForMiningAdjudicatorMock {
 
-    struct MinerInfo {
-        uint256 value;
-        uint16 stubValue1;
-        uint16 stubValue2;
-        bool stubValue3;
-        uint16 stubValue4;
-        uint16 stubValue5;
-    }
-
     uint32 public secondsPerPeriod = 1;
-    mapping (address => MinerInfo) public minerInfo;
+    mapping (address => uint256) public minerInfo;
     mapping (address => uint256) public rewardInfo;
 
     function setMinerInfo(address _miner, uint256 _amount) public {
-        minerInfo[_miner].value = _amount;
+        minerInfo[_miner] = _amount;
+    }
+
+    function getAllTokens(address _miner) public view returns (uint256) {
+        return minerInfo[_miner];
     }
 
     function slashMiner(
@@ -37,7 +32,7 @@ contract MinersEscrowForMiningAdjudicatorMock {
     )
         public
     {
-        minerInfo[_miner].value -= _penalty;
+        minerInfo[_miner] -= _penalty;
         rewardInfo[_investigator] += _reward;
     }
 

--- a/tests/blockchain/eth/contracts/contracts/UserEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/UserEscrowTestSet.sol
@@ -19,6 +19,7 @@ contract MinersEscrowForUserEscrowMock {
     uint256 public index;
     bool public reStake;
     uint16 public lockReStakeUntilPeriod;
+    address public worker;
 
     constructor(NuCypherToken _token) public {
         token = _token;
@@ -66,6 +67,10 @@ contract MinersEscrowForUserEscrowMock {
 
     function lockReStake(uint16 _lockReStakeUntilPeriod) public {
         lockReStakeUntilPeriod = _lockReStakeUntilPeriod;
+    }
+
+    function setWorker(address _worker) public {
+        worker = _worker;
     }
 }
 

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -373,6 +373,8 @@ def test_all(testerchain,
     # Deposit tokens for 1 owner
     tx = escrow.functions.preDeposit([ursula2], [1000], [9]).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula2).transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
     assert reward + 1000 == token.functions.balanceOf(escrow.address).call()
     assert 1000 == escrow.functions.minerInfo(ursula2).call()[VALUE_FIELD]
     assert 0 == escrow.functions.getLockedTokens(ursula2).call()
@@ -398,6 +400,8 @@ def test_all(testerchain,
 
     # Ursula transfer some tokens to the escrow and lock them
     tx = escrow.functions.deposit(1000, 10).transact({'from': ursula1})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula1).transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.confirmActivity().transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -57,15 +57,17 @@ def token(testerchain):
 def escrow(testerchain, token):
     # Creator deploys the escrow
     contract, _ = testerchain.interface.deploy_contract(
-        'MinersEscrow',
-        token.address,
-        1,
-        4 * 2 * 10 ** 7,
-        4,
-        4,
-        2,
-        100,
-        2000)
+        contract_name='MinersEscrow',
+        _token=token.address,
+        _hoursPerPeriod=1,
+        _miningCoefficient=8*10**7,
+        _lockedPeriodsCoefficient=4,
+        _rewardedPeriods=4,
+        _minLockedPeriods=2,
+        _minAllowableLockedTokens=100,
+        _maxAllowableLockedTokens=2000,
+        _minWorkerPeriods=2
+    )
 
     secret_hash = testerchain.interface.w3.keccak(escrow_secret)
     dispatcher, _ = testerchain.interface.deploy_contract('Dispatcher', contract.address, secret_hash)
@@ -596,15 +598,17 @@ def test_all(testerchain,
     policy_manager_v1 = policy_manager.functions.target().call()
     # Creator deploys the contracts as the second versions
     escrow_v2, _ = testerchain.interface.deploy_contract(
-        'MinersEscrow',
-        token.address,
-        1,
-        4 * 2 * 10 ** 7,
-        4,
-        4,
-        2,
-        100,
-        2000)
+        contract_name='MinersEscrow',
+        _token=token.address,
+        _hoursPerPeriod=1,
+        _miningCoefficient=8 * 10 ** 7,
+        _lockedPeriodsCoefficient=4,
+        _rewardedPeriods=4,
+        _minLockedPeriods=2,
+        _minAllowableLockedTokens=100,
+        _maxAllowableLockedTokens=2000,
+        _minWorkerPeriods=2
+    )
     policy_manager_v2, _ = testerchain.interface.deploy_contract('PolicyManager', escrow.address)
     # Ursula and Alice can't upgrade contracts, only owner can
     with pytest.raises((TransactionFailed, ValueError)):

--- a/tests/blockchain/eth/contracts/main/miners_escrow/conftest.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/conftest.py
@@ -47,7 +47,8 @@ def escrow_contract(testerchain, token, request):
             _rewardedPeriods=4,
             _minLockedPeriods=2,
             _minAllowableLockedTokens=100,
-            _maxAllowableLockedTokens=max_allowed_locked_tokens
+            _maxAllowableLockedTokens=max_allowed_locked_tokens,
+            _minWorkerPeriods=1
         )
 
         if request.param:

--- a/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow.py
@@ -108,6 +108,8 @@ def test_staking(testerchain, token, escrow_contract):
     current_period = escrow.functions.getCurrentPeriod().call()
     tx = escrow.functions.deposit(1000, 2).transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula1).transact({'from': ursula1})
+    testerchain.wait_for_receipt(tx)
     assert 1000 == token.functions.balanceOf(escrow.address).call()
     assert 9000 == token.functions.balanceOf(ursula1).call()
     assert 0 == escrow.functions.getLockedTokens(ursula1).call()
@@ -132,6 +134,8 @@ def test_staking(testerchain, token, escrow_contract):
 
     # Ursula(2) stakes tokens also
     tx = escrow.functions.deposit(500, 2).transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula2).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     assert 1500 == token.functions.balanceOf(escrow.address).call()
     assert 9500 == token.functions.balanceOf(ursula2).call()
@@ -468,6 +472,8 @@ def test_max_sub_stakes(testerchain, token, escrow_contract):
 
     # Lock one sub stake from current period and others from next one
     tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula).transact({'from': ursula})
     testerchain.wait_for_receipt(tx)
     assert 1 == escrow.functions.getSubStakesLength(ursula).call()
 

--- a/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow_additional.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow_additional.py
@@ -231,13 +231,15 @@ def test_re_stake(testerchain, token, escrow_contract):
     assert ursula == event_args['miner']
     assert period + 1 == event_args['lockUntilPeriod']
 
-    # Ursula deposits some tokens
+    # Ursula deposits some tokens and confirms activity
     tx = token.functions.transfer(ursula, 10000).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = token.functions.approve(escrow.address, 10000).transact({'from': ursula})
     testerchain.wait_for_receipt(tx)
     sub_stake = 1000
     tx = escrow.functions.deposit(sub_stake, 10).transact({'from': ursula})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.confirmActivity().transact({'from': ursula})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
     period = escrow.functions.getCurrentPeriod().call()
@@ -336,11 +338,15 @@ def test_re_stake(testerchain, token, escrow_contract):
     sub_stake_duration = escrow.functions.getSubStakeInfo(ursula, 0).call()[2]
     tx = escrow.functions.deposit(sub_stake_2, sub_stake_duration).transact({'from': ursula})
     testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.confirmActivity().transact({'from': ursula})
+    testerchain.wait_for_receipt(tx)
     tx = token.functions.transfer(ursula2, stake).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = token.functions.approve(escrow.address, stake).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.deposit(stake, sub_stake_duration).transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.confirmActivity().transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
     tx = escrow.functions.confirmActivity().transact({'from': ursula})

--- a/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow_additional.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow_additional.py
@@ -99,6 +99,8 @@ def test_upgrading(testerchain, token):
     testerchain.wait_for_receipt(tx)
     tx = contract.functions.lockReStake(contract.functions.getCurrentPeriod().call() + 1).transact({'from': miner})
     testerchain.wait_for_receipt(tx)
+    tx = contract.functions.setWorker(miner).transact({'from': miner})
+    testerchain.wait_for_receipt(tx)
 
     # Upgrade to the second version
     tx = dispatcher.functions.upgrade(contract_library_v2.address, secret, secret2_hash).transact({'from': creator})
@@ -434,3 +436,8 @@ def test_re_stake(testerchain, token, escrow_contract):
     assert sub_stake == escrow.functions.getLockedTokensInPast(ursula, 1).call()
     assert sub_stake == escrow.functions.getLockedTokens(ursula).call()
     assert sub_stake == escrow.functions.lockedPerPeriod(period - 1).call()
+
+
+@pytest.mark.slow
+def test_worker(testerchain, token, escrow_contract):
+    pass

--- a/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow_additional.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/test_miners_escrow_additional.py
@@ -48,7 +48,8 @@ def test_upgrading(testerchain, token):
         _rewardedPeriods=4,
         _minLockedPeriods=2,
         _minAllowableLockedTokens=100,
-        _maxAllowableLockedTokens=1500
+        _maxAllowableLockedTokens=1500,
+        _minWorkerPeriods=1
     )
     dispatcher, _ = testerchain.interface.deploy_contract('Dispatcher', contract_library_v1.address, secret_hash)
 
@@ -63,6 +64,7 @@ def test_upgrading(testerchain, token):
         _minLockedPeriods=2,
         _minAllowableLockedTokens=2,
         _maxAllowableLockedTokens=2,
+        _minWorkerPeriods=2,
         _valueToCheck=2
     )
 
@@ -124,7 +126,8 @@ def test_upgrading(testerchain, token):
         _rewardedPeriods=2,
         _minLockedPeriods=2,
         _minAllowableLockedTokens=2,
-        _maxAllowableLockedTokens=2
+        _maxAllowableLockedTokens=2,
+        _minWorkerPeriods=2
     )
     with pytest.raises((TransactionFailed, ValueError)):
         tx = dispatcher.functions.upgrade(contract_library_v1.address, secret2, secret_hash)\

--- a/tests/blockchain/eth/contracts/main/miners_escrow/test_mining.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/test_mining.py
@@ -72,9 +72,13 @@ def test_mining(testerchain, token, escrow_contract):
     # Ursula and Ursula(2) transfer some tokens to the escrow and lock them
     tx = escrow.functions.deposit(1000, 2).transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula1).transact({'from': ursula1})
+    testerchain.wait_for_receipt(tx)
     tx = escrow.functions.confirmActivity().transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.deposit(500, 2).transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula2).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.confirmActivity().transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
@@ -331,6 +335,8 @@ def test_slashing(testerchain, token, escrow_contract):
     tx = token.functions.approve(escrow.address, 10000).transact({'from': ursula})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula).transact({'from': ursula})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.confirmActivity().transact({'from': ursula})
     testerchain.wait_for_receipt(tx)
@@ -625,6 +631,8 @@ def test_slashing(testerchain, token, escrow_contract):
 
     # Two deposits in consecutive periods
     tx = escrow.functions.deposit(100, 4).transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(ursula2).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.confirmActivity().transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)

--- a/tests/blockchain/eth/contracts/main/miners_escrow/test_tracking.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/test_tracking.py
@@ -65,6 +65,8 @@ def test_sampling(testerchain, token, escrow_contract):
         testerchain.wait_for_receipt(tx)
         tx = escrow.functions.deposit(balance, index + 2).transact({'from': miner})
         testerchain.wait_for_receipt(tx)
+        tx = escrow.functions.setWorker(miner).transact({'from': miner})
+        testerchain.wait_for_receipt(tx)
         tx = escrow.functions.confirmActivity().transact({'from': miner})
         testerchain.wait_for_receipt(tx)
         all_locked_tokens += balance

--- a/tests/blockchain/eth/contracts/main/miners_escrow/test_tracking.py
+++ b/tests/blockchain/eth/contracts/main/miners_escrow/test_tracking.py
@@ -65,6 +65,8 @@ def test_sampling(testerchain, token, escrow_contract):
         testerchain.wait_for_receipt(tx)
         tx = escrow.functions.deposit(balance, index + 2).transact({'from': miner})
         testerchain.wait_for_receipt(tx)
+        tx = escrow.functions.confirmActivity().transact({'from': miner})
+        testerchain.wait_for_receipt(tx)
         all_locked_tokens += balance
 
     # Miners are active from the next period

--- a/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
+++ b/tests/blockchain/eth/contracts/main/mining_adjudicator/test_mining_adjudicator.py
@@ -105,14 +105,14 @@ def test_evaluate_cfrag(testerchain,
     args[-2] = signed_miner_umbral_public_key  # FIXME  #962  #962
 
     # Challenge using good data
-    assert worker_stake == escrow.functions.minerInfo(miner).call()[0]
+    assert worker_stake == escrow.functions.getAllTokens(miner).call()
 
     tx = adjudicator_contract.functions.evaluateCFrag(*args).transact({'from': investigator})
     testerchain.wait_for_receipt(tx)
     number_of_evaluations += 1
     # Hash of the data is saved and miner was not slashed
     assert adjudicator_contract.functions.evaluatedCFrags(data_hash).call()
-    assert worker_stake == escrow.functions.minerInfo(miner).call()[0]
+    assert worker_stake == escrow.functions.getAllTokens(miner).call()
     assert investigator_balance == escrow.functions.rewardInfo(investigator).call()
 
     events = evaluation_log.get_all_entries()
@@ -156,7 +156,7 @@ def test_evaluate_cfrag(testerchain,
     investigator_balance += reward
     worker_penalty_history += 1
 
-    assert worker_stake == escrow.functions.minerInfo(miner).call()[0]
+    assert worker_stake == escrow.functions.getAllTokens(miner).call()
     assert investigator_balance == escrow.functions.rewardInfo(investigator).call()
 
     events = evaluation_log.get_all_entries()
@@ -210,7 +210,7 @@ def test_evaluate_cfrag(testerchain,
     data_hash = evaluation_hash(capsule, cfrag)
     assert not adjudicator_contract.functions.evaluatedCFrags(data_hash).call()
 
-    worker_stake = escrow.functions.minerInfo(miner).call()[0]
+    worker_stake = escrow.functions.getAllTokens(miner).call()
     investigator_balance = escrow.functions.rewardInfo(investigator).call()
 
     assert not adjudicator_contract.functions.evaluatedCFrags(data_hash).call()
@@ -228,7 +228,7 @@ def test_evaluate_cfrag(testerchain,
     investigator_balance += reward
     worker_penalty_history += 1
 
-    assert worker_stake == escrow.functions.minerInfo(miner).call()[0]
+    assert worker_stake == escrow.functions.getAllTokens(miner).call()
     assert investigator_balance == escrow.functions.rewardInfo(investigator).call()
 
     events = evaluation_log.get_all_entries()
@@ -254,7 +254,7 @@ def test_evaluate_cfrag(testerchain,
     data_hash = evaluation_hash(capsule, cfrag)
     assert not adjudicator_contract.functions.evaluatedCFrags(data_hash).call()
 
-    worker_stake = escrow.functions.minerInfo(miner).call()[0]
+    worker_stake = escrow.functions.getAllTokens(miner).call()
     investigator_balance = escrow.functions.rewardInfo(investigator).call()
 
     tx = adjudicator_contract.functions.evaluateCFrag(*args).transact({'from': investigator})
@@ -270,7 +270,7 @@ def test_evaluate_cfrag(testerchain,
     investigator_balance += reward
     worker_penalty_history += 1
 
-    assert worker_stake == escrow.functions.minerInfo(miner).call()[0]
+    assert worker_stake == escrow.functions.getAllTokens(miner).call()
     assert investigator_balance == escrow.functions.rewardInfo(investigator).call()
 
     events = evaluation_log.get_all_entries()

--- a/tests/blockchain/eth/entities/actors/test_miner.py
+++ b/tests/blockchain/eth/entities/actors/test_miner.py
@@ -102,6 +102,7 @@ def test_miner_collects_staking_reward(testerchain, miner, three_agents, token_e
 
     miner.initialize_stake(amount=NU(token_economics.minimum_allowed_locked, 'NuNit'),  # Lock the minimum amount of tokens
                            lock_periods=int(token_economics.minimum_locked_periods))    # ... for the fewest number of periods
+    miner.set_worker(worker_address=miner.checksum_public_address)
 
     # ...wait out the lock period...
     for _ in range(token_economics.minimum_locked_periods):

--- a/tests/blockchain/eth/entities/agents/test_miner_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_miner_escrow_agent.py
@@ -131,6 +131,7 @@ def test_confirm_activity(three_agents):
     agent = miner_agent
     testerchain = agent.blockchain
     origin, someone, *everybody_else = testerchain.interface.w3.eth.accounts
+    _txhash = agent.set_worker(node_address=someone, worker_address=someone)
     txhash = agent.confirm_activity(node_address=someone)
     testerchain = agent.blockchain
     receipt = testerchain.wait_for_receipt(txhash)

--- a/tests/blockchain/eth/entities/agents/test_miner_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_miner_escrow_agent.py
@@ -186,7 +186,10 @@ def test_collect_staking_reward(three_agents):
 
     # Confirm Activity
     _txhash = agent.confirm_activity(node_address=someone)
-    testerchain.time_travel(periods=1)
+    testerchain.time_travel(periods=2)
+
+    # Mint
+    _txhash = agent.mint(node_address=someone)
 
     old_balance = token_agent.get_balance(address=someone)
 

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -146,8 +146,7 @@ def test_deposit_and_withdraw_as_miner(testerchain, agent, three_agents, allocat
     assert miner_agent.get_locked_tokens(miner_address=agent.contract_address, periods=token_economics.minimum_locked_periods) == token_economics.minimum_allowed_locked
     assert miner_agent.get_locked_tokens(miner_address=agent.contract_address, periods=token_economics.minimum_locked_periods+1) == 0
 
-    testerchain.time_travel(periods=1)
-    for _ in range(token_economics.minimum_locked_periods-1):
+    for _ in range(token_economics.minimum_locked_periods):
         agent.confirm_activity()
         testerchain.time_travel(periods=1)
     testerchain.time_travel(periods=1)

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -138,6 +138,7 @@ def test_deposit_and_withdraw_as_miner(testerchain, agent, three_agents, allocat
     # Move the tokens to the MinerEscrow
     txhash = agent.deposit_as_miner(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
     assert txhash  # TODO
+    _txhash = agent.set_worker(worker=agent.beneficiary)
 
     assert token_agent.get_balance(address=agent.contract_address) == allocation_value - token_economics.minimum_allowed_locked
     assert agent.unvested_tokens == allocation_value
@@ -158,6 +159,9 @@ def test_deposit_and_withdraw_as_miner(testerchain, agent, three_agents, allocat
     assert txhash  # TODO
     assert token_agent.get_balance(address=agent.contract_address) == allocation_value
 
+    # Release worker
+    _txhash = agent.set_worker(worker=testerchain.etherbase_account)
+
     txhash = agent.withdraw_as_miner(value=miner_agent.owned_tokens(address=agent.contract_address))
     assert txhash
     assert token_agent.get_balance(address=agent.contract_address) > allocation_value
@@ -168,6 +172,7 @@ def test_collect_policy_reward(testerchain, agent, three_agents, token_economics
     deployer_address, beneficiary_address, author, ursula, *everybody_else = testerchain.interface.w3.eth.accounts
 
     _txhash = agent.deposit_as_miner(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
+    _txhash = agent.set_worker(worker=agent.beneficiary)
     testerchain.time_travel(periods=1)
 
     _txhash = policy_agent.create_policy(policy_id=os.urandom(16),

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -138,7 +138,7 @@ def test_deposit_and_withdraw_as_miner(testerchain, agent, three_agents, allocat
     # Move the tokens to the MinerEscrow
     txhash = agent.deposit_as_miner(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
     assert txhash  # TODO
-    _txhash = agent.set_worker(worker=agent.beneficiary)
+    _txhash = agent.set_worker(worker_address=agent.beneficiary)
 
     assert token_agent.get_balance(address=agent.contract_address) == allocation_value - token_economics.minimum_allowed_locked
     assert agent.unvested_tokens == allocation_value
@@ -160,7 +160,7 @@ def test_deposit_and_withdraw_as_miner(testerchain, agent, three_agents, allocat
     assert token_agent.get_balance(address=agent.contract_address) == allocation_value
 
     # Release worker
-    _txhash = agent.set_worker(worker=testerchain.etherbase_account)
+    _txhash = agent.set_worker(worker_address=testerchain.etherbase_account)
 
     txhash = agent.withdraw_as_miner(value=miner_agent.owned_tokens(address=agent.contract_address))
     assert txhash
@@ -172,7 +172,7 @@ def test_collect_policy_reward(testerchain, agent, three_agents, token_economics
     deployer_address, beneficiary_address, author, ursula, *everybody_else = testerchain.interface.w3.eth.accounts
 
     _txhash = agent.deposit_as_miner(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
-    _txhash = agent.set_worker(worker=agent.beneficiary)
+    _txhash = agent.set_worker(worker_address=agent.beneficiary)
     testerchain.time_travel(periods=1)
 
     _txhash = policy_agent.create_policy(policy_id=os.urandom(16),

--- a/tests/blockchain/eth/entities/deployers/test_economics.py
+++ b/tests/blockchain/eth/entities/deployers/test_economics.py
@@ -127,8 +127,8 @@ def test_exact_economics():
                                       365,      # Max periods that will be additionally rewarded (awarded_periods)
                                       30,       # Min amount of periods during which tokens can be locked
                                       15000000000000000000000,    # min locked NuNits
-                                      4000000000000000000000000)  # max locked NuNits
-
+                                      4000000000000000000000000,  # max locked NuNits
+                                      2)        # Min worker periods
     #
     # Token Economics
     #

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -243,6 +243,13 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     tx = miner_functions.deposit(MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS).transact({'from': ursula3})
     testerchain.wait_for_receipt(tx)
 
+    tx = miner_functions.setWorker(ursula1).transact({'from': ursula1})
+    testerchain.wait_for_receipt(tx)
+    tx = miner_functions.setWorker(ursula2).transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
+    tx = miner_functions.setWorker(ursula3).transact({'from': ursula3})
+    testerchain.wait_for_receipt(tx)
+
     tx = miner_functions.confirmActivity().transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
     tx = miner_functions.confirmActivity().transact({'from': ursula2})

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -243,6 +243,13 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     tx = miner_functions.deposit(MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS).transact({'from': ursula3})
     testerchain.wait_for_receipt(tx)
 
+    tx = miner_functions.confirmActivity().transact({'from': ursula1})
+    testerchain.wait_for_receipt(tx)
+    tx = miner_functions.confirmActivity().transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
+    tx = miner_functions.confirmActivity().transact({'from': ursula3})
+    testerchain.wait_for_receipt(tx)
+
     #
     # Wait 1 period and confirm activity
     #


### PR DESCRIPTION
Before this PR a staker can't be an intermediary contract (such as User Escrow) because contract can't sign anything (and we can't slash it). 
Now miner/staker can set worker who can confirm activity and doesn't matter how many intermediary contracts between worker and MinersEscrow.

Any suggestions on renaming "worker" are welcome.

`MinersEscrow` API cahnges:
* `lock` method no longer includes `mint` and `confirmActivity` methods
* `setWorker(address)` method - necessary to set worker before confirm activity
* `getWorkerByMiner(address)`
* `getMinerByWorker(address)`
* Only worker can call `confirmActivity()`

Also `MiningAdjudicator` uses `getMinerByWorker(address)` to get miner for slashing
