### PR TITLE
"Resume" and single-contract deployments via CLI.

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -218,7 +218,7 @@ class DeployerActor(NucypherTokenActor):
         return Deployer
 
     @staticmethod
-    def __collect_deployment_secret(deployer) -> str:
+    def collect_deployment_secret(deployer) -> str:
         secret = click.prompt(f'Enter {deployer.contract_name} Deployment Secret',
                               hide_input=True,
                               confirmation_prompt=True)
@@ -227,7 +227,7 @@ class DeployerActor(NucypherTokenActor):
     def collect_deployment_secrets(self) -> dict:
         secrets = dict()
         for deployer in self.upgradeable_deployer_classes:
-            secrets[deployer.contract_name] = self.__collect_deployment_secret(deployer)
+            secrets[deployer.contract_name] = self.collect_deployment_secret(deployer)
         return secrets
 
     def deploy_contract(self,

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -160,6 +160,7 @@ class Web3Client:
         if not self.is_local:
             return self.unlock_account(address, password)
 
+    @property
     def is_connected(self):
         return self.w3.isConnected()
 
@@ -178,8 +179,12 @@ class Web3Client:
         self.w3.middleware_onion.inject(middleware, **kwargs)
 
     @property
-    def chain_id(self) -> str:
-        return self.w3.net.version
+    def chain_id(self) -> str:  # TODO : Make this return an integer?
+        return str(int(self.w3.eth.chainId, 16))
+
+    @property
+    def net_version(self) -> str:  # TODO : Make this return an integer?
+        return str(self.w3.net.version)
 
     def get_contract(self, **kwargs):
         return self.w3.eth.contract(**kwargs)
@@ -243,8 +248,6 @@ class Web3Client:
             check_for_timeout(t=120)
 
         while self.syncing:
-
-            # current =
             self.log.info(f"Syncing {self.syncing['currentBlock']}/{self.syncing['highestBlock']}")
             time.sleep(5)
 
@@ -257,9 +260,6 @@ class Web3Client:
         eth-tester signing interface to do so.
         """
         return self.w3.eth.sign(account, data=message)
-
-    def sign_transaction(self, transaction: dict) -> bytes:
-        raise NotImplementedError
 
 
 class GethClient(Web3Client):
@@ -394,7 +394,7 @@ class NuCypherGethProcess(LoggingMixin, BaseGethProcess):
     def provider_uri(self, scheme: str = None) -> str:
         if not scheme:
             scheme = self.IPC_PROTOCOL
-        if scheme == 'file':
+        if scheme in ('file', 'ipc'):
             location = self.ipc_path
         elif scheme in ('http', 'ws'):
             location = f'{self.rpc_host}:{self.rpc_port}'

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -318,7 +318,7 @@ class BlockchainInterface:
             payload = {}
 
         nonce = self.client.w3.eth.getTransactionCount(sender_address)
-        payload.update({'chainId': int(self.client.chain_id),
+        payload.update({'chainId': int(self.client.net_version),
                         'nonce': nonce,
                         'from': sender_address,
                         'gasPrice': self.client.gas_price,

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -455,6 +455,7 @@ class BlockchainInterface:
 
 class BlockchainDeployerInterface(BlockchainInterface):
 
+    TIMEOUT = 600  # seconds
     _contract_factory = Contract
 
     class NoDeployerAddress(RuntimeError):

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -206,7 +206,6 @@ def deploy(action,
         #
         # Stage Deployment
         #
-
         secrets = deployer.collect_deployment_secrets()
 
         click.clear()

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -26,6 +26,7 @@ from nucypher.cli.types import (
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @click.option('--quiet', '-Q', help="Disable logging", is_flag=True)
 @click.option('--hw-wallet/--no-hw-wallet', default=False)  # TODO: Make True or deprecate.
+@click.option('--sync/--no-sync', default=True)
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--poa', help="Inject POA middleware", is_flag=True)
 @click.option('--offline', help="Operate in offline mode", is_flag=True)
@@ -55,6 +56,7 @@ def stake(click_config,
           poa,
           registry_filepath,
           provider_uri,
+          sync,
 
           # Stake
           staking_address,

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -119,11 +119,6 @@ class TransactingPower(CryptoPowerUp):
         Instantiates a TransactingPower for the given checksum_address.
         """
         self.blockchain = blockchain
-        if blockchain.is_connected:
-            self.client = blockchain.client
-        else:
-            self.client = NO_BLOCKCHAIN_CONNECTION
-
         self.__account = account
 
         # TODO: Is there a better way to design this Flag?
@@ -147,32 +142,30 @@ class TransactingPower(CryptoPowerUp):
 
     @property
     def account(self) -> str:
-        # TODO: Implement HD Path here?
         return self.__account
 
     def activate(self, password: str = None):
         """Be Consumed"""
-        self.blockchain.connect()
-        self.client = self.blockchain.client       # Connect
+        self.blockchain.connect(sync_now=False)
         self.unlock_account(password=password or self.__password)
-        self.blockchain.transacting_power = self   # Attach
-        self.__password = None                     # Discard
+        self.__password = None
+        self.blockchain.transacting_power = self
 
     def lock_account(self):
         if self.device:
-            # TODO: Force Disconnect Devices
+            # TODO: Force Disconnect Devices?
             pass
         else:
-            _result = self.client.lock_account(address=self.account)
+            _result = self.blockchain.client.lock_account(address=self.account)
         self.__unlocked = False
 
     def unlock_account(self, password: str = None):
         if self.device:
             unlocked = True
         else:
-            if self.client is NO_BLOCKCHAIN_CONNECTION:
+            if self.blockchain.client is NO_BLOCKCHAIN_CONNECTION:
                 raise self.NoBlockchainConnection
-            unlocked = self.client.unlock_account(address=self.account, password=password)
+            unlocked = self.blockchain.client.unlock_account(address=self.account, password=password)
         self.__unlocked = unlocked
 
     def sign_message(self, message: bytes) -> bytes:
@@ -181,7 +174,7 @@ class TransactingPower(CryptoPowerUp):
         """
         if not self.is_unlocked:
             raise self.AccountLocked("Failed to unlock account {}".format(self.account))
-        signature = self.client.sign_message(account=self.account, message=message)
+        signature = self.blockchain.client.sign_message(account=self.account, message=message)
         return signature
 
     def sign_transaction(self, unsigned_transaction: dict) -> HexBytes:

--- a/tests/blockchain/eth/clients/test_mocked_clients.py
+++ b/tests/blockchain/eth/clients/test_mocked_clients.py
@@ -24,9 +24,10 @@ class MockGanacheProvider:
 
 
 class ChainIdReporter:
+
     # Support older and newer versions of web3 py in-test
     version = 5
-    chainID = 5
+    chainId = hex(5)
 
 
 #
@@ -36,6 +37,7 @@ class ChainIdReporter:
 class MockWeb3:
 
     net = ChainIdReporter
+    eth = ChainIdReporter
 
     def __init__(self, provider):
         self.provider = provider
@@ -44,10 +46,14 @@ class MockWeb3:
     def clientVersion(self):
         return self.provider.clientVersion
 
+    @property
+    def isConnected(self):
+        return lambda: True
 
 #
 # Mock Blockchain
 #
+
 
 class BlockchainInterfaceTestBase(BlockchainInterface):
 
@@ -96,7 +102,7 @@ def test_geth_web3_client():
     assert interface.client.backend == 'go1.7'
 
     assert interface.client.is_local is False
-    assert interface.client.chain_id == 5
+    assert interface.client.chain_id == '5'  # Hardcoded above
 
 
 def test_parity_web3_client():

--- a/tests/blockchain/eth/entities/actors/test_stakeholder.py
+++ b/tests/blockchain/eth/entities/actors/test_stakeholder.py
@@ -52,7 +52,7 @@ def test_software_stakeholder_configuration(testerchain,
 
 def test_initialize_stake_with_existing_account(software_stakeholder, stake_value, token_economics):
 
-    # There is one staker and one stake.
+    # There are no stakes.
     assert len(software_stakeholder.stakers) == 0
     assert len(software_stakeholder.stakes) == 0
 

--- a/tests/characters/test_crypto_characters_and_their_powers.py
+++ b/tests/characters/test_crypto_characters_and_their_powers.py
@@ -129,7 +129,6 @@ def test_character_transacting_power_signing(testerchain, agency):
                                          password=INSECURE_DEVELOPMENT_PASSWORD,
                                          account=eth_address)
 
-    assert testerchain.transacting_power != transacting_power
     signer._crypto_power.consume_power_up(transacting_power)
 
     # Retrieve the power up

--- a/tests/crypto/test_powers.py
+++ b/tests/crypto/test_powers.py
@@ -75,7 +75,6 @@ def test_transacting_power_sign_transaction(testerchain):
 
     # Sign
     power.activate()
-    assert power.is_active is True
     assert power.is_unlocked is True
     signed_transaction = power.sign_transaction(unsigned_transaction=transaction_dict)
 
@@ -111,7 +110,7 @@ def test_transacting_power_sign_agent_transaction(testerchain, agency):
     token_agent = NucypherTokenAgent(blockchain=testerchain)
     contract_function = token_agent.contract.functions.approve(testerchain.etherbase_account, 100)
 
-    payload = {'chainId': int(testerchain.client.chain_id),
+    payload = {'chainId': int(testerchain.client.net_version),
                'nonce': testerchain.client.w3.eth.getTransactionCount(testerchain.etherbase_account),
                'from': testerchain.etherbase_account,
                'gasPrice': testerchain.client.gas_price}


### PR DESCRIPTION
Based on #1130 

Uses Agency and Deployer methods to deploy a single contract by it's registry name form the CLI.  This may act as a good secondary means of managing failed deployments as part of an automated series.