### PR TITLE
Clean startup

### DIFF
--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -44,7 +44,10 @@ def load_seednodes(min_stake: int,
 
     teacher_nodes = list()
     if teacher_uris is None:
-        teacher_uris = TEACHER_NODES[network_domain]
+        try:
+            teacher_uris = TEACHER_NODES[network_domain]
+        except KeyError:
+            raise KeyError(f"No default teacher nodes exist for the specified network: {network_domain}")
     for uri in teacher_uris:
         teacher_node = Ursula.from_teacher_uri(teacher_uri=uri,
                                                min_stake=min_stake,

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -9,6 +9,8 @@ from nucypher.characters.lawful import Ursula
 from nucypher.cli.config import NucypherClickConfig
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, USER_LOG_DIR
 from nucypher.network.middleware import RestMiddleware
+from nucypher.network.teachers import TEACHER_NODES
+
 
 DESTRUCTION = '''
 *Permanently and irreversibly delete all* nucypher files including:
@@ -35,14 +37,14 @@ console_emitter = NucypherClickConfig.emit
 
 def load_seednodes(min_stake: int,
                    federated_only: bool,
+                   network_domain: str,
                    network_middleware: RestMiddleware = None,
                    teacher_uris: list = None
                    ) -> List[Ursula]:
 
     teacher_nodes = list()
     if teacher_uris is None:
-        # Default teacher nodes can be placed here
-        return teacher_nodes
+        teacher_uris = TEACHER_NODES[network_domain]
     for uri in teacher_uris:
         teacher_node = Ursula.from_teacher_uri(teacher_uri=uri,
                                                min_stake=min_stake,

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -1,5 +1,4 @@
 import datetime
-from base64 import b64encode
 
 import click
 import maya
@@ -21,7 +20,7 @@ from nucypher.config.constants import GLOBAL_DOMAIN
 @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT, default=9151)  # TODO
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT, default=8151)  # TODO
 @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--network', help="Network Domain Name", type=click.STRING, default='goerli-testnet')
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -118,10 +118,11 @@ def alice(click_config,
         click_config.unlock_keyring(character_configuration=alice_config)
 
     # Teacher Ursula
-    teacher_uris = [teacher_uri] if teacher_uri else list()
+    teacher_uris = [teacher_uri] if teacher_uri else None
     teacher_nodes = actions.load_seednodes(teacher_uris=teacher_uris,
                                            min_stake=min_stake,
                                            federated_only=federated_only,
+                                           network_domain=network,
                                            network_middleware=click_config.middleware)
     # Produce
     ALICE = alice_config(known_nodes=teacher_nodes, network_middleware=click_config.middleware)

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -103,10 +103,11 @@ def bob(click_config,
                                                              config_file=config_file)
 
     # Teacher Ursula
-    teacher_uris = [teacher_uri] if teacher_uri else list()
+    teacher_uris = [teacher_uri] if teacher_uri else None
     teacher_nodes = actions.load_seednodes(teacher_uris=teacher_uris,
                                            min_stake=min_stake,
                                            federated_only=federated_only,
+                                           network_domain=network,
                                            network_middleware=click_config.middleware)
 
     if not dev:

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -18,7 +18,7 @@ from nucypher.crypto.powers import DecryptingPower
 @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT, default=6151)  # TODO
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT, default=11151)  # TODO
 @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--network', help="Network Domain Name", type=click.STRING, default='goerli-testnet')
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -13,7 +13,7 @@ from nucypher.config.characters import FelixConfiguration
 @click.argument('action')
 @click.option('--teacher-uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--network', help="Network Domain Name", type=click.STRING, default='goerli-testnet')
 @click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
 @click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
 @click.option('--discovery-port', help="The host port to run Felix Node Discovery services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_LEARNER_PORT)

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -110,10 +110,11 @@ def felix(click_config,
     else:
 
         # Produce Teacher Ursulas
-        teacher_uris = [teacher_uri] if teacher_uri else list()
+        teacher_uris = [teacher_uri] if teacher_uri else None
         teacher_nodes = actions.load_seednodes(teacher_uris=teacher_uris,
                                                min_stake=min_stake,
                                                federated_only=False,
+                                               network_domain=network,
                                                network_middleware=click_config.middleware)
 
         # Produce Felix

--- a/nucypher/cli/characters/moe.py
+++ b/nucypher/cli/characters/moe.py
@@ -12,7 +12,7 @@ from nucypher.network.middleware import RestMiddleware
 @click.command()
 @click.option('--teacher-uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--network', help="Network Domain Name", type=click.STRING, default='goerli-testnet')
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT, default=12500)
 @click.option('--ws-port', help="The host port to run websocket network services on", type=NETWORK_PORT, default=9000)
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)

--- a/nucypher/cli/characters/moe.py
+++ b/nucypher/cli/characters/moe.py
@@ -28,10 +28,11 @@ def moe(click_config, teacher_uri, min_stake, network, ws_port, dry_run, http_po
         click.secho(MOE_BANNER)
 
     # Teacher Ursula
-    teacher_uris = [teacher_uri] if teacher_uri else list()
+    teacher_uris = [teacher_uri] if teacher_uri else None
     teacher_nodes = actions.load_seednodes(teacher_uris=teacher_uris,
                                            min_stake=min_stake,
                                            federated_only=True,    # TODO: hardcoded for now
+                                           network_domain=network,
                                            network_middleware=click_config.middleware)
 
     # Deserialize network domain name if override passed

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -47,7 +47,7 @@ from nucypher.utilities.sandbox.constants import (
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @click.option('--lonely', help="Do not connect to seednodes", is_flag=True)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--network', help="Network Domain Name", type=click.STRING, default='goerli-testnet')
 @click.option('--teacher-uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @click.option('--rest-host', help="The host IP address to run Ursula network services on", type=click.STRING)

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -240,10 +240,11 @@ def ursula(click_config,
         click_config.emit(message="WARNING: Running in Federated mode", color='yellow')
 
     # Seed - Step 1
-    teacher_uris = [teacher_uri] if teacher_uri else list()
+    teacher_uris = [teacher_uri] if teacher_uri else None
     teacher_nodes = actions.load_seednodes(teacher_uris=teacher_uris,
                                            min_stake=min_stake,
                                            federated_only=ursula_config.federated_only,
+                                           network_domain=network,
                                            network_middleware=click_config.middleware)
 
     # Produce - Step 2

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -65,7 +65,7 @@ class NodeConfiguration(ABC):
     DEFAULT_OPERATING_MODE = 'decentralized'
 
     # Domains
-    DEFAULT_DOMAIN = GLOBAL_DOMAIN
+    DEFAULT_DOMAIN = b'goerli-testnet'
 
     # Serializers
     NODE_SERIALIZER = binascii.hexlify

--- a/nucypher/network/teachers.py
+++ b/nucypher/network/teachers.py
@@ -1,0 +1,22 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+
+# Hardcoded teacher nodes for, both, our testnet and mainnet.
+TESTNET = []
+
+MAINNET = []

--- a/nucypher/network/teachers.py
+++ b/nucypher/network/teachers.py
@@ -17,6 +17,8 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 
 # Hardcoded teacher nodes for, both, our testnet and mainnet.
-TESTNET = []
-
-MAINNET = []
+# Stored as a dict with the domain as the key.
+TEACHER_NODES = {
+    'goerli-testnet': [],
+    'mainnet': [],
+}


### PR DESCRIPTION
### What this does:

1. Adds a `TEACHER_NODES` constant dict with network domains as keys.
2. Sets the default network flag to `goerli-testnet`.
3. Modifies the `cli.actions.load_seednodes` function to use the `TEACHER_NODES` default via network domain.
    - Raises a `KeyError` if the network domain specified has no teacher nodes specified for it.
4. `--teacher-uri` and `--network` are now basically optional for the testnet.

**Related Issue: https://github.com/nucypher/nucypher/issues/967**
