### PR TITLE
Defenestrate 'nucypher remove' from the CLI

### DIFF
--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -23,7 +23,6 @@ from twisted.logger import globalLogPublisher
 from nucypher.characters.banners import NUCYPHER_BANNER
 from nucypher.characters.control.emitters import StdoutEmitter, IPCStdoutEmitter
 from nucypher.cli import status
-from nucypher.cli.actions import destroy_configuration_root
 from nucypher.cli.characters import moe, ursula, alice, bob, enrico, felix
 from nucypher.cli.config import nucypher_click_config, NucypherClickConfig
 from nucypher.cli.painting import echo_version
@@ -101,14 +100,6 @@ def nucypher_cli(click_config,
         click_config.emit(message="Verbose mode is enabled", color='blue')
 
 
-@click.command()
-@click.option('--logs', help="Also destroy logs", is_flag=True)
-@click.option('--force', help="Don't ask for confirmation and Ignore Errors", is_flag=True)
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
-def remove(logs, force, config_root):
-    destroy_configuration_root(config_root=config_root, force=force, logs=logs)
-
-
 #
 # Character CLI Entry Points (Fan Out Input)
 #
@@ -137,7 +128,6 @@ Inversely, commenting out an entry point here will disable it.
 ENTRY_POINTS = (
 
     # Utility Sub-Commands
-    remove,         # Remove NuCypher Files
     status.status,  # Network Status
 
     # Characters

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -250,20 +250,3 @@ def test_corrupted_configuration(click_runner, custom_filepath, testerchain, moc
     top_level_config_root = os.listdir(custom_filepath)
     assert 'ursula.config' not in top_level_config_root                                # config file was destroyed
     assert len(os.listdir(os.path.join(custom_filepath, 'keyring', 'private'))) == 0   # keys were destroyed
-
-
-def test_nucypher_removal(click_runner, custom_filepath):
-    """Remove all nucypher configuration files, keys, node metadata, and logs from the local filesystem"""
-
-    # Remove nucypher completely
-    destruction_args = ('remove', '--force', '--config-root', custom_filepath)
-    result = click_runner.invoke(nucypher_cli, destruction_args, catch_exceptions=False)
-    assert result.exit_code == 0
-    assert not os.path.isdir(custom_filepath)
-
-    # Everything is gone, but we'll try again anyways...
-    destruction_args = ('remove', '--config-root', custom_filepath)
-    result = click_runner.invoke(nucypher_cli, destruction_args, input='Y\n', catch_exceptions=False)
-    assert result.exit_code == 0
-    assert not os.path.isdir(custom_filepath)
-    assert "No NuCypher configuration root directory found" in result.output  # Graceful crash


### PR DESCRIPTION
### What this does:

1. Defenestrates the `nucypher remove` command from the CLI.
2. Closes #1096 

### Why?

1. It deleted my home directory and now it must die.

### Cute picture:

![The Defenestration of nucypher remove](https://upload.wikimedia.org/wikipedia/commons/b/be/Defenestration-prague-1618.jpg)