### PR TITLE
Standardize pip reqs files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - validate_reqs_files:
+          filters:
+            tags:
+              only: /.*/
       - pip_install_37:
           filters:
             tags:
@@ -430,6 +434,15 @@ jobs:
           command: ./scripts/circle/run_finnegans_wake_demo_docker-circle.sh
       - store_artifacts:
           path: /tmp/ursulas-logs
+
+  validate_reqs_files:
+    working_directory: ~/nucypher
+    <<: *python_37_base
+    steps:
+      - pipenv_install
+      - run:
+          name: Run Requirements comparison
+          command: ./scripts/circle/compare_reqs.sh
 
   mypy:
     <<: *python_36_base

--- a/scripts/circle/compare_reqs.sh
+++ b/scripts/circle/compare_reqs.sh
@@ -2,22 +2,40 @@
 
 set -e
 
+# update lock and build requirements files
 yes | ./scripts/installation/rebuild_pipenv.sh circlereqs
 
-if [ $(md5 -q requirements.txt) == $(md5 -q circlereqs.txt) ]; then
-    echo "requirements.txt is valid"
+echo "---- validating requirements.txt ----"
+REQSHASH=$(md5sum requirements.txt | cut -d ' ' -f1)
+TESTHASH=$(md5sum circlereqs.txt | cut -d ' ' -f1)
+
+echo "- $REQSHASH"
+echo "- $TESTHASH"
+if [ $REQSHASH == $TESTHASH ]; then
+    echo "- requirements.txt is valid ...."
 
 else
-    echo "requirements.txt contains inconsistencies"
+    echo "- requirements.txt contains inconsistencies ...."
+    echo "- you may want to run `pipenv sync --dev` and then ./scripts/installation/rebuild_pipenv.sh ...."
+    echo "- which will rebuild your *requirements.txt files ...."
     diff requirements.txt circlereqs.txt
     exit 2
 fi
 
-if [ $(md5 -q dev-requirements.txt) == $(md5 -q dev-circlereqs.txt) ]; then
-    echo "requirements.txt is valid"
+echo "---- validating dev-requirements.txt ----"
+REQSHASH=$(md5sum dev-requirements.txt | cut -d ' ' -f1)
+TESTHASH=$(md5sum dev-circlereqs.txt | cut -d ' ' -f1)
+
+echo "- $REQSHASH"
+echo "- $TESTHASH"
+
+if [ $REQSHASH == $TESTHASH ]; then
+    echo "- dev-requirements.txt is valid ...."
 
 else
-    echo "dev-requirements.txt contains inconsistencies"
+    echo "- dev-requirements.txt contains inconsistencies ...."
+    echo "- you may want to run `pipenv sync --dev` and then ./scripts/installation/rebuild_pipenv.sh ...."
+    echo "- which will rebuild your *requirements.txt files ...."
     diff dev-requirements.txt dev-circlereqs.txt
     exit 2
 fi

--- a/scripts/circle/compare_reqs.sh
+++ b/scripts/circle/compare_reqs.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+yes | ./scripts/installation/rebuild_pipenv.sh circlereqs
+
+if [ $(md5 -q requirements.txt) == $(md5 -q circlereqs.txt) ]; then
+    echo "requirements.txt is valid"
+
+else
+    echo "requirements.txt contains inconsistencies"
+    diff requirements.txt circlereqs.txt
+    exit 2
+fi
+
+if [ $(md5 -q dev-requirements.txt) == $(md5 -q dev-circlereqs.txt) ]; then
+    echo "requirements.txt is valid"
+
+else
+    echo "dev-requirements.txt contains inconsistencies"
+    diff dev-requirements.txt dev-circlereqs.txt
+    exit 2
+fi

--- a/scripts/installation/rebuild_pipenv.sh
+++ b/scripts/installation/rebuild_pipenv.sh
@@ -4,7 +4,7 @@
 PREFIX=${1:-requirements}
 
 read -p "Ok if we update your pip and setuptools? (type y or Y) " -n 1 -r
-echo 
+echo
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
     pip install --upgrade pip
@@ -17,9 +17,12 @@ rm dev-$PREFIX.txt
 touch $PREFIX.txt
 touch dev-$PREFIX.txt
 
-set -e 
+set -e
 echo "rebuilding pipenv.lock... this will take awhile."
-pipenv lock --clear
 
-pipenv lock --clear --pre --requirements > $PREFIX.txt
+echo "bulding dev-$PREFIX.txt"
 pipenv lock --clear --pre --requirements --dev > dev-$PREFIX.txt
+
+echo "building $PREFIX.txt"
+pipenv lock --clear --pre --requirements > $PREFIX.txt
+

--- a/scripts/installation/rebuild_pipenv.sh
+++ b/scripts/installation/rebuild_pipenv.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# can change output file names with rebuild_pipenv.sh <prefix>
+PREFIX=${1:-requirements}
+
 read -p "Ok if we update your pip and setuptools? (type y or Y) " -n 1 -r
 echo 
 if [[ $REPLY =~ ^[Yy]$ ]]
@@ -8,17 +11,15 @@ then
     pip install --upgrade setuptools
 fi
 
-rm requirements.txt
-rm dev-requirements.txt
+rm $PREFIX.txt
+rm dev-$PREFIX.txt
 
-touch requirements.txt
-touch dev-requirements.txt
+touch $PREFIX.txt
+touch dev-$PREFIX.txt
 
 set -e 
 echo "rebuilding pipenv.lock... this will take awhile."
 pipenv lock --clear
 
-pipenv lock -r > requirements.txt
-pipenv lock -r --dev > dev-requirements.txt
-
-
+pipenv lock --clear --pre --requirements > $PREFIX.txt
+pipenv lock --clear --pre --requirements --dev > dev-$PREFIX.txt

--- a/scripts/installation/rebuild_pipenv.sh
+++ b/scripts/installation/rebuild_pipenv.sh
@@ -11,8 +11,8 @@ then
     pip install --upgrade setuptools
 fi
 
-rm $PREFIX.txt
-rm dev-$PREFIX.txt
+rm -f $PREFIX.txt
+rm -f dev-$PREFIX.txt
 
 touch $PREFIX.txt
 touch dev-$PREFIX.txt


### PR DESCRIPTION
Our requirements.txt and dev-requirements.txt files have undergone many massive but seemingly arbitrary revisions over the last few months, mostly depending on who the last person was to generate them.

This PR  adds a test in Circle which ensures that requirements files are generated by consistent methods.

Note:  It will also fail if sub-dependencies are updated without an accompanying update of reqs files.
I think this is probably a good thing.