### PR TITLE
Auto-detect for file scheme provider uri

### DIFF
--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -339,8 +339,8 @@ class BlockchainInterface:
             if not provider_scheme:
                 if os.path.exists(provider_uri):
                     # file is available - assume ipc/file scheme
-                    self.log.info(f"Auto-detecting provider scheme as 'file://' for provider {provider_uri}")
                     provider_scheme = 'file'
+                    self.log.info(f"Auto-detected provider scheme as 'file://' for provider {provider_uri}")
 
             try:
                 self._provider = providers[provider_scheme](provider_uri)

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-
+import os
 import pprint
 import time
 from typing import List
@@ -55,8 +55,8 @@ from nucypher.blockchain.eth.providers import (
 )
 from nucypher.blockchain.eth.registry import EthereumContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
-from nucypher.crypto.powers import TransactingPower
 from nucypher.characters.control.emitters import StdoutEmitter
+from nucypher.crypto.powers import TransactingPower
 
 Web3Providers = Union[IPCProvider, WebsocketProvider, HTTPProvider, EthereumTester]
 
@@ -334,6 +334,14 @@ class BlockchainInterface:
                     'https': _get_HTTP_provider,
                 }
                 provider_scheme = uri_breakdown.scheme
+
+            # auto-detect for file based ipc
+            if not provider_scheme:
+                if os.path.exists(provider_uri):
+                    # file is available - assume ipc/file scheme
+                    self.log.info(f"Auto-detecting provider scheme as 'file://' for provider {provider_uri}")
+                    provider_scheme = 'file'
+
             try:
                 self._provider = providers[provider_scheme](provider_uri)
             except KeyError:

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -82,6 +82,9 @@ class BlockchainInterface:
     class NoProvider(InterfaceError):
         pass
 
+    class UnsupportedProvider(InterfaceError):
+        pass
+
     class ConnectionFailed(InterfaceError):
         pass
 
@@ -345,7 +348,7 @@ class BlockchainInterface:
             try:
                 self._provider = providers[provider_scheme](provider_uri)
             except KeyError:
-                raise ValueError(f"{provider_uri} is an invalid or unsupported blockchain provider URI")
+                raise self.UnsupportedProvider(f"{provider_uri} is an invalid or unsupported blockchain provider URI")
             else:
                 self.provider_uri = provider_uri or NO_BLOCKCHAIN_CONNECTION
         else:

--- a/tests/blockchain/eth/clients/test_mocked_clients.py
+++ b/tests/blockchain/eth/clients/test_mocked_clients.py
@@ -208,6 +208,12 @@ class GanacheClientTestInterface(BlockchainInterfaceTestBase):
         super()._attach_provider(provider=MockGanacheProvider())
 
 
+def test_client_no_provider():
+    with pytest.raises(BlockchainInterface.NoProvider) as e:
+        interface = BlockchainInterfaceTestBase()
+        interface.connect(fetch_registry=False, sync_now=False)
+
+
 def test_geth_web3_client():
     interface = GethClientTestBlockchain(provider_uri='file:///ipc.geth')
     interface.connect(fetch_registry=False, sync_now=False)
@@ -232,7 +238,7 @@ def test_autodetect_provider_type_file(tempfile_path):
 
 
 def test_autodetect_provider_type_file_none_existent():
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(BlockchainInterface.UnsupportedProvider) as e:
         interface = BlockchainInterfaceTestBase(provider_uri='/none_existent.ipc.geth')
         interface.connect(fetch_registry=False, sync_now=False)
 

--- a/tests/blockchain/eth/clients/test_mocked_clients.py
+++ b/tests/blockchain/eth/clients/test_mocked_clients.py
@@ -191,9 +191,6 @@ class GethClientTestBlockchain(BlockchainInterfaceTestBase):
     def _attach_provider(self, *args, **kwargs) -> None:
         super()._attach_provider(provider=MockGethProvider())
 
-    def _get_infura_provider(self):
-        return MockInfuraProvider()
-
     @property
     def is_local(self):
         return int(self.w3.net.version) not in PUBLIC_CHAINS
@@ -281,7 +278,7 @@ def test_detect_provider_type_ws():
     interface.connect(fetch_registry=False, sync_now=False)
     assert isinstance(interface.client, GethClient)
 
-    
+
 def test_infura_web3_client():
     interface = InfuraTestClient(provider_uri='infura://1234567890987654321abcdef')
     interface.connect(fetch_registry=False, sync_now=False)

--- a/tests/blockchain/eth/clients/test_mocked_clients.py
+++ b/tests/blockchain/eth/clients/test_mocked_clients.py
@@ -167,7 +167,7 @@ class ProviderTypeTestClient(BlockchainInterfaceTestBase):
                  actual_provider_to_attach,
                  *args,
                  **kwargs):
-        BlockchainInterfaceTestBase.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.expected_provider_class = expected_provider_class
         self.test_provider_to_attach = actual_provider_to_attach
 


### PR DESCRIPTION
Allow `--provider` uri option to not require a scheme for files (`file://` or `ipc://`) on the cli. 

Without the scheme specified, this would allow for autcompletion of file paths in our cli when `--provider` is used.