### PR TITLE
UX: Add the ability to provide progress during NuCypher contract deployments

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -288,13 +288,17 @@ class DeployerActor(NucypherTokenActor):
         for deployer_class in self.deployer_classes:
             total_deployment_transactions += deployer_class.number_of_deployment_transactions
 
-        with click.progressbar(length=total_deployment_transactions, label="Deploying Contracts") as bar:
+        first_iteration = True
+        with click.progressbar(length=total_deployment_transactions, label="Deployment progress") as bar:
+            bar.short_limit = 0
             for deployer_class in self.deployer_classes:
-                if interactive:
+                if interactive and not first_iteration:
                     click.pause(info="\nPress any key to continue")
 
                 if emitter:
                     emitter.echo(f"\nDeploying {deployer_class.contract_name} ...")
+                    bar._last_line = None
+                    bar.render_progress()
 
                 if deployer_class in self.standard_deployer_classes:
                     receipts, deployer = self.deploy_contract(contract_name=deployer_class.contract_name,
@@ -313,6 +317,7 @@ class DeployerActor(NucypherTokenActor):
                                               emitter=emitter)
 
                 deployment_receipts[deployer_class.contract_name] = receipts
+                first_iteration = False
 
         return deployment_receipts
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -284,11 +284,11 @@ class DeployerActor(NucypherTokenActor):
         gas_limit = None  # TODO: Gas management
 
         # deploy contracts
-        total_deployment_steps = 0
+        total_deployment_transactions = 0
         for deployer_class in self.deployer_classes:
-            total_deployment_steps += deployer_class.num_deployment_steps
+            total_deployment_transactions += deployer_class.number_of_deployment_transactions
 
-        with click.progressbar(length=total_deployment_steps, label="Deploying Contracts") as bar:
+        with click.progressbar(length=total_deployment_transactions, label="Deploying Contracts") as bar:
             for deployer_class in self.deployer_classes:
                 if interactive:
                     click.pause(info="\nPress any key to continue")

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -24,7 +24,7 @@ from web3.contract import Contract
 
 from nucypher.blockchain.eth.constants import DISPATCHER_CONTRACT_NAME, STAKING_ESCROW_CONTRACT_NAME, \
     POLICY_MANAGER_CONTRACT_NAME, USER_ESCROW_CONTRACT_NAME, USER_ESCROW_PROXY_CONTRACT_NAME, \
-    LIBRARY_LINKER_CONTRACT_NAME, ADJUDICATOR_CONTRACT_NAME
+    LIBRARY_LINKER_CONTRACT_NAME, ADJUDICATOR_CONTRACT_NAME, NUCYPHER_TOKEN_CONTRACT_NAME
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.registry import AllocationRegistry
@@ -124,7 +124,7 @@ class EthereumContractAgent:
 
 class NucypherTokenAgent(EthereumContractAgent, metaclass=Agency):
 
-    registry_contract_name = "NuCypherToken"
+    registry_contract_name = NUCYPHER_TOKEN_CONTRACT_NAME
 
     def get_balance(self, address: str = None) -> int:
         """Get the balance of a token address, or of this contract address"""

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -14,7 +14,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-import time
 from typing import Tuple, Dict
 
 from constant_sorrow.constants import CONTRACT_NOT_DEPLOYED, NO_DEPLOYER_CONFIGURED, NO_BENEFICIARY
@@ -172,7 +171,6 @@ class NucypherTokenDeployer(ContractDeployer):
                                                                        gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         self._contract = contract
         return {'txhash': deployment_receipt}
@@ -202,7 +200,7 @@ class DispatcherDeployer(ContractDeployer):
         dispatcher_contract, receipt = self.blockchain.deploy_contract(gas_limit=gas_limit, *args)
         if progress:
             progress.update(1)
-            time.sleep(3)
+
         self._contract = dispatcher_contract
         return {'deployment': receipt}
 
@@ -297,7 +295,6 @@ class StakingEscrowDeployer(ContractDeployer):
         the_escrow_contract, deploy_receipt = self._deploy_essential(gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         # 2 - Deploy the dispatcher used for updating this contract #
         dispatcher_deployer = DispatcherDeployer(blockchain=self.blockchain,
@@ -307,7 +304,6 @@ class StakingEscrowDeployer(ContractDeployer):
         dispatcher_deploy_receipt = dispatcher_deployer.deploy(secret_hash=secret_hash, gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         # Cache the dispatcher contract
         dispatcher_contract = dispatcher_deployer.contract
@@ -329,7 +325,6 @@ class StakingEscrowDeployer(ContractDeployer):
                                                           payload=origin_args)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         # Make a call.
         _escrow_balance = self.token_agent.get_balance(address=the_escrow_contract.address)
@@ -342,7 +337,6 @@ class StakingEscrowDeployer(ContractDeployer):
                                                         payload=origin_args)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         # Gather the transaction hashes
         deployment_receipts = {'deploy': deploy_receipt,
@@ -442,7 +436,6 @@ class PolicyManagerDeployer(ContractDeployer):
         policy_manager_contract, deploy_receipt = self._deploy_essential(gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         proxy_deployer = self.__proxy_deployer(blockchain=self.blockchain,
                                                target_contract=policy_manager_contract,
@@ -451,7 +444,6 @@ class PolicyManagerDeployer(ContractDeployer):
         proxy_deploy_receipt = proxy_deployer.deploy(secret_hash=secret_hash, gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         # Cache the dispatcher contract
         proxy_contract = proxy_deployer.contract
@@ -471,7 +463,6 @@ class PolicyManagerDeployer(ContractDeployer):
                                                                       payload=tx_args)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         # Gather the transaction hashes
         deployment_receipts = {'deployment': deploy_receipt,
@@ -543,7 +534,7 @@ class LibraryLinkerDeployer(ContractDeployer):
         linker_contract, linker_deployment_txhash = self.blockchain.deploy_contract(gas_limit=gas_limit, *linker_args)
         if progress:
             progress.update(1)
-            time.sleep(3)
+
         self._contract = linker_contract
         return {'txhash': linker_deployment_txhash}
 
@@ -597,7 +588,7 @@ class UserEscrowProxyDeployer(ContractDeployer):
         user_escrow_proxy_contract, deployment_receipt = self._deploy_essential(gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
+
         receipts['deployment'] = deployment_receipt
 
         # UserEscrowLibraryLinker
@@ -608,7 +599,6 @@ class UserEscrowProxyDeployer(ContractDeployer):
         linker_deployment_receipt = linker_deployer.deploy(secret_hash=secret_hash, gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         receipts['linker_deployment'] = linker_deployment_receipt['txhash']
         self._contract = user_escrow_proxy_contract
@@ -745,7 +735,7 @@ class UserEscrowDeployer(ContractDeployer):
         user_escrow_contract, deploy_receipt = self.blockchain.deploy_contract(*args, gas_limit=gas_limit, enroll=False)
         if progress:
             progress.update(1)
-            time.sleep(3)
+
         self._contract = user_escrow_contract
         return deploy_receipt
 
@@ -781,7 +771,6 @@ class AdjudicatorDeployer(ContractDeployer):
         adjudicator_contract, deploy_receipt = self._deploy_essential(gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         proxy_deployer = self.__proxy_deployer(blockchain=self.blockchain,
                                                target_contract=adjudicator_contract,
@@ -790,7 +779,6 @@ class AdjudicatorDeployer(ContractDeployer):
         proxy_deploy_receipt = proxy_deployer.deploy(secret_hash=secret_hash, gas_limit=gas_limit)
         if progress:
             progress.update(1)
-            time.sleep(3)
 
         # Cache the dispatcher contract
         proxy_contract = proxy_deployer.contract

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -38,7 +38,7 @@ class ContractDeployer:
 
     agency = NotImplemented
     contract_name = NotImplemented
-    num_deployment_steps = NotImplemented
+    number_of_deployment_transactions = NotImplemented
     _interface_class = BlockchainDeployerInterface
     _upgradeable = NotImplemented
     __linker_deployer = NotImplemented
@@ -142,7 +142,7 @@ class NucypherTokenDeployer(ContractDeployer):
 
     agency = NucypherTokenAgent
     contract_name = agency.registry_contract_name
-    num_deployment_steps = 1
+    number_of_deployment_transactions = 1
     _upgradeable = False
 
     def __init__(self,
@@ -183,7 +183,7 @@ class DispatcherDeployer(ContractDeployer):
     """
 
     contract_name = DISPATCHER_CONTRACT_NAME
-    num_deployment_steps = 1
+    number_of_deployment_transactions = 1
     _upgradeable = False
 
     DISPATCHER_SECRET_LENGTH = 32
@@ -241,7 +241,7 @@ class StakingEscrowDeployer(ContractDeployer):
 
     agency = StakingEscrowAgent
     contract_name = agency.registry_contract_name
-    num_deployment_steps = 4
+    number_of_deployment_transactions = 4
     _upgradeable = True
     __proxy_deployer = DispatcherDeployer
 
@@ -410,7 +410,7 @@ class PolicyManagerDeployer(ContractDeployer):
 
     agency = PolicyManagerAgent
     contract_name = agency.registry_contract_name
-    num_deployment_steps = 3
+    number_of_deployment_transactions = 3
     _upgradeable = True
     __proxy_deployer = DispatcherDeployer
 
@@ -520,7 +520,7 @@ class PolicyManagerDeployer(ContractDeployer):
 class LibraryLinkerDeployer(ContractDeployer):
 
     contract_name = 'UserEscrowLibraryLinker'
-    num_deployment_steps = 1
+    number_of_deployment_transactions = 1
 
     def __init__(self, target_contract: Contract, bare: bool = False, *args, **kwargs):
         self.target_contract = target_contract
@@ -558,7 +558,7 @@ class LibraryLinkerDeployer(ContractDeployer):
 class UserEscrowProxyDeployer(ContractDeployer):
 
     contract_name = 'UserEscrowProxy'
-    num_deployment_steps = 2
+    number_of_deployment_transactions = 2
     __linker_deployer = LibraryLinkerDeployer
 
     def __init__(self, *args, **kwargs):
@@ -645,7 +645,7 @@ class UserEscrowDeployer(ContractDeployer):
 
     agency = UserEscrowAgent
     contract_name = agency.registry_contract_name
-    num_deployment_steps = 1
+    number_of_deployment_transactions = 1
     _upgradeable = True
     __linker_deployer = LibraryLinkerDeployer
     __allocation_registry = AllocationRegistry
@@ -744,7 +744,7 @@ class AdjudicatorDeployer(ContractDeployer):
 
     agency = AdjudicatorAgent
     contract_name = agency.registry_contract_name
-    num_deployment_steps = 3
+    number_of_deployment_transactions = 3
     _upgradeable = True
     __proxy_deployer = DispatcherDeployer
 

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -227,7 +227,9 @@ def deploy(action,
         paint_deployment_delay(emitter=emitter)
 
         # Execute Deployment
-        deployment_receipts = DEPLOYER.deploy_network_contracts(secrets=secrets, emitter=emitter)
+        deployment_receipts = DEPLOYER.deploy_network_contracts(secrets=secrets,
+                                                                emitter=emitter,
+                                                                interactive=not force)
 
         # Paint outfile paths
         registry_outfile = DEPLOYER.blockchain.registry.filepath

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -306,7 +306,7 @@ def paint_contract_deployment(emitter, contract_name: str, contract_address: str
     # TODO: switch to using an explicit emitter
 
     # Paint heading
-    heading = '\n{} ({})'.format(contract_name, contract_address)
+    heading = f'\r{" "*80}\n{contract_name} ({contract_address})'
     emitter.echo(heading, bold=True)
     emitter.echo('*' * (42 + 3 + len(contract_name)))
 

--- a/tests/blockchain/eth/entities/deployers/conftest.py
+++ b/tests/blockchain/eth/entities/deployers/conftest.py
@@ -35,3 +35,16 @@ def staking_escrow_deployer(session_testerchain, token_deployer):
     staking_escrow_deployer = StakingEscrowDeployer(blockchain=session_testerchain,
                                                     deployer_address=session_testerchain.etherbase_account)
     return staking_escrow_deployer
+
+
+@pytest.fixture(scope="function")
+def deployment_progress():
+    class DeploymentProgress:
+        num_steps = 0
+
+        def update(self, steps: int):
+            self.num_steps += steps
+
+    progress = DeploymentProgress()
+
+    return progress

--- a/tests/blockchain/eth/entities/deployers/test_adjudicator_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_adjudicator_deployer.py
@@ -48,7 +48,7 @@ def test_adjudicator_deployer(session_testerchain, slashing_economics, deploymen
 
     assert len(deployment_receipts) == 3
     # deployment steps must match expected number of steps
-    assert deployment_progress.num_steps == deployer.num_deployment_steps
+    assert deployment_progress.num_steps == deployer.number_of_deployment_transactions
 
     for title, receipt in deployment_receipts.items():
         assert receipt['status'] == 1

--- a/tests/blockchain/eth/entities/deployers/test_adjudicator_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_adjudicator_deployer.py
@@ -29,7 +29,7 @@ from nucypher.blockchain.eth.deployers import (
 
 
 @pytest.mark.slow()
-def test_adjudicator_deployer(session_testerchain, slashing_economics):
+def test_adjudicator_deployer(session_testerchain, slashing_economics, deployment_progress):
     testerchain = session_testerchain
     origin = testerchain.etherbase_account
 
@@ -43,9 +43,12 @@ def test_adjudicator_deployer(session_testerchain, slashing_economics):
     staking_agent = staking_escrow_deployer.make_agent()  # 2 Staker Escrow
 
     deployer = AdjudicatorDeployer(deployer_address=origin, blockchain=testerchain)
-    deployment_receipts = deployer.deploy(secret_hash=os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH))
+    deployment_receipts = deployer.deploy(secret_hash=os.urandom(DispatcherDeployer.DISPATCHER_SECRET_LENGTH),
+                                          progress=deployment_progress)
 
     assert len(deployment_receipts) == 3
+    # deployment steps must match expected number of steps
+    assert deployment_progress.num_steps == deployer.num_deployment_steps
 
     for title, receipt in deployment_receipts.items():
         assert receipt['status'] == 1

--- a/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
+++ b/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
@@ -30,7 +30,7 @@ from nucypher.blockchain.eth.deployers import (NucypherTokenDeployer,
 
 
 @pytest.mark.slow()
-def test_deploy_ethereum_contracts(session_testerchain):
+def test_deploy_ethereum_contracts(session_testerchain, deployment_progress):
     testerchain = session_testerchain
 
     origin, *everybody_else = testerchain.client.accounts
@@ -45,7 +45,7 @@ def test_deploy_ethereum_contracts(session_testerchain):
         assert token_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not token_deployer.is_deployed
 
-    token_deployer.deploy()
+    token_deployer.deploy(progress=deployment_progress)
     assert token_deployer.is_deployed
     assert len(token_deployer.contract_address) == 42
 
@@ -70,7 +70,7 @@ def test_deploy_ethereum_contracts(session_testerchain):
         assert staking_escrow_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not staking_escrow_deployer.is_deployed
 
-    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret))
+    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret), progress=deployment_progress)
     assert staking_escrow_deployer.is_deployed
     assert len(staking_escrow_deployer.contract_address) == 42
 
@@ -97,7 +97,7 @@ def test_deploy_ethereum_contracts(session_testerchain):
         assert policy_manager_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not policy_manager_deployer.is_deployed
 
-    policy_manager_deployer.deploy(secret_hash=keccak(policy_manager_secret))
+    policy_manager_deployer.deploy(secret_hash=keccak(policy_manager_secret), progress=deployment_progress)
     assert policy_manager_deployer.is_deployed
     assert len(policy_manager_deployer.contract_address) == 42
 
@@ -124,7 +124,7 @@ def test_deploy_ethereum_contracts(session_testerchain):
         assert adjudicator_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not adjudicator_deployer.is_deployed
 
-    adjudicator_deployer.deploy(secret_hash=keccak(adjudicator_secret))
+    adjudicator_deployer.deploy(secret_hash=keccak(adjudicator_secret), progress=deployment_progress)
     assert adjudicator_deployer.is_deployed
     assert len(adjudicator_deployer.contract_address) == 42
 
@@ -135,3 +135,9 @@ def test_deploy_ethereum_contracts(session_testerchain):
     another_adjudicator_agent = AdjudicatorAgent()
     assert len(another_adjudicator_agent.contract_address) == 42
     assert another_adjudicator_agent.contract_address == adjudicator_deployer.contract_address == adjudicator_agent.contract_address
+
+    # overall deployment steps must match aggregated individual expected number of steps
+    assert deployment_progress.num_steps == (token_deployer.num_deployment_steps +
+                                             staking_escrow_deployer.num_deployment_steps +
+                                             policy_manager_deployer.num_deployment_steps +
+                                             adjudicator_deployer.num_deployment_steps)

--- a/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
+++ b/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
@@ -137,7 +137,7 @@ def test_deploy_ethereum_contracts(session_testerchain, deployment_progress):
     assert another_adjudicator_agent.contract_address == adjudicator_deployer.contract_address == adjudicator_agent.contract_address
 
     # overall deployment steps must match aggregated individual expected number of steps
-    assert deployment_progress.num_steps == (token_deployer.num_deployment_steps +
-                                             staking_escrow_deployer.num_deployment_steps +
-                                             policy_manager_deployer.num_deployment_steps +
-                                             adjudicator_deployer.num_deployment_steps)
+    assert deployment_progress.num_steps == (token_deployer.number_of_deployment_transactions +
+                                             staking_escrow_deployer.number_of_deployment_transactions +
+                                             policy_manager_deployer.number_of_deployment_transactions +
+                                             adjudicator_deployer.number_of_deployment_transactions)

--- a/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
@@ -42,7 +42,7 @@ def test_policy_manager_deployment(policy_manager_deployer, staking_escrow_deplo
                                                          progress=deployment_progress)
     assert len(deployment_receipts) == 3
     # deployment steps must match expected number of steps
-    assert deployment_progress.num_steps == policy_manager_deployer.num_deployment_steps
+    assert deployment_progress.num_steps == policy_manager_deployer.number_of_deployment_transactions
 
     for title, receipt in deployment_receipts.items():
         assert receipt['status'] == 1

--- a/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
@@ -37,10 +37,12 @@ def policy_manager_deployer(staking_escrow_deployer, session_testerchain):
     return policy_manager_deployer
 
 
-def test_policy_manager_deployment(policy_manager_deployer, staking_escrow_deployer):
-
-    deployment_receipts = policy_manager_deployer.deploy(secret_hash=keccak(text=POLICY_MANAGER_DEPLOYMENT_SECRET))
+def test_policy_manager_deployment(policy_manager_deployer, staking_escrow_deployer, deployment_progress):
+    deployment_receipts = policy_manager_deployer.deploy(secret_hash=keccak(text=POLICY_MANAGER_DEPLOYMENT_SECRET),
+                                                         progress=deployment_progress)
     assert len(deployment_receipts) == 3
+    # deployment steps must match expected number of steps
+    assert deployment_progress.num_steps == policy_manager_deployer.num_deployment_steps
 
     for title, receipt in deployment_receipts.items():
         assert receipt['status'] == 1

--- a/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
@@ -30,7 +30,7 @@ def test_staking_escrow_deployment(staking_escrow_deployer, deployment_progress)
 
     assert len(deployment_receipts) == 4
     # deployment steps must match expected number of steps
-    assert deployment_progress.num_steps == staking_escrow_deployer.num_deployment_steps
+    assert deployment_progress.num_steps == staking_escrow_deployer.number_of_deployment_transactions
 
     for title, receipt in deployment_receipts.items():
         assert receipt['status'] == 1

--- a/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
@@ -24,11 +24,13 @@ from nucypher.blockchain.eth.deployers import (StakingEscrowDeployer,
 from nucypher.utilities.sandbox.blockchain import STAKING_ESCROW_DEPLOYMENT_SECRET
 
 
-def test_staking_escrow_deployment(staking_escrow_deployer):
+def test_staking_escrow_deployment(staking_escrow_deployer, deployment_progress):
     secret_hash = keccak(text=STAKING_ESCROW_DEPLOYMENT_SECRET)
-    deployment_receipts = staking_escrow_deployer.deploy(secret_hash=secret_hash)
+    deployment_receipts = staking_escrow_deployer.deploy(secret_hash=secret_hash, progress=deployment_progress)
 
     assert len(deployment_receipts) == 4
+    # deployment steps must match expected number of steps
+    assert deployment_progress.num_steps == staking_escrow_deployer.num_deployment_steps
 
     for title, receipt in deployment_receipts.items():
         assert receipt['status'] == 1

--- a/tests/blockchain/eth/entities/deployers/test_token_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_token_deployer.py
@@ -21,7 +21,7 @@ from nucypher.blockchain.eth.deployers import NucypherTokenDeployer
 from nucypher.blockchain.eth.interfaces import EthereumContractRegistry
 
 
-def test_token_deployer_and_agent(session_testerchain):
+def test_token_deployer_and_agent(session_testerchain, deployment_progress):
     testerchain = session_testerchain
     origin = testerchain.etherbase_account
 
@@ -32,10 +32,13 @@ def test_token_deployer_and_agent(session_testerchain):
     # The big day...
     deployer = NucypherTokenDeployer(blockchain=testerchain, deployer_address=origin)
 
-    deployment_receipts = deployer.deploy()
+    deployment_receipts = deployer.deploy(progress=deployment_progress)
 
     for title, receipt in deployment_receipts.items():
         assert receipt['status'] == 1
+
+    # deployment steps must match expected number of steps
+    assert deployment_progress.num_steps == deployer.num_deployment_steps
 
     # Create a token instance
     token_agent = deployer.make_agent()

--- a/tests/blockchain/eth/entities/deployers/test_token_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_token_deployer.py
@@ -38,7 +38,7 @@ def test_token_deployer_and_agent(session_testerchain, deployment_progress):
         assert receipt['status'] == 1
 
     # deployment steps must match expected number of steps
-    assert deployment_progress.num_steps == deployer.num_deployment_steps
+    assert deployment_progress.num_steps == deployer.number_of_deployment_transactions
 
     # Create a token instance
     token_agent = deployer.make_agent()

--- a/tests/blockchain/eth/entities/deployers/test_user_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_user_escrow_deployer.py
@@ -50,7 +50,7 @@ def test_user_escrow_deployer(session_testerchain, session_agency, user_escrow_p
 
     assert len(user_escrow_proxy_receipts) == 2
     # deployment steps must match expected number of steps
-    assert deployment_progress.num_steps == user_escrow_proxy_deployer.num_deployment_steps
+    assert deployment_progress.num_steps == user_escrow_proxy_deployer.number_of_deployment_transactions
 
     for title, receipt in user_escrow_proxy_receipts.items():
         assert receipt['status'] == 1

--- a/tests/blockchain/eth/entities/deployers/test_user_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_user_escrow_deployer.py
@@ -40,13 +40,18 @@ def user_escrow_proxy_deployer(session_testerchain, session_agency):
 
 
 @pytest.mark.slow()
-def test_user_escrow_deployer(session_testerchain, session_agency, user_escrow_proxy_deployer):
+def test_user_escrow_deployer(session_testerchain, session_agency, user_escrow_proxy_deployer, deployment_progress):
     testerchain = session_testerchain
     deployer_account = testerchain.etherbase_account
     secret_hash = keccak_digest(USER_ESCROW_PROXY_DEPLOYMENT_SECRET.encode())
-    user_escrow_proxy_receipts = user_escrow_proxy_deployer.deploy(secret_hash=secret_hash)
+
+    user_escrow_proxy_receipts = user_escrow_proxy_deployer.deploy(secret_hash=secret_hash,
+                                                                   progress=deployment_progress)
 
     assert len(user_escrow_proxy_receipts) == 2
+    # deployment steps must match expected number of steps
+    assert deployment_progress.num_steps == user_escrow_proxy_deployer.num_deployment_steps
+
     for title, receipt in user_escrow_proxy_receipts.items():
         assert receipt['status'] == 1
 


### PR DESCRIPTION
Deploying NuCypher contracts during installation can take some time, so adding a progress bar would improve UX.

Note: deploying to a local blockchain will be much faster.

Example output from my testing
```
Press any key to continue
Deploying Contracts  [##----------------------------------]    7%  00:00:38
NuCypherToken (0x1e31e55280412d033E817a4eC04d07b34a006c21)
**********************************************************
OK | txhash | 0x4b6d009c2ec2b3f29571bb25c2e5126a4ae1857d1a785b78c20e8a12b2d5f73c (782882 gas)
Block #14 | 0xa5d1732c412b66ab8d3640ca62a8d3aa4b29d095142c84fd648df2a7f1580187


Press any key to continue
Deploying Contracts  [#############-----------------------]   38%  00:00:29
StakingEscrow (0x1E3452C1708fd8246D63a1119E866C52580deaA2)
**********************************************************
OK | deploy | 0x23858278a717d1b2fc8ffc689d67e6740984e93759f145a28ac48501c2890bad (6155118 gas)
Block #15 | 0xb7d471ba979ee0c314ce23f82b391821d760bffaf1b8438bc5e8bbe5e982029f

OK | dispatcher_deploy | 0x6e2a5329c063feb6dec6caa14d39e8fa6200587a9d71ea91581aac8062dd4004 (1290319 gas)
Block #16 | 0x94a29086694cb02e70f273950bd12a5b42d333e1194961f0631919182fe6eaaa

OK | reward_transfer | 0xea63b61e99ed9ada0797bb896b356f75911faca230838909774d53135008cebc (51692 gas)
Block #17 | 0x55a1a4fdac39a9982cee707c0e37b1198ec1f37d846aea92769d90a1043e24f7

OK | initialize | 0xefbdbd80b72f703359202cf0d2c1b7865247dede82cb0725bc01637d4dfff77f (96002 gas)
Block #18 | 0xa3fc6e902136d664c13188cb5807d310491ab7b087b7d62aa6f9d4ef3dea5eff


Press any key to continue
Deploying Contracts  [######################--------------]   61%  00:00:18
PolicyManager (0xD84fFc5B60cc5039D110a54F6595D9a4e73DBF55)
**********************************************************
OK | deployment | 0xa6a031079bfb38bf56fc05f52e521b1bbf3ae9bc802fa701d1ddfc3f97aa7f8e (2728132 gas)
Block #19 | 0x7f0917441c360612b3dac7a95eedd631bd9ddc2b3f82ce529cbfca544071bbe0

OK | dispatcher_deployment | 0x3bb85694a1fb139675a8b6ffa5f0076eead4dc4a0322bea3e70a7eba9dad0248 (1340963 gas)
Block #20 | 0x8ddfa99e7be0ae4bac217e9097a3ea3cc19320b6aebb8d08c54ff2d6c739d1b4

OK | set_policy_manager | 0x5de9d182a83623f7401ca6b0b319357a9678cdaf642d91795aa4d0fa6b7f7a64 (50586 gas)
Block #21 | 0xec56935f16d7a1e678bee25ebe5818f37ffad19b0b0acc2cd926c4982d9b1876


Press any key to continue
Deploying Contracts  [###########################---------]   76%  00:00:10
UserEscrowProxy (0xeB6292e2beDcd7B6E354df567F1605b39e216906)
************************************************************
OK | deployment | 0x860eb8395c1ebdd73812c1559953554605e91d56ec192d0d9b80ac787e402f75 (1224443 gas)
Block #22 | 0xd1a3319d64b09cea419a01001be811c249cc6184be9730722a58e35c38e1961e

OK | linker_deployment | 0x4fc2421a4e942207c27b58a0cba02386d6bd9a166c6c02a41ccd18d4993d6627 (377996 gas)
Block #23 | 0xf0774febd661cbdc5cd2ef088ebe4088033407259d735fb07dc5639f3944e592


Press any key to continue
Deploying Contracts  [####################################]  100%
Adjudicator (0x90B9dAd3B1FA74Fd16b11ef006cFd52d10a70149)
********************************************************
OK | deployment | 0x565ac99ba62332108a16af25d4d298c9ce6c0881fb2982da49210eb3c8c4abaa (4405759 gas)
Block #24 | 0x5e7401e42551c237500b70f9f38c3a912f063532dee48682f2531a7688ed09cf

OK | dispatcher_deployment | 0x8a2dcd3dc9ff20db14b36803207f81486376c3034eb0f32399c5f0005085855e (1222687 gas)
Block #25 | 0x32ddecdea18472d176d788d215635a7fda7a567c969b22f51551c5dc12cce135

OK | set_adjudicator | 0xb04ec9124f969cb36c87b7c76cb88e47d23ebb6e4b8c5e363256aee0eeff757b (50543 gas)
Block #26 | 0x604134852abe0d2f6b66c900ff9efebdb7ae788b81732349c2234a3bf044038f


Generated registry /Users/derek/Library/Application Support/nucypher/contract_registry.json
Saved deployment receipts to /Users/derek/Library/Application Support/nucypher/deployment-receipts-0x65E0-1564409685.json
(nucypher)
```