### PR TITLE
Fix for issue #1138

### DIFF
--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -143,12 +143,12 @@ def bob(click_config,
             rpc_controller.start()
             return
 
-        click_config.emitter(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
+        click_config.emit(message=f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
         bob_encrypting_key = bytes(BOB.public_keys(DecryptingPower)).hex()
         click_config.emit(message=f"Bob Encrypting Key {bob_encrypting_key}", color="blue", bold=True)
 
         # Start Controller
-        controller = BOB.make_control_transport()
+        controller = BOB.make_web_controller(crash_on_error=click_config.debug)
         BOB.log.info('Starting HTTP Character Web Controller')
         return controller.start(http_port=http_port, dry_run=dry_run)
 


### PR DESCRIPTION
Fix for issue #1138 , by replacing `make_control_transport()` with the new function. Also replaced the emitter with emit at Line:146 of nucypher/cli/characters/bob.py