### PR TITLE
TransactingPower

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ jobs:
       - run:
           name: Tests for Blockhain interfaces, Crypto functions, Node Configuration and Keystore
           command: |
-            pipenv run pytest $(circleci tests glob "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" "tests/blockchain/eth/clients/**/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest $(circleci tests glob "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" "tests/blockchain/eth/clients/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   network:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -397,7 +397,7 @@ jobs:
       - run:
           name: Tests for Blockhain interfaces, Crypto functions, Node Configuration and Keystore
           command: |
-            pipenv run pytest $(circleci tests glob "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" "tests/blockchain/eth/clients/test_*.py" | circleci tests split --split-by=timings)
+            pipenv run pytest $(circleci tests glob "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" "tests/blockchain/eth/clients/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   network:

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -170,12 +170,6 @@ class Deployer(NucypherTokenActor):
                                                               deployer_address=self.deployer_address)
         return r
 
-    @classmethod
-    def from_blockchain(cls, provider_uri: str, registry=None, *args, **kwargs):
-        blockchain = BlockchainInterface.connect(provider_uri=provider_uri, registry=registry)
-        instance = cls(blockchain=blockchain, *args, **kwargs)
-        return instance
-
     @property
     def deployer_address(self):
         return self.blockchain.deployer_address

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -26,7 +26,6 @@ import maya
 from constant_sorrow.constants import (
     CONTRACT_NOT_DEPLOYED,
     NO_DEPLOYER_ADDRESS,
-    NO_STAKING_DEVICE,
     WORKER_NOT_RUNNING
 )
 from eth_tester.exceptions import TransactionFailed
@@ -141,7 +140,6 @@ class Deployer(NucypherTokenActor):
     def __init__(self,
                  blockchain: BlockchainInterface,
                  deployer_address: str = None,
-                 device = NO_STAKING_DEVICE,
                  client_password: str = None,
                  bare: bool = True
                  ) -> None:
@@ -162,8 +160,7 @@ class Deployer(NucypherTokenActor):
 
         blockchain.transacting_power = TransactingPower(blockchain=blockchain,
                                                         account=deployer_address,
-                                                        password=client_password,
-                                                        device=device)
+                                                        password=client_password)
         blockchain.transacting_power.activate()
         self.log = Logger("Deployment-Actor")
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -118,7 +118,7 @@ class NucypherTokenAgent(EthereumContractAgent, metaclass=Agency):
         """Approve the transfer of token from the sender address to the target address."""
         payload = {'gas': 500_000}  # TODO #413: gas needed for use with geth.
         contract_function = self.contract.functions.approve(target_address, amount)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function,
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    payload=payload,
                                                    sender_address=sender_address)
         return receipt
@@ -126,7 +126,7 @@ class NucypherTokenAgent(EthereumContractAgent, metaclass=Agency):
     def transfer(self, amount: int, target_address: str, sender_address: str):
         self.approve_transfer(amount=amount, target_address=target_address, sender_address=sender_address)
         contract_function = self.contract.functions.transfer(target_address, amount)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=sender_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=sender_address)
         return receipt
 
 
@@ -186,13 +186,13 @@ class StakingEscrowAgent(EthereumContractAgent, metaclass=Agency):
     def deposit_tokens(self, amount: int, lock_periods: int, sender_address: str):
         """Send tokens to the escrow from the staker's address"""
         contract_function = self.contract.functions.deposit(amount, lock_periods)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function,
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    sender_address=sender_address)
         return receipt
 
     def divide_stake(self, staker_address: str, stake_index: int, target_value: int, periods: int):
         contract_function = self.contract.functions.divideStake(stake_index, target_value, periods)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=staker_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
         return receipt
 
     def get_last_active_period(self, address: str) -> int:
@@ -209,7 +209,7 @@ class StakingEscrowAgent(EthereumContractAgent, metaclass=Agency):
 
     def set_worker(self, staker_address: str, worker_address: str):
         contract_function = self.contract.functions.setWorker(worker_address)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=staker_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
         return receipt
 
     def release_worker(self, staker_address: str):
@@ -220,7 +220,7 @@ class StakingEscrowAgent(EthereumContractAgent, metaclass=Agency):
         For each period that the worker confirms activity, the staker is rewarded.
         """
         contract_function = self.contract.functions.confirmActivity()
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=worker_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=worker_address)
         return receipt
 
     def mint(self, staker_address: str):
@@ -230,7 +230,7 @@ class StakingEscrowAgent(EthereumContractAgent, metaclass=Agency):
         when you intend to withdraw 100% of tokens.
         """
         contract_function = self.contract.functions.mint()
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=staker_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
         return receipt
 
     @validate_checksum_address
@@ -252,7 +252,7 @@ class StakingEscrowAgent(EthereumContractAgent, metaclass=Agency):
         """Withdraw tokens"""
         payload = {'gas': 500_000}  # TODO: #842 Gas Management
         contract_function = self.contract.functions.withdraw(amount)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function,
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    payload=payload,
                                                    sender_address=staker_address)
         return receipt
@@ -322,7 +322,7 @@ class PolicyAgent(EthereumContractAgent, metaclass=Agency):
 
         payload = {'value': value}
         contract_function = self.contract.functions.createPolicy(policy_id, periods, initial_reward, node_addresses)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function,
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    payload=payload,
                                                    sender_address=author_address)
         return receipt
@@ -335,13 +335,13 @@ class PolicyAgent(EthereumContractAgent, metaclass=Agency):
     def revoke_policy(self, policy_id: bytes, author_address: str):
         """Revoke by arrangement ID; Only the policy's author_address can revoke the policy."""
         contract_function = self.contract.functions.revokePolicy(policy_id)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=author_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
     def collect_policy_reward(self, collector_address: str, staker_address: str):
         """Collect rewarded ETH"""
         contract_function = self.contract.functions.withdraw(collector_address)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=staker_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
         return receipt
 
     def fetch_policy_arrangements(self, policy_id):
@@ -352,17 +352,17 @@ class PolicyAgent(EthereumContractAgent, metaclass=Agency):
 
     def revoke_arrangement(self, policy_id: str, node_address: str, author_address: str):
         contract_function = self.contract.functions.revokeArrangement(policy_id, node_address)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=author_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
     def calculate_refund(self, policy_id: str, author_address: str):
         contract_function = self.contract.functions.calculateRefundValue(policy_id)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=author_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
     def collect_refund(self, policy_id: str, author_address: str):
         contract_function = self.contract.functions.refund(policy_id)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=author_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
 
@@ -455,47 +455,47 @@ class UserEscrowAgent(EthereumContractAgent):
 
     def lock(self, amount: int, periods: int):
         contract_function = self.__proxy_contract.functions.lock(amount, periods)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def withdraw_tokens(self, value: int):
         contract_function = self.principal_contract.functions.withdrawTokens(value)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def withdraw_eth(self):
         contract_function = self.principal_contract.functions.withdrawETH()
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def deposit_as_staker(self, value: int, periods: int):
         contract_function = self.__proxy_contract.functions.depositAsStaker(value, periods)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def withdraw_as_staker(self, value: int):
         contract_function = self.__proxy_contract.functions.withdrawAsStaker(value)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def set_worker(self, worker_address: str):
         contract_function = self.__proxy_contract.functions.setWorker(worker_address)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def mint(self):
         contract_function = self.__proxy_contract.functions.mint()
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def collect_policy_reward(self):
         contract_function = self.__proxy_contract.functions.withdrawPolicyReward()
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
     def set_min_reward_rate(self, rate: int):
         contract_function = self.__proxy_contract.functions.setMinRewardRate(rate)
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function, sender_address=self.__beneficiary)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
 
@@ -513,7 +513,7 @@ class AdjudicatorAgent(EthereumContractAgent, metaclass=Agency):
         """
         payload = {'gas': 500_000}  # TODO #413: gas needed for use with geth.
         contract_function = self.contract.functions.evaluateCFrag(*evidence.evaluation_arguments())
-        receipt = self.blockchain.send_transaction(transaction_function=contract_function,
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    sender_address=sender_address,
                                                    payload=payload)
         return receipt

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -59,7 +59,7 @@ LOCAL_CHAINS = {1337: "GethDev",
                 5777: "Ganache/TestRPC"}
 
 
-class Web3Client(object):
+class Web3Client:
 
     is_local = False
 
@@ -297,8 +297,11 @@ class EthereumTesterClient(Web3Client):
 
     is_local = True
 
-    def unlock_account(self, address, password):
-        return True
+    def unlock_account(self, address, password) -> bool:
+        """Returns True if the testing backend keyring has control of the given address."""
+        address = to_canonical_address(address)
+        keystore = self.w3.provider.ethereum_tester.backend._key_lookup
+        return address in keystore
 
     def sync(self, *args, **kwargs):
         return True

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -151,6 +151,10 @@ class Web3Client(object):
     def syncing(self) -> Union[bool, dict]:
         return self.w3.eth.syncing
 
+    def lock_account(self, address):
+        if not self.is_local:
+            return self.lock_account(address=address)
+
     def unlock_account(self, address, password) -> bool:
         if not self.is_local:
             return self.unlock_account(address, password)

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -204,7 +204,7 @@ class DispatcherDeployer(ContractDeployer):
 
         origin_args = {'from': self.deployer_address, 'gasPrice': self.blockchain.client.gas_price}  # TODO: Gas management
         upgrade_function = self._contract.functions.upgrade(new_target, existing_secret_plaintext, new_secret_hash)
-        upgrade_receipt = self.blockchain.send_transaction(transaction_function=upgrade_function,
+        upgrade_receipt = self.blockchain.send_transaction(contract_function=upgrade_function,
                                                            sender_address=self.deployer_address,
                                                            payload=origin_args)
         return upgrade_receipt
@@ -212,7 +212,7 @@ class DispatcherDeployer(ContractDeployer):
     def rollback(self, existing_secret_plaintext: bytes, new_secret_hash: bytes) -> dict:
         origin_args = {'from': self.deployer_address, 'gasPrice': self.blockchain.client.gas_price}  # TODO: Gas management
         rollback_function = self._contract.functions.rollback(existing_secret_plaintext, new_secret_hash)
-        rollback_receipt = self.blockchain.send_transaction(transaction_function=rollback_function,
+        rollback_receipt = self.blockchain.send_transaction(contract_function=rollback_function,
                                                             sender_address=self.deployer_address,
                                                             payload=origin_args)
         return rollback_receipt
@@ -294,7 +294,7 @@ class StakingEscrowDeployer(ContractDeployer):
         reward_function = self.token_agent.contract.functions.transfer(the_escrow_contract.address,
                                                                        self.__economics.erc20_reward_supply)
 
-        reward_receipt = self.blockchain.send_transaction(transaction_function=reward_function,
+        reward_receipt = self.blockchain.send_transaction(contract_function=reward_function,
                                                           sender_address=self.deployer_address,
                                                           payload=origin_args)
 
@@ -304,7 +304,7 @@ class StakingEscrowDeployer(ContractDeployer):
         # 4 - Initialize the Staker Escrow contract
         init_function = the_escrow_contract.functions.initialize()
 
-        init_receipt = self.blockchain.send_transaction(transaction_function=init_function,
+        init_receipt = self.blockchain.send_transaction(contract_function=init_function,
                                                         sender_address=self.deployer_address,
                                                         payload=origin_args)
 
@@ -418,7 +418,7 @@ class PolicyManagerDeployer(ContractDeployer):
         if gas_limit:
             tx_args.update({'gas': gas_limit})
         set_policy_manager_function = self.staking_agent.contract.functions.setPolicyManager(policy_manager_contract.address)
-        set_policy_manager_receipt = self.blockchain.send_transaction(transaction_function=set_policy_manager_function,
+        set_policy_manager_receipt = self.blockchain.send_transaction(contract_function=set_policy_manager_function,
                                                                       sender_address=self.deployer_address,
                                                                       payload=tx_args)
 
@@ -505,7 +505,7 @@ class LibraryLinkerDeployer(ContractDeployer):
 
         origin_args = {'from': self.deployer_address}  # TODO: Gas management
         retarget_function = self._contract.functions.upgrade(new_target, existing_secret_plaintext, new_secret_hash)
-        retarget_receipt = self.blockchain.send_transaction(transaction_function=retarget_function,
+        retarget_receipt = self.blockchain.send_transaction(contract_function=retarget_function,
                                                             sender_address=self.deployer_address,
                                                             payload=origin_args)
         return retarget_receipt
@@ -636,7 +636,7 @@ class UserEscrowDeployer(ContractDeployer):
         # TODO: #413, #842 - Gas Management
         payload = {'from': self.deployer_address, 'gas': 500_000, 'gasPrice': self.blockchain.client.gas_price}
         transfer_owner_function = self.contract.functions.transferOwnership(beneficiary_address)
-        transfer_owner_receipt = self.blockchain.send_transaction(transaction_function=transfer_owner_function,
+        transfer_owner_receipt = self.blockchain.send_transaction(contract_function=transfer_owner_function,
                                                                   payload=payload,
                                                                   sender_address=self.deployer_address)
         self.__beneficiary_address = beneficiary_address
@@ -657,7 +657,7 @@ class UserEscrowDeployer(ContractDeployer):
                 'gasPrice': self.blockchain.client.gas_price,
                 'gas': 200_000}
         deposit_function = self.contract.functions.initialDeposit(value, duration)
-        deposit_receipt = self.blockchain.send_transaction(transaction_function=deposit_function,
+        deposit_receipt = self.blockchain.send_transaction(contract_function=deposit_function,
                                                            sender_address=self.deployer_address,
                                                            payload=args)
 
@@ -748,7 +748,7 @@ class AdjudicatorDeployer(ContractDeployer):
         if gas_limit:
             tx_args.update({'gas': gas_limit})
         set_adjudicator_function = self.staking_agent.contract.functions.setAdjudicator(adjudicator_contract.address)
-        set_adjudicator_receipt = self.blockchain.send_transaction(transaction_function=set_adjudicator_function,
+        set_adjudicator_receipt = self.blockchain.send_transaction(contract_function=set_adjudicator_function,
                                                                    sender_address=self.deployer_address,
                                                                    payload=tx_args)
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -285,7 +285,7 @@ class BlockchainInterface:
             self._provider = provider
 
     def send_transaction(self,
-                         transaction_function: ContractFunction,
+                         contract_function: ContractFunction,
                          sender_address: str,
                          payload: dict = None,
                          ) -> dict:
@@ -308,9 +308,9 @@ class BlockchainInterface:
 
         # Get interface name
         try:
-            transaction_name = transaction_function.fn_name.upper()
+            transaction_name = contract_function.fn_name.upper()
         except AttributeError:
-            if isinstance(transaction_function, ContractConstructor):
+            if isinstance(contract_function, ContractConstructor):
                 transaction_name = 'DEPLOY'
             else:
                 transaction_name = 'UNKNOWN'
@@ -500,7 +500,7 @@ class BlockchainDeployerInterface(BlockchainInterface):
         # Transmit the deployment tx #
         #
 
-        receipt = self.send_transaction(transaction_function=transaction_function,
+        receipt = self.send_transaction(contract_function=transaction_function,
                                         sender_address=self.deployer_address,
                                         payload=deploy_transaction)
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -31,7 +31,7 @@ from constant_sorrow.constants import (
     READ_ONLY_INTERFACE
 )
 from eth_tester import EthereumTester
-from eth_utils import to_checksum_address
+from eth_utils import to_checksum_address, to_canonical_address
 from twisted.logger import Logger
 from web3 import Web3, WebsocketProvider, HTTPProvider, IPCProvider
 from web3.contract import ConciseContract
@@ -317,10 +317,10 @@ class BlockchainInterface:
 
         # Build transaction payload
         try:
-            unsigned_transaction = transaction_function.buildTransaction(payload)
+            unsigned_transaction = contract_function.buildTransaction(payload)
         except ValidationError:
             # TODO: Handle validation failures for gas limits, invalid fields, etc.
-            pass
+            raise
 
         #
         # Broadcast
@@ -439,8 +439,12 @@ class BlockchainDeployerInterface(BlockchainInterface):
         super().__init__(*args, **kwargs)
 
         self.compiler = compiler or SolidityCompiler()
-        self._setup_solidity(compiler=self.compiler)
         self.__deployer_address = deployer_address or NO_DEPLOYER_CONFIGURED
+
+    def connect(self, *args, **kwargs):
+        super().connect(*args, **kwargs)
+        self._setup_solidity(compiler=self.compiler)
+        return self.is_connected
 
     @property
     def deployer_address(self):

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -164,11 +164,6 @@ class BlockchainInterface:
         self.transacting_power = transacting_power
         self.registry = registry
 
-        # self.connect(provider=provider,
-        #              provider_uri=provider_uri,
-        #              fetch_registry=fetch_registry,
-        #              sync_now=sync_now)
-
         BlockchainInterface._instance = self
 
     def __repr__(self):
@@ -188,6 +183,8 @@ class BlockchainInterface:
         """
         https://web3py.readthedocs.io/en/stable/__provider.html#examples-using-automated-detection
         """
+        if self.client is NO_BLOCKCHAIN_CONNECTION:
+            return False
         return self.client.is_connected
 
     def disconnect(self):

--- a/nucypher/blockchain/eth/policies.py
+++ b/nucypher/blockchain/eth/policies.py
@@ -285,7 +285,7 @@ class BlockchainPolicy(Policy):
 
         # Transact
         contract_function = self.author.policy_agent.contract.functions.createPolicy(*policy_args)
-        receipt = self.author.blockchain.send_transaction(transaction_function=contract_function,
+        receipt = self.author.blockchain.send_transaction(contract_function=contract_function,
                                                           sender_address=self.author.checksum_address,
                                                           payload=payload)
         txhash = receipt['transactionHash']

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -80,6 +80,7 @@ class Character(Learner):
                  keyring_root: str = None,
                  crypto_power: CryptoPower = None,
                  crypto_power_ups: List[CryptoPowerUp] = None,
+                 additional_powers: List[CryptoPower] = None,
                  *args, **kwargs
                  ) -> None:
 

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -176,7 +176,7 @@ class Character(Learner):
         # Decentralized
         #
         if not federated_only:
-            if not blockchain:
+            if not blockchain and is_me:
                 raise ValueError('No blockchain interface provided to run decentralized mode.')
             if not checksum_address:
                 raise ValueError("No checksum_address provided to run in decentralized mode.")

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -176,8 +176,10 @@ class Character(Learner):
         # Decentralized
         #
         if not federated_only:
+            if not blockchain:
+                raise ValueError('No blockchain interface provided to run decentralized mode.')
             if not checksum_address:
-                raise ValueError("No checksum_address provided while running in a non-federated mode.")
+                raise ValueError("No checksum_address provided to run in decentralized mode.")
             else:
                 self._checksum_address = checksum_address  # TODO: Check that this matches TransactingPower
         #

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -179,7 +179,7 @@ class Character(Learner):
             if not checksum_address:
                 raise ValueError("No checksum_address provided while running in a non-federated mode.")
             else:
-                self._checksum_address = checksum_address  # TODO: Check that this matches BlockchainPower
+                self._checksum_address = checksum_address  # TODO: Check that this matches TransactingPower
         #
         # Federated
         #
@@ -304,7 +304,7 @@ class Character(Learner):
             except TypeError:
                 umbral_key = public_key
 
-            crypto_power.consume_power_up(power_up(pubkey=umbral_key))
+            crypto_power.consume_power_up(power_up(public_key=umbral_key))
 
         return cls(is_me=False, federated_only=federated_only, crypto_power=crypto_power, *args, **kwargs)
 

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -80,7 +80,6 @@ class Character(Learner):
                  keyring_root: str = None,
                  crypto_power: CryptoPower = None,
                  crypto_power_ups: List[CryptoPowerUp] = None,
-                 additional_powers: List[CryptoPower] = None,
                  *args, **kwargs
                  ) -> None:
 

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -182,9 +182,9 @@ class Felix(Character, NucypherTokenActor):
         self.db_engine = create_engine(f'sqlite:///{self.db_filepath}', convert_unicode=True)
 
         # Blockchain
-        blockchain_power = BlockchainPower(blockchain=self.blockchain, account=self.checksum_address)
-        self._crypto_power.consume_power_up(blockchain_power)
-        # blockchain_power.unlock_account(password=None)  # TODO: TransactingPower
+        transacting_power = TransactingPower(blockchain=self.blockchain, account=self.checksum_address)
+        self._crypto_power.consume_power_up(transacting_power)
+        # transacting_power.unlock_account(password=None)  # TODO: TransactingPower
 
         self.token_agent = NucypherTokenAgent(blockchain=self.blockchain)
         self.reserved_addresses = [self.checksum_address, BlockchainInterface.NULL_ADDRESS]

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -27,7 +27,7 @@ from nucypher.blockchain.eth.token import NU
 from nucypher.characters.banners import MOE_BANNER, FELIX_BANNER, NU_BANNER
 from nucypher.characters.base import Character
 from nucypher.config.constants import TEMPLATES_DIR
-from nucypher.crypto.powers import SigningPower, BlockchainPower
+from nucypher.crypto.powers import SigningPower, TransactingPower
 from nucypher.keystore.threading import ThreadedSession
 from nucypher.network.nodes import FleetStateTracker
 
@@ -129,7 +129,7 @@ class Felix(Character, NucypherTokenActor):
     research and the development of production-ready nucypher dApps.
     """
 
-    _default_crypto_powerups = [SigningPower]
+    _default_crypto_powerups = [SigningPower, TransactingPower]
 
     TEMPLATE_NAME = 'felix.html'
 

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -129,7 +129,7 @@ class Felix(Character, NucypherTokenActor):
     research and the development of production-ready nucypher dApps.
     """
 
-    _default_crypto_powerups = [SigningPower, TransactingPower]
+    _default_crypto_powerups = [SigningPower]
 
     TEMPLATE_NAME = 'felix.html'
 
@@ -161,6 +161,7 @@ class Felix(Character, NucypherTokenActor):
                  db_filepath: str,
                  rest_host: str,
                  rest_port: int,
+                 client_password: str = None,
                  crash_on_error: bool = False,
                  economics: TokenEconomics = None,
                  distribute_ether: bool = True,
@@ -182,9 +183,10 @@ class Felix(Character, NucypherTokenActor):
         self.db_engine = create_engine(f'sqlite:///{self.db_filepath}', convert_unicode=True)
 
         # Blockchain
-        transacting_power = TransactingPower(blockchain=self.blockchain, account=self.checksum_address)
+        transacting_power = TransactingPower(blockchain=self.blockchain,
+                                             password=client_password,
+                                             account=self.checksum_address)
         self._crypto_power.consume_power_up(transacting_power)
-        # transacting_power.unlock_account(password=None)  # TODO: TransactingPower
 
         self.token_agent = NucypherTokenAgent(blockchain=self.blockchain)
         self.reserved_addresses = [self.checksum_address, BlockchainInterface.NULL_ADDRESS]

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -895,11 +895,8 @@ class Ursula(Teacher, Character, Worker):
             if not federated_only:
 
                 # Access staking node via node's transacting keys
-                transacting_power = TransactingPower(account=self.checksum_address,
-                                                     device=device,
-                                                     password=client_password,  # FIXME: password from somewhere
-                                                     blockchain=self.blockchain)
-                self._crypto_power.consume_power_up(transacting_power)
+                transacting_power = TransactingPower(account=worker_address, device=device, blockchain=self.blockchain)
+                self._crypto_power.consume_power_up(transacting_power, client_password)
 
                 # Use blockchain power to substantiate stamp
                 self.substantiate_stamp(client_password=password)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -28,8 +28,8 @@ import requests
 from bytestring_splitter import BytestringKwargifier, BytestringSplittingError
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow import constants
-from constant_sorrow.constants import FEDERATED_POLICY, STRANGER_ALICE
-from constant_sorrow.constants import INCLUDED_IN_BYTESTRING, PUBLIC_ONLY
+from constant_sorrow.constants import INCLUDED_IN_BYTESTRING, PUBLIC_ONLY, FEDERATED_POLICY, STRANGER_ALICE, \
+    NO_STAKING_DEVICE
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 from cryptography.hazmat.primitives.serialization import Encoding
@@ -60,7 +60,7 @@ from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest, encrypt_and_sign
 from nucypher.crypto.constants import PUBLIC_KEY_LENGTH, PUBLIC_ADDRESS_LENGTH
 from nucypher.crypto.kits import UmbralMessageKit
-from nucypher.crypto.powers import SigningPower, DecryptingPower, DelegatingPower, BlockchainPower, PowerUpError
+from nucypher.crypto.powers import SigningPower, DecryptingPower, DelegatingPower, TransactingPower, PowerUpError
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.keystore.keypairs import HostingKeypair
 from nucypher.network.exceptions import NodeSeemsToBeDown
@@ -90,6 +90,7 @@ class Alice(Character, PolicyAuthor):
                  network_middleware=None,
                  controller=True,
                  policy_agent=None,
+                 device = NO_STAKING_DEVICE,
                  *args, **kwargs) -> None:
 
         #
@@ -124,10 +125,8 @@ class Alice(Character, PolicyAuthor):
                                   policy_agent=policy_agent,
                                   checksum_address=checksum_address)
 
-            # TODO: #1092 - TransactingPower
-            blockchain_power = BlockchainPower(blockchain=self.blockchain, account=self.checksum_address)
-            self._crypto_power.consume_power_up(blockchain_power)
-            self.blockchain.transacting_power = blockchain_power  # TODO: Embed in Powerups
+            transacting_power = TransactingPower(blockchain=self.blockchain, account=self.checksum_address)
+            self._crypto_power.consume_power_up(transacting_power)
 
         if is_me and controller:
             self.controller = self._controller_class(alice=self)
@@ -842,6 +841,8 @@ class Ursula(Teacher, Character, Worker):
                  checksum_address: str = None,  # Staker address
                  worker_address: str = None,
                  stake_tracker: StakeTracker = None,
+                 staking_agent: StakingEscrowAgent = None,
+                 device = NO_STAKING_DEVICE,
 
                  # Character
                  password: str = None,
@@ -896,16 +897,14 @@ class Ursula(Teacher, Character, Worker):
                                 stake_tracker=stake_tracker)
 
                 # Access to worker's ETH client via node's transacting keys
-                # TODO: #1092 - TransactingPower
-                blockchain_power = BlockchainPower(blockchain=self.blockchain, account=worker_address)
-                self._crypto_power.consume_power_up(blockchain_power)
-                self.blockchain.transacting_power = blockchain_power  # TODO: Embed in powerups
+                transacting_power = TransactingPower(blockchain=self.blockchain, account=worker_address)
+                self._crypto_power.consume_power_up(transacting_power)
                 self.substantiate_stamp(client_password=password)  # TODO: Use PowerUp / Derive from keyring
 
         #
-        # ProxyRESTServer and TLSHostingPower # TODO: Maybe we want _power_ups to be public after all?
+        # ProxyRESTServer and TLSHostingPower #
         #
-        if not crypto_power or (TLSHostingPower not in crypto_power._power_ups):
+        if not crypto_power or (TLSHostingPower not in crypto_power):
 
             #
             # Ephemeral Self-Ursula
@@ -966,15 +965,16 @@ class Ursula(Teacher, Character, Worker):
         certificate = self._crypto_power.power_ups(TLSHostingPower).keypair.certificate
         Teacher.__init__(self,
                          password=password,
-                         worker_address=worker_address,
                          domains=domains,
                          certificate=certificate,
                          certificate_filepath=certificate_filepath,
                          interface_signature=interface_signature,
                          timestamp=timestamp,
                          decentralized_identity_evidence=decentralized_identity_evidence,
+
+                         # TODO: #1091 When is_me and not federated_only, the stamp is substantiated twice
+                         worker_address=worker_address,
                          substantiate_immediately=is_me and not federated_only,
-                         # FIXME: When is_me and not federated_only, the stamp is substantiated twice
                          )
 
         #

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -28,8 +28,7 @@ import requests
 from bytestring_splitter import BytestringKwargifier, BytestringSplittingError
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow import constants
-from constant_sorrow.constants import INCLUDED_IN_BYTESTRING, PUBLIC_ONLY, FEDERATED_POLICY, STRANGER_ALICE, \
-    NO_STAKING_DEVICE
+from constant_sorrow.constants import INCLUDED_IN_BYTESTRING, PUBLIC_ONLY, FEDERATED_POLICY, STRANGER_ALICE
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 from cryptography.hazmat.primitives.serialization import Encoding
@@ -90,7 +89,6 @@ class Alice(Character, PolicyAuthor):
                  network_middleware=None,
                  controller=True,
                  policy_agent=None,
-                 device = NO_STAKING_DEVICE,
                  client_password: str = None,
                  *args, **kwargs) -> None:
 
@@ -122,9 +120,9 @@ class Alice(Character, PolicyAuthor):
 
         if is_me and not federated_only:  # TODO: #289
             transacting_power = TransactingPower(account=self.checksum_address,
-                                                 device=device,
+                                                 password=client_password,
                                                  blockchain=self.blockchain)
-            self._crypto_power.consume_power_up(transacting_power, password=client_password)
+            self._crypto_power.consume_power_up(transacting_power)
 
             PolicyAuthor.__init__(self,
                                   blockchain=self.blockchain,
@@ -844,8 +842,6 @@ class Ursula(Teacher, Character, Worker):
                  checksum_address: str = None,  # Staker address
                  worker_address: str = None,
                  stake_tracker: StakeTracker = None,
-                 staking_agent: StakingEscrowAgent = None,
-                 device = NO_STAKING_DEVICE,
                  client_password: str = None,
 
                  # Character
@@ -895,8 +891,10 @@ class Ursula(Teacher, Character, Worker):
             if not federated_only:
 
                 # Access staking node via node's transacting keys
-                transacting_power = TransactingPower(account=worker_address, device=device, blockchain=self.blockchain)
-                self._crypto_power.consume_power_up(transacting_power, client_password)
+                transacting_power = TransactingPower(account=worker_address,
+                                                     password=client_password,
+                                                     blockchain=self.blockchain)
+                self._crypto_power.consume_power_up(transacting_power)
 
                 # Use blockchain power to substantiate stamp
                 self.substantiate_stamp(client_password=password)

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -230,7 +230,6 @@ def make_cli_character(character_config,
                        dev: bool = False,
                        teacher_uri: str = None,
                        min_stake: int = 0,
-                       sync: bool = True,
                        **config_args):
 
     #
@@ -239,7 +238,7 @@ def make_cli_character(character_config,
 
     # Handle Blockchain
     if not character_config.federated_only:
-        character_config.get_blockchain_interface(sync_now=sync)
+        character_config.get_blockchain_interface()
 
     # Handle Keyring
     if not dev:

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -173,8 +173,7 @@ def alice(click_config,
                                        click_config=click_config,
                                        dev=dev,
                                        teacher_uri=teacher_uri,
-                                       min_stake=min_stake,
-                                       sync=sync)
+                                       min_stake=min_stake)
 
     #
     # Admin Actions

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -1,12 +1,15 @@
 import click
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 
+from nucypher.blockchain.eth.interfaces import BlockchainInterface
+from nucypher.blockchain.eth.registry import EthereumContractRegistry
 from nucypher.characters.banners import ALICE_BANNER
 from nucypher.cli import actions, painting, types
 from nucypher.cli.actions import get_password
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import AliceConfiguration
+from nucypher.crypto.powers import TransactingPower
 
 
 @click.command()
@@ -24,6 +27,7 @@ from nucypher.config.characters import AliceConfiguration
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
 @click.option('--sync/--no-sync', default=True)
+@click.option('--device/--no-device', default=False)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
 @click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
@@ -68,6 +72,7 @@ def alice(click_config,
           poa,
           no_registry,
           registry_filepath,
+          device,
 
           # Alice
           bob_encrypting_key,
@@ -79,7 +84,7 @@ def alice(click_config,
           rate,
           duration,
           expiration,
-          message_kit
+          message_kit,
 
           ):
 
@@ -168,7 +173,7 @@ def alice(click_config,
         except FileNotFoundError:
             return actions.handle_missing_configuration_file(character_config_class=AliceConfiguration,
                                                              config_file=config_file)
-
+    
     ALICE = actions.make_cli_character(character_config=alice_config,
                                        click_config=click_config,
                                        dev=dev,

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -2,8 +2,8 @@ import click
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 
 from nucypher.characters.banners import ALICE_BANNER
-from nucypher.cli import actions, painting
-from nucypher.cli import types
+from nucypher.cli import actions, painting, types
+from nucypher.cli.actions import get_password
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import AliceConfiguration
@@ -117,7 +117,7 @@ def alice(click_config,
         if not config_root:                         # Flag
             config_root = click_config.config_file  # Envvar
 
-        new_alice_config = AliceConfiguration.generate(password=click_config.get_password(confirm=True),
+        new_alice_config = AliceConfiguration.generate(password=get_password(confirm=True),
                                                        config_root=config_root,
                                                        checksum_address=pay_with,
                                                        domains={network} if network else None,

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -2,6 +2,7 @@ import click
 
 from nucypher.characters.banners import BOB_BANNER
 from nucypher.cli import actions, painting
+from nucypher.cli.actions import get_password
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import BobConfiguration
@@ -78,7 +79,7 @@ def bob(click_config,
         if not config_root:  # Flag
             config_root = click_config.config_file  # Envvar
 
-        new_bob_config = BobConfiguration.generate(password=click_config.get_password(confirm=True),
+        new_bob_config = BobConfiguration.generate(password=get_password(confirm=True),
                                                    config_root=config_root or DEFAULT_CONFIG_ROOT,
                                                    checksum_address=pay_with,
                                                    domains={network} if network else None,

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -3,7 +3,6 @@ import os
 import click
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 
-from nucypher.blockchain.eth.clients import NuCypherGethDevnetProcess
 from nucypher.characters.banners import FELIX_BANNER
 from nucypher.cli import actions, painting
 from nucypher.cli.actions import get_password, unlock_nucypher_keyring
@@ -11,7 +10,6 @@ from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import FelixConfiguration
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
-from nucypher.crypto.powers import TransactingPower
 
 
 @click.command()
@@ -119,11 +117,6 @@ def felix(click_config,
                     f"Check the filepath or run 'nucypher felix init' to create a new system configuration.")
         raise click.Abort
 
-    transacting_power = TransactingPower(account=felix_config.checksum_address,
-                                         device=False,
-                                         password=get_password(confirm=False),
-                                         blockchain=felix_config.blockchain)
-
     try:
 
         # Connect to Blockchain
@@ -140,9 +133,7 @@ def felix(click_config,
                                                network_middleware=click_config.middleware)
 
         # Produce Felix
-        FELIX = felix_config.produce(domains=network,
-                                     known_nodes=teacher_nodes,
-                                     additional_power=[transacting_power])
+        FELIX = felix_config.produce(domains=network, known_nodes=teacher_nodes)
         FELIX.make_web_app()  # attach web application, but dont start service
 
     except Exception as e:

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -11,6 +11,7 @@ from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import FelixConfiguration
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
+from nucypher.crypto.powers import TransactingPower
 
 
 @click.command()
@@ -118,6 +119,11 @@ def felix(click_config,
                     f"Check the filepath or run 'nucypher felix init' to create a new system configuration.")
         raise click.Abort
 
+    transacting_power = TransactingPower(account=felix_config.checksum_address,
+                                         device=False,
+                                         password=get_password(confirm=False),
+                                         blockchain=felix_config.blockchain)
+
     try:
 
         # Connect to Blockchain
@@ -134,7 +140,9 @@ def felix(click_config,
                                                network_middleware=click_config.middleware)
 
         # Produce Felix
-        FELIX = felix_config.produce(domains=network, known_nodes=teacher_nodes)
+        FELIX = felix_config.produce(domains=network,
+                                     known_nodes=teacher_nodes,
+                                     additional_power=[transacting_power])
         FELIX.make_web_app()  # attach web application, but dont start service
 
     except Exception as e:

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -6,6 +6,7 @@ from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 from nucypher.blockchain.eth.clients import NuCypherGethDevnetProcess
 from nucypher.characters.banners import FELIX_BANNER
 from nucypher.cli import actions, painting
+from nucypher.cli.actions import get_password, unlock_nucypher_keyring
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import FelixConfiguration
@@ -72,11 +73,8 @@ def felix(click_config,
         if not config_root:                         # Flag
             config_root = DEFAULT_CONFIG_ROOT       # Envvar or init-only default
 
-        # Acquire Keyring Password
-        new_password = click_config.get_password(confirm=True)
-
         try:
-            new_felix_config = FelixConfiguration.generate(password=new_password,
+            new_felix_config = FelixConfiguration.generate(password=get_password(confirm=True),
                                                            config_root=config_root,
                                                            rest_host=host,
                                                            rest_port=discovery_port,
@@ -123,12 +121,10 @@ def felix(click_config,
     try:
 
         # Connect to Blockchain
-        felix_config.connect_to_blockchain()
+        felix_config.get_blockchain_interface()
 
         # Authenticate
-        password = click_config.get_password(confirm=False)
-        click_config.unlock_keyring(character_configuration=felix_config,
-                                    password=password)
+        unlock_nucypher_keyring(character_configuration=felix_config, password=get_password(confirm=False))
 
         # Produce Teacher Ursulas
         teacher_nodes = actions.load_seednodes(teacher_uris=[teacher_uri] if teacher_uri else None,

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -18,16 +18,13 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 
 import click
-import socket
-
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 from twisted.internet import stdio
 
-from nucypher.blockchain.eth.clients import NuCypherGethDevnetProcess, NuCypherGethGoerliProcess
 from nucypher.blockchain.eth.token import NU
 from nucypher.characters.banners import URSULA_BANNER
 from nucypher.cli import actions, painting
-from nucypher.cli.actions import UnknownIPAddress, get_password
+from nucypher.cli.actions import get_password
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.processes import UrsulaCommandProtocol
 from nucypher.cli.types import (
@@ -36,8 +33,7 @@ from nucypher.cli.types import (
     EXISTING_READABLE_FILE,
     STAKE_DURATION,
     STAKE_EXTENSION,
-    STAKE_VALUE,
-    IPV4_ADDRESS)
+    STAKE_VALUE)
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.utilities.sandbox.constants import (
     TEMPORARY_DOMAIN,
@@ -66,6 +62,7 @@ from nucypher.utilities.sandbox.constants import (
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
 @click.option('--sync/--no-sync', default=True)
+@click.option('--device/--no-device', default=False)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
 @click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
@@ -105,6 +102,7 @@ def ursula(click_config,
            list_,
            divide,
            sync,
+           device,
            interactive,
 
            ) -> None:
@@ -243,7 +241,6 @@ def ursula(click_config,
             message = "'nucypher ursula destroy' cannot be used in --dev mode - There is nothing to destroy."
             raise click.BadOptionUsage(option_name='--dev', message=message)
         return actions.destroy_configuration(character_config=ursula_config, force=force)
-
 
     #
     # Make Ursula

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -251,7 +251,6 @@ def ursula(click_config,
 
     URSULA = actions.make_cli_character(character_config=ursula_config,
                                         click_config=click_config,
-                                        sync=sync,
                                         min_stake=min_stake,
                                         teacher_uri=teacher_uri,
                                         dev=dev,

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -27,7 +27,7 @@ from nucypher.blockchain.eth.clients import NuCypherGethDevnetProcess, NuCypherG
 from nucypher.blockchain.eth.token import NU
 from nucypher.characters.banners import URSULA_BANNER
 from nucypher.cli import actions, painting
-from nucypher.cli.actions import UnknownIPAddress
+from nucypher.cli.actions import UnknownIPAddress, get_password
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.processes import UrsulaCommandProtocol
 from nucypher.cli.types import (
@@ -68,7 +68,6 @@ from nucypher.utilities.sandbox.constants import (
 @click.option('--sync/--no-sync', default=True)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--recompile-solidity', help="Compile solidity from source when making a web3 connection", is_flag=True)
 @click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--value', help="Token value of stake", type=click.INT)
@@ -98,7 +97,6 @@ def ursula(click_config,
            config_file,
            provider_uri,
            geth,
-           recompile_solidity,
            no_registry,
            registry_filepath,
            value,
@@ -178,9 +176,7 @@ def ursula(click_config,
         if not rest_host:
             rest_host = actions.determine_external_ip_address(force=force)
 
-        new_password = click_config.get_password(confirm=True)
-
-        ursula_config = UrsulaConfiguration.generate(password=new_password,
+        ursula_config = UrsulaConfiguration.generate(password=get_password(confirm=True),
                                                      config_root=config_root,
                                                      rest_host=rest_host,
                                                      rest_port=rest_port,

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -21,13 +21,10 @@ import collections
 import os
 
 import click
-from constant_sorrow.constants import NO_PASSWORD, NO_BLOCKCHAIN_CONNECTION
-from nacl.exceptions import CryptoError
 from twisted.logger import Logger
 from twisted.logger import globalLogPublisher
 
 from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT
-from nucypher.config.node import CharacterConfiguration
 from nucypher.utilities.logging import (
     logToSentry,
     getTextFileObserver,
@@ -68,53 +65,6 @@ class NucypherClickConfig:
         self.quiet = False
         self.log = Logger(self.__class__.__name__)
 
-        # Auth
-        self.__keyring_password = NO_PASSWORD
-
-        # Blockchain
-        self.accounts = NO_BLOCKCHAIN_CONNECTION
-        self.blockchain = NO_BLOCKCHAIN_CONNECTION
-
-    def connect_to_blockchain(self, character_configuration, sync_now: bool = True):
-        character_configuration.connect_to_blockchain(sync_now=sync_now)
-        character_configuration.connect_to_contracts()
-        self.blockchain = character_configuration.blockchain
-        self.accounts = self.blockchain.client.accounts
-
-    def get_password(self, confirm: bool = False) -> str:
-        keyring_password = os.environ.get("NUCYPHER_KEYRING_PASSWORD", NO_PASSWORD)
-
-        if keyring_password is NO_PASSWORD:  # Collect password, prefer env var
-            prompt = "Enter keyring password"
-            keyring_password = click.prompt(prompt, confirmation_prompt=confirm, hide_input=True)
-
-        self.__keyring_password = keyring_password
-        return self.__keyring_password
-
-    def unlock_keyring(self,
-                       password: str,
-                       character_configuration: CharacterConfiguration,
-                       unlock_wallet: bool = True):
-
-        if not self.quiet:
-            self.emit(message='Decrypting NuCypher keyring...', color='yellow')
-
-        if character_configuration.dev_mode:
-            return True  # Dev accounts are always unlocked
-
-        # NuCypher
-        try:
-            character_configuration.attach_keyring()
-            character_configuration.keyring.unlock(password=password)  # Takes ~3 seconds, ~1GB Ram
-        except CryptoError:
-            raise character_configuration.keyring.AuthenticationFailed
-
-        # Ethereum Client  # TODO : Integrate with Powers API
-        if not character_configuration.federated_only and unlock_wallet:
-            self.emit(message='Decrypting Ethereum Node Keyring...', color='yellow')
-            character_configuration.blockchain.client.unlock_account(address=character_configuration.checksum_address,
-                                                                        password=password)
-
     @classmethod
     def attach_emitter(cls, emitter) -> None:
         cls.__emitter = emitter
@@ -128,9 +78,6 @@ class NucypherDeployerClickConfig(NucypherClickConfig):
 
     __secrets = ('staker_secret', 'policy_secret', 'escrow_proxy_secret', 'adjudicator_secret')
     Secrets = collections.namedtuple('Secrets', __secrets)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     def collect_deployment_secrets(self) -> Secrets:
 
@@ -159,10 +106,10 @@ class NucypherDeployerClickConfig(NucypherClickConfig):
                                                               hide_input=True,
                                                               confirmation_prompt=True)
 
-        secrets = self.Secrets(staker_secret=self.staking_escrow_deployment_secret,                    # type: str
-                               policy_secret=self.policy_manager_deployment_secret,                 # type: str
-                               escrow_proxy_secret=self.user_escrow_proxy_deployment_secret,        # type: str
-                               adjudicator_secret=self.adjudicator_deployment_secret  # type: str
+        secrets = self.Secrets(staker_secret=self.staking_escrow_deployment_secret,           # type: str
+                               policy_secret=self.policy_manager_deployment_secret,           # type: str
+                               escrow_proxy_secret=self.user_escrow_proxy_deployment_secret,  # type: str
+                               adjudicator_secret=self.adjudicator_deployment_secret          # type: str
                                )
         return secrets
 

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -31,7 +31,7 @@ from nucypher.characters.banners import NU_BANNER
 from nucypher.cli.config import nucypher_deployer_config
 from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, EXISTING_READABLE_FILE
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 
 
 @click.command()
@@ -124,7 +124,7 @@ def deploy(click_config,
         click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
 
     # TODO: Integrate with Deployer Actor (Character)
-    blockchain.transacting_power = BlockchainPower(blockchain=blockchain, account=deployer_address)
+    blockchain.transacting_power = TransactingPower(blockchain=blockchain, account=deployer_address)
     deployer = Deployer(blockchain=blockchain, deployer_address=deployer_address)
 
     # Verify ETH Balance

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -41,7 +41,7 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--sync/--no-sync', default=True)
-@click.option('--device/--no-device', default=True)
+@click.option('--device/--no-device', default=False)  # TODO: Make True by default.
 @click.option('--enode', help="An ethereum bootnode enode address to start learning from", type=click.STRING)
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -105,9 +105,7 @@ def deploy(click_config,
     blockchain = BlockchainDeployerInterface(provider_uri=provider_uri,
                                              poa=poa,
                                              registry=registry,
-                                             compiler=SolidityCompiler(),
-                                             fetch_registry=False,
-                                             sync_now=sync)
+                                             compiler=SolidityCompiler())
 
     blockchain.connect(fetch_registry=False, sync_now=sync)
 

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -297,12 +297,6 @@ def deploy(click_config,
         txhash = token_agent.transfer(amount=amount, sender_address=token_agent.contract_address, target_address=recipient_address)
         click.secho(f"OK | {txhash}")
 
-    elif action == "destroy-registry":
-        registry_filepath = deployer.blockchain.registry.filepath
-        click.confirm(f"Are you absolutely sure you want to destroy the contract registry at {registry_filepath}?", abort=True)
-        os.remove(registry_filepath)
-        click.secho(f"Successfully destroyed {registry_filepath}", fg='red')
-
     else:
         raise click.BadArgumentUsage(message=f"Unknown action '{action}'")
 

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -19,6 +19,7 @@ import time
 
 import click
 import maya
+from constant_sorrow.constants import NO_STAKING_DEVICE
 
 from nucypher.blockchain.eth.actors import Deployer
 from nucypher.blockchain.eth.agents import NucypherTokenAgent
@@ -27,10 +28,10 @@ from nucypher.blockchain.eth.interfaces import BlockchainDeployerInterface
 from nucypher.blockchain.eth.registry import EthereumContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.characters.banners import NU_BANNER
+from nucypher.cli.actions import get_password
 from nucypher.cli.config import nucypher_deployer_config
 from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, EXISTING_READABLE_FILE
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
-from nucypher.crypto.powers import TransactingPower
 
 
 @click.command()
@@ -125,12 +126,10 @@ def deploy(click_config,
     if not force:
         click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
 
-    # TODO: Integrate with Deployer Actor (Character)
-    blockchain.transacting_power = TransactingPower(blockchain=blockchain,
-                                                    account=deployer_address,
-                                                    password=click.prompt("Enter ETH node password", hide_input=True))
-    blockchain.transacting_power.activate()
-    deployer = Deployer(blockchain=blockchain, deployer_address=deployer_address)
+    deployer = Deployer(blockchain=blockchain,
+                        device=NO_STAKING_DEVICE,
+                        client_password=get_password(confirm=False),
+                        deployer_address=deployer_address)
 
     # Verify ETH Balance
     click.secho(f"\n\nDeployer ETH balance: {deployer.eth_balance}")

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -125,7 +125,7 @@ def deploy(click_config,
         click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
 
     password = None
-    if not device:
+    if not device and not blockchain.client.is_local:
         password = get_password(confirm=False)
 
     deployer = Deployer(blockchain=blockchain,

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -19,7 +19,6 @@ import time
 
 import click
 import maya
-from constant_sorrow.constants import NO_STAKING_DEVICE
 
 from nucypher.blockchain.eth.actors import Deployer
 from nucypher.blockchain.eth.agents import NucypherTokenAgent
@@ -42,6 +41,7 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--sync/--no-sync', default=True)
+@click.option('--device/--no-device', default=True)
 @click.option('--enode', help="An ethereum bootnode enode address to start learning from", type=click.STRING)
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)
@@ -70,6 +70,7 @@ def deploy(click_config,
            recipient_address,
            config_root,
            sync,
+           device,
            force):
     """Manage contract and registry deployment"""
 
@@ -100,7 +101,6 @@ def deploy(click_config,
     if registry_filepath is not None:
         registry = EthereumContractRegistry(registry_filepath=registry_filepath)
 
-    # TODO: Move to Deployer with TransactingPower
     # Deployment-tuned blockchain connection
     blockchain = BlockchainDeployerInterface(provider_uri=provider_uri,
                                              poa=poa,
@@ -124,9 +124,12 @@ def deploy(click_config,
     if not force:
         click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
 
+    password = None
+    if not device:
+        password = get_password(confirm=False)
+
     deployer = Deployer(blockchain=blockchain,
-                        device=NO_STAKING_DEVICE,
-                        client_password=get_password(confirm=False),
+                        client_password=password,
                         deployer_address=deployer_address)
 
     # Verify ETH Balance

--- a/nucypher/cli/status.py
+++ b/nucypher/cli/status.py
@@ -38,8 +38,8 @@ def status(click_config, config_file):
     #
     ursula_config = UrsulaConfiguration.from_configuration_file(filepath=config_file)
     if not ursula_config.federated_only:
-        ursula_config.connect_to_blockchain(provider_uri=ursula_config.provider_uri)
-        ursula_config.connect_to_contracts()
+        ursula_config.get_blockchain_interface(provider_uri=ursula_config.provider_uri)
+        ursula_config.acquire_agency()
 
         # Contracts
         paint_contract_status(ursula_config=ursula_config, click_config=click_config)

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -34,7 +34,7 @@ from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate
 from eth_account import Account
 from eth_keys import KeyAPI as EthKeyAPI
-from eth_utils import to_checksum_address, is_checksum_address
+from eth_utils import to_checksum_address
 from nacl.exceptions import CryptoError
 from nacl.secret import SecretBox
 from twisted.logger import Logger
@@ -49,10 +49,8 @@ from nucypher.crypto.powers import (
     DecryptingPower,
     KeyPairBasedPower,
     DerivedKeyBasedPower,
-    BlockchainPower
+    TransactingPower
 )
-
-from constant_sorrow.constants import FEDERATED_ADDRESS
 from nucypher.network.server import TLSHostingPower
 
 FILE_ENCODING = 'utf-8'
@@ -499,9 +497,10 @@ class NucypherKeyring:
             keying_material = SecretBox(wrap_key).decrypt(key_data['key'])
             new_cryptopower = power_class(keying_material=keying_material)
 
-        elif power_class is BlockchainPower:
-            # new_cryptopower = power_class(account=self.checksum_address)
-            pass  # TODO: Needs refactoring with TransactingPower
+        elif power_class is TransactingPower:
+            # TODO: Is it possible to derive TransactingPower from the NuCypher keyring?
+            # new_cryptopower = power_class(client=Blockchain.connect(), account=self.checksum_address)
+            pass
 
         else:
             failure_message = "{} is an invalid type for deriving a CryptoPower.".format(power_class.__name__)

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -193,6 +193,7 @@ class CharacterConfiguration(BaseConfiguration):
                                               sync_now=sync_now)
 
         # Read Ethereum Node Keyring
+        self.blockchain.connect(sync_now=sync_now)
         self.accounts = self.blockchain.client.accounts
 
     def connect_to_contracts(self) -> None:

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -178,15 +178,13 @@ class CharacterConfiguration(BaseConfiguration):
     def dev_mode(self) -> bool:
         return self.__dev_mode
 
-    def get_blockchain_interface(self, sync_now: bool = False) -> None:
+    def get_blockchain_interface(self) -> None:
         if self.federated_only:
             raise CharacterConfiguration.ConfigurationError("Cannot connect to blockchain in federated mode")
 
         self.blockchain = BlockchainInterface(provider_uri=self.provider_uri,
                                               poa=self.poa,
-                                              fetch_registry=True,
-                                              provider_process=self.provider_process,
-                                              sync_now=sync_now)
+                                              provider_process=self.provider_process)
 
     def acquire_agency(self) -> None:
         self.token_agent = NucypherTokenAgent(blockchain=self.blockchain)

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -148,7 +148,6 @@ class TransactingPower(CryptoPowerUp):
     def unlock_account(self, password: str = None):
         if self.device is not NO_STAKING_DEVICE:
             # TODO: Embed in TrustedDevice
-            _hd_path = self.device.get_address_path(checksum_address=self.account)
             ping = 'PING|PONG'
             pong = self.device.client.ping(ping)  # TODO: Use pin protection?
             if not ping == pong:

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -14,16 +14,16 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-import inspect
 
-from eth_keys.datatypes import PublicKey, Signature as EthSignature
-from eth_keys.exceptions import BadSignature
-from eth_utils import keccak
+
+import inspect
 from typing import List, Tuple, Optional
+
+from constant_sorrow.constants import NO_STAKING_DEVICE
+from hexbytes import HexBytes
 from umbral import pre
 from umbral.keys import UmbralPublicKey, UmbralPrivateKey, UmbralKeyingMaterial
 
-from nucypher.crypto.signing import InvalidSignature
 from nucypher.keystore import keypairs
 from nucypher.keystore.keypairs import SigningKeypair, DecryptingKeypair
 
@@ -40,21 +40,27 @@ class NoDecryptingPower(PowerUpError):
     pass
 
 
-class NoBlockchainPower(PowerUpError):
+class NoTransactingPower(PowerUpError):
     pass
 
 
 class CryptoPower(object):
     def __init__(self, power_ups: list = None) -> None:
-        self._power_ups = {}   # type: dict
+        self.__power_ups = {}   # type: dict
         # TODO: The keys here will actually be IDs for looking up in a KeyStore.
         self.public_keys = {}  # type: dict
 
         if power_ups is not None:
             for power_up in power_ups:
                 self.consume_power_up(power_up)
+
+    def __contains__(self, item):
+        try:
+            self.power_ups(item)
+        except PowerUpError:
+            return False
         else:
-            power_ups = []  # default
+            return True
 
     def consume_power_up(self, power_up):
         if isinstance(power_up, CryptoPowerUp):
@@ -67,14 +73,14 @@ class CryptoPower(object):
             raise TypeError(
                 ("power_up must be a subclass of CryptoPowerUp or an instance "
                  "of a CryptoPowerUp subclass."))
-        self._power_ups[power_up_class] = power_up_instance
+        self.__power_ups[power_up_class] = power_up_instance
 
         if power_up.confers_public_key:
             self.public_keys[power_up_class] = power_up_instance.public_key()
 
     def power_ups(self, power_up_class):
         try:
-            return self._power_ups[power_up_class]
+            return self.__power_ups[power_up_class]
         except KeyError:
             raise power_up_class.not_found_error
 
@@ -86,17 +92,20 @@ class CryptoPowerUp(object):
     confers_public_key = False
 
 
-class BlockchainPower(CryptoPowerUp):
+class TransactingPower(CryptoPowerUp):
     """
     Allows for transacting on a Blockchain via web3 backend.
     """
-    not_found_error = NoBlockchainPower
+    not_found_error = NoTransactingPower
+    __accounts = {}
 
-    def __init__(self, blockchain: 'Blockchain', account: str, device = None) -> None:
+    def __init__(self, blockchain: 'Blockchain', account: str, device = NO_STAKING_DEVICE):
         """
-        Instantiates a BlockchainPower for the given account id.
+        # TODO: TrustedDevice Integration
+        Instantiates a TransactingPower for the given checksum_address.
         """
         self.blockchain = blockchain
+        self.client = self.blockchain.client
         self.account = account
         self.device = device
         self.is_unlocked = False
@@ -106,30 +115,58 @@ class BlockchainPower(CryptoPowerUp):
         Unlocks the account for the specified duration. If no duration is
         provided, it will remain unlocked indefinitely.
         """
-        self.is_unlocked = self.blockchain.client.unlock_account(self.account, password)
         if not self.is_unlocked:
             raise PowerUpError("Failed to unlock account {}".format(self.account))
+        
+        if self.device is not NO_STAKING_DEVICE:
+            _hd_path = self.device.get_address_path(checksum_address=self.account)
+            ping = 'PING|PONG'
+            pong = self.device.client.ping(ping)  # TODO: Use pin protection?
+            if not ping == pong:
+                raise self.device.NoDeviceDetected
+            unlocked = True
+
+        else:
+            unlocked = self.client.unlock_account(address=self.account, password=password)
+
+        self.is_unlocked = unlocked
 
     def sign_message(self, message: bytes) -> bytes:
         """
-        Signs the message with the private key of the BlockchainPower.
+        Signs the message with the private key of the TransactingPower.
         """
+
         if not self.is_unlocked:
-            raise PowerUpError("Account is not unlocked.")
-        signature = self.blockchain.client.sign_message(account=self.account, message=message)
+            raise PowerUpError("Failed to unlock account {}".format(self.account))
+
+        # HW Signer
+        if self.device is not NO_STAKING_DEVICE:
+            signature = self.device.sign_message(checksum_address=self.account, message=message)
+            signature = signature.signature  # TODO: Use a common type from clients and devices
+
+        # Web3 Signer
+        else:
+            signature = self.client.sign_message(account=self.account, message=message)
+
         return signature
 
-    def sign_transaction(self, unsigned_transaction: dict):
-        if self.device:
-            # TODO: Implement TrustedDevice
-            raise NotImplementedError
+    def sign_transaction(self, checksum_address: str, unsigned_transaction: dict) -> HexBytes:
+        if not self.__accounts.get(checksum_address, False):
+            raise PowerUpError("Account is locked.")
 
-        # This check is also performed client-side.
-        sender_address = unsigned_transaction['from']
-        if sender_address != self.account:
-            raise PowerUpError(f"'from' field must match account {self.account}, but it was {sender_address}")
-        signed_transaction = self.blockchain.client.sign_transaction(transaction=unsigned_transaction, account=self.account)
-        return signed_transaction
+        # HW Signer
+        if self.device is not NO_STAKING_DEVICE:
+            signed_raw_transaction = self.device.sign_eth_transaction(unsigned_transaction=unsigned_transaction,
+                                                                      checksum_address=checksum_address)
+        # Web3 Signer
+        else:
+            # This check is also performed client-side.
+            sender_address = unsigned_transaction['from']
+            if sender_address != self.account:
+                raise PowerUpError(f"'from' field must match key's {self.account}, but it was {sender_address}")
+            signed_raw_transaction = self.blockchain.client.sign_transaction(transaction=unsigned_transaction,
+                                                                             account=self.account)
+        return signed_raw_transaction
 
 
 class KeyPairBasedPower(CryptoPowerUp):
@@ -138,25 +175,24 @@ class KeyPairBasedPower(CryptoPowerUp):
     _default_private_key_class = UmbralPrivateKey
 
     def __init__(self,
-                 pubkey: UmbralPublicKey = None,
+                 public_key: UmbralPublicKey = None,
                  keypair: keypairs.Keypair = None,
                  ) -> None:
-        if keypair and pubkey:
-            raise ValueError(
-                "Pass keypair or pubkey_bytes (or neither), but not both.")
+        if keypair and public_key:
+            raise ValueError("Pass keypair or pubkey_bytes (or neither), but not both.")
         elif keypair:
             self.keypair = keypair
         else:
             # They didn't pass a keypair; we'll make one with the bytes or
             # UmbralPublicKey if they provided such a thing.
-            if pubkey:
+            if public_key:
                 try:
-                    public_key = pubkey.as_umbral_pubkey()
+                    public_key = public_key.as_umbral_pubkey()
                 except AttributeError:
                     try:
-                        public_key = UmbralPublicKey.from_bytes(pubkey)
+                        public_key = UmbralPublicKey.from_bytes(public_key)
                     except TypeError:
-                        public_key = pubkey
+                        public_key = public_key
                 self.keypair = self._keypair_class(
                     public_key=public_key)
             else:
@@ -170,8 +206,8 @@ class KeyPairBasedPower(CryptoPowerUp):
             except AttributeError:
                 raise PowerUpError(
                     "This {} has a keypair, {}, which doesn't provide {}.".format(self.__class__,
-                                                                                  self.keypair.__class__,
-                                                                                  item))
+                                                                                   self.keypair.__class__,
+                                                                                   item))
         else:
             raise PowerUpError("This {} doesn't provide {}.".format(self.__class__, item))
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -117,7 +117,7 @@ class TransactingPower(CryptoPowerUp):
         """
         if not self.is_unlocked:
             raise PowerUpError("Failed to unlock account {}".format(self.account))
-        
+
         if self.device is not NO_STAKING_DEVICE:
             _hd_path = self.device.get_address_path(checksum_address=self.account)
             ping = 'PING|PONG'

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -147,7 +147,7 @@ class TransactingPower(CryptoPowerUp):
         """Be Consumed"""
         self.blockchain.connect()
         self.client = self.blockchain.client       # Connect
-        self.unlock_account(password=password)     # Unlock
+        self.unlock_account(password=password or self.__password)
         self.blockchain.transacting_power = self   # Attach
         self.__password = None                     # Discard
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -222,10 +222,8 @@ class KeyPairBasedPower(CryptoPowerUp):
             try:
                 return getattr(self.keypair, item)
             except AttributeError:
-                raise PowerUpError(
-                    "This {} has a keypair, {}, which doesn't provide {}.".format(self.__class__,
-                                                                                   self.keypair.__class__,
-                                                                                   item))
+                message = f"This {self.__class__} has a keypair, {self.keypair.__class__}, which doesn't provide {item}."
+                raise PowerUpError(message)
         else:
             raise PowerUpError("This {} doesn't provide {}.".format(self.__class__, item))
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -183,20 +183,7 @@ class TransactingPower(CryptoPowerUp):
         """
         if not self.is_unlocked:
             raise self.AccountLocked("Failed to unlock account {}".format(self.account))
-
-        # Note: This check is also performed client-side.
-        sender_address = unsigned_transaction['from']
-        if sender_address != self.account:
-            raise PowerUpError(f"'from' field must match key's {self.account}, but it was {sender_address}")
-
-        try:
-            transaction_fields = dissoc(unsigned_transaction, 'from')
-            assert_valid_fields(transaction_fields)
-        except TypeError as e:
-            raise self.InvalidSigningRequest(f"Invalid Transaction: '{str(e)}'")
-
-        signed_raw_transaction = self.blockchain.client.sign_transaction(transaction=unsigned_transaction,
-                                                                         account=self.account)
+        signed_raw_transaction = self.blockchain.client.sign_transaction(transaction=unsigned_transaction)
         return signed_raw_transaction
 
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -49,7 +49,7 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.config.constants import SeednodeMetadata
 from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest, verify_eip_191, recover_address_eip_191
-from nucypher.crypto.powers import BlockchainPower, SigningPower, DecryptingPower, NoSigningPower
+from nucypher.crypto.powers import TransactingPower, SigningPower, DecryptingPower, NoSigningPower
 from nucypher.crypto.signing import signature_splitter
 from nucypher.network import LEARNING_LOOP_VERSION
 from nucypher.network.exceptions import NodeSeemsToBeDown
@@ -915,7 +915,7 @@ class Teacher:
         self.__worker_address = None
 
         if substantiate_immediately:
-            # TODO: #1091
+            # TODO: #1091 When is_me and not federated_only, the stamp is substantiated twice
             self.substantiate_stamp(client_password=password)
 
     class InvalidNode(SuspiciousActivity):
@@ -1149,13 +1149,12 @@ class Teacher:
                                                             signature=self.decentralized_identity_evidence)
         return self.__worker_address
 
-    def substantiate_stamp(self, client_password: str):
-        # TODO: #1092 - TransactingPower
-        blockchain_power = self._crypto_power.power_ups(BlockchainPower)
-        blockchain_power.unlock_account(password=client_password)  # TODO: #349
-        signature = blockchain_power.sign_message(message=bytes(self.stamp))
+    def substantiate_stamp(self, client_password: str = None):
+        transacting_power = self._crypto_power.power_ups(TransactingPower)
+        transacting_power.unlock_account(password=client_password)  # TODO: #349
+        signature = transacting_power.sign_message(message=bytes(self.stamp))
         self.__decentralized_identity_evidence = signature
-        self.__worker_address = blockchain_power.account
+        self.__worker_address = transacting_power.account
 
     #
     # Interface

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -32,7 +32,7 @@ from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.utils import epoch_to_period
 from nucypher.config.constants import BASE_DIR
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import (
     NUMBER_OF_ETH_TEST_ACCOUNTS,
     NUMBER_OF_STAKERS_IN_BLOCKCHAIN_TESTS,
@@ -110,12 +110,13 @@ class TesterBlockchain(BlockchainDeployerInterface):
                          *args, **kwargs)
 
         self.log = Logger("test-blockchain")
+        self.connect()
 
         # Generate additional ethereum accounts for testing
         population = test_accounts
-        enough_accounts = len(self.w3.eth.accounts) >= population
+        enough_accounts = len(self.client.accounts) >= population
         if not enough_accounts:
-            accounts_to_make = population - len(self.w3.eth.accounts)
+            accounts_to_make = population - len(self.client.accounts)
             self.__generate_insecure_unlocked_accounts(quantity=accounts_to_make)
             assert test_accounts == len(self.w3.eth.accounts)
 
@@ -212,7 +213,7 @@ class TesterBlockchain(BlockchainDeployerInterface):
         """For use with metric testing scripts"""
 
         testerchain = cls(compiler=SolidityCompiler())
-        power = BlockchainPower(blockchain=testerchain, account=testerchain.client.etherbase)
+        power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
         power.unlock_account(password=INSECURE_DEVELOPMENT_PASSWORD)
         testerchain.transacting_power = power
 

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -214,7 +214,7 @@ class TesterBlockchain(BlockchainDeployerInterface):
 
         testerchain = cls(compiler=SolidityCompiler())
         power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
-        power.unlock_account(password=INSECURE_DEVELOPMENT_PASSWORD)
+        power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
         testerchain.transacting_power = power
 
         origin = testerchain.client.etherbase

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -52,7 +52,7 @@ def token_airdrop(token_agent, amount: NU, origin: str, addresses: List[str]):
         args = {'from': origin, 'gasPrice': token_agent.blockchain.client.gas_price}
         for address in addresses:
             contract_function = token_agent.contract.functions.transfer(address, int(amount))
-            _receipt = token_agent.blockchain.send_transaction(transaction_function=contract_function,
+            _receipt = token_agent.blockchain.send_transaction(contract_function=contract_function,
                                                                sender_address=origin,
                                                                payload=args)
             yield _receipt

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -213,8 +213,10 @@ class TesterBlockchain(BlockchainDeployerInterface):
         """For use with metric testing scripts"""
 
         testerchain = cls(compiler=SolidityCompiler())
-        power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
-        power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+        power = TransactingPower(blockchain=testerchain,
+                                 password=INSECURE_DEVELOPMENT_PASSWORD,
+                                 account=testerchain.etherbase_account)
+        power.activate()
         testerchain.transacting_power = power
 
         origin = testerchain.client.etherbase

--- a/nucypher/utilities/sandbox/ursula.py
+++ b/nucypher/utilities/sandbox/ursula.py
@@ -23,11 +23,12 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.token import StakeTracker
 from nucypher.characters.lawful import Ursula
 from nucypher.config.characters import UrsulaConfiguration
+from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import (
     MOCK_KNOWN_URSULAS_CACHE,
     MOCK_URSULA_STARTING_PORT,
     NUMBER_OF_URSULAS_IN_DEVELOPMENT_NETWORK,
-    MOCK_URSULA_DB_FILEPATH)
+    MOCK_URSULA_DB_FILEPATH, INSECURE_DEVELOPMENT_PASSWORD)
 
 
 def make_federated_ursulas(ursula_config: UrsulaConfiguration,

--- a/tests/blockchain/eth/clients/test_geth_integration.py
+++ b/tests/blockchain/eth/clients/test_geth_integration.py
@@ -16,6 +16,7 @@ def test_geth_EIP_191_client_signature_integration(geth_dev_node):
 
     # Start a geth process
     blockchain = BlockchainInterface(provider_process=geth_dev_node, sync_now=False)
+    blockchain.connect(fetch_registry=False, sync_now=False)
 
     # Sign a message (RPC) and verify it.
     etherbase = blockchain.client.accounts[0]

--- a/tests/blockchain/eth/clients/test_geth_integration.py
+++ b/tests/blockchain/eth/clients/test_geth_integration.py
@@ -15,7 +15,7 @@ def test_geth_EIP_191_client_signature_integration(geth_dev_node):
         pytest.skip("Do not run Geth nodes in CI")
 
     # Start a geth process
-    blockchain = BlockchainInterface(provider_process=geth_dev_node, sync_now=False)
+    blockchain = BlockchainInterface(provider_process=geth_dev_node)
     blockchain.connect(fetch_registry=False, sync_now=False)
 
     # Sign a message (RPC) and verify it.

--- a/tests/blockchain/eth/clients/test_mocked_clients.py
+++ b/tests/blockchain/eth/clients/test_mocked_clients.py
@@ -86,7 +86,9 @@ class GanacheClientTestInterface(BlockchainInterfaceTestBase):
 
 
 def test_geth_web3_client():
-    interface = GethClientTestBlockchain(provider_uri='file:///ipc.geth', sync_now=False)
+    interface = GethClientTestBlockchain(provider_uri='file:///ipc.geth')
+    interface.connect(fetch_registry=False, sync_now=False)
+
     assert isinstance(interface.client, GethClient)
     assert interface.client.node_technology == 'Geth'
     assert interface.client.node_version == 'v1.4.11-stable-fed692f6'
@@ -98,7 +100,9 @@ def test_geth_web3_client():
 
 
 def test_parity_web3_client():
-    interface = ParityClientTestInterface(provider_uri='file:///ipc.parity', sync_now=False)
+    interface = ParityClientTestInterface(provider_uri='file:///ipc.parity')
+    interface.connect(fetch_registry=False, sync_now=False)
+
     assert isinstance(interface.client, ParityClient)
     assert interface.client.node_technology == 'Parity-Ethereum'
     assert interface.client.node_version == 'v2.5.1-beta-e0141f8-20190510'
@@ -107,7 +111,9 @@ def test_parity_web3_client():
 
 
 def test_ganache_web3_client():
-    interface = GanacheClientTestInterface(provider_uri='http://ganache:8445', sync_now=False)
+    interface = GanacheClientTestInterface(provider_uri='http://ganache:8445')
+    interface.connect(fetch_registry=False, sync_now=False)
+
     assert isinstance(interface.client, GanacheClient)
     assert interface.client.node_technology == 'EthereumJS TestRPC'
     assert interface.client.node_version == 'v2.1.5'

--- a/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
@@ -28,6 +28,7 @@ from nucypher.crypto.powers import TransactingPower
 def escrow(testerchain):
     # Mock Powerup consumption (Deployer)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power.activate()
     escrow, _ = testerchain.deploy_contract('StakingEscrowForAdjudicatorMock')
     return escrow
 

--- a/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
@@ -22,12 +22,15 @@ from web3.contract import Contract
 
 from nucypher.blockchain.eth.deployers import DispatcherDeployer
 from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
 @pytest.fixture()
 def escrow(testerchain):
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=testerchain.etherbase_account)
     testerchain.transacting_power.activate()
     escrow, _ = testerchain.deploy_contract('StakingEscrowForAdjudicatorMock')
     return escrow

--- a/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
@@ -21,13 +21,13 @@ import pytest
 from web3.contract import Contract
 
 from nucypher.blockchain.eth.deployers import DispatcherDeployer
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 
 
 @pytest.fixture()
 def escrow(testerchain):
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
     escrow, _ = testerchain.deploy_contract('StakingEscrowForAdjudicatorMock')
     return escrow
 

--- a/tests/blockchain/eth/entities/actors/test_deployer.py
+++ b/tests/blockchain/eth/entities/actors/test_deployer.py
@@ -25,18 +25,17 @@ from nucypher.blockchain.eth.actors import Deployer
 from nucypher.blockchain.eth.registry import InMemoryAllocationRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.crypto.powers import TransactingPower
-
+# Prevents TesterBlockchain to be picked up by py.test as a test class
+from nucypher.utilities.sandbox.blockchain import TesterBlockchain as _TesterBlockchain
 from nucypher.utilities.sandbox.constants import (
     ONE_YEAR_IN_SECONDS,
     USER_ESCROW_PROXY_DEPLOYMENT_SECRET,
     ADJUDICATOR_DEPLOYMENT_SECRET,
     POLICY_MANAGER_DEPLOYMENT_SECRET,
     STAKING_ESCROW_DEPLOYMENT_SECRET,
-    NUMBER_OF_ALLOCATIONS_IN_TESTS
+    NUMBER_OF_ALLOCATIONS_IN_TESTS,
+    INSECURE_DEVELOPMENT_PASSWORD
 )
-
-# Prevents TesterBlockchain to be picked up by py.test as a test class
-from nucypher.utilities.sandbox.blockchain import TesterBlockchain as _TesterBlockchain
 
 
 @pytest.mark.slow()
@@ -50,6 +49,7 @@ def test_rapid_deployment(token_economics):
 
     # TODO: #1092 - TransactingPower
     blockchain.transacting_power = TransactingPower(blockchain=blockchain, account=blockchain.etherbase_account)
+    blockchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
     deployer_address = blockchain.etherbase_account
 
     deployer = Deployer(blockchain=blockchain, deployer_address=deployer_address)

--- a/tests/blockchain/eth/entities/actors/test_deployer.py
+++ b/tests/blockchain/eth/entities/actors/test_deployer.py
@@ -22,20 +22,21 @@ import pytest
 from web3.auto import w3
 
 from nucypher.blockchain.eth.actors import Deployer
-from nucypher.blockchain.eth.interfaces import BlockchainDeployerInterface
-from nucypher.blockchain.eth.registry import InMemoryEthereumContractRegistry, InMemoryAllocationRegistry
+from nucypher.blockchain.eth.registry import InMemoryAllocationRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
-from nucypher.crypto.powers import BlockchainPower
-# Prevents TesterBlockchain to be picked up by py.test as a test class
-from nucypher.utilities.sandbox.blockchain import TesterBlockchain as _TesterBlockchain
+from nucypher.crypto.powers import TransactingPower
+
 from nucypher.utilities.sandbox.constants import (
     ONE_YEAR_IN_SECONDS,
     USER_ESCROW_PROXY_DEPLOYMENT_SECRET,
     ADJUDICATOR_DEPLOYMENT_SECRET,
     POLICY_MANAGER_DEPLOYMENT_SECRET,
     STAKING_ESCROW_DEPLOYMENT_SECRET,
-    NUMBER_OF_ALLOCATIONS_IN_TESTS,
-    TEST_PROVIDER_URI)
+    NUMBER_OF_ALLOCATIONS_IN_TESTS
+)
+
+# Prevents TesterBlockchain to be picked up by py.test as a test class
+from nucypher.utilities.sandbox.blockchain import TesterBlockchain as _TesterBlockchain
 
 
 @pytest.mark.slow()
@@ -48,7 +49,7 @@ def test_rapid_deployment(token_economics):
                                    compiler=compiler)
 
     # TODO: #1092 - TransactingPower
-    blockchain.transacting_power = BlockchainPower(blockchain=blockchain, account=blockchain.etherbase_account)
+    blockchain.transacting_power = TransactingPower(blockchain=blockchain, account=blockchain.etherbase_account)
     deployer_address = blockchain.etherbase_account
 
     deployer = Deployer(blockchain=blockchain, deployer_address=deployer_address)

--- a/tests/blockchain/eth/entities/actors/test_deployer.py
+++ b/tests/blockchain/eth/entities/actors/test_deployer.py
@@ -48,8 +48,10 @@ def test_rapid_deployment(token_economics):
                                    compiler=compiler)
 
     # TODO: #1092 - TransactingPower
-    blockchain.transacting_power = TransactingPower(blockchain=blockchain, account=blockchain.etherbase_account)
-    blockchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    blockchain.transacting_power = TransactingPower(blockchain=blockchain,
+                                                    password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                    account=blockchain.etherbase_account)
+    blockchain.transacting_power.activate()
     deployer_address = blockchain.etherbase_account
 
     deployer = Deployer(blockchain=blockchain, deployer_address=deployer_address)

--- a/tests/blockchain/eth/entities/actors/test_staker.py
+++ b/tests/blockchain/eth/entities/actors/test_staker.py
@@ -43,8 +43,10 @@ def test_staker_locking_tokens(testerchain, agency, staker, token_economics):
     token_agent, staking_agent, policy_agent = agency
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker.checksum_address)
+    testerchain.transacting_power.activate()
 
     assert NU(token_economics.minimum_allowed_locked, 'NuNit') < staker.token_balance, "Insufficient staker balance"
 
@@ -108,8 +110,10 @@ def test_staker_collects_staking_reward(testerchain, staker, blockchain_ursulas,
     assert token_agent.get_balance(staker.checksum_address) == initial_balance
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker.checksum_address)
+    testerchain.transacting_power.activate()
 
     staker.initialize_stake(amount=NU(token_economics.minimum_allowed_locked, 'NuNit'),  # Lock the minimum amount of tokens
                             lock_periods=int(token_economics.minimum_locked_periods))    # ... for the fewest number of periods
@@ -134,8 +138,10 @@ def test_staker_collects_staking_reward(testerchain, staker, blockchain_ursulas,
     testerchain.time_travel(periods=2)
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker.checksum_address)
+    testerchain.transacting_power.activate()
 
     # Profit!
     staker.collect_staking_reward()

--- a/tests/blockchain/eth/entities/actors/test_staker.py
+++ b/tests/blockchain/eth/entities/actors/test_staker.py
@@ -20,7 +20,7 @@ import pytest
 
 from nucypher.blockchain.eth.actors import Staker
 from nucypher.blockchain.eth.token import NU, Stake
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.blockchain import token_airdrop
 from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUNT
 from nucypher.utilities.sandbox.ursula import make_decentralized_ursulas
@@ -43,7 +43,7 @@ def test_staker_locking_tokens(testerchain, agency, staker, token_economics):
     token_agent, staking_agent, policy_agent = agency
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=staker.checksum_address)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
 
     assert NU(token_economics.minimum_allowed_locked, 'NuNit') < staker.token_balance, "Insufficient staker balance"
 
@@ -106,8 +106,8 @@ def test_staker_collects_staking_reward(testerchain, staker, blockchain_ursulas,
     initial_balance = staker.token_balance
     assert token_agent.get_balance(staker.checksum_address) == initial_balance
 
-    # Mock Powerup consumption (Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=staker.checksum_address)
+    # Mock Powerup consumption (Ursula-Worker)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
 
     staker.initialize_stake(amount=NU(token_economics.minimum_allowed_locked, 'NuNit'),  # Lock the minimum amount of tokens
                             lock_periods=int(token_economics.minimum_locked_periods))    # ... for the fewest number of periods
@@ -131,8 +131,8 @@ def test_staker_collects_staking_reward(testerchain, staker, blockchain_ursulas,
     # ...wait more...
     testerchain.time_travel(periods=2)
 
-    # Mock Powerup consumption (Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=staker.checksum_address)
+    # Mock Powerup consumption (Ursula-Worker)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
 
     # Profit!
     staker.collect_staking_reward()

--- a/tests/blockchain/eth/entities/actors/test_staker.py
+++ b/tests/blockchain/eth/entities/actors/test_staker.py
@@ -22,7 +22,7 @@ from nucypher.blockchain.eth.actors import Staker
 from nucypher.blockchain.eth.token import NU, Stake
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.blockchain import token_airdrop
-from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUNT
+from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUNT, INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.ursula import make_decentralized_ursulas
 
 
@@ -44,6 +44,7 @@ def test_staker_locking_tokens(testerchain, agency, staker, token_economics):
 
     # Mock Powerup consumption (Ursula-Staker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     assert NU(token_economics.minimum_allowed_locked, 'NuNit') < staker.token_balance, "Insufficient staker balance"
 
@@ -108,6 +109,7 @@ def test_staker_collects_staking_reward(testerchain, staker, blockchain_ursulas,
 
     # Mock Powerup consumption (Ursula-Worker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     staker.initialize_stake(amount=NU(token_economics.minimum_allowed_locked, 'NuNit'),  # Lock the minimum amount of tokens
                             lock_periods=int(token_economics.minimum_locked_periods))    # ... for the fewest number of periods
@@ -133,6 +135,7 @@ def test_staker_collects_staking_reward(testerchain, staker, blockchain_ursulas,
 
     # Mock Powerup consumption (Ursula-Worker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker.checksum_address)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     # Profit!
     staker.collect_staking_reward()

--- a/tests/blockchain/eth/entities/agents/test_adjudicator_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_adjudicator_agent.py
@@ -27,6 +27,7 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.token import NU
 from nucypher.crypto.powers import TransactingPower
 from nucypher.crypto.signing import SignatureStamp
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
 def mock_ursula(testerchain, account):
@@ -59,6 +60,7 @@ def test_adjudicator_slashes(agency,
 
     # Mock Powerup consumption (Deployer)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power.activate()
 
     # The staker receives an initial amount of tokens
     _txhash = token_agent.transfer(amount=locked_tokens,
@@ -67,6 +69,7 @@ def test_adjudicator_slashes(agency,
 
     # Mock Powerup consumption (Staker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
+    testerchain.transacting_power.activate()
 
     # Deposit: The staker deposits tokens in the StakingEscrow contract.
     staker = Staker(checksum_address=staker_account, is_me=True, blockchain=testerchain)
@@ -98,6 +101,8 @@ def test_adjudicator_slashes(agency,
 
     # Mock Powerup consumption (Bob)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=bob_account)
+    testerchain.transacting_power.activate()
+
     adjudicator_agent.evaluate_cfrag(evidence=evidence, sender_address=bob_account)
 
     assert adjudicator_agent.was_this_evidence_evaluated(evidence)

--- a/tests/blockchain/eth/entities/agents/test_adjudicator_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_adjudicator_agent.py
@@ -25,7 +25,7 @@ from nucypher.blockchain.eth.actors import NucypherTokenActor, Staker
 from nucypher.blockchain.eth.agents import AdjudicatorAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.token import NU
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 from nucypher.crypto.signing import SignatureStamp
 
 
@@ -58,7 +58,7 @@ def test_adjudicator_slashes(agency,
     locked_tokens = token_economics.minimum_allowed_locked * 5
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
 
     # The staker receives an initial amount of tokens
     _txhash = token_agent.transfer(amount=locked_tokens,
@@ -66,7 +66,7 @@ def test_adjudicator_slashes(agency,
                                    sender_address=testerchain.etherbase_account)
 
     # Mock Powerup consumption (Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=staker_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
 
     # Deposit: The staker deposits tokens in the StakingEscrow contract.
     staker = Staker(checksum_address=staker_account, is_me=True, blockchain=testerchain)
@@ -97,7 +97,7 @@ def test_adjudicator_slashes(agency,
     bobby_old_balance = bobby.token_balance
 
     # Mock Powerup consumption (Bob)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=bob_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=bob_account)
     adjudicator_agent.evaluate_cfrag(evidence=evidence, sender_address=bob_account)
 
     assert adjudicator_agent.was_this_evidence_evaluated(evidence)

--- a/tests/blockchain/eth/entities/agents/test_adjudicator_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_adjudicator_agent.py
@@ -59,7 +59,9 @@ def test_adjudicator_slashes(agency,
     locked_tokens = token_economics.minimum_allowed_locked * 5
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=testerchain.etherbase_account)
     testerchain.transacting_power.activate()
 
     # The staker receives an initial amount of tokens
@@ -68,7 +70,9 @@ def test_adjudicator_slashes(agency,
                                    sender_address=testerchain.etherbase_account)
 
     # Mock Powerup consumption (Staker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker_account)
     testerchain.transacting_power.activate()
 
     # Deposit: The staker deposits tokens in the StakingEscrow contract.
@@ -100,7 +104,9 @@ def test_adjudicator_slashes(agency,
     bobby_old_balance = bobby.token_balance
 
     # Mock Powerup consumption (Bob)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=bob_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=bob_account)
     testerchain.transacting_power.activate()
 
     adjudicator_agent.evaluate_cfrag(evidence=evidence, sender_address=bob_account)

--- a/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
@@ -20,7 +20,7 @@ import collections
 import pytest
 from eth_utils import is_checksum_address
 
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 
 MockPolicyMetadata = collections.namedtuple('MockPolicyMetadata', 'policy_id author addresses')
 
@@ -50,7 +50,7 @@ def test_create_policy(testerchain, agency, token_economics):
     agent = policy_agent
 
     # Mock Powerup consumption
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=testerchain.alice_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.alice_account)
 
     policy_id = os.urandom(16)
     node_addresses = list(staking_agent.sample(quantity=3, duration=1))
@@ -111,13 +111,13 @@ def test_calculate_refund(testerchain, agency, policy_meta):
     worker = staking_agent.get_worker_from_staker(staker)
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
 
     testerchain.time_travel(hours=9)
     _receipt = staking_agent.confirm_activity(worker_address=worker)
 
     # Mock Powerup consumption (Alice)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=testerchain.alice_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.alice_account)
 
     receipt = agent.calculate_refund(policy_id=policy_meta.policy_id, author_address=policy_meta.author)
     assert receipt['status'] == 1, "Transaction Rejected"
@@ -144,7 +144,7 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
     worker = staking_agent.get_worker_from_staker(staker)
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
 
     old_eth_balance = token_agent.blockchain.client.get_balance(staker)
 
@@ -153,7 +153,7 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
         testerchain.time_travel(periods=1)
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=staker)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker)
 
     receipt = agent.collect_policy_reward(collector_address=staker, staker_address=staker)
     assert receipt['status'] == 1, "Transaction Rejected"

--- a/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
@@ -51,8 +51,10 @@ def test_create_policy(testerchain, agency, token_economics):
     agent = policy_agent
 
     # Mock Powerup consumption
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.alice_account)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=testerchain.alice_account)
+    testerchain.transacting_power.activate()
 
     policy_id = os.urandom(16)
     node_addresses = list(staking_agent.sample(quantity=3, duration=1))
@@ -113,15 +115,19 @@ def test_calculate_refund(testerchain, agency, policy_meta):
     worker = staking_agent.get_worker_from_staker(staker)
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=worker)
+    testerchain.transacting_power.activate()
 
     testerchain.time_travel(hours=9)
     _receipt = staking_agent.confirm_activity(worker_address=worker)
 
     # Mock Powerup consumption (Alice)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.alice_account)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=testerchain.alice_account)
+    testerchain.transacting_power.activate()
 
     receipt = agent.calculate_refund(policy_id=policy_meta.policy_id, author_address=policy_meta.author)
     assert receipt['status'] == 1, "Transaction Rejected"
@@ -148,8 +154,10 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
     worker = staking_agent.get_worker_from_staker(staker)
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=worker)
+    testerchain.transacting_power.activate()
 
     old_eth_balance = token_agent.blockchain.client.get_balance(staker)
 
@@ -158,8 +166,10 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
         testerchain.time_travel(periods=1)
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker)
+    testerchain.transacting_power.activate()
 
     receipt = agent.collect_policy_reward(collector_address=staker, staker_address=staker)
     assert receipt['status'] == 1, "Transaction Rejected"

--- a/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
@@ -21,6 +21,7 @@ import pytest
 from eth_utils import is_checksum_address
 
 from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 MockPolicyMetadata = collections.namedtuple('MockPolicyMetadata', 'policy_id author addresses')
 
@@ -51,6 +52,7 @@ def test_create_policy(testerchain, agency, token_economics):
 
     # Mock Powerup consumption
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.alice_account)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     policy_id = os.urandom(16)
     node_addresses = list(staking_agent.sample(quantity=3, duration=1))
@@ -112,12 +114,14 @@ def test_calculate_refund(testerchain, agency, policy_meta):
 
     # Mock Powerup consumption (Ursula-Worker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     testerchain.time_travel(hours=9)
     _receipt = staking_agent.confirm_activity(worker_address=worker)
 
     # Mock Powerup consumption (Alice)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.alice_account)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     receipt = agent.calculate_refund(policy_id=policy_meta.policy_id, author_address=policy_meta.author)
     assert receipt['status'] == 1, "Transaction Rejected"
@@ -145,6 +149,7 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
 
     # Mock Powerup consumption (Ursula-Worker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     old_eth_balance = token_agent.blockchain.client.get_balance(staker)
 
@@ -154,6 +159,7 @@ def test_collect_policy_reward(testerchain, agency, policy_meta, token_economics
 
     # Mock Powerup consumption (Ursula-Staker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     receipt = agent.collect_policy_reward(collector_address=staker, staker_address=staker)
     assert receipt['status'] == 1, "Transaction Rejected"

--- a/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
@@ -23,6 +23,7 @@ from eth_utils.address import to_checksum_address, is_address
 from nucypher.blockchain.eth.agents import StakingEscrowAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
 @pytest.mark.slow()
@@ -35,6 +36,7 @@ def test_deposit_tokens(testerchain, agency, token_economics):
 
     # Mock Powerup consumption (Deployer)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     balance = token_agent.get_balance(address=staker_account)
     assert balance == 0
@@ -46,6 +48,7 @@ def test_deposit_tokens(testerchain, agency, token_economics):
 
     # Mock Powerup consumption (Ursula-Staker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     #
     # Deposit: The staker deposits tokens in the StakingEscrow contract.
@@ -166,6 +169,7 @@ def test_confirm_activity(agency, testerchain):
 
     # Mock Powerup consumption (Ursula-Worker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker_account)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     receipt = staking_agent.confirm_activity(worker_address=worker_account)
     assert receipt['status'] == 1, "Transaction Rejected"
@@ -220,6 +224,7 @@ def test_collect_staking_reward(agency, testerchain):
 
     # Mock Powerup consumption (Ursula-Staker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     # Mint
     _receipt = staking_agent.mint(staker_address=staker_account)

--- a/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
@@ -35,8 +35,10 @@ def test_deposit_tokens(testerchain, agency, token_economics):
     staker_account = testerchain.unassigned_accounts[0]
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=testerchain.etherbase_account)
+    testerchain.transacting_power.activate()
 
     balance = token_agent.get_balance(address=staker_account)
     assert balance == 0
@@ -47,8 +49,10 @@ def test_deposit_tokens(testerchain, agency, token_economics):
                                    sender_address=testerchain.etherbase_account)
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker_account)
+    testerchain.transacting_power.activate()
 
     #
     # Deposit: The staker deposits tokens in the StakingEscrow contract.
@@ -168,8 +172,10 @@ def test_confirm_activity(agency, testerchain):
     staker_account, worker_account, *other = testerchain.unassigned_accounts
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker_account)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=worker_account)
+    testerchain.transacting_power.activate()
 
     receipt = staking_agent.confirm_activity(worker_address=worker_account)
     assert receipt['status'] == 1, "Transaction Rejected"
@@ -223,8 +229,10 @@ def test_collect_staking_reward(agency, testerchain):
     testerchain.time_travel(periods=2)
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker_account)
+    testerchain.transacting_power.activate()
 
     # Mint
     _receipt = staking_agent.mint(staker_address=staker_account)

--- a/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
@@ -22,7 +22,7 @@ from eth_utils.address import to_checksum_address, is_address
 
 from nucypher.blockchain.eth.agents import StakingEscrowAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 
 
 @pytest.mark.slow()
@@ -34,7 +34,7 @@ def test_deposit_tokens(testerchain, agency, token_economics):
     staker_account = testerchain.unassigned_accounts[0]
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
 
     balance = token_agent.get_balance(address=staker_account)
     assert balance == 0
@@ -45,7 +45,7 @@ def test_deposit_tokens(testerchain, agency, token_economics):
                                    sender_address=testerchain.etherbase_account)
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=staker_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
 
     #
     # Deposit: The staker deposits tokens in the StakingEscrow contract.
@@ -165,7 +165,7 @@ def test_confirm_activity(agency, testerchain):
     staker_account, worker_account, *other = testerchain.unassigned_accounts
 
     # Mock Powerup consumption (Ursula-Worker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=worker_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker_account)
 
     receipt = staking_agent.confirm_activity(worker_address=worker_account)
     assert receipt['status'] == 1, "Transaction Rejected"
@@ -219,7 +219,7 @@ def test_collect_staking_reward(agency, testerchain):
     testerchain.time_travel(periods=2)
 
     # Mock Powerup consumption (Ursula-Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=staker_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=staker_account)
 
     # Mint
     _receipt = staking_agent.mint(staker_address=staker_account)

--- a/tests/blockchain/eth/entities/agents/test_token_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_token_agent.py
@@ -20,6 +20,7 @@ from eth_tester.exceptions import TransactionFailed
 from nucypher.blockchain.eth.agents import NucypherTokenAgent
 from nucypher.blockchain.eth.deployers import NucypherTokenDeployer, DispatcherDeployer
 from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
 @pytest.fixture(scope='module')
@@ -68,6 +69,7 @@ def test_approve_transfer(agent, token_economics):
 
     # Mock Powerup consumption
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=someone)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     # Approve
     receipt = agent.approve_transfer(amount=token_economics.minimum_allowed_locked,
@@ -84,6 +86,7 @@ def test_transfer(agent, token_economics):
 
     # Mock Powerup consumption (Deployer)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=origin)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     old_balance = agent.get_balance(someone)
     receipt = agent.transfer(amount=token_economics.minimum_allowed_locked,

--- a/tests/blockchain/eth/entities/agents/test_token_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_token_agent.py
@@ -68,8 +68,10 @@ def test_approve_transfer(agent, token_economics):
     deployer, someone, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=someone)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=someone)
+    testerchain.transacting_power.activate()
 
     # Approve
     receipt = agent.approve_transfer(amount=token_economics.minimum_allowed_locked,
@@ -85,8 +87,10 @@ def test_transfer(agent, token_economics):
     origin, someone, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=origin)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=origin)
+    testerchain.transacting_power.activate()
 
     old_balance = agent.get_balance(someone)
     receipt = agent.transfer(amount=token_economics.minimum_allowed_locked,

--- a/tests/blockchain/eth/entities/agents/test_token_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_token_agent.py
@@ -19,7 +19,7 @@ from eth_tester.exceptions import TransactionFailed
 
 from nucypher.blockchain.eth.agents import NucypherTokenAgent
 from nucypher.blockchain.eth.deployers import NucypherTokenDeployer, DispatcherDeployer
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 
 
 @pytest.fixture(scope='module')
@@ -67,7 +67,7 @@ def test_approve_transfer(agent, token_economics):
     deployer, someone, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=someone)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=someone)
 
     # Approve
     receipt = agent.approve_transfer(amount=token_economics.minimum_allowed_locked,
@@ -83,7 +83,7 @@ def test_transfer(agent, token_economics):
     origin, someone, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=origin)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=origin)
 
     old_balance = agent.get_balance(someone)
     receipt = agent.transfer(amount=token_economics.minimum_allowed_locked,

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -26,6 +26,7 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.deployers import UserEscrowDeployer, UserEscrowProxyDeployer, DispatcherDeployer
 from nucypher.blockchain.eth.registry import InMemoryAllocationRegistry
 from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 TEST_DURATION = 60*60
 TEST_ALLOCATION_REGISTRY = InMemoryAllocationRegistry()
@@ -57,6 +58,7 @@ def agent(testerchain, proxy_deployer, allocation_value) -> UserEscrowAgent:
 
     # Mock Powerup consumption (Deployer)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=deployer_address)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     # Escrow
     escrow_deployer = UserEscrowDeployer(deployer_address=deployer_address,
@@ -142,6 +144,7 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
 
     # Mock Powerup consumption (Beneficiary)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     # Move the tokens to the StakingEscrow
     receipt = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
@@ -160,6 +163,7 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
 
     # Mock Powerup consumption (Beneficiary-Worker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     for _ in range(token_economics.minimum_locked_periods):
         staking_agent.confirm_activity(worker_address=worker)
@@ -168,6 +172,7 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
 
     # Mock Powerup consumption (Beneficiary)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     agent.mint()
 
@@ -191,6 +196,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
 
     # Mock Powerup consumption (Beneficiary)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     _txhash = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
 
@@ -202,6 +208,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
 
     # Mock Powerup consumption (Alice)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=author)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     _txhash = policy_agent.create_policy(policy_id=os.urandom(16),
                                          author_address=author,
@@ -212,6 +219,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
 
     # Mock Powerup consumption (Beneficiary-Worker)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     _txhash = staking_agent.confirm_activity(worker_address=worker)
     testerchain.time_travel(periods=2)
@@ -221,6 +229,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
 
     # Mock Powerup consumption (Beneficiary)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     txhash = agent.collect_policy_reward()
     assert txhash  # TODO
@@ -233,6 +242,7 @@ def test_withdraw_tokens(testerchain, agent, agency, allocation_value):
 
     # Mock Powerup consumption (Beneficiary)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     assert token_agent.get_balance(address=agent.contract_address) == agent.unvested_tokens
     with pytest.raises((TransactionFailed, ValueError)):

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -25,7 +25,7 @@ from nucypher.blockchain.eth.agents import UserEscrowAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.deployers import UserEscrowDeployer, UserEscrowProxyDeployer, DispatcherDeployer
 from nucypher.blockchain.eth.registry import InMemoryAllocationRegistry
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 
 TEST_DURATION = 60*60
 TEST_ALLOCATION_REGISTRY = InMemoryAllocationRegistry()
@@ -56,7 +56,7 @@ def agent(testerchain, proxy_deployer, allocation_value) -> UserEscrowAgent:
     deployer_address, beneficiary_address, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=deployer_address)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=deployer_address)
 
     # Escrow
     escrow_deployer = UserEscrowDeployer(deployer_address=deployer_address,
@@ -141,7 +141,7 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
     assert token_agent.get_balance(address=agent.contract_address) == allocation_value
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
 
     # Move the tokens to the StakingEscrow
     receipt = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
@@ -159,7 +159,7 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
     assert staking_agent.get_locked_tokens(staker_address=agent.contract_address, periods=token_economics.minimum_locked_periods+1) == 0
 
     # Mock Powerup consumption (Beneficiary-Worker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
 
     for _ in range(token_economics.minimum_locked_periods):
         staking_agent.confirm_activity(worker_address=worker)
@@ -167,7 +167,7 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
     testerchain.time_travel(periods=1)
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
 
     agent.mint()
 
@@ -190,7 +190,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
     deployer_address, beneficiary_address, author, ursula, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
 
     _txhash = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
 
@@ -201,7 +201,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
     testerchain.time_travel(periods=1)
 
     # Mock Powerup consumption (Alice)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=author)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=author)
 
     _txhash = policy_agent.create_policy(policy_id=os.urandom(16),
                                          author_address=author,
@@ -211,7 +211,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
                                          node_addresses=[agent.contract_address])
 
     # Mock Powerup consumption (Beneficiary-Worker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=worker)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
 
     _txhash = staking_agent.confirm_activity(worker_address=worker)
     testerchain.time_travel(periods=2)
@@ -220,7 +220,7 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
     old_balance = testerchain.client.get_balance(account=agent.beneficiary)
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
 
     txhash = agent.collect_policy_reward()
     assert txhash  # TODO
@@ -232,7 +232,7 @@ def test_withdraw_tokens(testerchain, agent, agency, allocation_value):
     deployer_address, beneficiary_address, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=agent.beneficiary)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
 
     assert token_agent.get_balance(address=agent.contract_address) == agent.unvested_tokens
     with pytest.raises((TransactionFailed, ValueError)):

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -57,8 +57,10 @@ def agent(testerchain, proxy_deployer, allocation_value) -> UserEscrowAgent:
     deployer_address, beneficiary_address, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Deployer)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=deployer_address)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=deployer_address)
+    testerchain.transacting_power.activate()
 
     # Escrow
     escrow_deployer = UserEscrowDeployer(deployer_address=deployer_address,
@@ -143,8 +145,10 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
     assert token_agent.get_balance(address=agent.contract_address) == allocation_value
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=agent.beneficiary)
+    testerchain.transacting_power.activate()
 
     # Move the tokens to the StakingEscrow
     receipt = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
@@ -162,8 +166,10 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
     assert staking_agent.get_locked_tokens(staker_address=agent.contract_address, periods=token_economics.minimum_locked_periods+1) == 0
 
     # Mock Powerup consumption (Beneficiary-Worker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=worker)
+    testerchain.transacting_power.activate()
 
     for _ in range(token_economics.minimum_locked_periods):
         staking_agent.confirm_activity(worker_address=worker)
@@ -171,8 +177,10 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
     testerchain.time_travel(periods=1)
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=agent.beneficiary)
+    testerchain.transacting_power.activate()
 
     agent.mint()
 
@@ -195,8 +203,10 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
     deployer_address, beneficiary_address, author, ursula, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=agent.beneficiary)
+    testerchain.transacting_power.activate()
 
     _txhash = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
 
@@ -207,8 +217,10 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
     testerchain.time_travel(periods=1)
 
     # Mock Powerup consumption (Alice)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=author)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=author)
+    testerchain.transacting_power.activate()
 
     _txhash = policy_agent.create_policy(policy_id=os.urandom(16),
                                          author_address=author,
@@ -218,8 +230,10 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
                                          node_addresses=[agent.contract_address])
 
     # Mock Powerup consumption (Beneficiary-Worker)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=worker)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=worker)
+    testerchain.transacting_power.activate()
 
     _txhash = staking_agent.confirm_activity(worker_address=worker)
     testerchain.time_travel(periods=2)
@@ -228,8 +242,10 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
     old_balance = testerchain.client.get_balance(account=agent.beneficiary)
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=agent.beneficiary)
+    testerchain.transacting_power.activate()
 
     txhash = agent.collect_policy_reward()
     assert txhash  # TODO
@@ -241,8 +257,10 @@ def test_withdraw_tokens(testerchain, agent, agency, allocation_value):
     deployer_address, beneficiary_address, *everybody_else = testerchain.client.accounts
 
     # Mock Powerup consumption (Beneficiary)
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=agent.beneficiary)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=agent.beneficiary)
+    testerchain.transacting_power.activate()
 
     assert token_agent.get_balance(address=agent.contract_address) == agent.unvested_tokens
     with pytest.raises((TransactionFailed, ValueError)):

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -118,8 +118,8 @@ def test_anybody_can_verify():
 
 def test_character_client_transacting_power(testerchain, agency):
     # TODO: Handle multiple providers
-    eth_address = testerchain.interface.w3.eth.accounts[0]
-    sig_privkey = testerchain.interface.provider.ethereum_tester.backend._key_lookup[eth_utils.to_canonical_address(eth_address)]
+    eth_address = testerchain.etherbase_account
+    sig_privkey = testerchain.provider.ethereum_tester.backend._key_lookup[eth_utils.to_canonical_address(eth_address)]
     sig_pubkey = sig_privkey.public_key
 
     signer = Character(is_me=True, blockchain=testerchain, checksum_address=eth_address)

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -27,7 +27,7 @@ from nucypher.crypto.api import verify_eip_191
 from nucypher.crypto.powers import (CryptoPower,
                                     SigningPower,
                                     NoSigningPower,
-                                    BlockchainPower,
+                                    TransactingPower,
                                     PowerUpError)
 
 """
@@ -116,19 +116,22 @@ def test_anybody_can_verify():
     assert cleartext is constants.NO_DECRYPTION_PERFORMED
 
 
-def test_character_blockchain_power(testerchain, agency):
+def test_character_client_transacting_power(testerchain, agency):
     # TODO: Handle multiple providers
-    eth_address = testerchain.client.accounts[0]
-    canonical_address = eth_utils.to_canonical_address(eth_address)
-    sig_privkey = testerchain.provider.ethereum_tester.backend._key_lookup[canonical_address]
+    eth_address = testerchain.interface.w3.eth.accounts[0]
+    sig_privkey = testerchain.interface.provider.ethereum_tester.backend._key_lookup[eth_utils.to_canonical_address(eth_address)]
+    sig_pubkey = sig_privkey.public_key
 
     signer = Character(is_me=True, blockchain=testerchain, checksum_address=eth_address)
-    signer._crypto_power.consume_power_up(BlockchainPower(blockchain=testerchain, account=eth_address))
+    signer._crypto_power.consume_power_up(TransactingPower(blockchain=testerchain, account=eth_address))
 
-    # Due to testing backend, the account is already unlocked.
-    power = signer._crypto_power.power_ups(BlockchainPower)
-    power.is_unlocked = True
-    # power.unlock_account('this-is-not-a-secure-password')
+    power = signer._crypto_power.power_ups(TransactingPower)
+
+    # Test a signature without unlocking the account
+    with pytest.raises(PowerUpError):
+        power.sign_message(message=b'test', checksum_address=eth_address)
+
+    power.unlock_account(checksum_address=eth_address)
 
     data_to_sign = b'What does Ursula look like?!?'
     sig = power.sign_message(message=data_to_sign)
@@ -142,8 +145,10 @@ def test_character_blockchain_power(testerchain, agency):
                                  signature=sig)
     assert is_verified is False
 
+    # Test lockAccount call
+    power.lock_account(checksum_address=eth_address)
+
     # Test a signature without unlocking the account
-    power.is_unlocked = False
     with pytest.raises(PowerUpError):
         power.sign_message(message=b'test')
 
@@ -174,7 +179,7 @@ def test_anybody_can_encrypt():
 def test_node_deployer(federated_ursulas):
     for ursula in federated_ursulas:
         deployer = ursula.get_deployer()
-        assert deployer.options['https_port'] == ursula.rest_interface.port
+        assert deployer.options['https_port'] == ursula.rest_information()[0].port
         assert deployer.application == ursula.rest_app
 
 

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -29,6 +29,7 @@ from nucypher.crypto.powers import (CryptoPower,
                                     NoSigningPower,
                                     TransactingPower,
                                     PowerUpError)
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 """
 Chapter 1: SIGNING
@@ -123,15 +124,17 @@ def test_character_client_transacting_power(testerchain, agency):
     sig_pubkey = sig_privkey.public_key
 
     signer = Character(is_me=True, blockchain=testerchain, checksum_address=eth_address)
-    signer._crypto_power.consume_power_up(TransactingPower(blockchain=testerchain, account=eth_address))
-
+    transacting_power = TransactingPower(blockchain=testerchain, account=eth_address)
+    signer._crypto_power.consume_power_up(transacting_power)
     power = signer._crypto_power.power_ups(TransactingPower)
+
+    power.lock_account()
 
     # Test a signature without unlocking the account
     with pytest.raises(PowerUpError):
-        power.sign_message(message=b'test', checksum_address=eth_address)
+        power.sign_message(message=b'test')
 
-    power.unlock_account(checksum_address=eth_address)
+    power.unlock_account(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     data_to_sign = b'What does Ursula look like?!?'
     sig = power.sign_message(message=data_to_sign)
@@ -146,7 +149,7 @@ def test_character_client_transacting_power(testerchain, agency):
     assert is_verified is False
 
     # Test lockAccount call
-    power.lock_account(checksum_address=eth_address)
+    power.lock_account()
 
     # Test a signature without unlocking the account
     with pytest.raises(PowerUpError):

--- a/tests/cli/test_alice.py
+++ b/tests/cli/test_alice.py
@@ -44,7 +44,7 @@ def test_alice_control_starts_with_mocked_keyring(click_runner, mocker):
 
     user_input = '{password}\n{password}\n'.format(password=INSECURE_DEVELOPMENT_PASSWORD)
     result = click_runner.invoke(nucypher_cli, init_args, input=user_input)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.exception
 
 
 def test_initialize_alice_with_custom_configuration_root(custom_filepath, click_runner):

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -73,6 +73,7 @@ class MockSideChannel:
 @pt.inlineCallbacks
 @pytest.mark.parametrize('federated', (True, False))
 def test_cli_lifecycle(click_runner,
+                       testerchain,
                        random_policy_label,
                        federated_ursulas,
                        blockchain_ursulas,
@@ -108,7 +109,8 @@ def test_cli_lifecycle(click_runner,
     if federated:
         alice_init_args += ('--federated-only', )
     else:
-        alice_init_args += ('--provider-uri', TEST_PROVIDER_URI)
+        alice_init_args += ('--provider-uri', TEST_PROVIDER_URI,
+                            '--pay-with', testerchain.alice_account)
 
     alice_init_response = click_runner.invoke(nucypher_cli, alice_init_args, catch_exceptions=False, env=envvars)
     assert alice_init_response.exit_code == 0
@@ -137,7 +139,8 @@ def test_cli_lifecycle(click_runner,
     if federated:
         bob_init_args += ('--federated-only', )
     else:
-        bob_init_args += ('--provider-uri', TEST_PROVIDER_URI)
+        bob_init_args += ('--provider-uri', TEST_PROVIDER_URI,
+                          '--pay-with', testerchain.bob_account)
 
     bob_init_response = click_runner.invoke(nucypher_cli, bob_init_args, catch_exceptions=False, env=envvars)
     assert bob_init_response.exit_code == 0

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -379,24 +379,3 @@ def test_nucypher_deploy_allocation_contracts(click_runner,
 
     # Destroy existing blockchain
     testerchain.disconnect()
-
-
-def test_destroy_registry(click_runner, mock_primary_registry_filepath):
-
-    #   ... I changed my mind, destroy the registry!
-    destroy_command = ('destroy-registry',
-                       '--registry-infile', mock_primary_registry_filepath,
-                       '--provider-uri', TEST_PROVIDER_URI,
-                       '--poa')
-
-    # TODO: #1036 - Providers and unlocking are not needed for this command
-    account_index = '0\n'
-    yes = 'Y\n'
-    user_input = account_index + yes + yes
-
-    result = click_runner.invoke(deploy, destroy_command, input=user_input, catch_exceptions=False)
-    assert result.exit_code == 0
-    assert mock_primary_registry_filepath in result.output
-    assert DEFAULT_CONFIG_ROOT not in result.output, 'WARNING: Deploy CLI tests are using default config root dir!'
-    assert f'Successfully destroyed {mock_primary_registry_filepath}' in result.output
-    assert not os.path.isfile(mock_primary_registry_filepath)

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -82,7 +82,7 @@ def test_nucypher_deploy_contracts(click_runner,
                '--provider-uri', TEST_PROVIDER_URI,
                '--poa']
 
-    user_input = '0\n' + 'Y\n' + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + (f'{INSECURE_SECRETS[1]}\n' * 8) + 'DEPLOY'
+    user_input = '0\n' + 'Y\n' + (f'{INSECURE_SECRETS[1]}\n' * 8) + 'DEPLOY'
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -285,7 +285,7 @@ def test_rollback(click_runner, mock_primary_registry_filepath):
     # Stage Rollbacks
     old_secret = INSECURE_SECRETS[PLANNED_UPGRADES]
     rollback_secret = generate_insecure_secret()
-    user_input = '0\n' + yes + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + old_secret + rollback_secret + rollback_secret
+    user_input = '0\n' + yes + old_secret + rollback_secret + rollback_secret
 
     contracts_to_rollback = ('StakingEscrow',  # v4 -> v3
                              'PolicyManager',  # v4 -> v3
@@ -356,8 +356,7 @@ def test_nucypher_deploy_allocation_contracts(click_runner,
 
     account_index = '0\n'
     yes = 'Y\n'
-    node_password = f'{INSECURE_DEVELOPMENT_PASSWORD}\n'
-    user_input = account_index + yes + node_password + yes
+    user_input = account_index + yes + yes
 
     result = click_runner.invoke(deploy,
                                  deploy_command,

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -11,12 +11,12 @@ from nucypher.blockchain.eth.agents import (
     StakingEscrowAgent,
     UserEscrowAgent,
     PolicyAgent,
-    Agency, AdjudicatorAgent)
+    Agency)
 from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainDeployerInterface
-from nucypher.blockchain.eth.registry import AllocationRegistry, EthereumContractRegistry
+from nucypher.blockchain.eth.registry import AllocationRegistry
 from nucypher.cli.deploy import deploy
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 # Prevents TesterBlockchain to be picked up by py.test as a test class
 from nucypher.utilities.sandbox.blockchain import TesterBlockchain as _TesterBlockchain
 from nucypher.utilities.sandbox.constants import (
@@ -44,7 +44,7 @@ def make_testerchain():
 
     # Set the deployer address from a freshly created test account
     testerchain.deployer_address = testerchain.etherbase_account
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain, account=testerchain.etherbase_account)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
     return testerchain
 
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -82,7 +82,7 @@ def test_nucypher_deploy_contracts(click_runner,
                '--provider-uri', TEST_PROVIDER_URI,
                '--poa']
 
-    user_input = '0\n' + 'Y\n' + (f'{INSECURE_SECRETS[1]}\n' * 8) + 'DEPLOY'
+    user_input = '0\n' + 'Y\n' + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + (f'{INSECURE_SECRETS[1]}\n' * 8) + 'DEPLOY'
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -172,7 +172,7 @@ def test_upgrade_contracts(click_runner, mock_primary_registry_filepath):
         except KeyError:
             continue
         #             addr-----secret----new deploy secret (2x for confirmation)
-        user_input = '0\n' + yes + old_secret + (new_secret * 2)
+        user_input = '0\n' + yes + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + old_secret + (new_secret * 2)
         upgrade_inputs[next_version] = user_input
 
     #
@@ -285,7 +285,7 @@ def test_rollback(click_runner, mock_primary_registry_filepath):
     # Stage Rollbacks
     old_secret = INSECURE_SECRETS[PLANNED_UPGRADES]
     rollback_secret = generate_insecure_secret()
-    user_input = '0\n' + yes + old_secret + rollback_secret + rollback_secret
+    user_input = '0\n' + yes + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + old_secret + rollback_secret + rollback_secret
 
     contracts_to_rollback = ('StakingEscrow',  # v4 -> v3
                              'PolicyManager',  # v4 -> v3

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -172,7 +172,7 @@ def test_upgrade_contracts(click_runner, mock_primary_registry_filepath):
         except KeyError:
             continue
         #             addr-----secret----new deploy secret (2x for confirmation)
-        user_input = '0\n' + yes + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + old_secret + (new_secret * 2)
+        user_input = '0\n' + yes + old_secret + (new_secret * 2)
         upgrade_inputs[next_version] = user_input
 
     #

--- a/tests/config/test_keyring.py
+++ b/tests/config/test_keyring.py
@@ -5,17 +5,18 @@ from umbral.signing import Signer
 
 from nucypher.config.keyring import NucypherKeyring
 from nucypher.crypto.powers import DelegatingPower, DecryptingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
+from constant_sorrow.constants import FEDERATED_ADDRESS
 
 
 def test_generate_alice_keyring(tmpdir):
-    password = 'x' * 16
 
     keyring = NucypherKeyring.generate(
-        password=password,
+        checksum_address=FEDERATED_ADDRESS,
+        password=INSECURE_DEVELOPMENT_PASSWORD,
         encrypting=True,
         rest=False,
-        keyring_root=tmpdir,
-        federated=True
+        keyring_root=tmpdir
     )
 
     enc_pubkey = keyring.encrypting_public_key
@@ -24,7 +25,7 @@ def test_generate_alice_keyring(tmpdir):
     with pytest.raises(NucypherKeyring.KeyringLocked):
         _dec_keypair = keyring.derive_crypto_power(DecryptingPower).keypair
 
-    keyring.unlock(password)
+    keyring.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
     dec_keypair = keyring.derive_crypto_power(DecryptingPower).keypair
 
     assert enc_pubkey == dec_keypair.pubkey

--- a/tests/crypto/test_powers.py
+++ b/tests/crypto/test_powers.py
@@ -88,7 +88,7 @@ def test_transacting_power_sign_transaction(testerchain):
     # Try signing with missing transaction fields
     del transaction_dict['gas']
     del transaction_dict['nonce']
-    with pytest.raises(TransactingPower.InvalidSigningRequest):
+    with pytest.raises(TypeError):
         power.sign_transaction(unsigned_transaction=transaction_dict)
 
     # Try signing with a re-locked account.

--- a/tests/crypto/test_powers.py
+++ b/tests/crypto/test_powers.py
@@ -1,0 +1,129 @@
+import pytest
+from eth_account._utils.transactions import Transaction
+from eth_utils import to_checksum_address
+
+from nucypher.blockchain.eth.agents import NucypherTokenAgent
+from nucypher.crypto.api import verify_eip_191
+from nucypher.crypto.powers import (PowerUpError)
+from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
+
+
+def test_transacting_power_sign_message(testerchain):
+
+    # Manually create a TransactingPower
+    testerchain.connect()
+    eth_address = testerchain.etherbase_account
+    power = TransactingPower(blockchain=testerchain, account=eth_address)
+
+    # The default state of the account is locked.
+    # Test a signature without unlocking the account
+    with pytest.raises(PowerUpError):
+        power.sign_message(message=b'test')
+
+    # Manually unlock
+    power.unlock_account(password=INSECURE_DEVELOPMENT_PASSWORD)
+
+    # Sign
+    data_to_sign = b'Premium Select Luxury Pencil Holder'
+    signature = power.sign_message(message=data_to_sign)
+
+    # Verify
+    is_verified = verify_eip_191(address=eth_address, message=data_to_sign, signature=signature)
+    assert is_verified is True
+
+    # Test invalid address/pubkey pair
+    is_verified = verify_eip_191(address=testerchain.client.accounts[1],
+                                 message=data_to_sign,
+                                 signature=signature)
+    assert is_verified is False
+
+    # Test lockAccount call
+    power.lock_account()
+
+    # Test a signature without unlocking the account
+    with pytest.raises(PowerUpError):
+        power.sign_message(message=b'test')
+
+    del power      # Locks account
+
+
+def test_transacting_power_sign_transaction(testerchain):
+
+    eth_address = testerchain.unassigned_accounts[2]
+    power = TransactingPower(blockchain=testerchain,
+                             password=INSECURE_DEVELOPMENT_PASSWORD,
+                             account=eth_address)
+
+    assert power.is_active is False
+    assert power.is_unlocked is False
+
+    transaction_dict = {'nonce': testerchain.client.w3.eth.getTransactionCount(eth_address),
+                        'gasPrice': testerchain.client.w3.eth.gasPrice,
+                        'gas': 100000,
+                        'from': eth_address,
+                        'to': testerchain.unassigned_accounts[1],
+                        'value': 1,
+                        'data': b''}
+
+    # The default state of the account is locked.
+    # Test a signature without unlocking the account
+    with pytest.raises(TransactingPower.AccountLocked):
+        power.sign_transaction(unsigned_transaction=transaction_dict)
+
+    # Sign
+    power.activate()
+    assert power.is_active is True
+    assert power.is_unlocked is True
+    signed_transaction = power.sign_transaction(unsigned_transaction=transaction_dict)
+
+    # Demonstrate that the transaction is valid RLP encoded.
+    from eth_account._utils.transactions import Transaction
+    restored_transaction = Transaction.from_bytes(serialized_bytes=signed_transaction)
+    restored_dict = restored_transaction.as_dict()
+    assert to_checksum_address(restored_dict['to']) == transaction_dict['to']
+
+    # Try signing with missing transaction fields
+    del transaction_dict['gas']
+    del transaction_dict['nonce']
+    with pytest.raises(TransactingPower.InvalidSigningRequest):
+        power.sign_transaction(unsigned_transaction=transaction_dict)
+
+    # Try signing with a re-locked account.
+    power.lock_account()
+    with pytest.raises(TransactingPower.AccountLocked):
+        power.sign_transaction(unsigned_transaction=transaction_dict)
+
+    power.unlock_account(password=INSECURE_DEVELOPMENT_PASSWORD)
+    assert power.is_unlocked is True
+
+    # Tear-Down Test
+    power = TransactingPower(blockchain=testerchain,
+                             password=INSECURE_DEVELOPMENT_PASSWORD,
+                             account=testerchain.etherbase_account)
+    power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+
+
+def test_transacting_power_sign_agent_transaction(testerchain, agency):
+
+    token_agent = NucypherTokenAgent(blockchain=testerchain)
+    contract_function = token_agent.contract.functions.approve(testerchain.etherbase_account, 100)
+
+    payload = {'chainId': int(testerchain.client.chain_id),
+               'nonce': testerchain.client.w3.eth.getTransactionCount(testerchain.etherbase_account),
+               'from': testerchain.etherbase_account,
+               'gasPrice': testerchain.client.gas_price}
+
+    unsigned_transaction = contract_function.buildTransaction(payload)
+
+    # Sign with Transacting Power
+    transacting_power = TransactingPower(blockchain=testerchain,
+                                         password=INSECURE_DEVELOPMENT_PASSWORD,
+                                         account=testerchain.etherbase_account)
+    transacting_power.activate()
+    signed_raw_transaction = transacting_power.sign_transaction(unsigned_transaction)
+
+    # Demonstrate that the transaction is valid RLP encoded.
+    restored_transaction = Transaction.from_bytes(serialized_bytes=signed_raw_transaction)
+    restored_dict = restored_transaction.as_dict()
+    assert to_checksum_address(restored_dict['to']) == unsigned_transaction['to']

--- a/tests/crypto/test_powers.py
+++ b/tests/crypto/test_powers.py
@@ -14,7 +14,9 @@ def test_transacting_power_sign_message(testerchain):
     # Manually create a TransactingPower
     testerchain.connect()
     eth_address = testerchain.etherbase_account
-    power = TransactingPower(blockchain=testerchain, account=eth_address)
+    power = TransactingPower(blockchain=testerchain,
+                             password=INSECURE_DEVELOPMENT_PASSWORD,
+                             account=eth_address)
 
     # The default state of the account is locked.
     # Test a signature without unlocking the account

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -368,12 +368,12 @@ def testerchain():
     # Create the blockchain
     testerchain = TesterBlockchain(eth_airdrop=True, free_transactions=True)
 
-    # Mock TransactingPower Consumption
+    # Mock TransactingPower Consumption (Deployer)
     testerchain.transacting_power = TransactingPower(blockchain=testerchain,
                                                      password=INSECURE_DEVELOPMENT_PASSWORD,
                                                      account=testerchain.etherbase_account)
     testerchain.deployer_address = testerchain.etherbase_account
-    testerchain.transacting_power.unlock_account()
+    testerchain.transacting_power.activate()
     yield testerchain
     testerchain.disconnect()
 
@@ -424,13 +424,15 @@ def clear_out_agency():
 
 
 @pytest.fixture(scope="module")
-def stakers(agency, token_economics):
+def stakers(testerchain, agency, token_economics):
     token_agent, _staking_agent, _policy_agent = agency
     blockchain = token_agent.blockchain
 
     # Mock Powerup consumption (Deployer)
     blockchain.transacting_power = TransactingPower(blockchain=blockchain,
+                                                    password=INSECURE_DEVELOPMENT_PASSWORD,
                                                     account=blockchain.etherbase_account)
+    blockchain.transacting_power.activate()
 
     token_airdrop(origin=blockchain.etherbase_account,
                   addresses=blockchain.stakers_accounts,
@@ -443,8 +445,9 @@ def stakers(agency, token_economics):
 
         # Mock TransactingPower consumption
         staker.blockchain.transacting_power = TransactingPower(blockchain=blockchain,
-                                                               account=account,
-                                                               password=INSECURE_DEVELOPMENT_PASSWORD)
+                                                               password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                               account=account)
+        staker.blockchain.transacting_power.activate()
 
         min_stake, balance = token_economics.minimum_allowed_locked, staker.token_balance
         amount = random.randint(min_stake, balance)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -293,7 +293,6 @@ def capsule_side_channel(enacted_federated_policy):
             self.messages = []
             self()
 
-
     return _CapsuleSideChannel()
 
 
@@ -313,8 +312,12 @@ def federated_alice(alice_federated_test_config):
 
 
 @pytest.fixture(scope="module")
-def blockchain_alice(alice_blockchain_test_config):
-    _alice = alice_blockchain_test_config.produce()
+def blockchain_alice(alice_blockchain_test_config, testerchain):
+    transacting_power = TransactingPower(blockchain=testerchain,
+                                         account=alice_blockchain_test_config.checksum_address,
+                                         password=INSECURE_DEVELOPMENT_PASSWORD)
+    transacting_power.activate()
+    _alice = alice_blockchain_test_config.produce(additional_powers=[transacting_power])
     return _alice
 
 
@@ -325,8 +328,11 @@ def federated_bob(bob_federated_test_config):
 
 
 @pytest.fixture(scope="module")
-def blockchain_bob(bob_blockchain_test_config):
-    _bob = bob_blockchain_test_config.produce()
+def blockchain_bob(bob_blockchain_test_config, testerchain):
+    transacting_power = TransactingPower(blockchain=testerchain,
+                                         account=bob_blockchain_test_config.checksum_address,
+                                         password=INSECURE_DEVELOPMENT_PASSWORD)
+    _bob = bob_blockchain_test_config.produce(additional_powers=[transacting_power])
     return _bob
 
 
@@ -370,8 +376,10 @@ def testerchain():
 
     # Mock TransactingPower Consumption (Deployer)
     testerchain.deployer_address = testerchain.etherbase_account
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.deployer_address)
-    testerchain.transacting_power.activate(password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=testerchain.deployer_address)
+    testerchain.transacting_power.activate()
 
     yield testerchain
     testerchain.disconnect()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -313,11 +313,7 @@ def federated_alice(alice_federated_test_config):
 
 @pytest.fixture(scope="module")
 def blockchain_alice(alice_blockchain_test_config, testerchain):
-    transacting_power = TransactingPower(blockchain=testerchain,
-                                         account=alice_blockchain_test_config.checksum_address,
-                                         password=INSECURE_DEVELOPMENT_PASSWORD)
-    transacting_power.activate()
-    _alice = alice_blockchain_test_config.produce(additional_powers=[transacting_power])
+    _alice = alice_blockchain_test_config.produce()
     return _alice
 
 
@@ -329,10 +325,7 @@ def federated_bob(bob_federated_test_config):
 
 @pytest.fixture(scope="module")
 def blockchain_bob(bob_blockchain_test_config, testerchain):
-    transacting_power = TransactingPower(blockchain=testerchain,
-                                         account=bob_blockchain_test_config.checksum_address,
-                                         password=INSECURE_DEVELOPMENT_PASSWORD)
-    _bob = bob_blockchain_test_config.produce(additional_powers=[transacting_power])
+    _bob = bob_blockchain_test_config.produce()
     return _bob
 
 

--- a/tests/learning/test_fault_tolerance.py
+++ b/tests/learning/test_fault_tolerance.py
@@ -9,7 +9,7 @@ from bytestring_splitter import VariableLengthBytestring
 from constant_sorrow.constants import NOT_SIGNED
 
 from nucypher.characters.base import Character
-from nucypher.crypto.powers import BlockchainPower
+from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nicknames import nickname_from_seed
 from nucypher.network.nodes import FleetStateTracker
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
@@ -84,8 +84,8 @@ def test_invalid_workers_tolerance(testerchain,
     periods = token_economics.minimum_locked_periods
 
     # Mock Powerup consumption (Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain,
-                                                    account=idle_staker.checksum_address)
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
+                                                     account=idle_staker.checksum_address)
 
     idle_staker.initialize_stake(amount=amount, lock_periods=periods)
 
@@ -122,7 +122,7 @@ def test_invalid_workers_tolerance(testerchain,
     # She withdraws up to the last penny (well, last nunit, actually).
 
     # Mock Powerup consumption (Staker)
-    testerchain.transacting_power = BlockchainPower(blockchain=testerchain,
+    testerchain.transacting_power = TransactingPower(blockchain=testerchain,
                                                     account=idle_staker.checksum_address)
     idle_staker.mint()
     testerchain.time_travel(periods=1)

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -34,6 +34,7 @@ from zope.interface import provider
 
 from nucypher.blockchain.economics import TokenEconomics
 from nucypher.blockchain.eth.agents import NucypherTokenAgent, StakingEscrowAgent, PolicyAgent, AdjudicatorAgent
+from nucypher.crypto.powers import TransactingPower
 from nucypher.crypto.signing import SignatureStamp
 from nucypher.policy.models import Policy
 from nucypher.utilities.sandbox.blockchain import TesterBlockchain

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -24,9 +24,9 @@ import os
 import re
 import sys
 import time
-from mock import Mock
 from os.path import abspath, dirname
 
+from mock import Mock
 from twisted.logger import globalLogPublisher, Logger, jsonFileLogObserver, ILogObserver
 from umbral.keys import UmbralPrivateKey
 from umbral.signing import Signer
@@ -34,7 +34,6 @@ from zope.interface import provider
 
 from nucypher.blockchain.economics import TokenEconomics
 from nucypher.blockchain.eth.agents import NucypherTokenAgent, StakingEscrowAgent, PolicyAgent, AdjudicatorAgent
-from nucypher.crypto.powers import TransactingPower
 from nucypher.crypto.signing import SignatureStamp
 from nucypher.policy.models import Policy
 from nucypher.utilities.sandbox.blockchain import TesterBlockchain


### PR DESCRIPTION
Formalizes `BlockchainPower` as `TransactingPower`, which can be "activated" through character consumption, and attached to a `BlockchainInterface` to give it the "power" to transact through `TransactingPower.sign_transaction`.  Provides a canonical method for transaction signing that can handle both hardware and software signing backends.

Extracted from concept PR #1082 

Fixes: #1024 #349 

Supports hardware wallet transactions via geth 1.9.0; Accommodates Items in #1117 