### PR TITLE
Fixes debug docker problem.

### DIFF
--- a/dev/docker/8-federated-ursulas.yml
+++ b/dev/docker/8-federated-ursulas.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - 11500
     image: dev:nucypher
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.1 --rest-port 11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.1 --rest-port 11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.1
@@ -38,7 +38,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.2 --rest-port 11500 --teacher-uri 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.2 --rest-port 11500 --teacher-uri 172.28.1.1:11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.2
@@ -51,7 +51,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.3 --rest-port 11500 --teacher-uri 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.3 --rest-port 11500 --teacher-uri 172.28.1.1:11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.3
@@ -64,7 +64,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.4 --rest-port 11500 --teacher-uri 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.4 --rest-port 11500 --teacher-uri 172.28.1.1:11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.4
@@ -77,7 +77,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.4 --rest-port 11500 --teacher-uri 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.5 --rest-port 11500 --teacher-uri 172.28.1.1:11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.5
@@ -90,7 +90,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.4 --rest-port 11500 --teacher-uri 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.6 --rest-port 11500 --teacher-uri 172.28.1.1:11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.6
@@ -103,7 +103,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.4 --rest-port 11500 --teacher-uri 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.7 --rest-port 11500 --teacher-uri 172.28.1.1:11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.7
@@ -116,7 +116,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher --debug ursula run --dev --federated-only --rest-host 172.28.1.4 --rest-port 11500 --teacher-uri 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.8 --rest-port 11500 --teacher-uri 172.28.1.1:11500
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.8

--- a/examples/finnegans_wake_demo/finnegans-wake-demo.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo.py
@@ -9,7 +9,7 @@ from umbral.keys import UmbralPublicKey
 from nucypher.characters.lawful import Alice, Bob, Ursula
 from nucypher.characters.lawful import Enrico as Enrico
 from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import SimpleObserver
+from nucypher.utilities.logging import SimpleObserver, GlobalConsoleLogger
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
 ######################
@@ -25,6 +25,7 @@ NUMBER_OF_LINES_TO_REENCRYPT = 25
 
 # Twisted Logger
 globalLogPublisher.addObserver(SimpleObserver())
+GlobalConsoleLogger.set_log_level(log_level_name='debug')
 
 
 #######################################

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -699,7 +699,7 @@ class Bob(Character):
 
         cleartexts = []
         the_airing_of_grievances = []
-        work_orders = work_orders.values()
+
         for work_order in work_orders:
             try:
                 cfrags = self.get_reencrypted_cfrags(work_order)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -703,6 +703,10 @@ class Bob(Character):
                     cfrags = self.get_reencrypted_cfrags(work_order)
                 except requests.exceptions.ConnectTimeout:
                     continue
+                except NotFound:
+                    # This Ursula claims not to have a matching KFrag.  Maybe this has been revoked?
+                    # TODO: What's the thing to do here?  Do we want to track these Ursulas in some way in case they're lying?
+                    continue
 
                 cfrag = cfrags[0]  # TODO: generalize for WorkOrders with more than one capsule/task
                 try:

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -62,6 +62,7 @@ from nucypher.utilities.sandbox.constants import (
 @click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--withdraw-address', help="Send reward collection to an alternate address", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
+@click.option('--interactive', '-I', help="Launch command interface after connecting to seednodes.", is_flag=True, default=False)
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
@@ -107,7 +108,8 @@ def ursula(click_config,
            index,
            list_,
            divide,
-           sync
+           sync,
+           interactive,
 
            ) -> None:
     """
@@ -293,7 +295,7 @@ def ursula(click_config,
                     color='blue',
                     bold=True)
 
-            if not click_config.debug:
+            if interactive:
                 stdio.StandardIO(UrsulaCommandProtocol(ursula=URSULA))
 
             if dry_run:

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -40,7 +40,7 @@ from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 @click.option('-L', '--no-logs', help="Disable all logging output", is_flag=True)
 @click.option('-D', '--debug', help="Enable debugging mode", is_flag=True)
 @click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
-@click.option('--log-level', help="The log level for this process.  Is overridden by --debug.", type=click.STRING, default="info")
+@click.option('--log-level', help="The log level for this process.  Is overridden by --debug.", type=click.STRING, default=False)
 @nucypher_click_config
 def nucypher_cli(click_config,
                  verbose,
@@ -61,8 +61,9 @@ def nucypher_cli(click_config,
     click_config.attach_emitter(emitter)
     click_config.emit(message=NUCYPHER_BANNER)
 
-    GlobalConsoleLogger.set_log_level(log_level_name=log_level)
-    globalLogPublisher.addObserver(SimpleObserver())
+    if log_level:
+        GlobalConsoleLogger.set_log_level(log_level_name=log_level)
+        globalLogPublisher.addObserver(SimpleObserver())
 
     if debug and quiet:
         raise click.BadOptionUsage(option_name="quiet", message="--debug and --quiet cannot be used at the same time.")

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -40,6 +40,7 @@ from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 @click.option('-L', '--no-logs', help="Disable all logging output", is_flag=True)
 @click.option('-D', '--debug', help="Enable debugging mode", is_flag=True)
 @click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
+@click.option('--log-level', help="The log level for this process.  Is overridden by --debug.", type=click.STRING, default="info")
 @nucypher_click_config
 def nucypher_cli(click_config,
                  verbose,
@@ -48,7 +49,8 @@ def nucypher_cli(click_config,
                  no_logs,
                  quiet,
                  debug,
-                 no_registry):
+                 no_registry,
+                 log_level):
 
     # Session Emitter for pre and post character control engagement.
     if json_ipc:
@@ -58,6 +60,9 @@ def nucypher_cli(click_config,
 
     click_config.attach_emitter(emitter)
     click_config.emit(message=NUCYPHER_BANNER)
+
+    GlobalConsoleLogger.set_log_level(log_level_name=log_level)
+    globalLogPublisher.addObserver(SimpleObserver())
 
     if debug and quiet:
         raise click.BadOptionUsage(option_name="quiet", message="--debug and --quiet cannot be used at the same time.")

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -778,6 +778,7 @@ class Learner:
         new_nodes = []
         for node in node_list:
             if not set(self.learning_domains).intersection(set(node.serving_domains)):
+                self.log.debug(f"Teacher {node} is serving {node.serving_domains}, but we're only learning {self.learning_domains}. any of our domains.")
                 continue  # This node is not serving any of our domains.
 
             # First, determine if this is an outdated representation of an already known node.

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -41,6 +41,7 @@ from nucypher.keystore.keypairs import HostingKeypair
 from nucypher.keystore.keystore import NotFound
 from nucypher.keystore.threading import ThreadedSession
 from nucypher.network import LEARNING_LOOP_VERSION
+from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.protocols import InterfaceInfo
 
 HERE = BASE_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -181,10 +182,13 @@ def make_rest_app(
                     message = f"Suspicious Activity: Discovered node with bad signature: {node}.  Announced via REST."
                     log.warn(message)
                     this_node.suspicious_activities_witnessed['vladimirs'].append(node)
-
+                except NodeSeemsToBeDown as e:
+                    # This is a rather odd situation - this node *just* contacted us and asked to be verified.  Where'd it go?  Maybe a NAT problem?
+                    log.info(f"Node announced itself to us just now, but seems to be down: {node}.  Response was {e}.")
+                    log.debug(f"Phantom node certificate: {node.certificate}")
                 # Async Sentinel
                 except Exception as e:
-                    log.critical(str(e))
+                    log.critical(f"This exception really needs to be handled differently: {e}")
                     raise
 
                 # Believable

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -141,7 +141,7 @@ def test_coexisting_configurations(click_runner,
     #
 
     # Run an Ursula amidst the other configuration files
-    run_args = ('ursula', 'run', '--dry-run',
+    run_args = ('ursula', 'run', '--dry-run', '--interactive',
                 '--config-file', another_ursula_configuration_file_location)
 
     user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'

--- a/tests/cli/ursula/test_federated_ursula.py
+++ b/tests/cli/ursula/test_federated_ursula.py
@@ -162,7 +162,9 @@ def test_run_federated_ursula_from_config_file(custom_filepath, click_runner):
     # Run Ursula
     run_args = ('ursula', 'run',
                 '--dry-run',
-                '--config-file', custom_config_filepath)
+                '--interactive',
+                '--config-file',
+                custom_config_filepath)
 
     result = click_runner.invoke(nucypher_cli, run_args,
                                  input='{}\nY\n'.format(INSECURE_DEVELOPMENT_PASSWORD),


### PR DESCRIPTION
Fixes #941 and also many of the issues that made it so difficult to track down the problem.

* Adds `--log-level` to top-level `nucypher` CLI interface.
* Adds a few key logging statements for understanding Ursula's early learning experience.
* Adds `--interactive` to `nucypher ursula ...` - `UrsulaCommandProtocol` now only launches if this flag is provided.
* Logs phantom nodes.
