### PR TITLE
CLI cleanup (vol. 2): Making CLI work with local non-dev private chain

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -930,11 +930,11 @@ class StakeHolder(BaseConfiguration):
     def set_worker(self, staker_address: str, worker_address: str, password: str = None):
         self.attach_transacting_power(checksum_address=staker_address, password=password)
         staker = self.get_active_staker(address=staker_address)
-        result = self.staking_agent.set_worker(staker_address=staker.checksum_address,
+        receipt = self.staking_agent.set_worker(staker_address=staker.checksum_address,
                                                worker_address=worker_address)
 
         self.to_configuration_file(override=True)
-        return result
+        return receipt
 
     def initialize_stake(self,
                          amount: NU,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -269,7 +269,8 @@ class DeployerActor(NucypherTokenActor):
         return user_escrow_deployer
 
     def deploy_network_contracts(self,
-                                 secrets: dict, interactive: bool = True,
+                                 secrets: dict,
+                                 interactive: bool = True,
                                  emitter: StdoutEmitter = None) -> dict:
         """
 
@@ -286,6 +287,9 @@ class DeployerActor(NucypherTokenActor):
         gas_limit = None  # TODO: Gas management
 
         # NuCypherToken
+        if emitter:
+            emitter.echo(f"\nDeploying {NUCYPHER_TOKEN_CONTRACT_NAME} ...")
+
         token_receipts, token_deployer = self.deploy_contract(contract_name=NUCYPHER_TOKEN_CONTRACT_NAME,
                                                               gas_limit=gas_limit)
 
@@ -296,10 +300,14 @@ class DeployerActor(NucypherTokenActor):
                                       emitter=emitter)
 
         deployment_receipts[NUCYPHER_TOKEN_CONTRACT_NAME] = token_receipts
-        if interactive:
-            click.pause(info="Press any key to continue")
 
         for contract_deployer in self.upgradeable_deployer_classes:
+            if interactive:
+                click.pause(info="Press any key to continue")
+
+            if emitter:
+                emitter.echo(f"\nDeploying {contract_deployer.contract_name} ...")
+
             receipts, deployer = self.deploy_contract(contract_name=contract_deployer.contract_name,
                                                       plaintext_secret=secrets[contract_deployer.contract_name],
                                                       gas_limit=gas_limit)
@@ -310,8 +318,6 @@ class DeployerActor(NucypherTokenActor):
                                           contract_address=deployer.contract_address,
                                           emitter=emitter)
             deployment_receipts[contract_deployer.contract_name] = receipts
-            if interactive:
-                click.pause(info="Press any key to continue")
 
         return deployment_receipts
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -788,14 +788,14 @@ class StakeHolder(BaseConfiguration):
         return payload
 
     @classmethod
-    def from_configuration_file(cls, filepath: str = None, **overrides) -> 'StakeHolder':
+    def from_configuration_file(cls, filepath: str = None, sync_now: bool = True, **overrides) -> 'StakeHolder':
         filepath = filepath or cls.default_filepath()
         payload = cls._read_configuration_file(filepath=filepath)
 
         # Sub config
         blockchain_payload = payload.pop('blockchain')
         blockchain = BlockchainInterface.from_dict(payload=blockchain_payload)
-        blockchain.connect()  # TODO: Leave this here?
+        blockchain.connect(sync_now=sync_now)  # TODO: Leave this here?
 
         payload.update(dict(blockchain=blockchain))
 

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -281,6 +281,10 @@ class GethClient(Web3Client):
             # TODO: Is there a more formalized check here for geth --dev mode?
             # Geth --dev accounts are unlocked by default.
             return True
+        debug_message = f"Unlocking account {address}"
+        if password is None:
+            debug_message += " without a password."
+        self.log.debug(debug_message)
         return self.w3.geth.personal.unlockAccount(address, password)
 
     def sign_transaction(self, transaction: dict) -> bytes:

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -255,7 +255,7 @@ class BlockchainInterface:
 
         # Establish contact with NuCypher contracts
         if not self.registry:
-            self._configure_registry()
+            self._configure_registry(fetch_registry=fetch_registry)
 
         return self.is_connected
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -890,14 +890,14 @@ class Ursula(Teacher, Character, Worker):
             #
             if not federated_only:
 
-                # Access staking node via node's transacting keys
+                # Prepare a TransactingPower from worker node's transacting keys
                 transacting_power = TransactingPower(account=worker_address,
                                                      password=client_password,
                                                      blockchain=self.blockchain)
                 self._crypto_power.consume_power_up(transacting_power)
 
-                # Use blockchain power to substantiate stamp
-                self.substantiate_stamp(client_password=password)
+                # Use this power to substantiate the stamp
+                self.substantiate_stamp()
 
                 Worker.__init__(self,
                                 is_me=is_me,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -881,7 +881,7 @@ class Ursula(Teacher, Character, Worker):
         # Self-Ursula
         #
         # TODO: Better handle ephemeral staking self ursula <-- Is this still relevant?
-
+        self.log.debug(f"URSULA worker: {worker_address}, staker {checksum_address}")
         if is_me is True:  # TODO: #340
             self._stored_treasure_maps = dict()
 
@@ -889,7 +889,6 @@ class Ursula(Teacher, Character, Worker):
             # Ursula is a Decentralized Worker
             #
             if not federated_only:
-
                 # Prepare a TransactingPower from worker node's transacting keys
                 transacting_power = TransactingPower(account=worker_address,
                                                      password=client_password,
@@ -898,6 +897,8 @@ class Ursula(Teacher, Character, Worker):
 
                 # Use this power to substantiate the stamp
                 self.substantiate_stamp()
+                self.log.debug(f"Created decentralized identity evidence: {self.decentralized_identity_evidence[:10].hex()}")
+                decentralized_identity_evidence = self.decentralized_identity_evidence
 
                 Worker.__init__(self,
                                 is_me=is_me,
@@ -969,17 +970,12 @@ class Ursula(Teacher, Character, Worker):
         certificate_filepath = self._crypto_power.power_ups(TLSHostingPower).keypair.certificate_filepath
         certificate = self._crypto_power.power_ups(TLSHostingPower).keypair.certificate
         Teacher.__init__(self,
-                         password=password,
                          domains=domains,
                          certificate=certificate,
                          certificate_filepath=certificate_filepath,
                          interface_signature=interface_signature,
                          timestamp=timestamp,
                          decentralized_identity_evidence=decentralized_identity_evidence,
-
-                         # TODO: #1091 When is_me and not federated_only, the stamp is substantiated twice
-                         worker_address=worker_address,
-                         substantiate_immediately=is_me and not federated_only,
                          )
 
         #

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -67,10 +67,10 @@ class UnknownIPAddress(RuntimeError):
 
 
 @validate_checksum_address
-def get_client_password(checksum_address) -> str:
+def get_client_password(checksum_address: str) -> str:
     prompt = f"Enter password to unlock account {checksum_address}"
-    keyring_password = click.prompt(prompt, hide_input=True)
-    return keyring_password
+    client_password = click.prompt(prompt, hide_input=True)
+    return client_password
 
 
 def get_nucypher_password(confirm: bool = False, envvar="NUCYPHER_KEYRING_PASSWORD") -> str:

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -343,7 +343,7 @@ def ursula(click_config,
         date = datetime_at_period(period=confirmed_period)
 
         emitter.echo(f'\nActivity confirmed for period #{confirmed_period} '
-                     f'(starting at {date}) !!', bold=True, color='blue')
+                     f'(starting at {date})', bold=True, color='blue')
         emitter.echo(f'Receipt: {txhash}')
         return
 

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -26,7 +26,11 @@ from nucypher.blockchain.eth.registry import EthereumContractRegistry
 from nucypher.blockchain.eth.utils import datetime_at_period
 from nucypher.characters.banners import URSULA_BANNER
 from nucypher.cli import actions, painting
-from nucypher.cli.actions import get_nucypher_password, select_client_account
+from nucypher.cli.actions import (
+    get_nucypher_password,
+    select_client_account,
+    get_client_password
+)
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.processes import UrsulaCommandProtocol
 from nucypher.cli.types import (
@@ -247,13 +251,18 @@ def ursula(click_config,
     #
     # Make Ursula
     #
-
+    # TODO: OH MY INDEED
+    client_password = None
+    if not ursula_config.federated_only:
+        if not dev and not click_config.json_ipc:
+            client_password = get_client_password(checksum_address=ursula_config.worker_address)
     URSULA = actions.make_cli_character(character_config=ursula_config,
                                         click_config=click_config,
                                         min_stake=min_stake,
                                         teacher_uri=teacher_uri,
                                         dev=dev,
-                                        lonely=lonely)
+                                        lonely=lonely,
+                                        client_password=client_password)
 
     #
     # Authenticated Action Switch

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -113,7 +113,7 @@ def deploy(action,
         # TODO: Need a way to detect a geth--dev registry filepath here. (then deprecate the --dev flag)
         registry_filepath = os.path.join(DEFAULT_CONFIG_ROOT, 'dev_contract_registry.json')
     registry = EthereumContractRegistry(registry_filepath=registry_filepath)
-    emitter.echo(f"Using contract registry filepath {registry_filepath}")
+    emitter.echo(f"Using contract registry filepath {registry.filepath}")
 
     #
     # Connect to Blockchain

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -244,11 +244,17 @@ def deploy(action,
 
     elif action == "transfer":
         token_agent = NucypherTokenAgent(blockchain=blockchain)
-        click.confirm(f"Transfer {amount} from {token_agent.contract_address} to {recipient_address}?", abort=True)
-        txhash = token_agent.transfer(amount=amount,
-                                      sender_address=token_agent.contract_address,
-                                      target_address=recipient_address)
-        emitter.echo(f"OK | {txhash}")
+        missing_options = list()
+        if recipient_address is None:
+            missing_options.append("--recipient-address")
+        if amount is None:
+            missing_options.append("--amount")
+        if missing_options:
+            raise click.BadOptionUsage(f"Need {' and '.join(missing_options)} to transfer tokens.")
+
+        click.confirm(f"Transfer {amount} from {deployer_address} to {recipient_address}?", abort=True)
+        receipt = token_agent.transfer(amount=amount, sender_address=deployer_address, target_address=recipient_address)
+        emitter.echo(f"OK | Receipt: {receipt['transactionHash'].hex()}")
         return  # Exit
 
     else:

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -132,7 +132,9 @@ def deploy(action,
 
     # Verify Address & collect password
     if not deployer_address:
-        deployer_address = select_client_account(emitter=emitter, blockchain=blockchain)
+        prompt = "Select deployer account"
+        deployer_address = select_client_account(emitter=emitter, blockchain=blockchain, prompt=prompt)
+
     if not force:
         click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
 
@@ -166,6 +168,8 @@ def deploy(action,
         return  # Exit
 
     elif action == 'rollback':
+        if not contract_name:
+            raise click.BadArgumentUsage(message="--contract-name is required when using --rollback")
         existing_secret = click.prompt('Enter existing contract upgrade secret', hide_input=True)
         new_secret = click.prompt('Enter new contract upgrade secret', hide_input=True, confirmation_prompt=True)
         DEPLOYER.rollback_contract(contract_name=contract_name,

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -337,4 +337,3 @@ def paint_deployment_delay(emitter, delay: int = 3) -> None:
     for i in range(delay)[::-1]:
         emitter.echo(f"{i}...", color='yellow')
         time.sleep(1)
-    emitter.echo(f"Deploying...", bold=True)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -201,7 +201,8 @@ Active Staking Ursulas ... {ursulas}
 
 
 def paint_staged_stake(emitter,
-                       ursula,
+                       stakeholder,
+                       staking_address,
                        stake_value,
                        duration,
                        start_period,
@@ -215,8 +216,8 @@ def paint_staged_stake(emitter,
     emitter.echo(f"\n{'=' * 30} STAGED STAKE {'=' * 30}", bold=True)
 
     emitter.echo(f"""
-{ursula}
-~ Chain      -> ID # {ursula.blockchain.client.chain_id} | {ursula.blockchain.client.chain_name}
+Staking address: {staking_address}
+~ Chain      -> ID # {stakeholder.blockchain.client.chain_id} | {stakeholder.blockchain.client.chain_name}
 ~ Value      -> {stake_value} ({Decimal(int(stake_value)):.2E} NuNits)
 ~ Duration   -> {duration} Days ({duration} Periods)
 ~ Enactment  -> {datetime_at_period(period=start_period)} (period #{start_period})
@@ -276,21 +277,23 @@ def paint_stakes(emitter, stakes):
 
 
 def paint_staged_stake_division(emitter,
-                                ursula,
+                                stakeholder,
                                 original_stake,
                                 target_value,
                                 extension):
 
     new_end_period = original_stake.end_period + extension
     new_duration = new_end_period - original_stake.start_period
+    staking_address = original_stake.checksum_address
 
     division_message = f"""
-{ursula}
+Staking address: {staking_address}
 ~ Original Stake: {prettify_stake(stake=original_stake, index=None)}
 """
 
     paint_staged_stake(emitter=emitter,
-                       ursula=ursula,
+                       stakeholder=stakeholder,
+                       staking_address=staking_address,
                        stake_value=target_value,
                        duration=new_duration,
                        start_period=original_stake.start_period,

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -47,13 +47,13 @@ def paint_new_installation_help(emitter, new_configuration):
     if character_name == 'felix':
         suggested_db_command = 'nucypher felix createdb'
         how_to_proceed_message = f'\nTo initialize a new faucet database run:'
-        emitter.message(how_to_proceed_message, color='green')
-        emitter.message(f'\n\'{suggested_db_command}\'', color='green')
+        emitter.echo(how_to_proceed_message, color='green')
+        emitter.echo(f'\n\'{suggested_db_command}\'', color='green')
 
     # Ursula
     elif character_name == 'ursula' and not new_configuration.federated_only:
         how_to_stake_message = f"\nIf you haven't done it already, initialize a NU stake with 'nucypher stake' or"
-        emitter.message(how_to_stake_message, color='green')
+        emitter.echo(how_to_stake_message, color='green')
 
     # Everyone: Give the use a suggestion as to what to do next
     vowels = ('a', 'e', 'i', 'o', 'u')
@@ -62,7 +62,7 @@ def paint_new_installation_help(emitter, new_configuration):
     suggested_command = f'nucypher {character_name} run'
     how_to_run_message = f"\nTo run {adjective} {character_name.capitalize()} node from the default configuration filepath run: \n\n'{suggested_command}'\n"
 
-    emitter.message(how_to_run_message.format(suggested_command), color='green')
+    emitter.echo(how_to_run_message.format(suggested_command), color='green')
 
 
 def build_fleet_state_status(ursula) -> str:

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -118,7 +118,8 @@ def stake(click_config,
     STAKEHOLDER = StakeHolder.from_configuration_file(filepath=config_file,
                                                       provider_uri=provider_uri,
                                                       registry_filepath=registry_filepath,
-                                                      offline=offline)
+                                                      offline=offline,
+                                                      sync_now=sync)
     #
     # Eager Actions
     #

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -68,12 +68,11 @@ def stake(click_config,
 
           ) -> None:
     """
-    Manage stakes and other staker-related operations
+    Manage stakes and other staker-related operations.
 
     \b
     Actions
     -------------------------------------------------
-    \b
     new-stakeholder  Create a new stakeholder configuration
     list             List active stakes for current stakeholder
     accounts         Show ETH and NU balances for stakeholder's accounts

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -98,10 +98,12 @@ def stake(click_config,
                                        message="--provider is required to create a new stakeholder.")
 
         registry = None
+        fetch_registry = True
         if registry_filepath:
             registry = EthereumContractRegistry(registry_filepath=registry_filepath)
+            fetch_registry = False
         blockchain = BlockchainInterface(provider_uri=provider_uri, registry=registry, poa=poa)
-        blockchain.connect()
+        blockchain.connect(sync_now=sync, fetch_registry=fetch_registry)
 
         new_stakeholder = StakeHolder(config_root=config_root,
                                       offline_mode=offline,

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -161,11 +161,11 @@ def stake(click_config,
         password = None
         if not hw_wallet and not STAKEHOLDER.blockchain.client.is_local:
             password = get_client_password(checksum_address=staking_address)
-        STAKEHOLDER.set_worker(staker_address=staking_address,
-                               password=password,
-                               worker_address=worker_address)
+        receipt = STAKEHOLDER.set_worker(staker_address=staking_address,
+                                         password=password,
+                                         worker_address=worker_address)
 
-        emitter.echo("OK!", color='green')
+        emitter.echo(f"OK | Receipt: {receipt['transactionHash'].hex()}", color='green')
         return  # Exit
 
     elif action == 'init':

--- a/nucypher/cli/stake.py
+++ b/nucypher/cli/stake.py
@@ -207,7 +207,8 @@ def stake(click_config,
 
         if not force:
             painting.paint_staged_stake(emitter=emitter,
-                                        ursula=STAKEHOLDER,
+                                        stakeholder=STAKEHOLDER,
+                                        staking_address=staking_address,
                                         stake_value=value,
                                         duration=duration,
                                         start_period=start_period,
@@ -256,7 +257,7 @@ def stake(click_config,
 
         if not force:
             painting.paint_staged_stake_division(emitter=emitter,
-                                                 ursula=STAKEHOLDER,
+                                                 stakeholder=STAKEHOLDER,
                                                  original_stake=current_stake,
                                                  target_value=value,
                                                  extension=extension)

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -128,9 +128,6 @@ class TransactingPower(CryptoPowerUp):
         self.__unlocked = False
         self.__activated = False
 
-    def __del__(self):
-        self.lock_account()
-
     @property
     def is_unlocked(self) -> bool:
         return self.__unlocked

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -873,15 +873,12 @@ class Teacher:
     __DEFAULT_MIN_SEED_STAKE = 0
 
     def __init__(self,
-                 worker_address: str,
                  domains: Set,
                  certificate: Certificate,
                  certificate_filepath: str,
                  interface_signature=NOT_SIGNED.bool_value(False),
                  timestamp=NOT_SIGNED,
                  decentralized_identity_evidence=NOT_SIGNED,
-                 substantiate_immediately=False,
-                 password=None,
                  ) -> None:
 
         #
@@ -913,10 +910,6 @@ class Teacher:
         self.verified_interface = False
         self.verified_node = False
         self.__worker_address = None
-
-        if substantiate_immediately:
-            # TODO: #1091 When is_me and not federated_only, the stamp is substantiated twice
-            self.substantiate_stamp(client_password=password)
 
     class InvalidNode(SuspiciousActivity):
         """Raised when a node has an invalid characteristic - stamp, interface, or address."""

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1149,9 +1149,8 @@ class Teacher:
                                                             signature=self.decentralized_identity_evidence)
         return self.__worker_address
 
-    def substantiate_stamp(self, client_password: str = None):
+    def substantiate_stamp(self):
         transacting_power = self._crypto_power.power_ups(TransactingPower)
-        transacting_power.unlock_account(password=client_password)  # TODO: #349
         signature = transacting_power.sign_message(message=bytes(self.stamp))
         self.__decentralized_identity_evidence = signature
         self.__worker_address = transacting_power.account

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -4,22 +4,20 @@ from random import SystemRandom
 from string import ascii_uppercase, digits
 
 import pytest
+from eth_utils import to_checksum_address
 
-from nucypher.blockchain.eth.actors import DeployerActor
 from nucypher.blockchain.eth.agents import (
     NucypherTokenAgent,
     StakingEscrowAgent,
     UserEscrowAgent,
     PolicyManagerAgent,
     AdjudicatorAgent,
-    Agency, EthereumContractAgent)
+    Agency,
+    EthereumContractAgent)
 from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainDeployerInterface
 from nucypher.blockchain.eth.registry import AllocationRegistry
 from nucypher.cli.deploy import deploy
-from nucypher.crypto.powers import TransactingPower
 
-# Prevents TesterBlockchain to be picked up by py.test as a test class
-from nucypher.utilities.sandbox.blockchain import TesterBlockchain as _TesterBlockchain
 from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,
     MOCK_REGISTRY_FILEPATH,
@@ -35,26 +33,6 @@ def generate_insecure_secret() -> str:
 
 PLANNED_UPGRADES = 4
 INSECURE_SECRETS = {v: generate_insecure_secret() for v in range(1, PLANNED_UPGRADES+1)}
-
-
-def make_testerchain():
-
-    # Create new blockchain
-    testerchain = _TesterBlockchain(eth_airdrop=True, free_transactions=False)
-
-    # Set the deployer address from a freshly created test account
-    testerchain.deployer_address = testerchain.etherbase_account
-    testerchain.transacting_power = TransactingPower(blockchain=testerchain, account=testerchain.etherbase_account)
-    return testerchain
-
-
-def pyevm_testerchain():
-    return 'tester://pyevm'
-
-
-def geth_poa_devchain():
-    _testerchain = make_testerchain()
-    return f'ipc://{_testerchain.provider.ipc_path}'
 
 
 def test_nucypher_deploy_contracts(click_runner,
@@ -131,6 +109,44 @@ def test_nucypher_deploy_contracts(click_runner,
     # This agent wasn't instantiated before, so we have to supply the blockchain
     blockchain = staking_agent.blockchain
     assert AdjudicatorAgent(blockchain=blockchain)
+
+
+def test_transfer_tokens(click_runner, mock_primary_registry_filepath):
+    #
+    # Setup
+    #
+
+    # Simulate "Reconnection"
+    real_attach_provider = BlockchainDeployerInterface._attach_provider
+    cached_blockchain = BlockchainDeployerInterface.reconnect()
+    registry = cached_blockchain.registry
+    assert registry.filepath == mock_primary_registry_filepath
+
+    def attach_cached_provider(interface, *args, **kwargs):
+        cached_provider = cached_blockchain.provider
+        real_attach_provider(interface, provider=cached_provider)
+
+    BlockchainDeployerInterface._attach_provider = attach_cached_provider
+
+    # Let's transfer some NU to a random stranger
+    recipient_address = to_checksum_address(os.urandom(20))
+
+    token_agent = NucypherTokenAgent()
+    assert token_agent.get_balance(address=recipient_address) == 0
+
+    command = ['transfer',
+               '--recipient-address', recipient_address,
+               '--amount', 42,
+               '--registry-infile', mock_primary_registry_filepath,
+               '--provider', TEST_PROVIDER_URI,
+               '--poa']
+
+    user_input = '0\n' + 'Y\n' + 'Y\n'
+    result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Check that the NU has arrived to the recipient
+    assert token_agent.get_balance(address=recipient_address) == 42
 
 
 def test_upgrade_contracts(click_runner, mock_primary_registry_filepath):
@@ -332,7 +348,6 @@ def test_rollback(click_runner, mock_primary_registry_filepath):
 
 def test_nucypher_deploy_allocation_contracts(click_runner,
                                               testerchain,
-                                              deploy_user_input,
                                               mock_primary_registry_filepath,
                                               mock_allocation_infile,
                                               token_economics):

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -161,7 +161,7 @@ def test_coexisting_configurations(click_runner,
                 '--interactive',
                 '--config-file', another_ursula_configuration_file_location)
 
-    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' * 2
     with pytest.raises(Teacher.DetachedWorker):
         # Worker init success, but unassigned.
         result = click_runner.invoke(nucypher_cli, run_args, input=user_input, catch_exceptions=False)

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -187,7 +187,7 @@ def test_stake_list(click_runner,
     assert str(stake_value) in result.output
 
 
-def test_ursula_divide_stakes(click_runner,
+def test_staker_divide_stakes(click_runner,
                               stakeholder_configuration_file_location,
                               token_economics,
                               manual_staker,
@@ -305,7 +305,7 @@ def test_ursula_run(click_runner,
                  '--dry-run',
                  '--config-file', custom_config_filepath)
 
-    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' * 2
     result = click_runner.invoke(nucypher_cli,
                                  init_args,
                                  input=user_input,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -529,7 +529,6 @@ def stakers(testerchain, agency, token_economics):
 @pytest.fixture(scope="module")
 def blockchain_ursulas(testerchain, stakers, ursula_decentralized_test_config):
 
-    # Leave out the last Ursula for manual stake testing
     _ursulas = make_decentralized_ursulas(blockchain=testerchain,
                                           ursula_config=ursula_decentralized_test_config,
                                           stakers_addresses=testerchain.stakers_accounts,


### PR DESCRIPTION
_Based on #1146._

Tested with a local private chain, but mocking "goerli" (chain ID 5) in order to pass as a public chain (i.e., not local). 
In case you want to replicate, this is [my genesis file](https://gist.github.com/cygnusv/12ccfa3ae559530efe65645ae8629cb9). I ran the geth node with the following params: `--networkid 5 --nodiscover --verbosity 5 --mine --minerthreads=1`

Steps followed:
```
# Deploy contracts

nucypher-deploy contracts --poa --provider file:///Users/david/dev/mi-genesis/geth.ipc


# Stakeholder

rm /Users/david/Library/Application\ Support/nucypher/stakeholder.json

nucypher stake new-stakeholder --provider ipc:///Users/david/dev/mi-genesis/geth.ipc  --poa --registry-filepath /Users/david/Library/Application\ Support/nucypher/contract_registry.json

# Fund staker

nucypher stake accounts --no-sync

nucypher-deploy transfer --poa --provider file:///Users/david/dev/mi-genesis/geth.ipc --amount 50000000000000000000000 --recipient-address 0xd590d3DD9070bc1155282F68A4577e6C364A7828

nucypher stake accounts --no-sync

# Create stake

nucypher stake init --no-sync

nucypher stake set-worker --no-sync
```