### PR TITLE
Improve format of stake enactment datetimes for stakes listing

### DIFF
--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -247,8 +247,8 @@ or set your Ursula worker node address by running 'nucypher stake set-worker'.
 
 def prettify_stake(stake, index: int = None) -> str:
 
-    start_datetime = str(stake.start_datetime.slang_date())
-    expiration_datetime = str(stake.end_datetime.slang_date())
+    start_datetime = stake.start_datetime.local_datetime().strftime("%b %d %H:%M:%S %Z")
+    expiration_datetime = stake.end_datetime.local_datetime().strftime("%b %d %H:%M:%S %Z")
     duration = stake.duration
 
     pretty_periods = f'{duration} periods {"." if len(str(duration)) == 2 else ""}'
@@ -266,10 +266,10 @@ def prettify_stake(stake, index: int = None) -> str:
 
 def paint_stakes(emitter, stakes):
 
-    title = "=========================== Active Stakes ==============================\n"
+    title = "======================================= Active Stakes =========================================\n"
 
     header = f'| ~ | Staker | Worker | # | Value    | Duration     | Enactment          '
-    breaky = f'|   | ------ | ------ | - | -------- | ------------ | ------------------ '
+    breaky = f'|   | ------ | ------ | - | -------- | ------------ | ----------------------------------------- '
 
     emitter.echo(title)
     emitter.echo(header, bold=True)


### PR DESCRIPTION
The `Enactment` listing provides full date and uses local timezone. Fixes #1198 

```
███╗   ██╗██╗   ██╗
████╗  ██║██║   ██║
██╔██╗ ██║██║   ██║
██║╚██╗██║██║   ██║
██║ ╚████║╚██████╔╝
╚═╝  ╚═══╝ ╚═════╝


======================================= Active Stakes =========================================

| ~ | Staker | Worker | # | Value    | Duration     | Enactment
|   | ------ | ------ | - | -------- | ------------ | -----------------------------------------
| 0 | 0xAE8B | 0x0000 | 0 | 45000 NU | 56 periods . | Aug 09 14:27:49 EDT - Oct 03 14:27:49 EDT
```
