### PR TITLE
[WIP] CLI options refactoring

### DIFF
--- a/examples/finnegans_wake_demo/finnegans-wake-demo.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo.py
@@ -9,7 +9,7 @@ from umbral.keys import UmbralPublicKey
 from nucypher.characters.lawful import Alice, Bob, Ursula
 from nucypher.characters.lawful import Enrico as Enrico
 from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import ConsoleLoggingObserver
+from nucypher.utilities.logging import GlobalLogger
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
 ######################
@@ -24,7 +24,7 @@ BOOK_PATH = os.path.join('.', 'finnegans-wake.txt')
 NUMBER_OF_LINES_TO_REENCRYPT = 25
 
 # Twisted Logger
-globalLogPublisher.addObserver(ConsoleLoggingObserver())
+GlobalLogger.set_console_logging(True)
 
 
 #######################################

--- a/examples/finnegans_wake_demo/finnegans-wake-demo.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo.py
@@ -9,7 +9,7 @@ from umbral.keys import UmbralPublicKey
 from nucypher.characters.lawful import Alice, Bob, Ursula
 from nucypher.characters.lawful import Enrico as Enrico
 from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import SimpleObserver
+from nucypher.utilities.logging import ConsoleLoggingObserver
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
 ######################
@@ -24,7 +24,7 @@ BOOK_PATH = os.path.join('.', 'finnegans-wake.txt')
 NUMBER_OF_LINES_TO_REENCRYPT = 25
 
 # Twisted Logger
-globalLogPublisher.addObserver(SimpleObserver())
+globalLogPublisher.addObserver(ConsoleLoggingObserver())
 
 
 #######################################

--- a/examples/heartbeat_demo/alicia.py
+++ b/examples/heartbeat_demo/alicia.py
@@ -9,7 +9,7 @@ from twisted.logger import globalLogPublisher
 
 from nucypher.characters.lawful import Bob, Ursula
 from nucypher.config.characters import AliceConfiguration
-from nucypher.utilities.logging import SimpleObserver
+from nucypher.utilities.logging import ConsoleLoggingObserver
 
 
 ######################
@@ -20,7 +20,7 @@ from nucypher.utilities.logging import SimpleObserver
 # Twisted Logger
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
-globalLogPublisher.addObserver(SimpleObserver())
+globalLogPublisher.addObserver(ConsoleLoggingObserver())
 
 TEMP_ALICE_DIR = os.path.join('/', 'tmp', 'heartbeat-demo-alice')
 

--- a/examples/heartbeat_demo/alicia.py
+++ b/examples/heartbeat_demo/alicia.py
@@ -9,7 +9,7 @@ from twisted.logger import globalLogPublisher
 
 from nucypher.characters.lawful import Bob, Ursula
 from nucypher.config.characters import AliceConfiguration
-from nucypher.utilities.logging import ConsoleLoggingObserver
+from nucypher.utilities.logging import GlobalLogger
 
 
 ######################
@@ -20,7 +20,7 @@ from nucypher.utilities.logging import ConsoleLoggingObserver
 # Twisted Logger
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
-globalLogPublisher.addObserver(ConsoleLoggingObserver())
+GlobalLogger.set_console_logging(True)
 
 TEMP_ALICE_DIR = os.path.join('/', 'tmp', 'heartbeat-demo-alice')
 

--- a/examples/heartbeat_demo/doctor.py
+++ b/examples/heartbeat_demo/doctor.py
@@ -17,10 +17,10 @@ from nucypher.network.middleware import RestMiddleware
 
 from umbral.keys import UmbralPublicKey
 
-from nucypher.utilities.logging import SimpleObserver
+from nucypher.utilities.logging import ConsoleLoggingObserver
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
-globalLogPublisher.addObserver(SimpleObserver())
+globalLogPublisher.addObserver(ConsoleLoggingObserver())
 
 ######################
 # Boring setup stuff #

--- a/examples/heartbeat_demo/doctor.py
+++ b/examples/heartbeat_demo/doctor.py
@@ -17,10 +17,10 @@ from nucypher.network.middleware import RestMiddleware
 
 from umbral.keys import UmbralPublicKey
 
-from nucypher.utilities.logging import ConsoleLoggingObserver
+from nucypher.utilities.logging import GlobalLogger
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
-globalLogPublisher.addObserver(ConsoleLoggingObserver())
+GlobalLogger.set_console_logging(True)
 
 ######################
 # Boring setup stuff #

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -275,7 +275,7 @@ def make_cli_character(character_config,
 
     # Switch to character control emitter
     if click_config.json_ipc:
-        CHARACTER.controller.emitter = IPCStdoutEmitter(quiet=click_config.quiet)
+        CHARACTER.controller.emitter = IPCStdoutEmitter(quiet=not click_config.log_to_console)
 
     # Federated
     if character_config.federated_only:

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -25,7 +25,6 @@ from nucypher.config.characters import AliceConfiguration
 @click.option('--sync/--no-sync', default=True)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--bob-encrypting-key', help="Bob's encrypting key as a hexadecimal string", type=click.STRING)
@@ -65,7 +64,6 @@ def alice(click_config,
           geth,
           sync,
           poa,
-          no_registry,
           registry_filepath,
 
           # Alice
@@ -122,7 +120,7 @@ def alice(click_config,
                                                        rest_host="localhost",
                                                        domains={network} if network else None,
                                                        federated_only=federated_only,
-                                                       download_registry=no_registry,
+                                                       download_registry=click_config.no_registry,
                                                        registry_filepath=registry_filepath,
                                                        provider_process=ETH_NODE,
                                                        poa=poa,

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -89,7 +89,7 @@ def alice(click_config,
 
     # Banner
     click.clear()
-    if not click_config.json_ipc and not click_config.quiet:
+    if not click_config.json_ipc and click_config.log_to_console:
         click.secho(ALICE_BANNER)
 
     #

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -13,7 +13,6 @@ from nucypher.crypto.powers import DecryptingPower
 @click.argument('action')
 @click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--teacher-uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-@click.option('--quiet', '-Q', help="Disable logging", is_flag=True)
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT)
@@ -33,7 +32,6 @@ from nucypher.crypto.powers import DecryptingPower
 @nucypher_click_config
 def bob(click_config,
         action,
-        quiet,
         teacher_uri,
         min_stake,
         http_port,

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -60,7 +60,7 @@ def bob(click_config,
 
     # Banner
     click.clear()
-    if not click_config.json_ipc and not click_config.quiet:
+    if not click_config.json_ipc and click_config.log_to_console:
         click.secho(BOB_BANNER)
 
     #

--- a/nucypher/cli/characters/enrico.py
+++ b/nucypher/cli/characters/enrico.py
@@ -29,7 +29,7 @@ def enrico(click_config, action, policy_encrypting_key, dry_run, http_port, mess
 
     # Banner
     click.clear()
-    if not click_config.json_ipc and not click_config.quiet:
+    if not click_config.json_ipc and click_config.log_to_console:
         click.secho(ENRICO_BANNER)
 
     #
@@ -39,7 +39,7 @@ def enrico(click_config, action, policy_encrypting_key, dry_run, http_port, mess
     policy_encrypting_key = UmbralPublicKey.from_bytes(bytes.fromhex(policy_encrypting_key))
     ENRICO = Enrico(policy_encrypting_key=policy_encrypting_key)
     if click_config.json_ipc:
-        ENRICO.controller.emitter = IPCStdoutEmitter(quiet=click_config.quiet)
+        ENRICO.controller.emitter = IPCStdoutEmitter(quiet=not click_config.log_to_console)
 
     #
     # Actions

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -56,7 +56,7 @@ def felix(click_config,
 
     # Intro
     click.clear()
-    if not click_config.quiet:
+    if click_config.log_to_console:
         click.secho(FELIX_BANNER.format(checksum_address or ''))
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -29,7 +29,6 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
@@ -51,7 +50,6 @@ def felix(click_config,
           poa,
           config_file,
           db_filepath,
-          no_registry,
           registry_filepath,
           dev,
           force):
@@ -83,7 +81,7 @@ def felix(click_config,
                                                            db_filepath=db_filepath,
                                                            domains={network} if network else None,
                                                            checksum_address=checksum_address,
-                                                           download_registry=not no_registry,
+                                                           download_registry=not click_config.no_registry,
                                                            registry_filepath=registry_filepath,
                                                            provider_uri=provider_uri,
                                                            provider_process=ETH_NODE,

--- a/nucypher/cli/characters/moe.py
+++ b/nucypher/cli/characters/moe.py
@@ -25,7 +25,7 @@ def moe(click_config, teacher_uri, min_stake, network, ws_port, dry_run, http_po
 
     # Banner
     click.clear()
-    if not click_config.json_ipc and not click_config.quiet:
+    if not click_config.json_ipc and click_config.log_to_console:
         click.secho(MOE_BANNER)
 
     # Teacher Ursula

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -47,7 +47,6 @@ from nucypher.utilities.sandbox.constants import (
 @click.command()
 @click.argument('action')
 @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--quiet', '-Q', help="Disable logging", is_flag=True)
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
@@ -79,7 +78,6 @@ from nucypher.utilities.sandbox.constants import (
 def ursula(click_config,
            action,
            dev,
-           quiet,
            dry_run,
            force,
            lonely,
@@ -134,7 +132,7 @@ def ursula(click_config,
     if federated_only and geth:
         raise click.BadOptionUsage(option_name="--geth", message="Federated only cannot be used with the --geth flag")
 
-    if click_config.debug and quiet:
+    if click_config.debug and click_config.quiet:
         raise click.BadOptionUsage(option_name="quiet", message="--debug and --quiet cannot be used at the same time.")
 
     # Banner
@@ -395,7 +393,7 @@ def ursula(click_config,
                                                             target_value=value,
                                                             additional_periods=extension)
 
-            if not quiet:
+            if not click_config.quiet:
                 click.secho('Successfully divided stake', fg='green')
                 click.secho(f'Transaction Hash ........... {new_stake.receipt}')
 
@@ -413,7 +411,7 @@ def ursula(click_config,
         if balance == 0:
             click.secho(f"{URSULA.checksum_address} has 0 NU.")
             raise click.Abort
-        if not quiet:
+        if not click_config.quiet:
             click.echo(f"Current balance: {balance}")
 
         # Gather stake value
@@ -424,7 +422,7 @@ def ursula(click_config,
             value = NU(int(value), 'NU')
 
         # Duration
-        if not quiet:
+        if not click_config.quiet:
             message = f"Minimum duration: {URSULA.economics.minimum_allowed_locked} | " \
                       f"Maximum Duration: {URSULA.economics.maximum_allowed_locked}"
             click.echo(message)

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -132,18 +132,15 @@ def ursula(click_config,
     if federated_only and geth:
         raise click.BadOptionUsage(option_name="--geth", message="Federated only cannot be used with the --geth flag")
 
-    if click_config.debug and click_config.quiet:
-        raise click.BadOptionUsage(option_name="quiet", message="--debug and --quiet cannot be used at the same time.")
-
     # Banner
-    if not click_config.json_ipc and not click_config.quiet:
+    if not click_config.json_ipc and click_config.log_to_console:
         click.secho(URSULA_BANNER.format(checksum_address or ''))
 
     #
     # Pre-Launch Warnings
     #
 
-    if not click_config.quiet:
+    if click_config.log_to_console:
         if dev:
             click.secho("WARNING: Running in Development mode", fg='yellow')
         if force:
@@ -393,7 +390,7 @@ def ursula(click_config,
                                                             target_value=value,
                                                             additional_periods=extension)
 
-            if not click_config.quiet:
+            if click_config.log_to_console:
                 click.secho('Successfully divided stake', fg='green')
                 click.secho(f'Transaction Hash ........... {new_stake.receipt}')
 
@@ -411,7 +408,7 @@ def ursula(click_config,
         if balance == 0:
             click.secho(f"{URSULA.checksum_address} has 0 NU.")
             raise click.Abort
-        if not click_config.quiet:
+        if click_config.log_to_console:
             click.echo(f"Current balance: {balance}")
 
         # Gather stake value
@@ -422,7 +419,7 @@ def ursula(click_config,
             value = NU(int(value), 'NU')
 
         # Duration
-        if not click_config.quiet:
+        if click_config.log_to_console:
             message = f"Minimum duration: {URSULA.economics.minimum_allowed_locked} | " \
                       f"Maximum Duration: {URSULA.economics.maximum_allowed_locked}"
             click.echo(message)

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -69,7 +69,6 @@ from nucypher.utilities.sandbox.constants import (
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
 @click.option('--recompile-solidity', help="Compile solidity from source when making a web3 connection", is_flag=True)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--value', help="Token value of stake", type=click.INT)
 @click.option('--duration', help="Period duration of stake", type=click.INT)
@@ -100,7 +99,6 @@ def ursula(click_config,
            provider_uri,
            geth,
            recompile_solidity,
-           no_registry,
            registry_filepath,
            value,
            duration,
@@ -188,7 +186,7 @@ def ursula(click_config,
                                                      domains={network} if network else None,
                                                      federated_only=federated_only,
                                                      checksum_address=checksum_address,
-                                                     download_registry=federated_only or no_registry,
+                                                     download_registry=federated_only or click_config.no_registry,
                                                      registry_filepath=registry_filepath,
                                                      provider_process=ETH_NODE,
                                                      provider_uri=provider_uri,

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -18,6 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 
 import collections
+from distutils.util import strtobool
 import functools
 import os
 
@@ -44,6 +45,15 @@ from nucypher.utilities.logging import (
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
+def get_env_bool(var_name: str, default: bool) -> bool:
+    if var_name in os.environ:
+        # TODO: which is better: to fail on an incorrect envvar, or to use the default?
+        # Currently doing the former.
+        return strtoobool(os.environ[var_name])
+    else:
+        return default
+
+
 class NucypherClickConfig:
 
     # Output Sinks
@@ -54,8 +64,8 @@ class NucypherClickConfig:
     # Environment Variables
     config_file = os.environ.get('NUCYPHER_CONFIG_FILE')
     sentry_endpoint = os.environ.get("NUCYPHER_SENTRY_DSN", __sentry_endpoint)
-    log_to_sentry = os.environ.get("NUCYPHER_SENTRY_LOGS", True)
-    log_to_file = os.environ.get("NUCYPHER_FILE_LOGS", True)
+    log_to_sentry = get_env_bool("NUCYPHER_SENTRY_LOGS", True)
+    log_to_file = get_env_bool("NUCYPHER_FILE_LOGS", True)
 
     # Sentry Logging
     if log_to_sentry is True:

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -34,14 +34,7 @@ from nucypher.characters.control.emitters import StdoutEmitter, IPCStdoutEmitter
 from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT
 from nucypher.config.node import NodeConfiguration
 from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import (
-    logToSentry,
-    getTextFileObserver,
-    initialize_sentry,
-    getJsonFileObserver,
-    GlobalLogger,
-    ConsoleLoggingObserver,
-)
+from nucypher.utilities.logging import GlobalLogger
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -77,7 +77,7 @@ def nucypher_cli(click_config,
 
     # Logging
     if not no_logs:
-        GlobalConsoleLogger.start_if_not_started()
+        GlobalConsoleLogger.start()
 
     # CLI Session Configuration
     click_config.verbose = verbose

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -20,85 +20,16 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import click
 from twisted.logger import globalLogPublisher
 
-from nucypher.characters.banners import NUCYPHER_BANNER
-from nucypher.characters.control.emitters import StdoutEmitter, IPCStdoutEmitter
 from nucypher.cli import status
 from nucypher.cli.actions import destroy_configuration_root
 from nucypher.cli.characters import moe, ursula, alice, bob, enrico, felix
-from nucypher.cli.config import nucypher_click_config, NucypherClickConfig
 from nucypher.cli.painting import echo_version
-from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import GlobalLogger, getJsonFileObserver, ConsoleLoggingObserver, logToSentry
-from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
 @click.group()
 @click.option('--version', help="Echo the CLI version", is_flag=True, callback=echo_version, expose_value=False, is_eager=True)
-@click.option('-v', '--verbose', help="Specify verbosity level", count=True)
-@click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True)
-@click.option('-J', '--json-ipc', help="Send all output to stdout as JSON", is_flag=True)
-@click.option('-Q', '--quiet', help="Disable console printing", is_flag=True)
-@click.option('-L', '--no-logs', help="Disable all logging output", is_flag=True)
-@click.option('-D', '--debug', help="Enable debugging mode", is_flag=True)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
-@nucypher_click_config
-def nucypher_cli(click_config,
-                 verbose,
-                 mock_networking,
-                 json_ipc,
-                 no_logs,
-                 quiet,
-                 debug,
-                 no_registry):
-
-    # Session Emitter for pre and post character control engagement.
-    if json_ipc:
-        emitter = IPCStdoutEmitter(quiet=quiet, capture_stdout=NucypherClickConfig.capture_stdout)
-    else:
-        emitter = StdoutEmitter(quiet=quiet, capture_stdout=NucypherClickConfig.capture_stdout)
-
-    click_config.attach_emitter(emitter)
-    click_config.emit(message=NUCYPHER_BANNER)
-
-    if debug and quiet:
-        raise click.BadOptionUsage(option_name="quiet", message="--debug and --quiet cannot be used at the same time.")
-
-    if debug:
-        click_config.log_to_sentry = False
-        click_config.log_to_file = True                 # File Logging
-        globalLogPublisher.addObserver(ConsoleLoggingObserver())  # Console Logging
-        globalLogPublisher.removeObserver(logToSentry)  # No Sentry
-        GlobalLogger.set_log_level(log_level_name='debug')
-
-    elif quiet:  # Disable Logging
-        globalLogPublisher.removeObserver(logToSentry)
-        globalLogPublisher.removeObserver(ConsoleLoggingObserver)
-        globalLogPublisher.removeObserver(getJsonFileObserver())
-
-    # Logging
-    if not no_logs:
-        GlobalLogger.start()
-
-    # CLI Session Configuration
-    click_config.verbose = verbose
-    click_config.mock_networking = mock_networking
-    click_config.json_ipc = json_ipc
-    click_config.no_logs = no_logs
-    click_config.quiet = quiet
-    click_config.no_registry = no_registry
-    click_config.debug = debug
-
-    # Only used for testing outputs;
-    # Redirects outputs to in-memory python containers.
-    if mock_networking:
-        click_config.emit(message="WARNING: Mock networking is enabled")
-        click_config.middleware = MockRestMiddleware()
-    else:
-        click_config.middleware = RestMiddleware()
-
-    # Global Warnings
-    if click_config.verbose:
-        click_config.emit(message="Verbose mode is enabled", color='blue')
+def nucypher_cli():
+    pass
 
 
 @click.command()

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -28,7 +28,7 @@ from nucypher.cli.characters import moe, ursula, alice, bob, enrico, felix
 from nucypher.cli.config import nucypher_click_config, NucypherClickConfig
 from nucypher.cli.painting import echo_version
 from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import GlobalConsoleLogger, getJsonFileObserver, SimpleObserver, logToSentry
+from nucypher.utilities.logging import GlobalLogger, getJsonFileObserver, ConsoleLoggingObserver, logToSentry
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
@@ -66,18 +66,18 @@ def nucypher_cli(click_config,
     if debug:
         click_config.log_to_sentry = False
         click_config.log_to_file = True                 # File Logging
-        globalLogPublisher.addObserver(SimpleObserver())  # Console Logging
+        globalLogPublisher.addObserver(ConsoleLoggingObserver())  # Console Logging
         globalLogPublisher.removeObserver(logToSentry)  # No Sentry
-        GlobalConsoleLogger.set_log_level(log_level_name='debug')
+        GlobalLogger.set_log_level(log_level_name='debug')
 
     elif quiet:  # Disable Logging
         globalLogPublisher.removeObserver(logToSentry)
-        globalLogPublisher.removeObserver(SimpleObserver)
+        globalLogPublisher.removeObserver(ConsoleLoggingObserver)
         globalLogPublisher.removeObserver(getJsonFileObserver())
 
     # Logging
     if not no_logs:
-        GlobalConsoleLogger.start()
+        GlobalLogger.start()
 
     # CLI Session Configuration
     click_config.verbose = verbose

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -65,15 +65,15 @@ def getTextFileObserver(name="nucypher.log", path=USER_LOG_DIR):
     return observer
 
 
-class SimpleObserver:
+class ConsoleLoggingObserver:
 
     @provider(ILogObserver)
     def __call__(self, event):
-        if event['log_level'] >= GlobalConsoleLogger.log_level:
+        if event['log_level'] >= GlobalLogger.log_level:
             print(formatEvent(event))
 
 
-class GlobalConsoleLogger:
+class GlobalLogger:
 
     log_level = LogLevel.levelWithName("info")
     started = False

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -81,18 +81,13 @@ class GlobalConsoleLogger:
     @classmethod
     def set_log_level(cls, log_level_name):
         cls.log_level = LogLevel.levelWithName(log_level_name)
-        if not cls.started:
-            cls.start()
 
     @classmethod
     def start(cls):
+        if cls.started:
+            return
         globalLogPublisher.addObserver(getTextFileObserver())
         cls.started = True
-
-    @classmethod
-    def start_if_not_started(cls):
-        if not cls.started:
-            cls.start()
 
 
 def logToSentry(event):

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -22,10 +22,8 @@ import pathlib
 from sentry_sdk import capture_exception, add_breadcrumb
 from sentry_sdk.integrations.logging import LoggingIntegration
 from twisted.logger import FileLogObserver, jsonFileLogObserver, formatEvent, formatEventAsClassicLogText
-from twisted.logger import ILogObserver
 from twisted.logger import LogLevel
 from twisted.python.logfile import DailyLogFile
-from zope.interface import provider
 
 import nucypher
 from nucypher.config.constants import USER_LOG_DIR
@@ -65,12 +63,9 @@ def getTextFileObserver(name="nucypher.log", path=USER_LOG_DIR):
     return observer
 
 
-class ConsoleLoggingObserver:
-
-    @provider(ILogObserver)
-    def __call__(self, event):
-        if event['log_level'] >= GlobalLogger.log_level:
-            print(formatEvent(event))
+def logToConsole(event):
+    if event['log_level'] >= GlobalLogger.log_level:
+        print(formatEvent(event))
 
 
 class GlobalLogger:
@@ -80,7 +75,6 @@ class GlobalLogger:
     log_to_file = False
     log_to_console = False
 
-    console_observer = None
     text_file_observer = None
     json_file_observer = None
 
@@ -125,12 +119,10 @@ class GlobalLogger:
     @classmethod
     def set_console_logging(cls, state: bool):
         if state and not cls.log_to_console:
-            cls.console_observer = ConsoleLoggingObserver()
-            globalLogPublisher.addObserver(cls.console_observer)
+            globalLogPublisher.addObserver(logToConsole)
             cls.log_to_console = True
         elif not state and cls.log_to_console:
-            globalLogPublisher.removeObserver(cls.console_observer)
-            cls.console_observer = None
+            globalLogPublisher.removeObserver(logToConsole)
             cls.log_to_console = False
 
 

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -47,19 +47,19 @@ def initialize_sentry(dsn: str):
     )
 
 
-def _get_or_create_user_log_dir():
-    return pathlib.Path(USER_LOG_DIR).mkdir(parents=True, exist_ok=True)
+def _ensure_dir_exists(path):
+    pathlib.Path(path).mkdir(parents=True, exist_ok=True)
 
 
 def getJsonFileObserver(name="ursula.log.json", path=USER_LOG_DIR):  # TODO: More configurable naming here?
-    _get_or_create_user_log_dir()
+    _ensure_dir_exists(path)
     logfile = DailyLogFile(name, path)
     observer = jsonFileLogObserver(outFile=logfile)
     return observer
 
 
 def getTextFileObserver(name="nucypher.log", path=USER_LOG_DIR):
-    _get_or_create_user_log_dir()
+    _ensure_dir_exists(path)
     logfile = DailyLogFile(name, path)
     observer = FileLogObserver(formatEvent=formatEventAsClassicLogText, outFile=logfile)
     return observer

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -70,7 +70,6 @@ class SimpleObserver:
     @provider(ILogObserver)
     def __call__(self, event):
         if event['log_level'] >= GlobalConsoleLogger.log_level:
-            event['log_format'] = event['log_format']
             print(formatEvent(event))
 
 

--- a/scripts/local_fleet/run_local_ursula_fleet.py
+++ b/scripts/local_fleet/run_local_ursula_fleet.py
@@ -28,8 +28,6 @@ from twisted.internet import protocol
 from twisted.internet import reactor
 from twisted.logger import globalLogPublisher
 
-from nucypher.utilities.logging import SimpleObserver
-
 
 FLEET_POPULATION = 5
 DEMO_NODE_STARTING_PORT = 11501

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -115,8 +115,8 @@ def test_cli_lifecycle(click_runner,
 
     # Alice uses her configuration file to run the character "view" command
     alice_configuration_file_location = os.path.join(alice_config_root, AliceConfiguration.CONFIG_FILENAME)
-    alice_view_args = ('--json-ipc',
-                       'alice', 'public-keys',
+    alice_view_args = ('alice',
+                       '--json-ipc', 'public-keys',
                        '--config-file', alice_configuration_file_location)
 
     alice_view_result = click_runner.invoke(nucypher_cli, alice_view_args, catch_exceptions=False, env=envvars)
@@ -142,8 +142,8 @@ def test_cli_lifecycle(click_runner,
 
     # Alice uses her configuration file to run the character "view" command
     bob_configuration_file_location = os.path.join(bob_config_root, BobConfiguration.CONFIG_FILENAME)
-    bob_view_args = ('--json-ipc',
-                     'bob', 'public-keys',
+    bob_view_args = ('bob',
+                     '--json-ipc', 'public-keys',
                      '--config-file', bob_configuration_file_location)
 
     bob_view_result = click_runner.invoke(nucypher_cli, bob_view_args, catch_exceptions=False, env=envvars)
@@ -162,9 +162,9 @@ def test_cli_lifecycle(click_runner,
 
     random_label = random_policy_label.decode()  # Unicode string
 
-    derive_args = ('--mock-networking',
+    derive_args = ('alice', 'derive-policy-pubkey',
+                   '--mock-networking',
                    '--json-ipc',
-                   'alice', 'derive-policy-pubkey',
                    '--config-file', alice_configuration_file_location,
                    '--label', random_label)
 
@@ -187,9 +187,9 @@ def test_cli_lifecycle(click_runner,
         # Fetch!
         policy = side_channel.fetch_policy()
 
-        enrico_args = ('--json-ipc',
-                       'enrico',
+        enrico_args = ('enrico',
                        'encrypt',
+                       '--json-ipc',
                        '--policy-encrypting-key', policy.encrypting_key,
                        '--message', PLAINTEXT)
 
@@ -212,9 +212,9 @@ def test_cli_lifecycle(click_runner,
         message_kit = encrypt_result['result']['message_kit']
 
         decrypt_args = (
+            'alice', 'decrypt',
             '--mock-networking',
             '--json-ipc',
-            'alice', 'decrypt',
             '--config-file', alice_configuration_file_location,
             '--message-kit', message_kit,
             '--label', policy.label,
@@ -259,9 +259,9 @@ def test_cli_lifecycle(click_runner,
         bob_encrypting_key = bob_keys.bob_encrypting_key
         bob_verifying_key = bob_keys.bob_verifying_key
 
-        grant_args = ('--mock-networking',
+        grant_args = ('alice', 'grant',
+                      '--mock-networking',
                       '--json-ipc',
-                      'alice', 'grant',
                       '--network', TEMPORARY_DOMAIN,
                       '--teacher-uri', teacher_uri,
                       '--config-file', alice_configuration_file_location,
@@ -302,9 +302,9 @@ def test_cli_lifecycle(click_runner,
 
         alice_signing_key = side_channel.fetch_alice_pubkey()
 
-        retrieve_args = ('--mock-networking',
+        retrieve_args = ('bob', 'retrieve',
+                         '--mock-networking',
                          '--json-ipc',
-                         'bob', 'retrieve',
                          '--teacher-uri', teacher_uri,
                          '--config-file', bob_configuration_file_location,
                          '--message-kit', ciphertext_message_kit,

--- a/tests/cli/test_felix.py
+++ b/tests/cli/test_felix.py
@@ -70,8 +70,8 @@ def test_run_felix(click_runner,
 
     # Felix Runs Web Services
     def run_felix():
-        args = ('--debug',
-                'felix', 'run',
+        args = ('felix', 'run',
+                '--debug',
                 '--config-file', configuration_file_location,
                 '--provider-uri', TEST_PROVIDER_URI,
                 '--dry-run',

--- a/tests/cli/ursula/test_blockchain_ursula.py
+++ b/tests/cli/ursula/test_blockchain_ursula.py
@@ -281,8 +281,8 @@ def test_collect_rewards_integration(click_runner,
     assert blockchain.interface.w3.eth.getBalance(burner_wallet.address) == 0
 
     # Snag a random teacher from the fleet
-    collection_args = ('--mock-networking',
-                       'ursula', 'collect-reward',
+    collection_args = ('ursula', 'collect-reward',
+                       '--mock-networking',
                        '--config-file', configuration_file_location,
                        '--withdraw-address', burner_wallet.address,
                        '--force')

--- a/tests/cli/ursula/test_run_ursula.py
+++ b/tests/cli/ursula/test_run_ursula.py
@@ -36,8 +36,8 @@ from nucypher.utilities.sandbox.ursula import start_pytest_ursula_services
 
 @pt.inlineCallbacks
 def test_run_lone_federated_default_development_ursula(click_runner):
-    args = ('--debug',                                  # Display log output; Do not attach console
-            'ursula', 'run',                            # Stat Ursula Command
+    args = ('ursula', 'run',                            # Stat Ursula Command
+            '--debug',                                  # Display log output; Do not attach console
             '--federated-only',                         # Operating Mode
             '--rest-port', MOCK_URSULA_STARTING_PORT,   # Network Port
             '--dev',                                    # Run in development mode (ephemeral node)
@@ -74,8 +74,8 @@ def test_federated_ursula_learns_via_cli(click_runner, federated_ursulas):
 
     def run_ursula(teacher_uri):
 
-        args = ('--debug',                                  # Display log output; Do not attach console
-                'ursula', 'run',
+        args = ('ursula', 'run',
+                '--debug',                                  # Display log output; Do not attach console
                 '--federated-only',                         # Operating Mode
                 '--rest-port', MOCK_URSULA_STARTING_PORT,   # Network Port
                 '--teacher-uri', teacher_uri,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,4 +105,4 @@ def pytest_collection_modifyitems(config, items):
     log_level_name = config.getoption("--log-level", "info", skip=True)
 
     GlobalLogger.set_log_level(log_level_name)
-    GlobalLogger.start()
+    GlobalLogger.set_file_logging(True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from twisted.logger import globalLogPublisher
 
 from nucypher.characters.control.emitters import WebEmitter
 from nucypher.cli.config import NucypherClickConfig
-from nucypher.utilities.logging import GlobalConsoleLogger, logToSentry
+from nucypher.utilities.logging import GlobalLogger, logToSentry
 # Logger Configuration
 #
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
@@ -104,5 +104,5 @@ def pytest_collection_modifyitems(config, items):
 
     log_level_name = config.getoption("--log-level", "info", skip=True)
 
-    GlobalConsoleLogger.set_log_level(log_level_name)
-    GlobalConsoleLogger.start()
+    GlobalLogger.set_log_level(log_level_name)
+    GlobalLogger.start()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,3 +105,4 @@ def pytest_collection_modifyitems(config, items):
     log_level_name = config.getoption("--log-level", "info", skip=True)
 
     GlobalConsoleLogger.set_log_level(log_level_name)
+    GlobalConsoleLogger.start()


### PR DESCRIPTION
This PR intends to simplify CLI option processing (mostly the ones related to logging) and remove duplicate options, which will in turn pave way for fixing issue #1018

*Note:* this branch started as a fix for issue #1018, but got transformed into CLI option rearrangement. Perhaps the last commit should be a separate PR

Public API changes:

1. All options are now specified after commands. That is, if before one would call

        $ nucypher alice --debug init --federated-only

    after the PR the syntax would be 

        $ nucypher alice init --debug --federated-only

    Cons:
    - this goes somewhat against `click` philosophy (see [this `click` issue](https://github.com/pallets/click/issues/108)). 
    - there is some amount of "magic" in `config.py` required for this to work.

    Pros:
    - this helps avoid code duplication (for option definition and processing).
    - this helps user discover these options in `--help`. That is, if before, in order to find out about `--debug`, one would have to call `nucypher --help` in addition to `nucypher alice --help`, now just `nucypher alice --help` will be enough - all the options will be there.

2. Added `--no-sentry` option to turn off Sentry logging.

3. `--debug` now just sets/unsets certain otherwise available CLI options (**TODO:** to be determined which ones exactly), acting as a shortcut.

4. `NUCYPHER_SENTRY_LOGS` and `NUCYPHER_FILE_LOGS` have stricter requirements for their contents (whatever [`strtobool`](https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool) can recognize)

4. **TODO:** `--verbose` sets the logging level

5. **TODO:** add an option to turn off banners

Internal changes:

1. `GlobalLogger` class manages all logging and observers.

2. **TODO:** get rid of `emit` methods in random classes and use standard existing logging facilities?
