### PR TITLE
Fix #1134 and #906: Support variable length ISO8601 dates

### DIFF
--- a/deploy/services/felix_faucet.j2
+++ b/deploy/services/felix_faucet.j2
@@ -6,7 +6,7 @@ User=root
 Type=simple
 Environment="NUCYPHER_KEYRING_PASSWORD={{ keyring_password }}"
 Environment="NUCYPHER_FELIX_DB_SECRET={{ db_secret }}"
-ExecStart={{ virtualenv_path }}/bin/nucypher --debug felix run --network {{ nucypher_network_domain }} --geth
+ExecStart={{ virtualenv_path }}/bin/nucypher felix run --debug --network {{ nucypher_network_domain }} --geth
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/services/firstula_node.j2
+++ b/deploy/services/firstula_node.j2
@@ -5,7 +5,7 @@ Description="Run 'Lonely Ursula' -  The Original Network Node."
 User=ubuntu
 Type=simple
 Environment="NUCYPHER_KEYRING_PASSWORD={{ ursula_password.stdout }}"
-ExecStart={{ virtualenv_path }}/bin/nucypher --debug ursula run --lonely --network {{ nucypher_network_domain }}
+ExecStart={{ virtualenv_path }}/bin/nucypher ursula run --debug --lonely --network {{ nucypher_network_domain }}
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/services/ursula_node.j2
+++ b/deploy/services/ursula_node.j2
@@ -5,7 +5,7 @@ Description="Run 'Ursula', A NuCypher Staking Node."
 User=ubuntu
 Type=simple
 Environment="NUCYPHER_KEYRING_PASSWORD={{ursula_password.stdout}}"
-ExecStart={{ virtualenv_path }}/bin/nucypher --debug ursula run --network {{ nucypher_network_domain }} --federated-only --teacher {{ seed_node_metadata.checksum_address }}@https://{{ seed_node_metadata.rest_host }}:{{seed_node_metadata.rest_port}}
+ExecStart={{ virtualenv_path }}/bin/nucypher ursula run --debug --network {{ nucypher_network_domain }} --federated-only --teacher {{ seed_node_metadata.checksum_address }}@https://{{ seed_node_metadata.rest_host }}:{{seed_node_metadata.rest_port}}
 
 [Install]
 WantedBy=multi-user.target

--- a/nucypher/blockchain/eth/policies.py
+++ b/nucypher/blockchain/eth/policies.py
@@ -154,6 +154,9 @@ class BlockchainPolicy(Policy):
                                             value=rate*duration,   # TODO Check the math/types here
                                             lock_periods=duration,
                                             expiration=end_block)
+        # TODO: #1173 - This method is unused and seems broken.
+        # I think that something here will fail as the arrangement ID is not
+        # passed above to the constructor, so a new random ID will be created.
 
         arrangement.is_published = True
         return arrangement

--- a/nucypher/characters/control/serializers.py
+++ b/nucypher/characters/control/serializers.py
@@ -86,7 +86,7 @@ class AliceControlJSONSerializer(CharacterControlJSONSerializer, MessageHandlerM
                             label=request['label'].encode(),
                             m=request['m'],
                             n=request['n'],
-                            expiration=request['expiration'])
+                            expiration=maya.MayaDT.from_iso8601(iso8601_string=request['expiration']))
         return parsed_input
 
     @staticmethod
@@ -120,7 +120,7 @@ class AliceControlJSONSerializer(CharacterControlJSONSerializer, MessageHandlerM
                             label=request['label'].encode(),
                             m=request['m'],
                             n=request['n'],
-                            expiration=maya.MayaDT.from_iso8601(request['expiration']))
+                            expiration=maya.MayaDT.from_iso8601(iso8601_string=request['expiration']))
         return parsed_input
 
     @staticmethod

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -368,7 +368,7 @@ def make_rest_app(
             do_store = treasure_map.public_id() == treasure_map_id
 
         if do_store:
-            log.info("{} storing TreasureMap {}".format(this_node.stamp, treasure_map_id))
+            log.info("{} storing TreasureMap {}".format(this_node, treasure_map_id))
 
             # TODO 341 - what if we already have this TreasureMap?
             treasure_map_index = bytes.fromhex(treasure_map_id)

--- a/nucypher/policy/models.py
+++ b/nucypher/policy/models.py
@@ -20,7 +20,6 @@ from collections import OrderedDict
 
 import maya
 import msgpack
-import uuid
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import UNKNOWN_KFRAG, NO_DECRYPTION_PERFORMED, NOT_SIGNED
 from cryptography.hazmat.backends.openssl import backend
@@ -76,10 +75,14 @@ class Arrangement:
 
         Other params are hopefully self-evident.
         """
-        self.id = arrangement_id or secure_random(self.ID_LENGTH)
+        if arrangement_id:
+            if len(arrangement_id) != self.ID_LENGTH:
+                raise ValueError(f"Arrangement ID must be of length {self.ID_LENGTH}.")
+            self.id = arrangement_id
+        else:
+            self.id = secure_random(self.ID_LENGTH)
         self.expiration = expiration
         self.alice = alice
-        self.uuid = uuid.uuid4()
         self.value = value
 
         """

--- a/scripts/local_fleet/run_local_fleet.sh
+++ b/scripts/local_fleet/run_local_fleet.sh
@@ -22,9 +22,9 @@ sleep 2
 
 # Connect Node #2 to Lonely Ursula
 echo "Starting Ursula #2..."
-nucypher --debug ursula run --dev --federated-only --teacher localhost:11500 --rest-port 11501 > /tmp/ursulas-logs/ursula-11501.txt 2>&1 &
+nucypher ursula run --debug --dev --federated-only --teacher localhost:11500 --rest-port 11501 > /tmp/ursulas-logs/ursula-11501.txt 2>&1 &
 sleep 1
 
 # Connect Node #3 to the local Fleet
 echo "Starting Ursula #3..."
-nucypher --debug ursula run --dev --federated-only --teacher localhost:11500 --rest-port 11502 > /tmp/ursulas-logs/ursula-11502.txt 2>&1 &
+nucypher ursula run --debug --dev --federated-only --teacher localhost:11500 --rest-port 11502 > /tmp/ursulas-logs/ursula-11502.txt 2>&1 &

--- a/scripts/local_fleet/run_local_ursula_fleet.py
+++ b/scripts/local_fleet/run_local_ursula_fleet.py
@@ -27,8 +27,6 @@ import os
 from twisted.internet import protocol
 from twisted.internet import reactor
 
-from nucypher.utilities.logging import SimpleObserver
-
 
 FLEET_POPULATION = 5
 DEMO_NODE_STARTING_PORT = 11501
@@ -44,8 +42,9 @@ def spin_up_federated_ursulas(quantity: int = FLEET_POPULATION):
     ursula_processes = list()
     for index, port in enumerate(ports):
 
-        args = ['nucypher', '--debug',
+        args = ['nucypher',
                 'ursula', 'run',
+                '--debug',
                 '--rest-port', port,
                 '--teacher', TEACHER_URI,
                 '--federated-only',

--- a/scripts/local_fleet/run_lonely_ursula.py
+++ b/scripts/local_fleet/run_lonely_ursula.py
@@ -28,8 +28,8 @@ from nucypher.cli.main import nucypher_cli
 
 click_runner = CliRunner()
 
-args = ['--debug',             # Non-Interactive + Verbose
-        'ursula', 'run',
+args = ['ursula', 'run',
+        '--debug',             # Non-Interactive + Verbose
         '--rest-port', 11500,  # REST Server
         '--federated-only',    # Operating Mode
         '--dev',               # In-Memory

--- a/scripts/local_fleet/run_single_ursula.py
+++ b/scripts/local_fleet/run_single_ursula.py
@@ -32,8 +32,8 @@ click_runner = CliRunner()
 DEMO_NODE_PORT = select_test_port()
 DEMO_FLEET_STARTING_PORT = 11500
 
-args = ['--debug',
-        'ursula', 'run',
+args = ['ursula', 'run',
+        '--debug',
         '--federated-only',
         '--teacher', f'https://127.0.0.1:{DEMO_FLEET_STARTING_PORT}',
         '--rest-port', DEMO_NODE_PORT,


### PR DESCRIPTION
It seems that the old issue of variable length ISO8601 dates (#906) was behind #1134.

For the record, this is the grant command that previously failed as in #1134, but now works after this fix:
```
nucypher alice grant --teacher-uri 127.0.0.1:11500 --bob-verifying-key 0277b5f24dbd68d4cdbbb9f54d6b892b52a48513695be4f703c2516a1f94e1dc9e --bob-encrypting-key 0277b5f24dbd68d4cdbbb9f54d6b892b52a48513695be4f703c2516a1f94e1dc9e --label asdf --expiration 2019-12-30T10:07:50Z --m 1 --n 1 --dev
```
Tested with a lonely dev ursula for the moment. The output seems to show everything is OK:
```

    / \  | (_) ___ ___
   / _ \ | | |/ __/ _ \
  / ___ \| | | (_|  __/
 /_/   \_|_|_|\___\___|

 the Authority.

WARNING: Running in Federated mode
treasure_map ...... MPoQ6eWorfP/lCRyODElVveCVEA/3Ed0q/RmJ2QCNTlwhqLpkSUn7EzpQ8sRqkKyxhkhduAwEYngN0akSNVpJjmJB6ppU1CztimP3PG4BHYCxO8X9cPiizAGiXc+o6xiAAABHANgefwHV3Aj5WrUoIMPJiHVGEvoUBOR5ckp2757yHAemAI37rO8Qy+lg6p32HvmQO4fb4s0jBFO5151y3yMZZTHojHj5KODWg9Rdm0DZZvKZ2dzD85InvQ4+z04NRJ3lXaMA73EUXTGq+WfIH4ZPvyeyeFgUQ8tfQWcQaCRO12+2aPt48SebLTxuOQfbBNFgXLa8WUHnSwbC2mt1mFa37fPHDQ0C4CFW9F9ywyprl5pkzfFIY9OVWdmvMkQrrwopQbjO5/NMdlYHQ/7YEPKXDSAarIbh4rQoGL54j0Bv0MlOGpCW+TXuxs7GGzumNIf+c44A8k3djoGFj0Z+XPWb5ygEH6pyE7kwb0jKcjIde+NlC2INpToxaJ+pdzw
policy_encrypting_key ...... 025c5f763863da6018447498af61b443f23c63dd7699502f0bcfd843dbda1274dd
alice_verifying_key ...... 03bdc45174c6abe59f207e193efc9ec9e160510f2d7d059c41a0913b5dbed9a3ed
request_id ...... 1564487069
duration ...... 0:00:01
```
-----
* Fixes #906.
* Fixes #1134.


