### PR TITLE
Minor CLI bug fixes for nucypher stake and nucypher ursula

### DIFF
--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -166,10 +166,12 @@ def ursula(click_config,
             blockchain.connect(fetch_registry=False)
 
             if not staker_address:
-                staker_address = select_client_account(emitter=emitter, blockchain=blockchain)
+                prompt = "Select staker account"
+                staker_address = select_client_account(emitter=emitter, blockchain=blockchain, prompt=prompt)
 
             if not worker_address:
-                worker_address = select_client_account(emitter=emitter, blockchain=blockchain)
+                prompt = "Select worker account"
+                worker_address = select_client_account(emitter=emitter, blockchain=blockchain, prompt=prompt)
 
         if not config_root:                         # Flag
             config_root = click_config.config_file  # Envvar

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -103,9 +103,7 @@ def ursula(click_config,
     save-metadata     Manually write node metadata to disk without running
     forget            Forget all known nodes.
     destroy           Delete Ursula node configuration.
-    stake             Manage stakes for this node.
     confirm-activity  Manually confirm-activity for the current period.
-    collect-reward    Withdraw staking reward.
 
     """
 

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -339,10 +339,13 @@ def ursula(click_config,
         return
 
     elif action == 'confirm-activity':
-        if not URSULA.stakes:
-            emitter.echo(f"There are no active stakes for {URSULA.checksum_address}")
-            return
-        URSULA.staking_agent.confirm_activity(node_address=URSULA.checksum_address)
+        receipt = URSULA.confirm_activity()
+
+        current_period = URSULA.staking_agent.get_current_period()
+        txhash = receipt["transactionHash"].hex()
+
+        emitter.echo(f'\nActivity confirmed for period #{current_period} !!', bold=True, color='blue')
+        emitter.echo(f'Receipt: {txhash}')
         return
 
     else:

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -23,6 +23,7 @@ from twisted.internet import stdio
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.registry import EthereumContractRegistry
+from nucypher.blockchain.eth.utils import datetime_at_period
 from nucypher.characters.banners import URSULA_BANNER
 from nucypher.cli import actions, painting
 from nucypher.cli.actions import get_password, select_client_account
@@ -341,10 +342,12 @@ def ursula(click_config,
     elif action == 'confirm-activity':
         receipt = URSULA.confirm_activity()
 
-        current_period = URSULA.staking_agent.get_current_period()
+        confirmed_period = URSULA.staking_agent.get_current_period() + 1
         txhash = receipt["transactionHash"].hex()
+        date = datetime_at_period(period=confirmed_period)
 
-        emitter.echo(f'\nActivity confirmed for period #{current_period} !!', bold=True, color='blue')
+        emitter.echo(f'\nActivity confirmed for period #{confirmed_period} '
+                     f'(starting at {date}) !!', bold=True, color='blue')
         emitter.echo(f'Receipt: {txhash}')
         return
 

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -50,8 +50,7 @@ def paint_new_installation_help(emitter, new_configuration):
 
     # Ursula
     elif character_name == 'ursula' and not new_configuration.federated_only:
-        suggested_staking_command = f'nucypher ursula stake'
-        how_to_stake_message = f"\nTo initialize a NU stake, run '{suggested_staking_command}' or"
+        how_to_stake_message = f"\nIf you haven't done it already, initialize a NU stake with 'nucypher stake' or"
         emitter.message(how_to_stake_message, color='green')
 
     # Everyone: Give the use a suggestion as to what to do next

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -66,6 +66,23 @@ def stake(click_config,
           staking_reward,
 
           ) -> None:
+    """
+        Manage stakes and other staker-related operations
+
+        \b
+        Actions
+        -------------------------------------------------
+        \b
+        new-stakeholder  Create a new stakeholder configuration
+        list             List active stakes for current stakeholder
+        accounts         Show ETH and NU balances for stakeholder's accounts
+        sync             Synchronize stake data with on-chain information
+        set-worker       Bound a worker to a staker
+        init             Create a new stake
+        divide           Create a new stake from part of an existing one
+        collect-reward   Withdraw staking reward
+
+    """
 
     # Banner
     emitter = click_config.emitter

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -78,6 +78,7 @@ def stake(click_config,
         accounts         Show ETH and NU balances for stakeholder's accounts
         sync             Synchronize stake data with on-chain information
         set-worker       Bound a worker to a staker
+        detach-worker    Detach worker currently bound to a staker
         init             Create a new stake
         divide           Create a new stake from part of an existing one
         collect-reward   Withdraw staking reward
@@ -140,13 +141,18 @@ def stake(click_config,
         emitter.echo("OK!", color='green')
         return  # Exit
 
-    elif action == 'set-worker':
+    elif action in ('set-worker', 'detach-worker'):
 
         if not staking_address:
             staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).owner_address
 
-        if not worker_address:
-            worker_address = click.prompt("Enter worker address", type=EIP55_CHECKSUM_ADDRESS)
+        if action == 'set-worker':
+            if not worker_address:
+                worker_address = click.prompt("Enter worker address", type=EIP55_CHECKSUM_ADDRESS)
+        elif action == 'detach-worker':
+            if worker_address:
+                raise click.BadOptionUsage(message="detach-worker cannot be used together with --worker-address option")
+            worker_address = BlockchainInterface.NULL_ADDRESS
 
         password = None
         if not hw_wallet:

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -279,4 +279,7 @@ def stake(click_config,
                                     staking=staking_reward,
                                     policy=policy_reward)
 
+    else:
+        ctx = click.get_current_context()
+        click.UsageError(message=f"Unknown action '{action}'.", ctx=ctx).show()
     return  # Exit

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -499,3 +499,34 @@ def test_collect_rewards_integration(click_runner,
 
     # The burner wallet has the reward ethers
     assert staker.token_agent.get_balance(address=staker_address)
+
+
+def test_stake_detach_worker(click_runner,
+                             testerchain,
+                             manual_staker,
+                             manual_worker,
+                             stakeholder_configuration_file_location):
+
+    staker = Staker(is_me=True,
+                    checksum_address=manual_staker,
+                    blockchain=testerchain)
+
+    assert staker.worker_address == manual_worker
+
+    init_args = ('stake', 'detach-worker',
+                 '--config-file', stakeholder_configuration_file_location,
+                 '--staking-address', manual_staker,
+                 '--force')
+
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=user_input,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    staker = Staker(is_me=True,
+                    checksum_address=manual_staker,
+                    blockchain=testerchain)
+
+    assert not staker.worker_address


### PR DESCRIPTION
- Fix #1162: Bad suggestion in `nucypher ursula init`
- Fix #1160: Better account hint in `nucypher ursula init`
- Fix #1158: Help text for `nucypher stake`
- Fix #1142: Fail on `nucypher stake <bad-action>`
- Fix #1164: Fix `nucypher ursula confirm-activity`
- Implement `nucypher stake detach-worker`: Useful in case the staker wants to remove her current relationship with her worker (e.g., the worker has been compromised, the worker is in a corrupt setting, etc.)