### PR TITLE
Logging/emitters refactoring

### DIFF
--- a/examples/finnegans_wake_demo/finnegans-wake-demo.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo.py
@@ -3,13 +3,12 @@ import sys
 
 import datetime
 import maya
-from twisted.logger import globalLogPublisher
 from umbral.keys import UmbralPublicKey
 
 from nucypher.characters.lawful import Alice, Bob, Ursula
 from nucypher.characters.lawful import Enrico as Enrico
 from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import SimpleObserver, GlobalConsoleLogger
+from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
 ######################
@@ -24,8 +23,8 @@ BOOK_PATH = os.path.join('.', 'finnegans-wake.txt')
 NUMBER_OF_LINES_TO_REENCRYPT = 25
 
 # Twisted Logger
-globalLogPublisher.addObserver(SimpleObserver())
-GlobalConsoleLogger.set_log_level(log_level_name='debug')
+GlobalLoggerSettings.set_log_level(log_level_name='debug')
+GlobalLoggerSettings.start_console_logging()
 
 
 #######################################

--- a/examples/heartbeat_demo/alicia.py
+++ b/examples/heartbeat_demo/alicia.py
@@ -5,11 +5,10 @@ import os
 import shutil
 
 import maya
-from twisted.logger import globalLogPublisher
 
 from nucypher.characters.lawful import Bob, Ursula
 from nucypher.config.characters import AliceConfiguration
-from nucypher.utilities.logging import SimpleObserver
+from nucypher.utilities.logging import GlobalLoggerSettings
 
 
 ######################
@@ -20,7 +19,7 @@ from nucypher.utilities.logging import SimpleObserver
 # Twisted Logger
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
-globalLogPublisher.addObserver(SimpleObserver())
+GlobalLoggerSettings.start_console_logging()
 
 TEMP_ALICE_DIR = os.path.join('/', 'tmp', 'heartbeat-demo-alice')
 

--- a/examples/heartbeat_demo/doctor.py
+++ b/examples/heartbeat_demo/doctor.py
@@ -7,8 +7,6 @@ import maya
 import traceback
 from timeit import default_timer as timer
 
-from twisted.logger import globalLogPublisher
-
 from nucypher.characters.lawful import Bob, Ursula, Enrico
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import DecryptingPower, SigningPower
@@ -17,10 +15,11 @@ from nucypher.network.middleware import RestMiddleware
 
 from umbral.keys import UmbralPublicKey
 
-from nucypher.utilities.logging import SimpleObserver
+from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
-globalLogPublisher.addObserver(SimpleObserver())
+
+GlobalLoggerSettings.start_console_logging()
 
 ######################
 # Boring setup stuff #

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -111,8 +111,6 @@ class Moe(Character):
         deployer = HendrixDeploy(action="start", options={"wsgi": rest_app, "http_port": http_port})
         deployer.add_non_tls_websocket_service(websocket_service)
 
-        click.secho(f"Running Moe on 127.0.0.1:{http_port}")
-
         if not dry_run:
             deployer.run()
 
@@ -330,7 +328,6 @@ class Felix(Character, NucypherTokenActor):
         self.start_time = maya.now()
         payload = {"wsgi": self.rest_app, "http_port": port}
         deployer = HendrixDeploy(action="start", options=payload)
-        click.secho(f"Running {self.__class__.__name__} on {host}:{port}")
 
         if distribution is True:
             self.start_distribution()

--- a/nucypher/characters/control/controllers.py
+++ b/nucypher/characters/control/controllers.py
@@ -409,10 +409,11 @@ class WebController(CharacterControlServer):
         #
         except _400_exceptions as e:
             __exception_code = 400
-            return self.emitter(e=e,
-                                log_level='debug',
-                                response_code=__exception_code,
-                                error_message=WebController._captured_status_codes[__exception_code])
+            return self.emitter.exception(
+                e=e,
+                log_level='debug',
+                response_code=__exception_code,
+                error_message=WebController._captured_status_codes[__exception_code])
 
         #
         # Server Errors
@@ -421,10 +422,11 @@ class WebController(CharacterControlServer):
             __exception_code = 500
             if self.crash_on_error:
                 raise
-            return self.emitter(e=e,
-                                log_level='critical',
-                                response_code=__exception_code,
-                                error_message=WebController._captured_status_codes[__exception_code])
+            return self.emitter.exception(
+                e=e,
+                log_level='critical',
+                response_code=__exception_code,
+                error_message=WebController._captured_status_codes[__exception_code])
 
         #
         # Unhandled Server Errors
@@ -433,10 +435,11 @@ class WebController(CharacterControlServer):
             __exception_code = 500
             if self.crash_on_error:
                 raise
-            return self.emitter(e=e,
-                                log_level='debug',
-                                response_code=__exception_code,
-                                error_message=WebController._captured_status_codes[__exception_code])
+            return self.emitter.exception(
+                e=e,
+                log_level='debug',
+                response_code=__exception_code,
+                error_message=WebController._captured_status_codes[__exception_code])
 
         #
         # Send to WebEmitter

--- a/nucypher/characters/control/controllers.py
+++ b/nucypher/characters/control/controllers.py
@@ -318,7 +318,7 @@ class JSONRPCController(CharacterControlServer):
 
         if not control_requests:
             e = self.emitter.InvalidRequest()
-            return self.emitter(e=e)
+            return self.emitter.error(e)
 
         batch_size = 0
         for request in control_requests:  # TODO: parallelism
@@ -332,7 +332,7 @@ class JSONRPCController(CharacterControlServer):
             control_request = json.loads(control_request)
         except JSONDecodeError:
             e = self.emitter.ParseError()
-            return self.emitter(e=e)
+            return self.emitter.error(e)
 
         # Handle batch of messages
         if isinstance(control_request, list):
@@ -343,12 +343,12 @@ class JSONRPCController(CharacterControlServer):
             return self.handle_message(message=control_request, *args, **kwargs)
 
         except self.emitter.JSONRPCError as e:
-            return self.emitter(e=e)
+            return self.emitter.error(e)
 
         except Exception as e:
             if self.crash_on_error:
                 raise
-            return self.emitter(e=e)
+            return self.emitter.error(e)
 
 
 class WebController(CharacterControlServer):

--- a/nucypher/characters/control/emitters.py
+++ b/nucypher/characters/control/emitters.py
@@ -201,12 +201,6 @@ class WebEmitter:
 
         self.log = Logger('web-emitter')
 
-    def __call__(self, *args, **kwargs):
-        if 'response' in kwargs:
-            return self.__emit_http_response(*args, **kwargs)
-        else:
-            return self.__emit_exception(*args, **kwargs)
-
     @staticmethod
     def assemble_response(response: dict, request_id: int, duration) -> dict:
         response_data = {'result': response,
@@ -215,11 +209,11 @@ class WebEmitter:
                          'duration': str(duration)}
         return response_data
 
-    def __emit_exception(drone_character,
-                         e,
-                         error_message: str,
-                         log_level: str = 'info',
-                         response_code: int = 500):
+    def exception(drone_character,
+                  e,
+                  error_message: str,
+                  log_level: str = 'info',
+                  response_code: int = 500):
 
         message = f"{drone_character} [{str(response_code)} - {error_message}] | ERROR: {str(e)}"
         logger = getattr(drone_character.log, log_level)
@@ -228,7 +222,7 @@ class WebEmitter:
             raise e
         return drone_character.sink(str(e), status=response_code)
 
-    def __emit_http_response(drone_character, response, request_id, duration) -> Response:
+    def ipc(drone_character, response, request_id, duration) -> Response:
         assembled_response = drone_character.assemble_response(response=response,
                                                                request_id=request_id,
                                                                duration=duration)

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -49,7 +49,7 @@ def character_control_interface(func):
         duration = responding - received
 
         # Emit
-        return instance.emitter(response=response, request_id=request_id, duration=duration)
+        return instance.emitter.ipc(response=response, request_id=request_id, duration=duration)
 
     return wrapped
 
@@ -76,7 +76,7 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
                       expiration: maya.MayaDT,
                       value: int = None,
                       ) -> dict:
-        
+
         from nucypher.characters.lawful import Bob
         bob = Bob.from_public_keys(encrypting_key=bob_encrypting_key,
                                    verifying_key=bob_verifying_key)

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -174,17 +174,18 @@ def forget(emitter, configuration):
     emitter.message(message, color='red')
 
 
-def confirm_staged_stake(stakeholder, value, duration):
+def confirm_staged_stake(staker_address, value, duration) -> None:
     click.confirm(f"""
 * Ursula Node Operator Notice *
 -------------------------------
 
 By agreeing to stake {str(value)} ({str(value.to_nunits())} NuNits):
 
-- Staked tokens will be locked, and unavailable for transactions for the stake duration.
+- Staked tokens will be locked for the stake duration.
 
-- You are obligated to maintain a networked and available Ursula-Worker node with the
-  for the duration of the stake(s) ({duration} periods)
+- You are obligated to maintain a networked and available Ursula-Worker node 
+  bonded to the staker address {staker_address} for the duration 
+  of the stake(s) ({duration} periods).
 
 - Agree to allow NuCypher network users to carry out uninterrupted re-encryption
   work orders at-will without interference.
@@ -193,8 +194,8 @@ Failure to keep your node online, or violation of re-encryption work orders
 will result in the loss of staked tokens as described in the NuCypher slashing protocol.
 
 Keeping your Ursula node online during the staking period and successfully
-performing accurate re-encryption work orders will result in rewards
-paid out in ETH retro-actively, on-demand.
+producing correct re-encryption work orders will result in rewards
+paid out in ethers retro-actively and on-demand.
 
 Accept ursula node operator obligation?""", abort=True)
 
@@ -268,7 +269,7 @@ def make_cli_character(character_config,
     #
 
     if CHARACTER.controller is not NO_CONTROL_PROTOCOL:
-        CHARACTER.controller.emitter = emitter # TODO: set it on object creation? Or not set at all?
+        CHARACTER.controller.emitter = emitter  # TODO: set it on object creation? Or not set at all?
 
     # Federated
     if character_config.federated_only:
@@ -277,11 +278,10 @@ def make_cli_character(character_config,
     return CHARACTER
 
 
-def select_stake(stakeholder) -> Stake:
+def select_stake(stakeholder, emitter) -> Stake:
     enumerated_stakes = dict(enumerate(stakeholder.stakes))
-    painting.paint_stakes(stakes=stakeholder.stakes)
+    painting.paint_stakes(stakes=stakeholder.stakes, emitter=emitter)
     choice = click.prompt("Select Stake", type=click.IntRange(min=0, max=len(enumerated_stakes)-1))
-
     chosen_stake = enumerated_stakes[choice]
     return chosen_stake
 
@@ -305,8 +305,7 @@ def confirm_deployment(emitter, deployer) -> bool:
         confirmed_chain_id = int(click.prompt("Enter the Chain ID to confirm deployment", type=click.INT))
         expected_chain_id = int(deployer.blockchain.client.chain_id)
         if confirmed_chain_id != expected_chain_id:
-            emitter.echo(f"Chain ID not a match ({confirmed_chain_id} != {expected_chain_id}) Aborting Deployment",
-                        fg='red',
-                        bold=True)
+            abort_message = f"Chain ID not a match ({confirmed_chain_id} != {expected_chain_id}) Aborting Deployment"
+            emitter.echo(abort_message, fg='red', bold=True)
             raise click.Abort()
     return True

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -22,16 +22,14 @@ from typing import List
 
 import click
 import requests
-from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION, NO_PASSWORD
+from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION, NO_PASSWORD, NO_CONTROL_PROTOCOL
 from nacl.exceptions import CryptoError
 from twisted.logger import Logger
 
 from nucypher.blockchain.eth.clients import NuCypherGethGoerliProcess
 from nucypher.blockchain.eth.token import Stake
-from nucypher.characters.control.emitters import JSONRPCStdoutEmitter
 from nucypher.characters.lawful import Ursula
 from nucypher.cli import painting
-from nucypher.cli.config import NucypherClickConfig
 from nucypher.cli.types import IPV4_ADDRESS
 from nucypher.config.node import CharacterConfiguration
 from nucypher.network.middleware import RestMiddleware
@@ -62,8 +60,6 @@ SUCCESSFUL_DESTRUCTION = "Successfully destroyed NuCypher configuration"
 
 LOG = Logger('cli.actions')
 
-console_emitter = NucypherClickConfig.emit
-
 
 class UnknownIPAddress(RuntimeError):
     pass
@@ -77,8 +73,8 @@ def get_password(confirm: bool = False) -> str:
     return keyring_password
 
 
-def unlock_nucypher_keyring(password: str, character_configuration: CharacterConfiguration):
-    console_emitter(message='Decrypting NuCypher keyring...', color='yellow')
+def unlock_nucypher_keyring(emitter, password: str, character_configuration: CharacterConfiguration):
+    emitter.message('Decrypting NuCypher keyring...', color='yellow')
     if character_configuration.dev_mode:
         return True  # Dev accounts are always unlocked
 
@@ -90,7 +86,8 @@ def unlock_nucypher_keyring(password: str, character_configuration: CharacterCon
         raise character_configuration.keyring.AuthenticationFailed
 
 
-def load_seednodes(min_stake: int,
+def load_seednodes(emitter,
+                   min_stake: int,
                    federated_only: bool,
                    network_domains: set,
                    network_middleware: RestMiddleware = None,
@@ -112,7 +109,7 @@ def load_seednodes(min_stake: int,
         except KeyError:
             # TODO: If this is a unknown domain, require the caller to pass a teacher URI explicitly?
             if not teacher_uris:
-                console_emitter(message=f"No default teacher nodes exist for the specified network: {domain}")
+                emitter.message(f"No default teacher nodes exist for the specified network: {domain}")
 
         for uri in teacher_uris:
             teacher_node = Ursula.from_teacher_uri(teacher_uri=uri,
@@ -122,7 +119,7 @@ def load_seednodes(min_stake: int,
             teacher_nodes.append(teacher_node)
 
     if not teacher_nodes:
-        console_emitter(message=f'WARNING - No Bootnodes Available')
+        emitter.message(f'WARNING - No Bootnodes Available')
 
     return teacher_nodes
 
@@ -135,7 +132,7 @@ def get_external_ip_from_centralized_source() -> str:
                            f"(status code {ip_request.status_code})")
 
 
-def determine_external_ip_address(force: bool = False) -> str:
+def determine_external_ip_address(emitter, force: bool = False) -> str:
     """
     Attempts to automatically get the external IP from ifconfig.me
     If the request fails, it falls back to the standard process.
@@ -151,12 +148,12 @@ def determine_external_ip_address(force: bool = False) -> str:
             if not click.confirm(f"Is this the public-facing IPv4 address ({rest_host}) you want to use for Ursula?"):
                 rest_host = click.prompt("Please enter Ursula's public-facing IPv4 address here:", type=IPV4_ADDRESS)
         else:
-            console_emitter(message=f"WARNING: --force is set, using auto-detected IP '{rest_host}'", color='yellow')
+            emitter.message(f"WARNING: --force is set, using auto-detected IP '{rest_host}'", color='yellow')
 
         return rest_host
 
 
-def destroy_configuration(character_config, force: bool = False) -> None:
+def destroy_configuration(emitter, character_config, force: bool = False) -> None:
     if not force:
         click.confirm(CHARACTER_DESTRUCTION.format(name=character_config._NAME,
                                                    root=character_config.config_root,
@@ -165,17 +162,16 @@ def destroy_configuration(character_config, force: bool = False) -> None:
                                                    config=character_config.filepath), abort=True)
     character_config.destroy()
     SUCCESSFUL_DESTRUCTION = "Successfully destroyed NuCypher configuration"
-    console_emitter(message=SUCCESSFUL_DESTRUCTION, color='green')
+    emitter.message(SUCCESSFUL_DESTRUCTION, color='green')
     character_config.log.debug(SUCCESSFUL_DESTRUCTION)
 
 
-def forget(configuration):
+def forget(emitter, configuration):
     """Forget all known nodes via storage"""
     click.confirm("Permanently delete all known node data?", abort=True)
     configuration.forget_nodes()
     message = "Removed all stored node node metadata and certificates"
-    console_emitter(message=message, color='red')
-    click.secho(message=message, fg='red')
+    emitter.message(message, color='red')
 
 
 def confirm_staged_stake(stakeholder, value, duration):
@@ -183,21 +179,21 @@ def confirm_staged_stake(stakeholder, value, duration):
 * Ursula Node Operator Notice *
 -------------------------------
 
-By agreeing to stake {str(value)} ({str(value.to_nunits())} NuNits): 
+By agreeing to stake {str(value)} ({str(value.to_nunits())} NuNits):
 
 - Staked tokens will be locked, and unavailable for transactions for the stake duration.
 
-- You are obligated to maintain a networked and available Ursula-Worker node with the 
+- You are obligated to maintain a networked and available Ursula-Worker node with the
   for the duration of the stake(s) ({duration} periods)
 
 - Agree to allow NuCypher network users to carry out uninterrupted re-encryption
-  work orders at-will without interference. 
+  work orders at-will without interference.
 
 Failure to keep your node online, or violation of re-encryption work orders
 will result in the loss of staked tokens as described in the NuCypher slashing protocol.
 
 Keeping your Ursula node online during the staking period and successfully
-performing accurate re-encryption work orders will result in rewards 
+performing accurate re-encryption work orders will result in rewards
 paid out in ETH retro-actively, on-demand.
 
 Accept ursula node operator obligation?""", abort=True)
@@ -231,6 +227,8 @@ def make_cli_character(character_config,
                        min_stake: int = 0,
                        **config_args):
 
+    emitter = click_config.emitter
+
     #
     # Pre-Init
     #
@@ -242,13 +240,15 @@ def make_cli_character(character_config,
     # Handle Keyring
     if not dev:
         character_config.attach_keyring()
-        unlock_nucypher_keyring(character_configuration=character_config,
+        unlock_nucypher_keyring(emitter,
+                                character_configuration=character_config,
                                 password=get_password(confirm=False))
 
     # Handle Teachers
     teacher_nodes = None
     if teacher_uri:
-        teacher_nodes = load_seednodes(teacher_uris=[teacher_uri] if teacher_uri else None,
+        teacher_nodes = load_seednodes(emitter,
+                                       teacher_uris=[teacher_uri] if teacher_uri else None,
                                        min_stake=min_stake,
                                        federated_only=character_config.federated_only,
                                        network_domains=character_config.domains,
@@ -267,14 +267,12 @@ def make_cli_character(character_config,
     # Post-Init
     #
 
-    # TODO: Move to character configuration
-    # Switch to character control emitter
-    if click_config.json_ipc:
-        CHARACTER.controller.emitter = JSONRPCStdoutEmitter(quiet=click_config.quiet)
+    if CHARACTER.controller is not NO_CONTROL_PROTOCOL:
+        CHARACTER.controller.emitter = emitter # TODO: set it on object creation? Or not set at all?
 
     # Federated
     if character_config.federated_only:
-        console_emitter(message="WARNING: Running in Federated mode", color='yellow')
+        emitter.message("WARNING: Running in Federated mode", color='yellow')
 
     return CHARACTER
 
@@ -288,26 +286,26 @@ def select_stake(stakeholder) -> Stake:
     return chosen_stake
 
 
-def select_client_account(blockchain, prompt: str = None, default=0) -> str:
+def select_client_account(emitter, blockchain, prompt: str = None, default=0) -> str:
     enumerated_accounts = dict(enumerate(blockchain.client.accounts))
     for index, account in enumerated_accounts.items():
-        click.secho(f"{index} | {account}")
+        emitter.echo(f"{index} | {account}")
     prompt = prompt or "Select Account"
     choice = click.prompt(prompt, type=click.IntRange(min=0, max=len(enumerated_accounts)-1), default=default)
     chosen_account = enumerated_accounts[choice]
     return chosen_account
 
 
-def confirm_deployment(deployer) -> bool:
+def confirm_deployment(emitter, deployer) -> bool:
     if deployer.blockchain.client.chain_id == 'UNKNOWN' or deployer.blockchain.client.is_local:
         if click.prompt("Type 'DEPLOY' to continue") != 'DEPLOY':
-            click.secho("Aborting Deployment", fg='red', bold=True)
+            emitter.echo("Aborting Deployment", fg='red', bold=True)
             raise click.Abort()
     else:
         confirmed_chain_id = int(click.prompt("Enter the Chain ID to confirm deployment", type=click.INT))
         expected_chain_id = int(deployer.blockchain.client.chain_id)
         if confirmed_chain_id != expected_chain_id:
-            click.secho(f"Chain ID not a match ({confirmed_chain_id} != {expected_chain_id}) Aborting Deployment",
+            emitter.echo(f"Chain ID not a match ({confirmed_chain_id} != {expected_chain_id}) Aborting Deployment",
                         fg='red',
                         bold=True)
             raise click.Abort()

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -142,10 +142,10 @@ def alice(click_config,
         """Paint an existing configuration to the console"""
         configuration_file_location = config_file or AliceConfiguration.default_filepath()
         response = AliceConfiguration._read_configuration_file(filepath=configuration_file_location)
-        return emitter.ipc(response=response, request_id=0, duration=0) # FIXME: what are request_id and duration here?
+        return emitter.ipc(response=response, request_id=0, duration=0)  # FIXME: what are request_id and duration here?
 
     #
-    # Make Alice
+    # Get Alice Configuration
     #
 
     if dev:

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -30,7 +30,6 @@ from nucypher.crypto.powers import TransactingPower
 @click.option('--hw-wallet/--no-hw-wallet', default=False)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--bob-encrypting-key', help="Bob's encrypting key as a hexadecimal string", type=click.STRING)
@@ -70,7 +69,6 @@ def alice(click_config,
           geth,
           sync,
           poa,
-          no_registry,
           registry_filepath,
           hw_wallet,
 
@@ -127,7 +125,7 @@ def alice(click_config,
                                                        checksum_address=pay_with,
                                                        domains={network} if network else None,
                                                        federated_only=federated_only,
-                                                       download_registry=no_registry,
+                                                       download_registry=click_config.no_registry,
                                                        registry_filepath=registry_filepath,
                                                        provider_process=ETH_NODE,
                                                        poa=poa,

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -60,9 +60,9 @@ def bob(click_config,
     #
 
     # Banner
-    click.clear()
-    if not click_config.json_ipc and not click_config.quiet:
-        click.secho(BOB_BANNER)
+    emitter = click_config.emitter
+    emitter.clear()
+    emitter.banner(BOB_BANNER)
 
     #
     # Eager Actions
@@ -86,13 +86,13 @@ def bob(click_config,
                                                    registry_filepath=registry_filepath,
                                                    provider_uri=provider_uri)
 
-        return painting.paint_new_installation_help(new_configuration=new_bob_config)
+        return painting.paint_new_installation_help(emitter, new_configuration=new_bob_config)
 
     # TODO
     # elif action == "view":
     #     """Paint an existing configuration to the console"""
     #     response = BobConfiguration._read_configuration_file(filepath=config_file or bob_config.config_file_location)
-    #     return BOB.controller.emitter(response=response)
+    #     return BOB.controller.emitter.ipc(response)
 
     #
     # Make Bob
@@ -132,7 +132,7 @@ def bob(click_config,
     if action == "run":
 
         # Echo Public Keys
-        click_config.emit(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
+        emitter.message(f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
 
         # RPC
         if click_config.json_ipc:
@@ -141,9 +141,9 @@ def bob(click_config,
             rpc_controller.start()
             return
 
-        click_config.emitter(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
+        emitter.message(f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
         bob_encrypting_key = bytes(BOB.public_keys(DecryptingPower)).hex()
-        click_config.emit(message=f"Bob Encrypting Key {bob_encrypting_key}", color="blue", bold=True)
+        emitter.message(f"Bob Encrypting Key {bob_encrypting_key}", color="blue", bold=True)
 
         # Start Controller
         controller = BOB.make_control_transport()
@@ -159,7 +159,7 @@ def bob(click_config,
             raise click.BadOptionUsage(option_name='--dev', message=message)
 
         # Request
-        return actions.destroy_configuration(character_config=bob_config)
+        return actions.destroy_configuration(emitter, character_config=bob_config)
 
     #
     # Bob API Actions

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -14,7 +14,6 @@ from nucypher.crypto.powers import DecryptingPower
 @click.argument('action')
 @click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--teacher-uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-@click.option('--quiet', '-Q', help="Disable logging", is_flag=True)
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT)
@@ -34,7 +33,6 @@ from nucypher.crypto.powers import DecryptingPower
 @nucypher_click_config
 def bob(click_config,
         action,
-        quiet,
         teacher_uri,
         min_stake,
         http_port,

--- a/nucypher/cli/characters/enrico.py
+++ b/nucypher/cli/characters/enrico.py
@@ -28,9 +28,9 @@ def enrico(click_config, action, policy_encrypting_key, dry_run, http_port, mess
         raise click.BadArgumentUsage('--policy-encrypting-key is required to start Enrico.')
 
     # Banner
-    click.clear()
-    if not click_config.json_ipc and not click_config.quiet:
-        click.secho(ENRICO_BANNER)
+    emitter = click_config.emitter
+    emitter.clear()
+    emitter.banner(ENRICO_BANNER)
 
     #
     # Make Enrico
@@ -38,8 +38,7 @@ def enrico(click_config, action, policy_encrypting_key, dry_run, http_port, mess
 
     policy_encrypting_key = UmbralPublicKey.from_bytes(bytes.fromhex(policy_encrypting_key))
     ENRICO = Enrico(policy_encrypting_key=policy_encrypting_key)
-    if click_config.json_ipc:
-        ENRICO.controller.emitter = JSONRPCStdoutEmitter(quiet=click_config.quiet)
+    ENRICO.controller.emitter = emitter # TODO: set it on object creation? Or not set at all?
 
     #
     # Actions

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -29,7 +29,6 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
@@ -51,7 +50,6 @@ def felix(click_config,
           poa,
           config_file,
           db_filepath,
-          no_registry,
           registry_filepath,
           dev,
           force):
@@ -80,7 +78,7 @@ def felix(click_config,
                                                            db_filepath=db_filepath,
                                                            domains={network} if network else None,
                                                            checksum_address=checksum_address,
-                                                           download_registry=not no_registry,
+                                                           download_registry=not click_config.no_registry,
                                                            registry_filepath=registry_filepath,
                                                            provider_uri=provider_uri,
                                                            provider_process=ETH_NODE,

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -173,6 +173,7 @@ ETH ........ {str(eth_balance)}
 
         try:
             click.secho("Waiting for blockchain sync...", fg='yellow')
+            click_config.emit(message=f"Running Felix on {host}:{port}")
             FELIX.start(host=host,
                         port=port,
                         web_services=not dry_run,

--- a/nucypher/cli/characters/moe.py
+++ b/nucypher/cli/characters/moe.py
@@ -44,4 +44,7 @@ def moe(click_config, teacher_uri, min_stake, network, ws_port, dry_run, http_po
 
     # Run
     MOE.start_learning_loop(now=learn_on_launch)
+
+    click_config.emit(message=f"Running Moe on 127.0.0.1:{http_port}")
+
     MOE.start(http_port=http_port, ws_port=ws_port, dry_run=dry_run)

--- a/nucypher/cli/characters/moe.py
+++ b/nucypher/cli/characters/moe.py
@@ -23,14 +23,16 @@ def moe(click_config, teacher_uri, min_stake, network, ws_port, dry_run, http_po
     "Moe" NuCypher node monitor CLI.
     """
 
+    emitter = click_config.emitter
+
     # Banner
-    click.clear()
-    if not click_config.json_ipc and not click_config.quiet:
-        click.secho(MOE_BANNER)
+    emitter.clear()
+    emitter.banner(MOE_BANNER)
 
     # Teacher Ursula
     teacher_uris = [teacher_uri] if teacher_uri else None
-    teacher_nodes = actions.load_seednodes(teacher_uris=teacher_uris,
+    teacher_nodes = actions.load_seednodes(emitter,
+                                           teacher_uris=teacher_uris,
                                            min_stake=min_stake,
                                            federated_only=True,    # TODO: hardcoded for now.  Is Moe a Character?
                                            network_domains={network} if network else None,
@@ -45,6 +47,6 @@ def moe(click_config, teacher_uri, min_stake, network, ws_port, dry_run, http_po
     # Run
     MOE.start_learning_loop(now=learn_on_launch)
 
-    click_config.emit(message=f"Running Moe on 127.0.0.1:{http_port}")
+    emitter.message(f"Running Moe on 127.0.0.1:{http_port}")
 
     MOE.start(http_port=http_port, ws_port=ws_port, dry_run=dry_run)

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -42,7 +42,6 @@ from nucypher.utilities.sandbox.constants import (
 @click.command()
 @click.argument('action')
 @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--quiet', '-Q', help="Disable logging", is_flag=True)
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
@@ -64,13 +63,11 @@ from nucypher.utilities.sandbox.constants import (
 @click.option('--hw-wallet/--no-hw-wallet', default=False)
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
 @click.option('--provider-uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @nucypher_click_config
 def ursula(click_config,
            action,
            dev,
-           quiet,
            dry_run,
            force,
            lonely,
@@ -90,7 +87,6 @@ def ursula(click_config,
            config_file,
            provider_uri,
            geth,
-           no_registry,
            registry_filepath,
            interactive,
            ) -> None:
@@ -125,10 +121,6 @@ def ursula(click_config,
         if staker_address:
             raise click.BadOptionUsage(option_name='--federated-only',
                                        message="Staking address canot be used in federated mode.")
-
-    if click_config.debug and quiet:
-        raise click.BadOptionUsage(option_name="quiet", message="--debug and --quiet cannot be used at the same time.")
-
 
     # Banner
     if not click_config.json_ipc and not click_config.quiet:
@@ -194,7 +186,7 @@ def ursula(click_config,
                                                      federated_only=federated_only,
                                                      checksum_address=staker_address,
                                                      worker_address=worker_address,
-                                                     download_registry=federated_only or no_registry,
+                                                     download_registry=federated_only or click_config.no_registry,
                                                      registry_filepath=registry_filepath,
                                                      provider_process=ETH_NODE,
                                                      provider_uri=provider_uri,

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -131,11 +131,10 @@ def ursula(click_config,
     # Pre-Launch Warnings
     #
 
-    if not click_config.quiet:
-        if dev:
-            emitter.echo("WARNING: Running in Development mode", color='yellow')
-        if force:
-            emitter.echo("WARNING: Force is enabled", color='yellow')
+    if dev:
+        emitter.echo("WARNING: Running in Development mode", color='yellow', verbosity=1)
+    if force:
+        emitter.echo("WARNING: Force is enabled", color='yellow', verbosity=1)
 
     #
     # Internal Ethereum Client

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -20,15 +20,10 @@ import os
 
 import click
 from twisted.logger import Logger
-from twisted.logger import globalLogPublisher
 
 from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT
-from nucypher.utilities.logging import (
-    logToSentry,
-    getTextFileObserver,
-    initialize_sentry,
-    getJsonFileObserver
-)
+from nucypher.config.node import CharacterConfiguration
+from nucypher.utilities.logging import GlobalLoggerSettings
 
 
 class NucypherClickConfig:
@@ -48,13 +43,12 @@ class NucypherClickConfig:
 
         # Sentry Logging
         if self.log_to_sentry is True:
-            initialize_sentry(dsn=NUCYPHER_SENTRY_ENDPOINT)
-            globalLogPublisher.addObserver(logToSentry)
+            GlobalLoggerSettings.start_sentry_logging(self.sentry_endpoint)
 
         # File Logging
         if self.log_to_file is True:
-            globalLogPublisher.addObserver(getTextFileObserver())
-            globalLogPublisher.addObserver(getJsonFileObserver())
+            GlobalLoggerSettings.start_text_file_logging()
+            GlobalLoggerSettings.start_json_file_logging()
 
         # You guessed it
         self.debug = False

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -17,6 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import collections
+from distutils.util import strtobool
 import functools
 import os
 
@@ -30,6 +31,15 @@ from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
+def get_env_bool(var_name: str, default: bool) -> bool:
+    if var_name in os.environ:
+        # TODO: which is better: to fail on an incorrect envvar, or to use the default?
+        # Currently doing the former.
+        return strtoobool(os.environ[var_name])
+    else:
+        return default
+
+
 class NucypherClickConfig:
 
     # Output Sinks
@@ -38,8 +48,8 @@ class NucypherClickConfig:
     # Environment Variables
     config_file = os.environ.get('NUCYPHER_CONFIG_FILE')
     sentry_endpoint = os.environ.get("NUCYPHER_SENTRY_DSN", NUCYPHER_SENTRY_ENDPOINT)
-    log_to_sentry = os.environ.get("NUCYPHER_SENTRY_LOGS", True)
-    log_to_file = os.environ.get("NUCYPHER_FILE_LOGS", True)
+    log_to_sentry = get_env_bool("NUCYPHER_SENTRY_LOGS", True)
+    log_to_file = get_env_bool("NUCYPHER_FILE_LOGS", True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -33,7 +33,6 @@ from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 class NucypherClickConfig:
 
     # Output Sinks
-    capture_stdout = False
     __emitter = None
 
     # Environment Variables
@@ -60,9 +59,9 @@ class NucypherClickConfig:
 
         # Session Emitter for pre and post character control engagement.
         if json_ipc:
-            emitter = JSONRPCStdoutEmitter(quiet=quiet, capture_stdout=NucypherClickConfig.capture_stdout)
+            emitter = JSONRPCStdoutEmitter(quiet=quiet)
         else:
-            emitter = StdoutEmitter(quiet=quiet, capture_stdout=NucypherClickConfig.capture_stdout)
+            emitter = StdoutEmitter(quiet=quiet)
 
         self.attach_emitter(emitter)
 
@@ -117,22 +116,22 @@ class NucypherClickConfig:
         # Only used for testing outputs;
         # Redirects outputs to in-memory python containers.
         if mock_networking:
-            self.emit(message="WARNING: Mock networking is enabled")
+            self.emitter.message("WARNING: Mock networking is enabled")
             self.middleware = MockRestMiddleware()
         else:
             self.middleware = RestMiddleware()
 
         # Global Warnings
         if self.verbose:
-            self.emit(message="Verbose mode is enabled", color='blue')
+            self.emitter.message("Verbose mode is enabled", color='blue')
 
     @classmethod
     def attach_emitter(cls, emitter) -> None:
         cls.__emitter = emitter
 
-    @classmethod
-    def emit(cls, *args, **kwargs):
-        cls.__emitter(*args, **kwargs)
+    @property
+    def emitter(cls):
+        return cls.__emitter
 
 
 # Register the above click configuration classes as a decorators

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -149,7 +149,7 @@ def deploy(action,
     # Add ETH Bootnode or Peer
     if enode:
         blockchain.client.add_peer(enode)
-        click.secho(f"Added ethereum peer {enode}")
+        emitter.echo(f"Added ethereum peer {enode}")
 
     #
     # Action switch
@@ -185,7 +185,7 @@ def deploy(action,
                 emitter.echo(message, color='red', bold=True)
                 raise click.Abort()
             else:
-                click.secho(f"Deploying {contract_name}")
+                emitter.echo(f"Deploying {contract_name}")
                 if contract_deployer._upgradeable:
                     secret = deployer.collect_deployment_secret(deployer=contract_deployer)
                     receipts, agent = deployer.deploy_contract(contract_name=contract_name, plaintext_secret=secret)
@@ -193,15 +193,16 @@ def deploy(action,
                     receipts, agent = deployer.deploy_contract(contract_name=contract_name, gas_limit=gas)
                 paint_contract_deployment(contract_name=contract_name,
                                           contract_address=agent.contract_address,
-                                          receipts=receipts)
+                                          receipts=receipts,
+                                          emitter=emitter)
             if ETH_NODE:
                 ETH_NODE.stop()
             return
 
         registry_filepath = deployer.blockchain.registry.filepath
         if os.path.isfile(registry_filepath):
-            click.secho(f"\nThere is an existing contract registry at {registry_filepath}.\n"
-                        f"Did you mean 'nucypher-deploy upgrade'?\n", fg='yellow')
+            emitter.echo(f"\nThere is an existing contract registry at {registry_filepath}.\n"
+                         f"Did you mean 'nucypher-deploy upgrade'?\n", color='yellow')
             click.confirm("Optionally, destroy existing local registry and continue?", abort=True)
             click.confirm(f"Confirm deletion of contract registry '{registry_filepath}'?", abort=True)
             os.remove(registry_filepath)
@@ -242,7 +243,7 @@ def deploy(action,
         #
         # DEPLOY
         #
-        deployment_receipts = deployer.deploy_network_contracts(secrets=secrets)
+        deployment_receipts = deployer.deploy_network_contracts(secrets=secrets, emitter=emitter)
 
         #
         # Success

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -19,93 +19,15 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import click
 
-from nucypher.characters.banners import NUCYPHER_BANNER
-from nucypher.characters.control.emitters import JSONRPCStdoutEmitter
-from nucypher.characters.control.emitters import StdoutEmitter
 from nucypher.cli import status, stake
 from nucypher.cli.characters import moe, ursula, alice, bob, enrico, felix
-from nucypher.cli.config import nucypher_click_config, NucypherClickConfig
 from nucypher.cli.painting import echo_version
-from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import GlobalLoggerSettings
-from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
 @click.group()
 @click.option('--version', help="Echo the CLI version", is_flag=True, callback=echo_version, expose_value=False, is_eager=True)
-@click.option('-v', '--verbose', help="Specify verbosity level", count=True)
-@click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True)
-@click.option('-J', '--json-ipc', help="Send all output to stdout as JSON", is_flag=True)
-@click.option('-Q', '--quiet', help="Disable console printing", is_flag=True)
-@click.option('-L', '--no-logs', help="Disable all logging output", is_flag=True)
-@click.option('-D', '--debug', help="Enable debugging mode", is_flag=True)
-@click.option('--no-registry', help="Skip importing the default contract registry", is_flag=True)
-@click.option('--log-level', help="The log level for this process.  Is overridden by --debug.", type=click.STRING, default=False)
-@nucypher_click_config
-def nucypher_cli(click_config,
-                 verbose,
-                 mock_networking,
-                 json_ipc,
-                 no_logs,
-                 quiet,
-                 debug,
-                 no_registry,
-                 log_level):
-
-    # Session Emitter for pre and post character control engagement.
-    if json_ipc:
-        emitter = JSONRPCStdoutEmitter(quiet=quiet, capture_stdout=NucypherClickConfig.capture_stdout)
-    else:
-        emitter = StdoutEmitter(quiet=quiet, capture_stdout=NucypherClickConfig.capture_stdout)
-
-    click_config.attach_emitter(emitter)
-    if not json_ipc:
-        click_config.emit(message=NUCYPHER_BANNER)
-
-    if log_level:
-        GlobalConsoleLogger.set_log_level(log_level_name=log_level)
-        globalLogPublisher.addObserver(SimpleObserver())
-
-    if debug and quiet:
-        raise click.BadOptionUsage(option_name="quiet", message="--debug and --quiet cannot be used at the same time.")
-
-    if debug:
-        click_config.log_to_sentry = False
-        click_config.log_to_file = True                 # File Logging
-        GlobalLoggerSettings.start_console_logging()
-        GlobalLoggerSettings.stop_sentry_logging()
-        GlobalLoggerSettings.set_log_level(log_level_name='debug')
-
-    elif quiet:  # Disable Logging
-        GlobalLoggerSettings.stop_sentry_logging()
-        GlobalLoggerSettings.stop_console_logging()
-        GlobalLoggerSettings.stop_json_file_logging()
-
-    # Logging
-    if not no_logs:
-        GlobalLoggerSettings.start_text_file_logging()
-
-    # CLI Session Configuration
-    click_config.verbose = verbose
-    click_config.mock_networking = mock_networking
-    click_config.json_ipc = json_ipc
-    click_config.no_logs = no_logs
-    click_config.quiet = quiet
-    click_config.no_registry = no_registry
-    click_config.debug = debug
-
-    # Only used for testing outputs;
-    # Redirects outputs to in-memory python containers.
-    if mock_networking:
-        click_config.emit(message="WARNING: Mock networking is enabled")
-        click_config.middleware = MockRestMiddleware()
-    else:
-        click_config.middleware = RestMiddleware()
-
-    # Global Warnings
-    if click_config.verbose:
-        click_config.emit(message="Verbose mode is enabled", color='blue')
-
+def nucypher_cli():
+    pass
 
 
 #

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -18,7 +18,6 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 
 import click
-from twisted.logger import globalLogPublisher
 
 from nucypher.characters.banners import NUCYPHER_BANNER
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter
@@ -28,7 +27,7 @@ from nucypher.cli.characters import moe, ursula, alice, bob, enrico, felix
 from nucypher.cli.config import nucypher_click_config, NucypherClickConfig
 from nucypher.cli.painting import echo_version
 from nucypher.network.middleware import RestMiddleware
-from nucypher.utilities.logging import GlobalConsoleLogger, getJsonFileObserver, SimpleObserver, logToSentry
+from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
@@ -73,18 +72,18 @@ def nucypher_cli(click_config,
     if debug:
         click_config.log_to_sentry = False
         click_config.log_to_file = True                 # File Logging
-        globalLogPublisher.addObserver(SimpleObserver())  # Console Logging
-        globalLogPublisher.removeObserver(logToSentry)  # No Sentry
-        GlobalConsoleLogger.set_log_level(log_level_name='debug')
+        GlobalLoggerSettings.start_console_logging()
+        GlobalLoggerSettings.stop_sentry_logging()
+        GlobalLoggerSettings.set_log_level(log_level_name='debug')
 
     elif quiet:  # Disable Logging
-        globalLogPublisher.removeObserver(logToSentry)
-        globalLogPublisher.removeObserver(SimpleObserver)
-        globalLogPublisher.removeObserver(getJsonFileObserver())
+        GlobalLoggerSettings.stop_sentry_logging()
+        GlobalLoggerSettings.stop_console_logging()
+        GlobalLoggerSettings.stop_json_file_logging()
 
     # Logging
     if not no_logs:
-        GlobalConsoleLogger.start_if_not_started()
+        GlobalLoggerSettings.start_text_file_logging()
 
     # CLI Session Configuration
     click_config.verbose = verbose
@@ -115,17 +114,17 @@ def nucypher_cli(click_config,
 
 r"""
             ursula
-              |                    
-              |  moe 
-              |  /                 
+              |
+              |  moe
+              |  /
               | /
 stdin --> cli.main --- alice
               | \
-              |  \ 
-              |  bob 
+              |  \
+              |  bob
               |
-            enrico 
-            
+            enrico
+
 
 
 New character CLI modules must be added here

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-import os
+
 from decimal import Decimal
 
 import click
@@ -297,19 +297,19 @@ def paint_staged_stake_division(emitter,
                        division_message=division_message)
 
 
-def paint_contract_deployment(contract_name: str, contract_address: str, receipts: dict):
+def paint_contract_deployment(emitter, contract_name: str, contract_address: str, receipts: dict):
 
     # TODO: switch to using an explicit emitter
 
     # Paint heading
     heading = '\n{} ({})'.format(contract_name, contract_address)
-    click.secho(heading, bold=True)
-    click.echo('*' * (42 + 3 + len(contract_name)))
+    emitter.echo(heading, bold=True)
+    emitter.echo('*' * (42 + 3 + len(contract_name)))
 
     # Paint Transactions
     for tx_name, receipt in receipts.items():
-        click.secho("OK", fg='green', nl=False, bold=True)
-        click.secho(" | {}".format(tx_name), fg='yellow', nl=False)
-        click.secho(" | {}".format(receipt['transactionHash'].hex()), fg='yellow', nl=False)
-        click.secho(" ({} gas)".format(receipt['cumulativeGasUsed']))
-        click.secho("Block #{} | {}\n".format(receipt['blockNumber'], receipt['blockHash'].hex()))
+        emitter.echo("OK", color='green', nl=False, bold=True)
+        emitter.echo(" | {}".format(tx_name), color='yellow', nl=False)
+        emitter.echo(" | {}".format(receipt['transactionHash'].hex()), color='yellow', nl=False)
+        emitter.echo(" ({} gas)".format(receipt['cumulativeGasUsed']))
+        emitter.echo("Block #{} | {}\n".format(receipt['blockNumber'], receipt['blockHash'].hex()))

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -245,9 +245,8 @@ def stake(click_config,
                                                              value=value,
                                                              duration=extension,
                                                              password=password)
-        if not click_config.quiet:
-            emitter.echo('Successfully divided stake', color='green')
-            emitter.echo(f'Receipt ........... {new_stake.receipt}')
+        emitter.echo('Successfully divided stake', color='green', verbosity=1)
+        emitter.echo(f'Receipt ........... {new_stake.receipt}', verbosity=1)
 
         # Show the resulting stake list
         painting.paint_stakes(emitter=emitter, stakes=STAKEHOLDER.stakes)

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -24,7 +24,6 @@ from nucypher.cli.types import (
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--quiet', '-Q', help="Disable logging", is_flag=True)
 @click.option('--hw-wallet/--no-hw-wallet', default=False)  # TODO: Make True or deprecate.
 @click.option('--sync/--no-sync', default=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
@@ -48,7 +47,6 @@ def stake(click_config,
 
           # Mode
           force,
-          quiet,
           offline,
           hw_wallet,
 
@@ -71,7 +69,7 @@ def stake(click_config,
           ) -> None:
 
     # Banner
-    if not quiet:
+    if not click_config.quiet:
         click.clear()
         click.secho(NU_BANNER)
 
@@ -244,14 +242,14 @@ def stake(click_config,
                                                              value=value,
                                                              duration=extension,
                                                              password=password)
-        if not quiet:
+        if not click_config.quiet:
             click.secho('Successfully divided stake', fg='green')
             click.secho(f'Receipt ........... {new_stake.receipt}')
 
         # Show the resulting stake list
         painting.paint_stakes(stakes=STAKEHOLDER.stakes)
         return  # Exit
-    
+
     elif action == 'collect-reward':
         """Withdraw staking reward to the specified wallet address"""
         password = None

--- a/nucypher/cli/status.py
+++ b/nucypher/cli/status.py
@@ -42,7 +42,7 @@ def status(click_config, config_file):
         ursula_config.acquire_agency()
 
         # Contracts
-        paint_contract_status(ursula_config=ursula_config, click_config=click_config)
+        paint_contract_status(click_config.emitter, ursula_config=ursula_config, click_config=click_config)
 
     # Known Nodes
-    paint_known_nodes(ursula=ursula_config)
+    paint_known_nodes(emitter=click_config.emitter, ursula=ursula_config)

--- a/scripts/local_fleet/run_local_ursula_fleet.py
+++ b/scripts/local_fleet/run_local_ursula_fleet.py
@@ -26,7 +26,6 @@ import os
 
 from twisted.internet import protocol
 from twisted.internet import reactor
-from twisted.logger import globalLogPublisher
 
 from nucypher.utilities.logging import SimpleObserver
 

--- a/tests/blockchain/eth/entities/actors/test_deployer.py
+++ b/tests/blockchain/eth/entities/actors/test_deployer.py
@@ -24,6 +24,7 @@ from web3.auto import w3
 from nucypher.blockchain.eth.actors import DeployerActor
 from nucypher.blockchain.eth.registry import InMemoryAllocationRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
+from nucypher.characters.control.emitters import StdoutEmitter
 from nucypher.crypto.powers import TransactingPower
 # Prevents TesterBlockchain to be picked up by py.test as a test class
 from nucypher.utilities.sandbox.blockchain import TesterBlockchain as _TesterBlockchain
@@ -56,7 +57,7 @@ def test_rapid_deployment(token_economics):
     for deployer_class in deployer.upgradeable_deployer_classes:
         secrets[deployer_class.contract_name] = INSECURE_DEVELOPMENT_PASSWORD
 
-    deployer.deploy_network_contracts(secrets=secrets)
+    deployer.deploy_network_contracts(secrets=secrets, emitter=StdoutEmitter())
 
     all_yall = blockchain.unassigned_accounts
 

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -117,8 +117,8 @@ def test_cli_lifecycle(click_runner,
 
     # Alice uses her configuration file to run the character "view" command
     alice_configuration_file_location = os.path.join(alice_config_root, AliceConfiguration.generate_filename())
-    alice_view_args = ('--json-ipc',
-                       'alice', 'public-keys',
+    alice_view_args = ('alice', 'public-keys',
+                       '--json-ipc',
                        '--config-file', alice_configuration_file_location)
 
     alice_view_result = click_runner.invoke(nucypher_cli, alice_view_args, catch_exceptions=False, env=envvars)
@@ -147,8 +147,8 @@ def test_cli_lifecycle(click_runner,
 
     # Alice uses her configuration file to run the character "view" command
     bob_configuration_file_location = os.path.join(bob_config_root, BobConfiguration.generate_filename())
-    bob_view_args = ('--json-ipc',
-                     'bob', 'public-keys',
+    bob_view_args = ('bob', 'public-keys',
+                     '--json-ipc',
                      '--config-file', bob_configuration_file_location)
 
     bob_view_result = click_runner.invoke(nucypher_cli, bob_view_args, catch_exceptions=False, env=envvars)
@@ -167,9 +167,9 @@ def test_cli_lifecycle(click_runner,
 
     random_label = random_policy_label.decode()  # Unicode string
 
-    derive_args = ('--mock-networking',
+    derive_args = ('alice', 'derive-policy-pubkey',
+                   '--mock-networking',
                    '--json-ipc',
-                   'alice', 'derive-policy-pubkey',
                    '--config-file', alice_configuration_file_location,
                    '--label', random_label)
 
@@ -192,9 +192,9 @@ def test_cli_lifecycle(click_runner,
         # Fetch!
         policy = side_channel.fetch_policy()
 
-        enrico_args = ('--json-ipc',
-                       'enrico',
+        enrico_args = ('enrico',
                        'encrypt',
+                       '--json-ipc',
                        '--policy-encrypting-key', policy.encrypting_key,
                        '--message', PLAINTEXT)
 
@@ -217,9 +217,9 @@ def test_cli_lifecycle(click_runner,
         message_kit = encrypt_result['result']['message_kit']
 
         decrypt_args = (
+            'alice', 'decrypt',
             '--mock-networking',
             '--json-ipc',
-            'alice', 'decrypt',
             '--config-file', alice_configuration_file_location,
             '--message-kit', message_kit,
             '--label', policy.label,
@@ -264,9 +264,9 @@ def test_cli_lifecycle(click_runner,
         bob_encrypting_key = bob_keys.bob_encrypting_key
         bob_verifying_key = bob_keys.bob_verifying_key
 
-        grant_args = ('--mock-networking',
+        grant_args = ('alice', 'grant',
+                      '--mock-networking',
                       '--json-ipc',
-                      'alice', 'grant',
                       '--network', TEMPORARY_DOMAIN,
                       '--teacher-uri', teacher_uri,
                       '--config-file', alice_configuration_file_location,
@@ -307,9 +307,9 @@ def test_cli_lifecycle(click_runner,
 
         alice_signing_key = side_channel.fetch_alice_pubkey()
 
-        retrieve_args = ('--mock-networking',
+        retrieve_args = ('bob', 'retrieve',
+                         '--mock-networking',
                          '--json-ipc',
-                         'bob', 'retrieve',
                          '--teacher-uri', teacher_uri,
                          '--config-file', bob_configuration_file_location,
                          '--message-kit', ciphertext_message_kit,

--- a/tests/cli/test_felix.py
+++ b/tests/cli/test_felix.py
@@ -54,8 +54,8 @@ def test_run_felix(click_runner,
                'FLASK_DEBUG': '1'}
 
     # Felix creates a system configuration
-    init_args = ('--debug',
-                 'felix', 'init',
+    init_args = ('felix', 'init',
+                 '--debug',
                  '--registry-filepath', mock_primary_registry_filepath,
                  '--checksum-address', testerchain.client.accounts[0],
                  '--config-root', MOCK_CUSTOM_INSTALLATION_PATH_2,
@@ -69,8 +69,8 @@ def test_run_felix(click_runner,
     configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH_2, FelixConfiguration.generate_filename())
 
     # Felix Creates a Database
-    db_args = ('--debug',
-               'felix', 'createdb',
+    db_args = ('felix', 'createdb',
+               '--debug',
                '--registry-filepath', mock_primary_registry_filepath,
                '--config-file', configuration_file_location,
                '--provider-uri', TEST_PROVIDER_URI)
@@ -80,8 +80,8 @@ def test_run_felix(click_runner,
 
     # Felix Runs Web Services
     def run_felix():
-        args = ('--debug',
-                'felix', 'run',
+        args = ('felix', 'run',
+                '--debug',
                 '--registry-filepath', mock_primary_registry_filepath,
                 '--config-file', configuration_file_location,
                 '--provider-uri', TEST_PROVIDER_URI,

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -264,7 +264,7 @@ def test_corrupted_configuration(click_runner, custom_filepath, testerchain, moc
 
     # Attempt destruction with invalid configuration (missing registry)
     ursula_file_location = os.path.join(custom_filepath, default_filename)
-    destruction_args = ('--debug', 'ursula', 'destroy', '--config-file', ursula_file_location)
+    destruction_args = ('ursula', '--debug', 'destroy', '--config-file', ursula_file_location)
     result = click_runner.invoke(nucypher_cli, destruction_args, input='Y\n', catch_exceptions=False, env=envvars)
     assert result.exit_code == 0
 

--- a/tests/cli/ursula/test_run_ursula.py
+++ b/tests/cli/ursula/test_run_ursula.py
@@ -37,8 +37,8 @@ from nucypher.utilities.sandbox.ursula import start_pytest_ursula_services
 
 @pt.inlineCallbacks
 def test_run_lone_federated_default_development_ursula(click_runner):
-    args = ('--debug',                                  # Display log output; Do not attach console
-            'ursula', 'run',                            # Stat Ursula Command
+    args = ('ursula', 'run',                            # Stat Ursula Command
+            '--debug',                                  # Display log output; Do not attach console
             '--federated-only',                         # Operating Mode
             '--rest-port', MOCK_URSULA_STARTING_PORT,   # Network Port
             '--dev',                                    # Run in development mode (ephemeral node)
@@ -75,8 +75,8 @@ def test_federated_ursula_learns_via_cli(click_runner, federated_ursulas):
 
     def run_ursula(teacher_uri):
 
-        args = ('--debug',                                  # Display log output; Do not attach console
-                'ursula', 'run',
+        args = ('ursula', 'run',
+                '--debug',                                  # Display log output; Do not attach console
                 '--federated-only',                         # Operating Mode
                 '--rest-port', MOCK_URSULA_STARTING_PORT,   # Network Port
                 '--teacher-uri', teacher_uri,

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -282,7 +282,7 @@ def test_ursula_init(click_runner,
         assert config_data['worker_address'] == manual_worker
         assert config_data['checksum_address'] == manual_staker
         assert TEMPORARY_DOMAIN in config_data['domains']
-        
+
 
 def test_ursula_run(click_runner,
                     manual_worker,
@@ -453,8 +453,8 @@ def test_collect_rewards_integration(click_runner,
     testerchain.transacting_power.activate()
 
     # Collect Policy Reward
-    collection_args = ('--mock-networking',
-                       'stake', 'collect-reward',
+    collection_args = ('stake', 'collect-reward',
+                       '--mock-networking',
                        '--config-file', stakeholder_configuration_file_location,
                        '--policy-reward',
                        '--no-staking-reward',
@@ -482,8 +482,8 @@ def test_collect_rewards_integration(click_runner,
         testerchain.time_travel(periods=1)
 
     # Collect Inflation Reward
-    collection_args = ('--mock-networking',
-                       'stake', 'collect-reward',
+    collection_args = ('stake', 'collect-reward',
+                       '--mock-networking',
                        '--config-file', stakeholder_configuration_file_location,
                        '--no-policy-reward',
                        '--staking-reward',

--- a/tests/cli/ursula/test_ursula_command.py
+++ b/tests/cli/ursula/test_ursula_command.py
@@ -7,8 +7,7 @@ from io import StringIO
 from nucypher.cli.config import NucypherClickConfig
 from nucypher.cli.processes import UrsulaCommandProtocol
 
-# Disable click sentry and file logging
-
+# Override environment variables
 NucypherClickConfig.log_to_sentry = False
 NucypherClickConfig.log_to_file = False
 

--- a/tests/cli/ursula/test_ursula_command.py
+++ b/tests/cli/ursula/test_ursula_command.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 import pytest
 from io import StringIO
 
+from nucypher.characters.control.emitters import StdoutEmitter
 from nucypher.cli.config import NucypherClickConfig
 from nucypher.cli.processes import UrsulaCommandProtocol
 
@@ -31,13 +32,15 @@ def ursula(federated_ursulas):
 
 @pytest.fixture(scope='module')
 def protocol(ursula):
-    protocol = UrsulaCommandProtocol(ursula=ursula)
+    emitter = StdoutEmitter()
+    protocol = UrsulaCommandProtocol(ursula=ursula, emitter=emitter)
     return protocol
 
 
 def test_ursula_command_protocol_creation(ursula):
 
-    protocol = UrsulaCommandProtocol(ursula=ursula)
+    emitter = StdoutEmitter()
+    protocol = UrsulaCommandProtocol(ursula=ursula, emitter=emitter)
 
     assert protocol.ursula == ursula
     assert b'Ursula' in protocol.prompt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,21 +17,17 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import os
 
 import pytest
-from twisted.logger import globalLogPublisher
 
 from nucypher.characters.control.emitters import WebEmitter
 from nucypher.cli.config import NucypherClickConfig
-from nucypher.utilities.logging import GlobalConsoleLogger, logToSentry
+from nucypher.utilities.logging import GlobalLoggerSettings
 # Logger Configuration
 #
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
 # Disable click sentry and file logging
-globalLogPublisher.removeObserver(logToSentry)
 NucypherClickConfig.log_to_sentry = False
-
-# Log to files
 NucypherClickConfig.log_to_file = True
 
 # Crash on server error by default
@@ -106,4 +102,6 @@ def pytest_collection_modifyitems(config, items):
 
     log_level_name = config.getoption("--log-level", "info", skip=True)
 
-    GlobalConsoleLogger.set_log_level(log_level_name)
+    GlobalLoggerSettings.set_log_level(log_level_name)
+    GlobalLoggerSettings.start_text_file_logging()
+    GlobalLoggerSettings.start_json_file_logging()


### PR DESCRIPTION
A reworked PR #1079, branched off the current `croquetas`, since there were a lot of changes introduced there.

Changes:

- All options are now specified after commands. That is, if before one would call

        $ nucypher alice --debug init --federated-only

    after the PR the syntax would be 

        $ nucypher alice init --debug --federated-only

    Pros:
    - helps avoid code duplication (for option definition and processing).
    - helps user discover these options in `--help`. That is, if before, in order to find out about `--debug`, one would have to call `nucypher --help` in addition to `nucypher alice --help`, now just `nucypher alice --help` will be enough - all the options will be there.

- A console output emitter is created only once (in `NucypherClickConfig`) and propagated to all classes/functions that need it.

- All `click.echo()` and `click.secho()` calls are replaced with `emitter.echo()` calls, so that it can control that output too.

- Instead of dispatching by keyword arguments in `emitter()`, specialized methods are used (`banner()`, `message()`, `ipc()`, `echo()`).

- Output trapping in emitters was removed, since it did not seem to be used anywhere.

- Added `--log-level` option from PR #1095 

- `--verbosity` and `--quiet` now govern console output only (**not** console observer for logs). The output shown with `--quiet` on should remain the same as before, `--verbosity` currently only sets the state of the emitter - actually using it is a matter for another PR. Probably enough to close issue #1018

- **NOTE:** before, when `--quiet` was on, logs were written to text file, but not to JSON file. Not sure if it was an omission or a conscious design decision. Now both JSON and text logs are turned on or off together, it can be rolled back.

- Parsing boolean envvars in `NucypherClickConfig` more rigorously using `strtobool()`.

- Added specific options `--console-logs/--no-console-logs`, `--file-logs/--no-file-logs` and `--sentry-logs/--no-sentry-logs` to override environment variables without resorting to `--debug`. Also made option description slightly more detailed.

TODO (may be better to leave for another PR):

- Add `--no-fun` for turning off banners? 

- Instead of specifying color in `echo()` and `message()`, use only semantic markup and leave colorizing to the emitter.

- Go through `emitter.message()` and `emitter.echo()` calls and decide which verbosity levels they should have.

To decide (probably for another PR too):

- What to do with a few remaining `click.secho()` and `print()` which lie beyond the scope of `NucypherClickConfig`

- `characters/control/controllers.py` still creates independent emitters; need to figure out if it is really necessary, and if not, how to propagate the main emitter there
