### PR TITLE
fixed emitter error for bob

### DIFF
--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -143,7 +143,7 @@ def bob(click_config,
             rpc_controller.start()
             return
 
-        click_config.emitter(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
+        click_config.emit(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
         bob_encrypting_key = bytes(BOB.public_keys(DecryptingPower)).hex()
         click_config.emit(message=f"Bob Encrypting Key {bob_encrypting_key}", color="blue", bold=True)
 


### PR DESCRIPTION
in line 146 of bob.py

it says:
`click_config.emitter(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)`

this line was throwing error when I tried to run: 
`nucypher bob run -d -F --teacher-uri localhost:10151 --http-port 3002`


i think it should be: 
`click_config.emit(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)`
