### PR TITLE
CLI staking via UserEscrow

### DIFF
--- a/docs/source/guides/staking_guide.rst
+++ b/docs/source/guides/staking_guide.rst
@@ -377,6 +377,44 @@ Divide an existing stake
     | 3 | 0xbb03 | 0xbb04 | 1 | 15000 NU | 40 periods . | Aug 09 12:30:38 CEST - Sep 17 12:30:38 CEST
 
 
+Staking using a preallocation contract
+---------------------------------------
+
+Each NuCypher staker with a preallocation will have some amount of tokens locked
+in a preallocation contract named ``UserEscrow``, which is used to stake and
+perform other staker-related operations.
+From the perspective of the main NuCypher contracts, each ``UserEscrow``
+contract represents a staker, no different from "regular" stakers.
+However, from the perspective of the preallocation user, things are different
+since the contract can't perform transactions, and it's the preallocation user
+(also known as the "`beneficiary`" of the contract) who have to operate.
+
+In general, preallocation users can use all staking-related operations offered
+by the CLI in the same way as described above, except that they have to include
+the ``--escrow`` flag to indicate they are acting as beneficiaries.
+
+For example, to create a stake:
+
+.. code:: bash
+
+    (nucypher)$ nucypher stake create --hw-wallet --escrow
+
+
+Or to set a worker:
+
+.. code:: bash
+
+    (nucypher)$ nucypher stake set-worker --hw-wallet --escrow
+
+
+Alternatively to the ``--escrow`` flag, preallocation users can directly specify
+their beneficiary address with the ``--beneficiary-address ADDRESS`` flag.
+
+The CLI will automatically look for a file named ``allocation_registry.json`` in
+the default installation path, although a custom path can be used with the flag
+``--allocation-filepath /path/to/allocation_registry.json``.
+
+
 Inline Method
 --------------
 

--- a/docs/source/guides/staking_guide.rst
+++ b/docs/source/guides/staking_guide.rst
@@ -387,7 +387,8 @@ From the perspective of the main NuCypher contracts, each ``UserEscrow``
 contract represents a staker, no different from "regular" stakers.
 However, from the perspective of the preallocation user, things are different
 since the contract can't perform transactions, and it's the preallocation user
-(also known as the "`beneficiary`" of the contract) who have to operate.
+(also known as the "`beneficiary`" of the contract)
+who has to perform staking operations.
 
 In general, preallocation users can use all staking-related operations offered
 by the CLI in the same way as described above, except that they have to include
@@ -407,7 +408,7 @@ Or to set a worker:
     (nucypher)$ nucypher stake set-worker --hw-wallet --escrow
 
 
-Alternatively to the ``--escrow`` flag, preallocation users can directly specify
+As an alternative to the ``--escrow`` flag, preallocation users can directly specify
 their beneficiary address with the ``--beneficiary-address ADDRESS`` flag.
 
 The CLI will automatically look for a file named ``allocation_registry.json`` in

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -678,13 +678,18 @@ class Staker(NucypherTokenActor):
     def deposit(self, amount: int, lock_periods: int) -> Tuple[str, str]:
         """Public facing method for token locking."""
 
-        approve_receipt = self.token_agent.approve_transfer(amount=amount,
-                                                            target_address=self.staking_agent.contract_address,
-                                                            sender_address=self.checksum_address)
-
-        deposit_receipt = self.staking_agent.deposit_tokens(amount=amount,
-                                                            lock_periods=lock_periods,
-                                                            sender_address=self.checksum_address)
+        if self.is_contract:
+            approve_receipt = self.token_agent.approve_transfer(amount=amount,
+                                                                target_address=self.staking_agent.contract_address,
+                                                                sender_address=self.beneficiary_address)
+            deposit_receipt = self.user_escrow_agent.deposit_as_staker(amount=amount, lock_periods=lock_periods)
+        else:
+            approve_receipt = self.token_agent.approve_transfer(amount=amount,
+                                                                target_address=self.staking_agent.contract_address,
+                                                                sender_address=self.checksum_address)
+            deposit_receipt = self.staking_agent.deposit_tokens(amount=amount,
+                                                                lock_periods=lock_periods,
+                                                                sender_address=self.checksum_address)
 
         return approve_receipt, deposit_receipt
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -739,7 +739,7 @@ class Staker(NucypherTokenActor):
         return receipt
 
     #
-    # Reward and Collection
+    # Bonding with Worker
     #
 
     @only_me
@@ -765,6 +765,20 @@ class Staker(NucypherTokenActor):
         if self.__worker_address == BlockchainInterface.NULL_ADDRESS:
             return NO_WORKER_ASSIGNED.bool_value(False)
         return self.__worker_address
+
+    @only_me
+    @save_receipt
+    def detach_worker(self) -> str:
+        if self.is_contract:
+            receipt = self.user_escrow_agent.release_worker()
+        else:
+            receipt = self.staking_agent.release_worker(staker_address=self.checksum_address)
+        self.__worker_address = BlockchainInterface.NULL_ADDRESS
+        return receipt
+
+    #
+    # Reward and Collection
+    #
 
     @only_me
     @save_receipt

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -90,6 +90,7 @@ class NucypherTokenActor:
     class ActorError(Exception):
         pass
 
+    @validate_checksum_address
     def __init__(self, registry: BaseContractRegistry, checksum_address: str = None):
 
         # TODO: Consider this pattern - None for address?.
@@ -710,6 +711,7 @@ class Staker(NucypherTokenActor):
 
     @only_me
     @save_receipt
+    @validate_checksum_address
     def set_worker(self, worker_address: str) -> str:
         if self.is_contract:
             receipt = self.user_escrow_agent.set_worker(worker_address=worker_address)
@@ -747,6 +749,7 @@ class Staker(NucypherTokenActor):
 
     @only_me
     @save_receipt
+    @validate_checksum_address
     def collect_policy_reward(self, collector_address=None) -> dict:
         """Collect rewarded ETH."""
         withdraw_address = collector_address or self.checksum_address
@@ -827,7 +830,7 @@ class Worker(NucypherTokenActor):
 
     @property
     def last_active_period(self) -> int:
-        period = self.staking_agent.get_last_active_period(address=self.checksum_address)
+        period = self.staking_agent.get_last_active_period(staker_address=self.checksum_address)
         return period
 
     @only_me

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -492,7 +492,8 @@ class ContractAdministrator(NucypherTokenActor):
                                                      interactive=interactive)
         # Save transaction metadata
         receipts_filepath = self.save_deployment_receipts(receipts=receipts, filename_prefix='allocation')
-        emitter.echo(f"Saved allocation receipts to {receipts_filepath}", color='blue', bold=True)
+        if emitter:
+            emitter.echo(f"Saved allocation receipts to {receipts_filepath}", color='blue', bold=True)
         return receipts
 
     def save_deployment_receipts(self, receipts: dict, filename_prefix: str = 'deployment') -> str:

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -675,6 +675,19 @@ class Staker(NucypherTokenActor):
 
         return new_stake
 
+    def deposit(self, amount: int, lock_periods: int) -> Tuple[str, str]:
+        """Public facing method for token locking."""
+
+        approve_receipt = self.token_agent.approve_transfer(amount=amount,
+                                                            target_address=self.staking_agent.contract_address,
+                                                            sender_address=self.checksum_address)
+
+        deposit_receipt = self.staking_agent.deposit_tokens(amount=amount,
+                                                            lock_periods=lock_periods,
+                                                            sender_address=self.checksum_address)
+
+        return approve_receipt, deposit_receipt
+
     @property
     def is_restaking(self) -> bool:
         restaking = self.staking_agent.is_restaking(staker_address=self.checksum_address)
@@ -705,6 +718,7 @@ class Staker(NucypherTokenActor):
     def disable_restaking(self) -> dict:
         receipt = self.staking_agent.set_restaking(staker_address=self.checksum_address, value=False)
         return receipt
+
     #
     # Reward and Collection
     #

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -660,8 +660,8 @@ class UserEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
-    def deposit_as_staker(self, value: int, periods: int):
-        contract_function = self.__proxy_contract.functions.depositAsStaker(value, periods)
+    def deposit_as_staker(self, amount: int, lock_periods: int):
+        contract_function = self.__proxy_contract.functions.depositAsStaker(amount, lock_periods)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -150,12 +150,14 @@ class NucypherTokenAgent(EthereumContractAgent):
         address = address if address is not None else self.contract_address
         return self.contract.functions.balanceOf(address).call()
 
+    @validate_checksum_address
     def increase_allowance(self, sender_address: str, target_address: str, increase: int):
         contract_function = self.contract.functions.increaseAllowance(target_address, increase)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    sender_address=sender_address)
         return receipt
 
+    @validate_checksum_address
     def approve_transfer(self, amount: int, target_address: str, sender_address: str):
         """Approve the transfer of tokens from the sender address to the target address."""
         payload = {'gas': 500_000}  # TODO #413: gas needed for use with geth.
@@ -165,6 +167,7 @@ class NucypherTokenAgent(EthereumContractAgent):
                                                    sender_address=sender_address)
         return receipt
 
+    @validate_checksum_address
     def transfer(self, amount: int, target_address: str, sender_address: str):
         contract_function = self.contract.functions.transfer(target_address, amount)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=sender_address)
@@ -253,9 +256,11 @@ class StakingEscrowAgent(EthereumContractAgent):
             at_period = self.contract.functions.getCurrentPeriod().call()
         return self.contract.functions.lockedPerPeriod(at_period).call()
 
+    @validate_checksum_address
     def get_staker_info(self, staker_address: str):
         return self.contract.functions.stakerInfo(staker_address).call()
 
+    @validate_checksum_address
     def get_locked_tokens(self, staker_address: str, periods: int = 0) -> int:
         """
         Returns the amount of tokens this staker has locked
@@ -265,22 +270,26 @@ class StakingEscrowAgent(EthereumContractAgent):
             raise ValueError(f"Periods value must not be negative, Got '{periods}'.")
         return self.contract.functions.getLockedTokens(staker_address, periods).call()
 
+    @validate_checksum_address
     def owned_tokens(self, staker_address: str) -> int:
         """
         Returns all tokens that belong to staker_address, including locked, unlocked and rewards.
         """
         return self.contract.functions.getAllTokens(staker_address).call()
 
+    @validate_checksum_address
     def get_substake_info(self, staker_address: str, stake_index: int) -> Tuple[int, int, int]:
         first_period, *others, locked_value = self.contract.functions.getSubStakeInfo(staker_address, stake_index).call()
         last_period = self.contract.functions.getLastPeriodOfSubStake(staker_address, stake_index).call()
         return first_period, last_period, locked_value
 
+    @validate_checksum_address
     def get_raw_substake_info(self, staker_address: str, stake_index: int) -> Tuple[int, int, int, int]:
         result = self.contract.functions.getSubStakeInfo(staker_address, stake_index).call()
         first_period, last_period, periods, locked = result
         return first_period, last_period, periods, locked
 
+    @validate_checksum_address
     def get_all_stakes(self, staker_address: str):
         stakes_length = self.contract.functions.getSubStakesLength(staker_address).call()
         if stakes_length == 0:
@@ -288,6 +297,7 @@ class StakingEscrowAgent(EthereumContractAgent):
         for stake_index in range(stakes_length):
             yield self.get_substake_info(staker_address=staker_address, stake_index=stake_index)
 
+    @validate_checksum_address
     def deposit_tokens(self, amount: int, lock_periods: int, sender_address: str):
         """Send tokens to the escrow from the staker's address"""
         contract_function = self.contract.functions.deposit(amount, lock_periods)
@@ -295,31 +305,38 @@ class StakingEscrowAgent(EthereumContractAgent):
                                                    sender_address=sender_address)
         return receipt
 
+    @validate_checksum_address
     def divide_stake(self, staker_address: str, stake_index: int, target_value: int, periods: int):
         contract_function = self.contract.functions.divideStake(stake_index, target_value, periods)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
         return receipt
 
-    def get_last_active_period(self, address: str) -> int:
-        period = self.contract.functions.getLastActivePeriod(address).call()
+    @validate_checksum_address
+    def get_last_active_period(self, staker_address: str) -> int:
+        period = self.contract.functions.getLastActivePeriod(staker_address).call()
         return int(period)
 
+    @validate_checksum_address
     def get_worker_from_staker(self, staker_address: str) -> str:
         worker = self.contract.functions.getWorkerFromStaker(staker_address).call()
         return to_checksum_address(worker)
 
+    @validate_checksum_address
     def get_staker_from_worker(self, worker_address: str) -> str:
         staker = self.contract.functions.getStakerFromWorker(worker_address).call()
         return to_checksum_address(staker)
 
+    @validate_checksum_address
     def set_worker(self, staker_address: str, worker_address: str):
         contract_function = self.contract.functions.setWorker(worker_address)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
         return receipt
 
+    @validate_checksum_address
     def release_worker(self, staker_address: str):
         return self.set_worker(staker_address=staker_address, worker_address=BlockchainInterface.NULL_ADDRESS)
 
+    @validate_checksum_address
     def confirm_activity(self, worker_address: str):
         """
         For each period that the worker confirms activity, the staker is rewarded.
@@ -328,6 +345,7 @@ class StakingEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=worker_address)
         return receipt
 
+    @validate_checksum_address
     def mint(self, staker_address: str):
         """
         Computes reward tokens for the staker's account;
@@ -478,6 +496,7 @@ class PolicyManagerAgent(EthereumContractAgent):
     registry_contract_name = POLICY_MANAGER_CONTRACT_NAME
     _proxy_name = DISPATCHER_CONTRACT_NAME
 
+    @validate_checksum_address
     def create_policy(self,
                       policy_id: str,
                       author_address: str,
@@ -498,12 +517,14 @@ class PolicyManagerAgent(EthereumContractAgent):
         blockchain_record = self.contract.functions.policies(policy_id).call()
         return blockchain_record
 
+    @validate_checksum_address
     def revoke_policy(self, policy_id: bytes, author_address: str):
         """Revoke by arrangement ID; Only the policy's author_address can revoke the policy."""
         contract_function = self.contract.functions.revokePolicy(policy_id)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
+    @validate_checksum_address
     def collect_policy_reward(self, collector_address: str, staker_address: str):
         """Collect rewarded ETH"""
         contract_function = self.contract.functions.withdraw(collector_address)
@@ -516,16 +537,19 @@ class PolicyManagerAgent(EthereumContractAgent):
             arrangement = self.contract.functions.getArrangementInfo(policy_id, index).call()
             yield arrangement
 
+    @validate_checksum_address
     def revoke_arrangement(self, policy_id: str, node_address: str, author_address: str):
         contract_function = self.contract.functions.revokeArrangement(policy_id, node_address)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
+    @validate_checksum_address
     def calculate_refund(self, policy_id: str, author_address: str):
         contract_function = self.contract.functions.calculateRefundValue(policy_id)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
+    @validate_checksum_address
     def collect_refund(self, policy_id: str, author_address: str):
         contract_function = self.contract.functions.refund(policy_id)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
@@ -544,6 +568,7 @@ class UserEscrowAgent(EthereumContractAgent):
         _proxy_name = LIBRARY_LINKER_CONTRACT_NAME
         _forward_address = False
 
+        @validate_checksum_address
         def _generate_beneficiary_agency(self, principal_address: str):
             contract = self.blockchain.client.get_contract(address=principal_address, abi=self.contract.abi)
             return contract
@@ -570,6 +595,7 @@ class UserEscrowAgent(EthereumContractAgent):
         contract = self.__proxy_agent._generate_beneficiary_agency(principal_address=self.principal_contract.address)
         self.__proxy_contract = contract
 
+    @validate_checksum_address
     def __fetch_principal_contract(self, contract_address: str = None) -> None:
         """Fetch the UserEscrow deployment directly from the AllocationRegistry."""
         if contract_address is not None:
@@ -584,6 +610,7 @@ class UserEscrowAgent(EthereumContractAgent):
     def __set_owner(self) -> None:
         self.__beneficiary = self.owner
 
+    @validate_checksum_address
     def __read_principal(self, contract_address: str = None) -> None:
         self.__fetch_principal_contract(contract_address=contract_address)
         self.__set_owner()
@@ -643,11 +670,13 @@ class UserEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
+    @validate_checksum_address
     def set_worker(self, worker_address: str):
         contract_function = self.__proxy_contract.functions.setWorker(worker_address)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
+    @validate_checksum_address
     def release_worker(self):
         receipt = self.set_worker(worker_address=BlockchainInterface.NULL_ADDRESS)
         return receipt
@@ -657,6 +686,7 @@ class UserEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
+    @validate_checksum_address
     def collect_policy_reward(self, collector_address: str):
         contract_function = self.__proxy_contract.functions.withdrawPolicyReward(collector_address)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
@@ -673,6 +703,7 @@ class AdjudicatorAgent(EthereumContractAgent):
     registry_contract_name = ADJUDICATOR_CONTRACT_NAME
     _proxy_name = DISPATCHER_CONTRACT_NAME
 
+    @validate_checksum_address
     def evaluate_cfrag(self, evidence, sender_address: str):
         """
         Submits proof that a worker created wrong CFrag
@@ -715,6 +746,7 @@ class AdjudicatorAgent(EthereumContractAgent):
     def reward_coefficient(self) -> int:
         return self.contract.functions.rewardCoefficient().call()
 
+    @validate_checksum_address
     def penalty_history(self, staker_address: str) -> int:
         return self.contract.functions.penaltyHistory(staker_address).call()
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -697,6 +697,26 @@ class UserEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
+    @validate_checksum_address
+    def set_restaking(self, value: bool) -> dict:
+        """
+        Enable automatic restaking for a fixed duration of lock periods.
+        If set to True, then all staking rewards will be automatically added to locked stake.
+        """
+        contract_function = self.__proxy_contract.functions.setReStake(value)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                   sender_address=self.__beneficiary)
+        # TODO: Handle ReStakeSet event (see #1193)
+        return receipt
+
+    @validate_checksum_address
+    def lock_restaking(self, release_period: int) -> dict:
+        contract_function = self.__proxy_contract.functions.lockReStake(release_period)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                   sender_address=self.__beneficiary)
+        # TODO: Handle ReStakeLocked event (see #1193)
+        return receipt
+
 
 class AdjudicatorAgent(EthereumContractAgent):
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -657,8 +657,8 @@ class UserEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
-    def collect_policy_reward(self):
-        contract_function = self.__proxy_contract.functions.withdrawPolicyReward()
+    def collect_policy_reward(self, collector_address: str):
+        contract_function = self.__proxy_contract.functions.withdrawPolicyReward(collector_address)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -676,7 +676,6 @@ class UserEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
-    @validate_checksum_address
     def release_worker(self):
         receipt = self.set_worker(worker_address=BlockchainInterface.NULL_ADDRESS)
         return receipt
@@ -697,7 +696,6 @@ class UserEscrowAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 
-    @validate_checksum_address
     def set_restaking(self, value: bool) -> dict:
         """
         Enable automatic restaking for a fixed duration of lock periods.
@@ -709,7 +707,6 @@ class UserEscrowAgent(EthereumContractAgent):
         # TODO: Handle ReStakeSet event (see #1193)
         return receipt
 
-    @validate_checksum_address
     def lock_restaking(self, release_period: int) -> dict:
         contract_function = self.__proxy_contract.functions.lockReStake(release_period)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -582,8 +582,7 @@ class UserEscrowAgent(EthereumContractAgent):
         self.__principal_contract = principal_contract
 
     def __set_owner(self) -> None:
-        owner = self.owner
-        self.__beneficiary = owner
+        self.__beneficiary = self.owner
 
     def __read_principal(self, contract_address: str = None) -> None:
         self.__fetch_principal_contract(contract_address=contract_address)
@@ -647,6 +646,10 @@ class UserEscrowAgent(EthereumContractAgent):
     def set_worker(self, worker_address: str):
         contract_function = self.__proxy_contract.functions.setWorker(worker_address)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
+        return receipt
+
+    def release_worker(self):
+        receipt = self.set_worker(worker_address=BlockchainInterface.NULL_ADDRESS)
         return receipt
 
     def mint(self):

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -322,8 +322,17 @@ class GethClient(Web3Client):
             # Geth --dev accounts are unlocked by default.
             return True
         debug_message = f"Unlocking account {address}"
+
+        if duration is None:
+            debug_message += f" for 5 minutes"
+        elif duration == 0:
+            debug_message += f" indefinitely"
+        elif duration > 0:
+            debug_message += f" for {duration} seconds"
+
         if password is None:
             debug_message += " with no password."
+
         self.log.debug(debug_message)
         return self.w3.geth.personal.unlockAccount(address, password, duration)
 

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -862,6 +862,7 @@ class UserEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Ownable
                                           contract_address=self.contract.address,
                                           contract_abi=self.contract.abi)
 
+    @validate_checksum_address
     def deliver(self, value: int, duration: int, beneficiary_address: str, progress=None) -> dict:
         """
         Transfer allocated tokens and hand-off the contract to the beneficiary.

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -44,6 +44,7 @@ from web3.middleware import geth_poa_middleware
 
 from nucypher.blockchain.eth.clients import NuCypherGethProcess
 from nucypher.blockchain.eth.clients import Web3Client
+from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.providers import (
     _get_tester_pyevm,
     _get_test_geth_parity_provider,
@@ -330,6 +331,7 @@ class BlockchainInterface:
         else:
             self._provider = provider
 
+    @validate_checksum_address
     def send_transaction(self,
                          contract_function: ContractFunction,
                          sender_address: str,
@@ -550,6 +552,7 @@ class BlockchainDeployerInterface(BlockchainInterface):
             __raw_contract_cache = NO_COMPILATION_PERFORMED
         self.__raw_contract_cache = __raw_contract_cache
 
+    @validate_checksum_address
     def deploy_contract(self,
                         deployer_address: str,
                         registry: BaseContractRegistry,
@@ -642,6 +645,7 @@ class BlockchainDeployerInterface(BlockchainInterface):
                                                        ContractFactoryClass=self._contract_factory)
         return wrapped_contract
 
+    @validate_checksum_address
     def get_proxy_contract(self,
                            registry: BaseContractRegistry,
                            target_address: str,

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -194,10 +194,12 @@ class BaseContractRegistry(ABC):
 
 class LocalContractRegistry(BaseContractRegistry):
 
+    REGISTRY_TYPE = 'contract'
+
     def __init__(self, filepath: str, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__filepath = filepath
-        self.log.info("Using contract registry {}".format(self.__filepath))
+        self.log.info(f"Using {self.REGISTRY_TYPE} registry {filepath}")
 
     def __repr__(self):
         r = f"{self.__class__.__name__}(filepath={self.filepath})"
@@ -344,6 +346,7 @@ class AllocationRegistry(LocalContractRegistry):
     _multi_contract = False
     _contract_name = USER_ESCROW_CONTRACT_NAME
 
+    REGISTRY_TYPE = 'allocation'
     REGISTRY_NAME = 'allocation_registry.json'
 
     _default_registry_filepath = os.path.join(DEFAULT_CONFIG_ROOT, REGISTRY_NAME)

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -30,6 +30,7 @@ from twisted.logger import Logger
 from web3.contract import Contract
 
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
+from nucypher.blockchain.eth.constants import USER_ESCROW_CONTRACT_NAME
 
 
 class BaseContractRegistry(ABC):
@@ -341,9 +342,11 @@ class InMemoryContractRegistry(BaseContractRegistry):
 class AllocationRegistry(LocalContractRegistry):
 
     _multi_contract = False
-    _contract_name = 'UserEscrow'
+    _contract_name = USER_ESCROW_CONTRACT_NAME
 
-    _default_registry_filepath = os.path.join(DEFAULT_CONFIG_ROOT, 'allocation_registry.json')
+    REGISTRY_NAME = 'allocation_registry.json'
+
+    _default_registry_filepath = os.path.join(DEFAULT_CONFIG_ROOT, REGISTRY_NAME)
 
     class NoAllocationRegistry(BaseContractRegistry.NoRegistry):
         pass
@@ -384,6 +387,14 @@ class AllocationRegistry(LocalContractRegistry):
                 contract_data = records[0]
 
         return contract_data
+
+    def is_beneficiary_enrolled(self, beneficiary_address: str) -> bool:
+        try:
+            _ = self.search(beneficiary_address=beneficiary_address)
+            return True
+        except self.UnknownBeneficiary:
+            return False
+        # TODO: Tests!
 
     def enroll(self, beneficiary_address, contract_address, contract_abi) -> None:
         contract_data = [contract_address, contract_abi]

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -425,7 +425,7 @@ contract StakingEscrow is Issuer {
     }
 
     /**
-    * @notice Set `reStake` parameter. If true then all mining reward will be added to locked stake
+    * @notice Set `reStake` parameter. If true then all staking rewards will be added to locked stake
     * Only if this parameter is not locked
     * @param _reStake Value for parameter
     **/

--- a/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
@@ -91,11 +91,12 @@ contract UserEscrowProxy {
     * @notice Deposit tokens to the staking escrow
     * @param _value Amount of token to deposit
     * @param _periods Amount of periods during which tokens will be locked
+    * @dev Assume that `this` is the UserEscrow contract
     **/
     function depositAsStaker(uint256 _value, uint16 _periods) public {
         UserEscrowProxy state = getStateContract();
         NuCypherToken tokenFromState = state.token();
-        require(tokenFromState.balanceOf(address(this)) > _value);
+        require(tokenFromState.balanceOf(address(this)) >= _value);
         StakingEscrow escrowFromState = state.escrow();
         tokenFromState.approve(address(escrowFromState), _value);
         escrowFromState.deposit(_value, _periods);

--- a/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/UserEscrowProxy.sol
@@ -149,9 +149,9 @@ contract UserEscrowProxy {
     /**
     * @notice Withdraw available reward from the policy manager to the user escrow
     **/
-    function withdrawPolicyReward() public {
-        uint256 value = getStateContract().policyManager().withdraw(msg.sender);
-        emit PolicyRewardWithdrawn(msg.sender, value);
+    function withdrawPolicyReward(address payable _recipient) public {
+        uint256 value = getStateContract().policyManager().withdraw(_recipient);
+        emit PolicyRewardWithdrawn(_recipient, value);
     }
 
     /**

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -95,7 +95,7 @@ class NU:
         return cls(value, denomination='NU')
 
     def to_tokens(self) -> Decimal:
-        """Returns an decimal value of NU"""
+        """Returns a decimal value of NU"""
         return currency.from_wei(self.__value, unit='ether')
 
     def to_nunits(self) -> int:

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -164,6 +164,7 @@ class Stake:
     class StakingError(Exception):
         """Raised when a staking operation cannot be executed due to failure."""
 
+    @validate_checksum_address
     def __init__(self,
                  staking_agent: StakingEscrowAgent,
                  checksum_address: str,
@@ -568,6 +569,7 @@ class WorkTracker:
 
 class StakeList(UserList):
 
+    @validate_checksum_address
     def __init__(self,
                  registry: BaseContractRegistry,
                  checksum_address: str = None,
@@ -593,12 +595,10 @@ class StakeList(UserList):
     def updated(self) -> maya.MayaDT:
         return self.__updated
 
-    @validate_checksum_address
     def refresh(self, checksum_addresses: List[str] = None) -> None:
         """Public staking cache invalidation method"""
         return self.__read_stakes()
 
-    @validate_checksum_address
     def __read_stakes(self,) -> None:
         """Rewrite the local staking cache by reading on-chain stakes"""
 

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -413,6 +413,7 @@ class Stake:
         # Transmit
         #
 
+        # TODO: Entrypoint for UserEscrowAgent here
         # Transmit the stake division transaction
         receipt = self.staking_agent.divide_stake(staker_address=self.staker_address,
                                                   stake_index=self.index,

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -578,11 +578,11 @@ class StakeList(UserList):
     def updated(self) -> maya.MayaDT:
         return self.__updated
 
-    def refresh(self, checksum_addresses: List[str] = None) -> None:
+    def refresh(self) -> None:
         """Public staking cache invalidation method"""
         return self.__read_stakes()
 
-    def __read_stakes(self,) -> None:
+    def __read_stakes(self) -> None:
         """Rewrite the local staking cache by reading on-chain stakes"""
 
         existing_records = len(self)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -15,7 +15,6 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 import json
-import random
 import time
 from base64 import b64encode
 from collections import OrderedDict
@@ -43,10 +42,10 @@ from umbral.signing import Signature
 
 import nucypher
 from nucypher.blockchain.eth.actors import BlockchainPolicyAuthor, Worker, Staker
-from nucypher.blockchain.eth.agents import StakingEscrowAgent, NucypherTokenAgent, ContractAgency
+from nucypher.blockchain.eth.agents import StakingEscrowAgent, NucypherTokenAgent, ContractAgency, UserEscrowAgent
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
-from nucypher.blockchain.eth.registry import BaseContractRegistry
+from nucypher.blockchain.eth.registry import BaseContractRegistry, AllocationRegistry
 from nucypher.blockchain.eth.token import StakeList, WorkTracker, NU
 from nucypher.characters.banners import ALICE_BANNER, BOB_BANNER, ENRICO_BANNER, URSULA_BANNER, STAKEHOLDER_BANNER
 from nucypher.characters.base import Character, Learner
@@ -1415,8 +1414,13 @@ class StakeHolder(Staker):
                  checksum_addresses: set = None,
                  password: str = None,
                  *args, **kwargs):
+
+        self.user_escrow_agent = None
+
         super().__init__(is_me=is_me, checksum_address=initial_address, *args, **kwargs)
         self.log = Logger(f"stakeholder")
+
+        self.allocation_registry = AllocationRegistry()  # FIXME
 
         # Wallet
         self.wallet = self.StakingWallet(registry=self.registry, checksum_addresses=checksum_addresses)
@@ -1429,11 +1433,25 @@ class StakeHolder(Staker):
 
     @validate_checksum_address
     def assimilate(self, checksum_address: str, password: str = None) -> None:
+        # In case the account stakes via a contract
+        has_staking_contract = self.allocation_registry.is_beneficiary_enrolled(checksum_address)
+        if has_staking_contract:
+            self.beneficiary_address = checksum_address
+            self.user_escrow_agent = UserEscrowAgent(registry=self.registry,
+                                                     allocation_registry=self.allocation_registry,
+                                                     beneficiary=self.beneficiary_address)
+            staking_address = self.user_escrow_agent.principal_contract.address
+        else:
+            staking_address = checksum_address
+            self.user_escrow_agent = None
+            self.beneficiary_address = None
+
         self.wallet.activate_account(checksum_address=checksum_address, password=password)
         original_form = self.checksum_address
-        self.checksum_address = checksum_address
-        self.stakes = StakeList(registry=self.registry, checksum_address=checksum_address)
+        self.checksum_address = staking_address
+        self.stakes = StakeList(registry=self.registry, checksum_address=staking_address)
         self.stakes.refresh()
+        # TODO: Not sure how to log all this new info (i.e. old or new address may be via contract)
         self.log.info(f"Resistance is futile - Assimilating Staker {original_form} -> {checksum_address}.")
 
     @property

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -392,7 +392,7 @@ def handle_client_account_for_staking(emitter,
                 click.confirm("Is this correct?", abort=True)
         else:
             message = (f"Beneficiary {client_account} doesn't have a preallocation contract in current registry.\n"
-                       f"Are you sure you are using the right allocation registry?\n"
+                       f"Are you sure you are using the correct allocation registry?\n"
                        f"Currently using {stakeholder.allocation_registry.filepath}")
             emitter.echo(message, color='red', verbosity=1)
             raise click.Abort()

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -423,7 +423,7 @@ def confirm_deployment(emitter, deployer_interface) -> bool:
 def confirm_enable_restaking_lock(emitter, staking_address: str, release_period: int) -> bool:
     restaking_lock_agreement = f"""
 By enabling the re-staking lock for {staking_address}, you are committing to automatically 
-re-stake all rewards until period a future period.  You will not be able to disable re-staking until {release_period}.
+re-stake all rewards until a future period.  You will not be able to disable re-staking until {release_period}.
     """
     emitter.message(restaking_lock_agreement)
     click.confirm(f"Confirm enable re-staking lock for staker {staking_address} until {release_period}?", abort=True)
@@ -431,9 +431,9 @@ re-stake all rewards until period a future period.  You will not be able to disa
 
 
 def confirm_enable_restaking(emitter, staking_address: str) -> bool:
-    restaking_lock_agreement = f"By enabling the re-staking for {staking_address}, " \
-                               f"All staking rewards will be automatically added to your existing stake."
-    emitter.message(restaking_lock_agreement)
+    restaking_agreement = f"By enabling the re-staking for {staking_address}, " \
+                          f"all staking rewards will be automatically added to your existing stake."
+    emitter.message(restaking_agreement)
     click.confirm(f"Confirm enable automatic re-staking for staker {staking_address}?", abort=True)
     return True
 

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -382,6 +382,7 @@ def handle_client_account_for_staking(emitter,
         else:
             client_account = select_client_account(prompt="Select beneficiary account",
                                                    emitter=emitter,
+                                                   registry=stakeholder.registry,
                                                    provider_uri=stakeholder.wallet.blockchain.provider_uri)
         staking_address = stakeholder.check_if_staking_via_contract(checksum_address=client_account)
         if staking_address:
@@ -401,6 +402,7 @@ def handle_client_account_for_staking(emitter,
         else:
             client_account = select_client_account(prompt="Select staking account",
                                                    emitter=emitter,
+                                                   registry=stakeholder.registry,
                                                    provider_uri=stakeholder.wallet.blockchain.provider_uri)
             staking_address = client_account
 

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -166,8 +166,10 @@ def stake(click_config,
         allocation_registry = None
         initial_address = staking_address
 
+    dummy_password = "Look Away, I'm Hideous"  # TODO: See #1385
     STAKEHOLDER = stakeholder_config.produce(initial_address=initial_address,
-                                             allocation_registry=allocation_registry)
+                                             allocation_registry=allocation_registry,
+                                             password=dummy_password)
     blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)  # Eager connection
     economics = STAKEHOLDER.economics
 

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -280,7 +280,8 @@ def stake(click_config,
             if staking_address:
                 message = f"Beneficiary {client_account} will use preallocation contract {staking_address} to stake."
                 emitter.echo(message, color='yellow', verbosity=1)
-                click.confirm("Is this correct?", abort=True)
+                if not force:
+                    click.confirm("Is this correct?", abort=True)
             else:
                 message = (f"Beneficiary {client_account} doesn't have a preallocation contract in current registry.\n"
                            f"Are you sure you are using the right allocation registry?\n"

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -421,6 +421,8 @@ def stake(click_config,
     elif action == 'collect-reward':
         """Withdraw staking reward to the specified wallet address"""
 
+        # TODO: Missing account selection
+
         password = None
         if not hw_wallet and not blockchain.client.is_local:
             password = get_client_password(checksum_address=staking_address)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -202,7 +202,7 @@ def paint_contract_status(registry, emitter):
 | '{blockchain.client.chain_name}' Blockchain Network |
 Gas Price ................ {Web3.fromWei(blockchain.client.gas_price, 'gwei')} Gwei
 Provider URI ............. {blockchain.provider_uri}
-Registry  ................ {registry.filepath}
+Registry ................. {registry.filepath}
     """
 
     confirmed, pending, inactive = staking_agent.partition_stakers_by_activity()

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -119,7 +119,7 @@ class TransactingPower(CryptoPowerUp):
         self.blockchain = BlockchainInterfaceFactory.get_interface()
         self.__account = account
 
-        # TODO: Is there a better way to design this Flag?
+        # TODO: Is there a better way to design this Flag? See #1385
         self.device = True if not password else False
 
         self.__password = password

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -653,7 +653,7 @@ def test_all(testerchain,
     testerchain.wait_for_receipt(tx)
     assert ursula2_balance < testerchain.client.get_balance(ursula2)
     ursula3_balance = testerchain.client.get_balance(ursula3)
-    tx = user_escrow_proxy_1.functions.withdrawPolicyReward().transact({'from': ursula3, 'gas_price': 0})
+    tx = user_escrow_proxy_1.functions.withdrawPolicyReward(ursula3).transact({'from': ursula3, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert ursula3_balance < testerchain.client.get_balance(ursula3)
 

--- a/tests/blockchain/eth/contracts/main/user_escrow/test_user_escrow.py
+++ b/tests/blockchain/eth/contracts/main/user_escrow/test_user_escrow.py
@@ -302,7 +302,7 @@ def test_policy(testerchain, policy_manager, user_escrow, user_escrow_proxy):
 
     # Nothing to withdraw
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = user_escrow_proxy.functions.withdrawPolicyReward().transact({'from': user, 'gas_price': 0})
+        tx = user_escrow_proxy.functions.withdrawPolicyReward(user).transact({'from': user, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = user_escrow.functions.withdrawETH().transact({'from': user, 'gas_price': 0})
@@ -320,14 +320,14 @@ def test_policy(testerchain, policy_manager, user_escrow, user_escrow_proxy):
 
     # Only user can withdraw reward
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = user_escrow_proxy.functions.withdrawPolicyReward().transact({'from': creator, 'gas_price': 0})
+        tx = user_escrow_proxy.functions.withdrawPolicyReward(creator).transact({'from': creator, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = user_escrow.functions.withdrawETH().transact({'from': creator, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # User withdraws reward
-    tx = user_escrow_proxy.functions.withdrawPolicyReward().transact({'from': user, 'gas_price': 0})
+    tx = user_escrow_proxy.functions.withdrawPolicyReward(user).transact({'from': user, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert user_balance + 10000 == testerchain.client.get_balance(user)
     assert 0 == testerchain.client.get_balance(policy_manager.address)

--- a/tests/blockchain/eth/entities/actors/test_worker.py
+++ b/tests/blockchain/eth/entities/actors/test_worker.py
@@ -54,7 +54,7 @@ def test_worker_auto_confirmations(testerchain,
 
     def verify(_):
         # Verify that periods were confirmed on-chain automatically
-        last_active_period = staker.staking_agent.get_last_active_period(address=staker.checksum_address)
+        last_active_period = staker.staking_agent.get_last_active_period(staker_address=staker.checksum_address)
         current_period = staker.staking_agent.get_current_period()
         assert (last_active_period - current_period) == 1
 

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -135,7 +135,7 @@ def test_deposit_and_withdraw_as_staker(testerchain, agent, agency, allocation_v
     testerchain.transacting_power.activate()
 
     # Move the tokens to the StakingEscrow
-    receipt = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked, periods=token_economics.minimum_locked_periods)
+    receipt = agent.deposit_as_staker(amount=token_economics.minimum_allowed_locked, lock_periods=token_economics.minimum_locked_periods)
     assert receipt  # TODO
 
     # User sets a worker in StakingEscrow via UserEscrow
@@ -189,8 +189,8 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics):
                                                      account=agent.beneficiary)
     testerchain.transacting_power.activate()
 
-    _receipt = agent.deposit_as_staker(value=token_economics.minimum_allowed_locked,
-                                       periods=token_economics.minimum_locked_periods)
+    _receipt = agent.deposit_as_staker(amount=token_economics.minimum_allowed_locked,
+                                       lock_periods=token_economics.minimum_locked_periods)
 
     # User sets a worker in StakingEscrow via UserEscrow
     worker = testerchain.ursula_account(0)

--- a/tests/blockchain/eth/interfaces/test_decorators.py
+++ b/tests/blockchain/eth/interfaces/test_decorators.py
@@ -52,6 +52,9 @@ def test_validate_checksum_address():
     with pytest.raises(InvalidChecksumAddress):
         optional_checksum_address(12, "0x_NOT_VALID")
 
+    with pytest.raises(InvalidChecksumAddress):
+        optional_checksum_address("whatever", get_random_checksum_address().lower())
+
     assert optional_checksum_address(123)
 
     assert optional_checksum_address(None, staking_address=get_random_checksum_address())

--- a/tests/blockchain/eth/interfaces/test_decorators.py
+++ b/tests/blockchain/eth/interfaces/test_decorators.py
@@ -1,0 +1,81 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import os
+import pytest
+
+from eth_utils import to_checksum_address
+
+from nucypher.blockchain.eth.decorators import validate_checksum_address, InvalidChecksumAddress
+
+
+def get_random_checksum_address():
+    canonical_address = os.urandom(20)
+    checksum_address = to_checksum_address(canonical_address)
+    return checksum_address
+
+
+def test_validate_checksum_address():
+
+    # Simple case: just one parameter, called "checksum_address"
+    @validate_checksum_address
+    def just_one_address(checksum_address):
+        return True
+
+    with pytest.raises(InvalidChecksumAddress):
+        just_one_address("0x_NOT_VALID")
+
+    with pytest.raises(TypeError):
+        just_one_address(123)
+
+    assert just_one_address(get_random_checksum_address())
+
+    # More complex case: the parameter is optional
+    @validate_checksum_address
+    def optional_checksum_address(whatever, staking_address=None):
+        return True
+
+    with pytest.raises(InvalidChecksumAddress):
+        optional_checksum_address(12, "0x_NOT_VALID")
+
+    assert optional_checksum_address(123)
+
+    assert optional_checksum_address(None, staking_address=get_random_checksum_address())
+
+    # Even more complex: there are multiple checksum addresses
+    @validate_checksum_address
+    def multiple_checksum_addresses(whatever, worker_address, staking_address=None):
+        return True
+
+    with pytest.raises(InvalidChecksumAddress):
+        multiple_checksum_addresses(12, "0x_NOT_VALID")
+
+    with pytest.raises(InvalidChecksumAddress):
+        multiple_checksum_addresses(12, get_random_checksum_address(), "0x_NOT_VALID")
+
+    with pytest.raises(InvalidChecksumAddress):
+        multiple_checksum_addresses(12, "0x_NOT_VALID", get_random_checksum_address())
+
+    with pytest.raises(TypeError):
+        multiple_checksum_addresses(12, None)
+
+    assert multiple_checksum_addresses(123, get_random_checksum_address(), None)
+    assert multiple_checksum_addresses(123, get_random_checksum_address())
+
+    assert multiple_checksum_addresses(42,
+                                       worker_address=get_random_checksum_address(),
+                                       staking_address=get_random_checksum_address())

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -20,14 +20,15 @@ import contextlib
 import json
 import os
 import shutil
-import sys
 
 import pytest
 from click.testing import CliRunner
 
+from nucypher.blockchain.eth.actors import ContractAdministrator
 from nucypher.blockchain.eth.registry import AllocationRegistry, InMemoryContractRegistry
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.utilities.sandbox.constants import (
+    MOCK_ALLOCATION_REGISTRY_FILEPATH,
     MOCK_CUSTOM_INSTALLATION_PATH,
     MOCK_ALLOCATION_INFILE,
     MOCK_REGISTRY_FILEPATH,
@@ -62,16 +63,31 @@ def nominal_federated_configuration_fields():
 def mock_allocation_infile(testerchain, token_economics):
     accounts = testerchain.unassigned_accounts
     allocation_data = [{'beneficiary_address': addr,
-                        'amount': token_economics.minimum_allowed_locked,
+                        'amount': 2 * token_economics.minimum_allowed_locked,
                         'duration_seconds': ONE_YEAR_IN_SECONDS}
                        for addr in accounts]
 
     with open(MOCK_ALLOCATION_INFILE, 'w') as file:
         file.write(json.dumps(allocation_data))
 
-    registry = AllocationRegistry(filepath=MOCK_ALLOCATION_INFILE)
-    yield registry
-    os.remove(MOCK_ALLOCATION_INFILE)
+    yield MOCK_ALLOCATION_INFILE
+    if os.path.isfile(MOCK_ALLOCATION_INFILE):
+        os.remove(MOCK_ALLOCATION_INFILE)
+
+
+@pytest.fixture(scope='module')
+def mock_allocation_registry(testerchain, test_registry, mock_allocation_infile):
+    admin = ContractAdministrator(registry=test_registry,
+                                  client_password=INSECURE_DEVELOPMENT_PASSWORD,
+                                  deployer_address=testerchain.etherbase_account)
+
+    admin.deploy_beneficiaries_from_file(allocation_data_filepath=mock_allocation_infile,
+                                         allocation_outfile=MOCK_ALLOCATION_REGISTRY_FILEPATH)
+
+    allocation_registry = AllocationRegistry(filepath=MOCK_ALLOCATION_REGISTRY_FILEPATH)
+    yield allocation_registry
+    if os.path.isfile(MOCK_ALLOCATION_REGISTRY_FILEPATH):
+        os.remove(MOCK_ALLOCATION_REGISTRY_FILEPATH)
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -26,7 +26,7 @@ from click.testing import CliRunner
 
 from nucypher.blockchain.eth.actors import ContractAdministrator
 from nucypher.blockchain.eth.registry import AllocationRegistry, InMemoryContractRegistry
-from nucypher.config.characters import UrsulaConfiguration
+from nucypher.config.characters import UrsulaConfiguration, StakeHolderConfiguration
 from nucypher.utilities.sandbox.constants import (
     MOCK_ALLOCATION_REGISTRY_FILEPATH,
     MOCK_CUSTOM_INSTALLATION_PATH,
@@ -125,3 +125,17 @@ def custom_filepath_2():
     finally:
         with contextlib.suppress(FileNotFoundError):
             shutil.rmtree(_custom_filepath, ignore_errors=True)
+
+
+@pytest.fixture(scope='module')
+def worker_configuration_file_location(custom_filepath):
+    _configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH,
+                                                UrsulaConfiguration.generate_filename())
+    return _configuration_file_location
+
+
+@pytest.fixture(scope='module')
+def stakeholder_configuration_file_location(custom_filepath):
+    _configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH,
+                                                StakeHolderConfiguration.generate_filename())
+    return _configuration_file_location

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -48,7 +48,6 @@ def registry_filepath():
 
 
 def test_nucypher_deploy_contracts(click_runner,
-                                   mock_allocation_infile,
                                    token_economics,
                                    registry_filepath):
 
@@ -352,7 +351,7 @@ def test_nucypher_deploy_allocation_contracts(click_runner,
 
     deploy_command = ('allocations',
                       '--registry-infile', registry_filepath,
-                      '--allocation-infile', mock_allocation_infile.filepath,
+                      '--allocation-infile', mock_allocation_infile,
                       '--allocation-outfile', MOCK_ALLOCATION_REGISTRY_FILEPATH,
                       '--provider', TEST_PROVIDER_URI,
                       '--poa')
@@ -376,4 +375,4 @@ def test_nucypher_deploy_allocation_contracts(click_runner,
     user_escrow_agent = UserEscrowAgent(registry=registry,
                                         beneficiary=beneficiary,
                                         allocation_registry=allocation_registry)
-    assert user_escrow_agent.unvested_tokens == token_economics.minimum_allowed_locked
+    assert user_escrow_agent.unvested_tokens == 2 * token_economics.minimum_allowed_locked

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -50,12 +50,12 @@ def test_nucypher_status_network(click_runner, testerchain, test_registry, agenc
 
     agents = (token_agent, staking_agent, policy_agent, adjudicator_agent)
     for agent in agents:
-        contract_regex = f"^{agent.contract_name} \.+ {agent.contract_address}"
+        contract_regex = f"^{agent.contract_name} \\.+ {agent.contract_address}"
         assert re.search(contract_regex, result.output, re.MULTILINE)
 
-    assert re.search(f"^Provider URI \.+ {TEST_PROVIDER_URI}", result.output, re.MULTILINE)
-    #assert re.search(f"^Registry \.+ {registry_filepath}", result.output, re.MULTILINE)
-    assert re.search(f"^Current Period \.+ {staking_agent.get_current_period()}", result.output, re.MULTILINE)
+    assert re.search(f"^Provider URI \\.+ {TEST_PROVIDER_URI}", result.output, re.MULTILINE)
+    assert re.search(f"^Registry \\.+ {registry_filepath}", result.output, re.MULTILINE)
+    assert re.search(f"^Current Period \\.+ {staking_agent.get_current_period()}", result.output, re.MULTILINE)
 
 
 def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agency, stakers):
@@ -91,7 +91,8 @@ def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agenc
     locked_tokens = NU.from_nunits(staking_agent.get_locked_tokens(staking_address))
 
     assert re.search(f"^Current period: {staking_agent.get_current_period()}", result.output, re.MULTILINE)
-    assert re.search(f"Worker:\s+{some_dude.worker_address}", result.output, re.MULTILINE)
-    assert re.search(f"Stake:\s+{round(owned_tokens, 2)}  \(Locked: {round(locked_tokens, 2)}\)", result.output, re.MULTILINE)
+    assert re.search(r"Worker:\s+" + some_dude.worker_address, result.output, re.MULTILINE)
+    assert re.search(r"Stake:\s+" + str(round(owned_tokens, 2)), result.output, re.MULTILINE)
+    assert re.search(r"Locked: " + str(round(locked_tokens, 2)), result.output, re.MULTILINE)
 
 

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -54,7 +54,7 @@ def test_nucypher_status_network(click_runner, testerchain, test_registry, agenc
         assert re.search(contract_regex, result.output, re.MULTILINE)
 
     assert re.search(f"^Provider URI \\.+ {TEST_PROVIDER_URI}", result.output, re.MULTILINE)
-    assert re.search(f"^Registry \\.+ {registry_filepath}", result.output, re.MULTILINE)
+    assert re.search(f"^Registry \\.+ {MOCK_REGISTRY_FILEPATH}", result.output, re.MULTILINE)
     assert re.search(f"^Current Period \\.+ {staking_agent.get_current_period()}", result.output, re.MULTILINE)
 
 

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -96,7 +96,7 @@ def test_stake_via_contract(click_runner,
     # The good stuff: Using `nucypher stake create --escrow`
     #
 
-    # Staking contract has not stakes yet
+    # Staking contract has no stakes yet
     staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
     stakes = list(staking_agent.get_all_stakes(staker_address=preallocation_contract_address))
     assert not stakes

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -1,0 +1,123 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import json
+
+from web3 import Web3
+
+from nucypher.blockchain.eth.agents import StakingEscrowAgent, ContractAgency, UserEscrowAgent, NucypherTokenAgent
+from nucypher.blockchain.eth.token import NU, Stake
+from nucypher.cli.main import nucypher_cli
+from nucypher.utilities.sandbox.constants import (
+    TEST_PROVIDER_URI,
+    INSECURE_DEVELOPMENT_PASSWORD,
+)
+
+
+# This test is intended to mirror tests/cli/ursula/test_stakeholder_and_ursula.py,
+# but using a staking contract (namely, UserEscrow)
+def test_stake_via_contract(click_runner,
+                            custom_filepath,
+                            test_registry,
+                            mock_allocation_registry,
+                            mock_registry_filepath,
+                            testerchain,
+                            stakeholder_configuration_file_location,
+                            stake_value,
+                            token_economics,
+                            agency,
+                            ):
+
+    #
+    # Inital checks: beneficiary and pre-allocation contract
+    #
+
+    # First, let's be give the beneficiary some cash for TXs
+    beneficiary = testerchain.unassigned_accounts[0]
+    tx = {'to': beneficiary,
+          'from': testerchain.etherbase_account,
+          'value': Web3.toWei('1', 'ether')}
+
+    txhash = testerchain.client.w3.eth.sendTransaction(tx)
+    _receipt = testerchain.wait_for_receipt(txhash)
+
+    # Next, let's be sure the beneficiary is in the allocation registry...
+    assert mock_allocation_registry.is_beneficiary_enrolled(beneficiary)
+
+    # ... and that the pre-allocation contract has enough tokens
+    user_escrow_agent = UserEscrowAgent(beneficiary=beneficiary,
+                                        registry=test_registry,
+                                        allocation_registry=mock_allocation_registry)
+    preallocation_contract_address = user_escrow_agent.principal_contract.address
+    token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=test_registry)
+    assert token_agent.get_balance(preallocation_contract_address) >= token_economics.minimum_allowed_locked
+
+    # Let's not forget to create a stakeholder
+    init_args = ('stake', 'init-stakeholder',
+                 '--poa',
+                 '--config-root', custom_filepath,
+                 '--provider', TEST_PROVIDER_URI,
+                 '--registry-filepath', mock_registry_filepath)
+
+    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    #
+    # The good stuff: Using `nucypher stake create --escrow`
+    #
+
+    # Staking contract has not stakes yet
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    stakes = list(staking_agent.get_all_stakes(staker_address=preallocation_contract_address))
+    assert not stakes
+
+    stake_args = ('stake', 'create',
+                  '--config-file', stakeholder_configuration_file_location,
+                  '--escrow',
+                  '--beneficiary-address', beneficiary,
+                  '--allocation-filepath', mock_allocation_registry.filepath,
+                  '--value', stake_value.to_tokens(),
+                  '--lock-periods', token_economics.minimum_locked_periods,
+                  '--force')
+
+    # TODO: This test is writing to the default system directory and ignoring updates to the passed filepath
+    user_input = '0\n' + 'Y\n' + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + 'Y\n'
+    result = click_runner.invoke(nucypher_cli, stake_args, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Test integration with BaseConfiguration
+    with open(stakeholder_configuration_file_location, 'r') as config_file:
+        _config_data = json.loads(config_file.read())
+
+    # Verify the stake is on-chain
+    # Test integration with Agency
+    stakes = list(staking_agent.get_all_stakes(staker_address=preallocation_contract_address))
+    assert len(stakes) == 1
+
+    # Test integration with NU
+    start_period, end_period, value = stakes[0]
+    assert NU(int(value), 'NuNit') == stake_value
+    assert (end_period - start_period) == token_economics.minimum_locked_periods - 1
+
+    # Test integration with Stake
+    stake = Stake.from_stake_info(index=0,
+                                  checksum_address=preallocation_contract_address,
+                                  stake_info=stakes[0],
+                                  staking_agent=staking_agent,
+                                  economics=token_economics)
+    assert stake.value == stake_value
+    assert stake.duration == token_economics.minimum_locked_periods

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -267,8 +267,7 @@ def test_stake_restake(click_runner,
                     '--enable',
                     '--config-file', stakeholder_configuration_file_location,
                     '--staking-address', manual_staker,
-                    '--force',
-                    '--debug')
+                    '--force')
 
     result = click_runner.invoke(nucypher_cli,
                                  restake_args,
@@ -285,8 +284,7 @@ def test_stake_restake(click_runner,
                  '--lock-until', release_period,
                  '--config-file', stakeholder_configuration_file_location,
                  '--staking-address', manual_staker,
-                 '--force',
-                 '--debug')
+                 '--force')
 
     result = click_runner.invoke(nucypher_cli,
                                  lock_args,
@@ -311,8 +309,7 @@ def test_stake_restake(click_runner,
                     '--disable',
                     '--config-file', stakeholder_configuration_file_location,
                     '--staking-address', manual_staker,
-                    '--force',
-                    '--debug')
+                    '--force')
 
     result = click_runner.invoke(nucypher_cli,
                                  disable_args,

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -67,12 +67,9 @@ def test_new_stakeholder(click_runner,
                  '--poa',
                  '--config-root', custom_filepath,
                  '--provider', TEST_PROVIDER_URI,
-                 '--no-sync',
                  '--registry-filepath', mock_registry_filepath)
 
-    result = click_runner.invoke(nucypher_cli,
-                                 init_args,
-                                 catch_exceptions=False)
+    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
     assert result.exit_code == 0
 
     # Files and Directories
@@ -106,11 +103,10 @@ def test_stake_init(click_runner,
                   '--config-file', stakeholder_configuration_file_location,
                   '--staking-address', manual_staker,
                   '--value', stake_value.to_tokens(),
-                  '--no-sync',
                   '--lock-periods', token_economics.minimum_locked_periods,
                   '--force')
 
-    # TODO: This test it writing to the default system directory and ignoring updates to the passes filepath
+    # TODO: This test is writing to the default system directory and ignoring updates to the passed filepath
     user_input = f'0\n' + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + f'Y\n'
     result = click_runner.invoke(nucypher_cli, stake_args, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
@@ -166,7 +162,6 @@ def test_staker_divide_stakes(click_runner,
                    '--force',
                    '--staking-address', manual_staker,
                    '--index', 0,
-                   '--no-sync',
                    '--value', NU(token_economics.minimum_allowed_locked, 'NuNit').to_tokens(),
                    '--lock-periods', 10)
 
@@ -197,7 +192,6 @@ def test_stake_set_worker(click_runner,
                  '--config-file', stakeholder_configuration_file_location,
                  '--staking-address', manual_staker,
                  '--worker-address', manual_worker,
-                 '--no-sync',
                  '--force')
 
     user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -1,10 +1,26 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 import datetime
 import json
 import os
 import random
 
 import maya
-import pytest
 from twisted.logger import Logger
 
 from nucypher.blockchain.eth.actors import Staker
@@ -12,10 +28,9 @@ from nucypher.blockchain.eth.agents import StakingEscrowAgent, ContractAgency
 from nucypher.blockchain.eth.token import NU, Stake
 from nucypher.characters.lawful import Enrico, Ursula
 from nucypher.cli.main import nucypher_cli
-from nucypher.config.characters import UrsulaConfiguration, BobConfiguration, StakeHolderConfiguration
+from nucypher.config.characters import UrsulaConfiguration, StakeHolderConfiguration
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import (
-    MOCK_CUSTOM_INSTALLATION_PATH,
     MOCK_IP_ADDRESS,
     TEST_PROVIDER_URI,
     MOCK_URSULA_STARTING_PORT,
@@ -25,37 +40,6 @@ from nucypher.utilities.sandbox.constants import (
     select_test_port,
 )
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
-
-
-@pytest.fixture(scope='module')
-def worker_configuration_file_location(custom_filepath):
-    _configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH, UrsulaConfiguration.generate_filename())
-    return _configuration_file_location
-
-
-@pytest.fixture(scope='module')
-def stakeholder_configuration_file_location(custom_filepath):
-    _configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH, StakeHolderConfiguration.generate_filename())
-    return _configuration_file_location
-
-
-@pytest.fixture(scope="module")
-def charlie_blockchain_test_config(blockchain_ursulas, agency):
-    token_agent, staking_agent, policy_agent = agency
-    etherbase, alice_address, bob_address, *everyone_else = token_agent.blockchain.client.accounts
-
-    config = BobConfiguration(dev_mode=True,
-                              provider_uri=TEST_PROVIDER_URI,
-                              checksum_address=bob_address,
-                              network_middleware=MockRestMiddleware(),
-                              known_nodes=blockchain_ursulas,
-                              start_learning_now=False,
-                              abort_on_learning_error=True,
-                              federated_only=False,
-                              save_metadata=False,
-                              reload_metadata=False)
-    yield config
-    config.cleanup()
 
 
 def test_new_stakeholder(click_runner,


### PR DESCRIPTION
The goal of this PR is to integrate UserEscrow with CLI staking (Closes #856)

#### Instructions:

##### Create a stake
```
nucypher stake create --escrow [--beneficiary-address 0xfoobar]
```

See the [staking guide](https://github.com/cygnusv/nucypher/blob/userescrow/docs/source/guides/staking_guide.rst#staking-using-a-preallocation-contract) for more information.

**Notes**
* You can use [this contract registry](https://gist.github.com/cygnusv/dfe16e5cb6a6570164eec78287dfaaf4) that includes an updated `UserEscrowProxy` deployment with the option `--registry-filepath PATH`.
* You need an allocation contract. Follow the instructions in #1319 .

#### Other:
* Changes to `UserEscrowProxy`:
    * Fixes bug in `UserEscrowProxy` that prevented `UserEscrow` contracts from staking all their tokens
    * Fixes signature mismatch in method `withdrawPolicyReward()` wrt to the `withdraw()` method in `PolicyManager`
* Improvement of the `@validate_checksum_address` decorator: now it validates all arguments ending with `_address` (e.g, `staker_address`, `worker_address`, etc.)
