### PR TITLE
Staking Process Relief

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -625,7 +625,7 @@ class Worker(NucypherTokenActor):
             self.stakes = StakeList(registry=self.registry, checksum_address=self.checksum_address)
             self.stakes.refresh()
             if check_active_worker and not len(self.stakes):
-                raise self.DetachedWorker
+                raise self.DetachedWorker(f"{self.__worker_address} is not bonded to {self.checksum_address}.")
 
             self.period_tracker = period_tracker or PeriodTracker(registry=self.registry)
             self.period_tracker.add_action(self._confirm_period)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -629,9 +629,9 @@ class Worker(NucypherTokenActor):
             if check_active_worker and not len(self.stakes):
                 raise self.DetachedWorker(f"{self.__worker_address} is not bonded to {self.checksum_address}.")
 
-            self.period_tracker = work_tracker or WorkTracker(worker=self)
+            self.work_tracker = work_tracker or WorkTracker(worker=self)
             if start_working_now:
-                self.period_tracker.start(act_now=False)
+                self.work_tracker.start(act_now=False)
 
     @property
     def last_active_period(self) -> int:

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -651,13 +651,13 @@ class Worker(NucypherTokenActor):
 
     @only_me
     def _confirm_period(self) -> None:
-        interval = self.period_tracker.current_period - self.last_active_period
+        interval = self.staking_agent.get_current_period() - self.last_active_period
 
         # TODO: Check for stake expiration and exit
-        if not interval:
+        if interval < 0:
             return  # No need to confirm this period.  Save the gas.
 
-        if interval > 1:
+        if interval > 0:
             # TODO: Follow-up actions for downtime
             self.log.warn(f"MISSED CONFIRMATIONS - {interval} missed staking confirmations detected.")
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -604,6 +604,7 @@ class Worker(NucypherTokenActor):
                  period_tracker: PeriodTracker = None,
                  worker_address: str = None,
                  start_working_loop: bool = True,
+                 confirm_now: bool = True,
                  check_active_worker: bool = True,
                  *args, **kwargs):
 
@@ -630,6 +631,9 @@ class Worker(NucypherTokenActor):
             self.period_tracker = period_tracker or PeriodTracker(registry=self.registry)
             self.period_tracker.add_action(self._confirm_period)
             self.stakes.start_tracking(self.period_tracker)
+
+            if confirm_now:
+                self.confirm_activity()
             if start_working_loop:
                 self.period_tracker.start(act_now=False)
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -515,8 +515,9 @@ class Staker(NucypherTokenActor):
 
         # Ensure the new stake will not exceed the staking limit
         if (self.current_stake + amount) > self.economics.maximum_allowed_locked:
-            raise Stake.StakingError(f"Cannot divide stake - "
-                                     f"Maximum stake value exceeded with a target value of {amount}.")
+            raise Stake.StakingError(f"Cannot initialize stake - "
+                                     f"Maximum stake value exceeded for {self.checksum_address} "
+                                     f"with a target value of {amount}.")
 
         # Write to blockchain
         new_stake = Stake.initialize_stake(staker=self,

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -165,7 +165,7 @@ class Web3Client:
 
     def unlock_account(self, address, password, duration=None) -> bool:
         if not self.is_local:
-            return self.unlock_account(address, password, duration=duration)
+            return self.unlock_account(address, password)
 
     @property
     def is_connected(self):
@@ -315,7 +315,7 @@ class GethClient(Web3Client):
         if password is None:
             debug_message += " with no password."
         self.log.debug(debug_message)
-        return self.w3.geth.personal.unlockAccount(address, password, duration=duration)
+        return self.w3.geth.personal.unlockAccount(address, password, duration)
 
     def sign_transaction(self, transaction: dict) -> bytes:
 
@@ -383,7 +383,7 @@ class EthereumTesterClient(Web3Client):
         else:
             return self.w3.provider.ethereum_tester.unlock_account(account=address,
                                                                    password=password,
-                                                                   duration=duration)
+                                                                   unlock_seconds=duration)
 
     def sync(self, *args, **kwargs):
         return True

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -313,9 +313,12 @@ class GethClient(Web3Client):
             return True
         debug_message = f"Unlocking account {address}"
         if password is None:
-            debug_message += " without a password."
+            debug_message += " with no password."
         self.log.debug(debug_message)
-        return self.w3.geth.personal.unlockAccount(address, password)
+
+        # TODO: #1282 - Handle account unlock duration
+        ONE_YEAR_IN_SECONDS = ((60 * 60) * 24) * 365
+        return self.w3.geth.personal.unlockAccount(address, password, duration=ONE_YEAR_IN_SECONDS*10)
 
     def sign_transaction(self, transaction: dict) -> bytes:
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -389,7 +389,6 @@ class BlockchainInterface:
         signed_raw_transaction = self.transacting_power.sign_transaction(unsigned_transaction)
         txhash = self.client.send_raw_transaction(signed_raw_transaction)
 
-
         try:
             receipt = self.client.wait_for_receipt(txhash, timeout=self.TIMEOUT)
         except TimeExhausted:

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -1,14 +1,12 @@
 from _pydecimal import Decimal
 from collections import UserList
-from typing import Union, Tuple, Callable, List
+from typing import Union, Tuple, List
 
 import maya
 from constant_sorrow.constants import (
     NEW_STAKE,
     NO_STAKING_RECEIPT,
     NOT_STAKING,
-    UNKNOWN_STAKES,
-    NO_STAKES,
     EMPTY_STAKING_SLOT,
     UNKNOWN_WORKER_STATUS
 )
@@ -450,45 +448,35 @@ class Stake:
         return stake
 
 
-class PeriodTracker:
+class WorkTracker:
 
     CLOCK = reactor
-    REFRESH_RATE = 60 * 60  # one hour.
-    __actions = list()   # type: List[Tuple[Callable, tuple]]
+    REFRESH_RATE = 60 * 15  # Fifteen minutes
 
-    def __init__(self, registry: BaseContractRegistry, refresh_rate: int = None, *args, **kwargs):
+    def __init__(self, worker, refresh_rate: int = None, *args, **kwargs):
 
         super().__init__(*args, **kwargs)
         self.log = Logger('stake-tracker')
 
-        self.staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)
+        self.worker = worker
+        self.staking_agent = self.worker.staking_agent
+
         self._refresh_rate = refresh_rate or self.REFRESH_RATE
-        self._tracking_task = task.LoopingCall(self.__update)
+        self._tracking_task = task.LoopingCall(self._do_work)
         self._tracking_task.clock = self.CLOCK
 
         self.__current_period = None
         self.__start_time = NOT_STAKING
         self.__uptime_period = NOT_STAKING
-        self._abort_on_stake_tracking_error = True
+        self._abort_on_error = True
 
     @property
     def current_period(self):
         return self.__current_period
 
-    def perform_actions(self) -> None:
-        for action, args in self.__actions:
-            self.log.info(f"Performing action: '{str(action.__name__)}'")
-            action(*args)
-
-    def add_action(self, func: Callable, args=()) -> None:
-        self.__actions.append((func, args))
-
-    def clear_actions(self) -> None:
-        self.__actions.clear()
-
     def stop(self) -> None:
         self._tracking_task.stop()
-        self.log.info(f"STOPPED STAKE TRACKING")
+        self.log.info(f"STOPPED WORK TRACKING")
 
     def start(self, act_now: bool = False, force: bool = False) -> None:
         """
@@ -505,11 +493,11 @@ class PeriodTracker:
         self.__current_period = self.__uptime_period
 
         d = self._tracking_task.start(interval=self._refresh_rate)
-        d.addErrback(self.handle_tracking_errors)
-        self.log.info(f"STARTED PERIOD TRACKING with {len(self.__actions)} registered actions.")
+        d.addErrback(self.handle_working_errors)
+        self.log.info(f"STARTED WORK TRACKING")
 
         if act_now:
-            self.perform_actions()
+            self._do_work()
 
     def _crash_gracefully(self, failure=None) -> None:
         """
@@ -519,20 +507,37 @@ class PeriodTracker:
         self._crashed = failure
         failure.raiseException()
 
-    def handle_tracking_errors(self, *args, **kwargs) -> None:
+    def handle_working_errors(self, *args, **kwargs) -> None:
         failure = args[0]
-        if self._abort_on_stake_tracking_error:
-            self.log.critical(f"Unhandled error during node stake tracking. {failure}")
+        if self._abort_on_error:
+            self.log.critical(f"Unhandled error during node work tracking. {failure}")
             reactor.callFromThread(self._crash_gracefully, failure=failure)
         else:
-            self.log.warn(f"Unhandled error during stake tracking: {failure.getTraceback()}")
+            self.log.warn(f"Unhandled error during work tracking: {failure.getTraceback()}")
 
-    def __update(self) -> None:
+    def _do_work(self) -> None:
+        # TODO: Check for stake expiration and exit
+        # TODO: Follow-up actions for downtime
+
+        # Update on-chain status
         self.log.info(f"Checking for new period. Current period is {self.__current_period}")
         onchain_period = self.staking_agent.get_current_period()  # < -- Read from contract
-        if self.__current_period != onchain_period:
-            self.perform_actions()
+        if self.current_period != onchain_period:
             self.__current_period = onchain_period
+            # self.worker.stakes.refresh()  # TODO: Track stakes
+
+        # Measure working interval
+        interval = onchain_period - self.worker.last_active_period
+        if interval < 0:
+            return  # No need to confirm this period.  Save the gas.
+        if interval > 0:
+            self.log.warn(f"MISSED CONFIRMATIONS - {interval} missed staking confirmations detected.")
+
+        # Confirm Activity
+        self.log.info("Confirmed activity for period {}".format(self.current_period))
+        transacting_power = self.worker.transacting_power
+        with transacting_power:
+            self.worker.confirm_activity()  # < --- blockchain WRITE
 
 
 class StakeList(UserList):
@@ -555,10 +560,6 @@ class StakeList(UserList):
                 raise ValueError(f'{checksum_address} is not a valid EIP-55 checksum address')
         self.checksum_address = checksum_address
         self.__updated = None
-
-    def start_tracking(self, period_tracker: PeriodTracker) -> None:
-        period_tracker.add_action(self.__read_stakes)
-        self.log.info(f"STARTED STAKE TRACKING for {self.checksum_address}")
 
     @property
     def updated(self) -> maya.MayaDT:

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -531,8 +531,8 @@ class PeriodTracker:
         self.log.info(f"Checking for new period. Current period is {self.__current_period}")
         onchain_period = self.staking_agent.get_current_period()  # < -- Read from contract
         if self.__current_period != onchain_period:
-            self.__current_period = onchain_period
             self.perform_actions()
+            self.__current_period = onchain_period
 
 
 class StakeList(UserList):

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -168,7 +168,7 @@ class Character(Learner):
         #
         # Stranger-Character
         #
-        
+
         else:  # Feel like a stranger
             if network_middleware is not None:
                 raise TypeError("Network middleware cannot be attached to a Stranger-Character.")

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -112,8 +112,6 @@ class Character(Learner):
         # Operating Mode
         #
 
-        if not bool(federated_only) ^ bool(registry):
-            raise ValueError(f"Pass either federated only or registry.  Got '{federated_only}'. '{registry}'")
         self.federated_only = federated_only  # type: bool
         self.registry = registry
 
@@ -142,6 +140,10 @@ class Character(Learner):
         #
         if is_me is True:
 
+            if not bool(federated_only) ^ bool(registry):
+                raise ValueError(f"Pass either federated only or registry for is_me Characters.  \
+                                 Got '{federated_only}' and '{registry}'.")
+
             self.keyring_root = keyring_root  # type: str
             self.treasure_maps = {}  # type: dict
             self.network_middleware = network_middleware or RestMiddleware()
@@ -166,9 +168,14 @@ class Character(Learner):
         #
         # Stranger-Character
         #
+        
         else:  # Feel like a stranger
             if network_middleware is not None:
                 raise TypeError("Network middleware cannot be attached to a Stranger-Character.")
+
+            if registry is not None:
+                raise TypeError("Registry cannot be attached to stranger-Characters.")
+
             self._stamp = StrangerStamp(self.public_keys(SigningPower))
             self.keyring_root = STRANGER
             self.network_middleware = STRANGER

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1099,7 +1099,7 @@ class Ursula(Teacher, Character, Worker):
         # Verify the node's TLS certificate
         try:
             potential_seed_node.verify_node(network_middleware=network_middleware,
-                                            accept_federated_only=federated_only,
+                                            registry=registry,
                                             certificate_filepath=temp_certificate_filepath)
         except potential_seed_node.InvalidNode:
             # TODO: What if our seed node fails verification?
@@ -1167,7 +1167,7 @@ class Ursula(Teacher, Character, Worker):
         domains_vbytes = VariableLengthBytestring.dispense(node_info['domains'])
         node_info['domains'] = set(d.decode('utf-8') for d in domains_vbytes)
 
-        ursula = cls.from_public_keys(registry=registry, federated_only=federated_only, **node_info)
+        ursula = cls.from_public_keys(federated_only=federated_only, **node_info)
         return ursula
 
     @classmethod

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -857,11 +857,6 @@ class Ursula(Teacher, Character, Worker):
                                 checksum_address=checksum_address,
                                 worker_address=worker_address,
                                 period_tracker=period_tracker)
-        # Stranger
-        elif not self.federated_only:
-            # TODO: Needed for on-chain learning verification
-            self.staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=self.registry)
-
 
         #
         # ProxyRESTServer and TLSHostingPower #

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -843,7 +843,7 @@ class Ursula(Teacher, Character, Worker):
             #
             if not federated_only:
                 # Prepare a TransactingPower from worker node's transacting keys
-                transacting_power = TransactingPower(account=worker_address, password=client_password)
+                transacting_power = TransactingPower(account=worker_address, password=client_password, cache=True)
                 self._crypto_power.consume_power_up(transacting_power)
 
                 # Use this power to substantiate the stamp

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1447,11 +1447,10 @@ class StakeHolder(Staker):
         return stakes
 
     @property
-    def current_stake(self) -> NU:
+    def total_stake(self) -> NU:
         """
         The total number of staked tokens, either locked or unlocked in the current period.
         """
-        # TODO: This is skipping a layer. Fix me?
         stake = sum(self.staking_agent.owned_tokens(staker_address=account) for account in self.wallet.accounts)
         nu_stake = NU.from_nunits(stake)
         return nu_stake

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -48,7 +48,7 @@ from nucypher.blockchain.eth.agents import StakingEscrowAgent, NucypherTokenAgen
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import BaseContractRegistry
-from nucypher.blockchain.eth.token import StakeList, PeriodTracker, NU
+from nucypher.blockchain.eth.token import StakeList, WorkTracker, NU
 from nucypher.characters.banners import ALICE_BANNER, BOB_BANNER, ENRICO_BANNER, URSULA_BANNER, STAKEHOLDER_BANNER
 from nucypher.characters.base import Character, Learner
 from nucypher.characters.control.controllers import (
@@ -795,7 +795,7 @@ class Ursula(Teacher, Character, Worker):
                  decentralized_identity_evidence: bytes = constants.NOT_SIGNED,
                  checksum_address: str = None,  # Staker address
                  worker_address: str = None,
-                 period_tracker: PeriodTracker = None,
+                 work_tracker: WorkTracker = None,
                  client_password: str = None,
 
                  # Character
@@ -843,8 +843,8 @@ class Ursula(Teacher, Character, Worker):
             #
             if not federated_only:
                 # Prepare a TransactingPower from worker node's transacting keys
-                transacting_power = TransactingPower(account=worker_address, password=client_password, cache=True)
-                self._crypto_power.consume_power_up(transacting_power)
+                self.transacting_power = TransactingPower(account=worker_address, password=client_password, cache=True)
+                self._crypto_power.consume_power_up(self.transacting_power)
 
                 # Use this power to substantiate the stamp
                 self.substantiate_stamp()
@@ -856,7 +856,7 @@ class Ursula(Teacher, Character, Worker):
                                 registry=self.registry,
                                 checksum_address=checksum_address,
                                 worker_address=worker_address,
-                                period_tracker=period_tracker)
+                                work_tracker=work_tracker)
 
         #
         # ProxyRESTServer and TLSHostingPower #

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -229,8 +229,8 @@ def ursula(click_config,
                                                              config_file=config_file)
         except NucypherKeyring.AuthenticationFailed as e:
             emitter.echo(str(e), color='red', bold=True)
-            click.get_current_context().exit(1)
             # TODO: Exit codes (not only for this, but for other exceptions)
+            return click.get_current_context().exit(1)
 
     #
     # Configured Pre-Authentication Actions
@@ -252,6 +252,7 @@ def ursula(click_config,
     #
     # Make Ursula
     #
+
     client_password = None
     if not ursula_config.federated_only:
         if not dev and not click_config.json_ipc:
@@ -268,8 +269,8 @@ def ursula(click_config,
                                             client_password=client_password)
     except NucypherKeyring.AuthenticationFailed as e:
         emitter.echo(str(e), color='red', bold=True)
-        click.get_current_context().exit(1)
         # TODO: Exit codes (not only for this, but for other exceptions)
+        return click.get_current_context().exit(1)
 
     #
     # Authenticated Action Switch

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -178,7 +178,7 @@ class CharacterConfiguration(BaseConfiguration):
         else:
             is_initialized = BlockchainInterfaceFactory.is_interface_initialized(provider_uri=self.provider_uri)
             if not is_initialized and provider_uri:
-                from nucypher.cli.config import NucypherClickConfig  # FIXME
+                from nucypher.cli.config import NucypherClickConfig  # TODO: Need a better place for global verbosity, non-local to the CLI.
 
                 BlockchainInterfaceFactory.initialize_interface(provider_uri=self.provider_uri,
                                                                 poa=self.poa,

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -243,7 +243,7 @@ class CharacterConfiguration(BaseConfiguration):
     def __setup_node_storage(self, node_storage=None) -> None:
         if self.dev_mode:
             node_storage = ForgetfulNodeStorage(registry=self.registry, federated_only=self.federated_only)
-        else:
+        elif not node_storage:
             node_storage = LocalFileBasedNodeStorage(registry=self.registry,
                                                      config_root=self.config_root,
                                                      federated_only=self.federated_only)

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -369,19 +369,15 @@ class LocalFileBasedNodeStorage(NodeStorage):
                                      self.__METADATA_FILENAME_TEMPLATE.format(checksum_address))
         return metadata_path
 
-    def __read_metadata(self,
-                        filepath: str,
-                        federated_only: bool,
-                        registry: BaseContractRegistry = None):
+    def __read_metadata(self, filepath: str, federated_only: bool):
 
-        # TODO: Use registry None to indicate federated only
         from nucypher.characters.lawful import Ursula
 
         try:
             with open(filepath, "rb") as seed_file:
                 seed_file.seek(0)
                 node_bytes = self.deserializer(seed_file.read())
-                node = Ursula.from_bytes(node_bytes, registry=registry, federated_only=federated_only)
+                node = Ursula.from_bytes(node_bytes, federated_only=federated_only)  # TODO: #466
         except FileNotFoundError:
             raise self.UnknownNode
         return node
@@ -410,9 +406,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
             known_nodes = set()
             for filename in filenames:
                 metadata_path = os.path.join(self.metadata_dir, filename)
-                node = self.__read_metadata(filepath=metadata_path,
-                                            registry=self.registry,
-                                            federated_only=federated_only)  # TODO: 466
+                node = self.__read_metadata(filepath=metadata_path, federated_only=federated_only)  # TODO: 466
                 known_nodes.add(node)
             return known_nodes
 
@@ -422,9 +416,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
             certificate = self.__read_tls_public_certificate(checksum_address=checksum_address)
             return certificate
         metadata_path = self.__generate_metadata_filepath(checksum_address=checksum_address)
-        node = self.__read_metadata(filepath=metadata_path,
-                                    registry=self.registry,
-                                    federated_only=federated_only)  # TODO: 466
+        node = self.__read_metadata(filepath=metadata_path, federated_only=federated_only)  # TODO: 466
         return node
 
     def store_node_certificate(self, certificate: Certificate):

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -419,8 +419,8 @@ class LocalFileBasedNodeStorage(NodeStorage):
         node = self.__read_metadata(filepath=metadata_path, federated_only=federated_only)  # TODO: 466
         return node
 
-    def store_node_certificate(self, certificate: Certificate):
-        certificate_filepath = self._write_tls_certificate(certificate=certificate)
+    def store_node_certificate(self, certificate: Certificate, force: bool = True):
+        certificate_filepath = self._write_tls_certificate(certificate=certificate, force=force)
         return certificate_filepath
 
     def store_node_metadata(self, node, filepath: str = None) -> str:
@@ -430,7 +430,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
         return filepath
 
     def save_node(self, node, force) -> Tuple[str, str]:
-        certificate_filepath = self.store_node_certificate(certificate=node.certificate)
+        certificate_filepath = self.store_node_certificate(certificate=node.certificate, force=force)
         metadata_filepath = self.store_node_metadata(node=node)
         return metadata_filepath, certificate_filepath
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -142,20 +142,20 @@ class TransactingPower(CryptoPowerUp):
 
     def activate(self, password: str = None):
         """Be Consumed"""
-        self.unlock_account(password=password or self.__password)
-        if not self.__cache:
+        self.unlock_account(password=password)
+        if self.__cache is False:
             self.__password = None
         self.blockchain.transacting_power = self
 
     def lock_account(self):
         if self.device:
-            # TODO: Force Disconnect Devices?
-            pass
+            pass  # TODO: Force Disconnect Devices?
         else:
             _result = self.blockchain.client.lock_account(address=self.account)
         self.__unlocked = False
 
     def unlock_account(self, password: str = None, duration: int = None):
+        password = password or self.__password
         if self.device:
             unlocked = True
         else:

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -153,6 +153,7 @@ class TransactingPower(CryptoPowerUp):
         else:
             _result = self.blockchain.client.lock_account(address=self.account)
         self.__unlocked = False
+        return self.__unlocked
 
     def unlock_account(self, password: str = None, duration: int = None):
         password = password or self.__password

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -112,7 +112,7 @@ class TransactingPower(CryptoPowerUp):
     class InvalidSigningRequest(PowerUpError):
         pass
 
-    def __init__(self, account: str, password: str = None):
+    def __init__(self, account: str, password: str = None, cache: bool = False):
         """
         Instantiates a TransactingPower for the given checksum_address.
         """
@@ -125,6 +125,7 @@ class TransactingPower(CryptoPowerUp):
         self.__password = password
         self.__unlocked = False
         self.__activated = False
+        self.__cache = cache
 
     @property
     def is_unlocked(self) -> bool:
@@ -142,7 +143,8 @@ class TransactingPower(CryptoPowerUp):
     def activate(self, password: str = None):
         """Be Consumed"""
         self.unlock_account(password=password or self.__password)
-        self.__password = None
+        if not self.__cache:
+            self.__password = None
         self.blockchain.transacting_power = self
 
     def lock_account(self):
@@ -153,14 +155,15 @@ class TransactingPower(CryptoPowerUp):
             _result = self.blockchain.client.lock_account(address=self.account)
         self.__unlocked = False
 
-    def unlock_account(self, password: str = None):
+    def unlock_account(self, password: str = None, duration: int = None):
         if self.device:
             unlocked = True
         else:
             if self.blockchain.client is NO_BLOCKCHAIN_CONNECTION:
                 raise self.NoBlockchainConnection
-            unlocked = self.blockchain.client.unlock_account(address=self.account, password=password)
+            unlocked = self.blockchain.client.unlock_account(address=self.account, password=password, duration=duration)
         self.__unlocked = unlocked
+        return self.__unlocked
 
     def sign_message(self, message: bytes) -> bytes:
         """
@@ -179,6 +182,12 @@ class TransactingPower(CryptoPowerUp):
             raise self.AccountLocked("Failed to unlock account {}".format(self.account))
         signed_raw_transaction = self.blockchain.client.sign_transaction(transaction=unsigned_transaction)
         return signed_raw_transaction
+
+    def __enter__(self):
+        return self.unlock_account()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        return self.lock_account()
 
 
 class KeyPairBasedPower(CryptoPowerUp):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1069,9 +1069,9 @@ class Teacher:
 
     def verify_node(self,
                     network_middleware,
-                    certificate_filepath: str = None,
-                    force: bool = False,
                     registry: BaseContractRegistry = None,
+                    certificate_filepath: str = None,
+                    force: bool = False
                     ) -> bool:
         """
         Three things happening here:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -351,9 +351,7 @@ class Learner:
     def known_nodes(self):
         return self.__known_nodes
 
-    def load_seednodes(self,
-                       read_storages: bool = True,
-                       retry_attempts: int = 3):  # TODO: why are these unused?
+    def load_seednodes(self, read_storage: bool = True, retry_attempts: int = 3):
         """
         Engage known nodes from storages and pre-fetch hardcoded seednode certificates for node learning.
         """
@@ -383,7 +381,7 @@ class Learner:
 
         self.done_seeding = True
 
-        if read_storages is True:
+        if read_storage is True:
             self.read_nodes_from_storage()
 
         if not self.known_nodes:
@@ -426,7 +424,7 @@ class Learner:
         try:
             node.verify_node(force=force_verification_check,
                              network_middleware=self.network_middleware,
-                             registry=self.registry)  # composed on character subclass
+                             registry=self.registry)  # composed on character subclass, determines operating mode
         except SSLError:
             return False  # TODO: Bucket this node as having bad TLS info - maybe it's an update that hasn't fully propagated?
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -321,10 +321,12 @@ class Learner:
 
         # Read
         if node_storage is None:
-            node_storage = self.__DEFAULT_NODE_STORAGE(federated_only=self.federated_only, # TODO: remove federated_only
-                                                       character_class=self.__class__)
+            from nucypher.characters.lawful import Ursula
+            node_storage = self.__DEFAULT_NODE_STORAGE(federated_only=self.federated_only,  # TODO: #466
+                                                       character_class=Ursula)
 
         self.node_storage = node_storage
+
         if save_metadata and node_storage is NO_STORAGE_AVAILIBLE:
             raise ValueError("Cannot save nodes without a configured node storage")
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -173,7 +173,7 @@ def make_rest_app(
                         certificate=node.certificate)
 
                     node.verify_node(this_node.network_middleware,
-                                     accept_federated_only=this_node.federated_only,  # TODO: 466
+                                     registry=this_node.registry,
                                      certificate_filepath=certificate_filepath)
 
                 # Suspicion

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -325,8 +325,7 @@ class Policy(ABC):
 
     def consider_arrangement(self, network_middleware, ursula, arrangement) -> bool:
         try:
-            ursula.verify_node(network_middleware,
-                               accept_federated_only=arrangement.federated)
+            ursula.verify_node(network_middleware, registry=self.alice.registry)  # From the perspective of alice.
         except ursula.InvalidNode:
             # TODO: What do we actually do here?  Report this at least (355)?
             # Maybe also have another bucket for invalid nodes?

--- a/nucypher/utilities/sandbox/ursula.py
+++ b/nucypher/utilities/sandbox/ursula.py
@@ -22,7 +22,7 @@ from nucypher.blockchain.eth.actors import Staker
 from nucypher.blockchain.eth.agents import StakingEscrowAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.registry import BaseContractRegistry
-from nucypher.blockchain.eth.token import PeriodTracker
+from nucypher.blockchain.eth.token import WorkTracker
 from nucypher.characters.lawful import Ursula
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.crypto.powers import TransactingPower
@@ -80,15 +80,11 @@ def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
     stakers_and_workers = zip(stakers_addresses, workers_addresses)
     ursulas = list()
 
-    registry = ursula_config.registry
-    period_tracker = PeriodTracker(registry=registry)
-
     for port, (staker_address, worker_address) in enumerate(stakers_and_workers, start=starting_port):
         ursula = ursula_config.produce(checksum_address=staker_address,
                                        worker_address=worker_address,
                                        db_filepath=MOCK_URSULA_DB_FILEPATH,
                                        rest_port=port + 100,
-                                       period_tracker=period_tracker,
                                        **ursula_overrides)
         if confirm_activity:
             ursula.confirm_activity()

--- a/tests/blockchain/eth/entities/actors/conftest.py
+++ b/tests/blockchain/eth/entities/actors/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from nucypher.blockchain.eth.actors import Staker
+from nucypher.utilities.sandbox.blockchain import token_airdrop
+from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUNT
+
+
+@pytest.fixture(scope='module')
+def staker(testerchain, agency, test_registry):
+    token_agent, staking_agent, policy_agent = agency
+    origin, staker_account, *everybody_else = testerchain.client.accounts
+    token_airdrop(token_agent=token_agent,
+                  origin=testerchain.etherbase_account,
+                  addresses=[staker_account],
+                  amount=DEVELOPMENT_TOKEN_AIRDROP_AMOUNT)
+    staker = Staker(checksum_address=staker_account, is_me=True, registry=test_registry)
+    return staker

--- a/tests/blockchain/eth/entities/actors/test_staker.py
+++ b/tests/blockchain/eth/entities/actors/test_staker.py
@@ -26,18 +26,6 @@ from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUN
 from nucypher.utilities.sandbox.ursula import make_decentralized_ursulas
 
 
-@pytest.fixture(scope='module')
-def staker(testerchain, agency, test_registry):
-    token_agent, staking_agent, policy_agent = agency
-    origin, staker_account, *everybody_else = testerchain.client.accounts
-    token_airdrop(token_agent=token_agent,
-                  origin=testerchain.etherbase_account,
-                  addresses=[staker_account],
-                  amount=DEVELOPMENT_TOKEN_AIRDROP_AMOUNT)
-    staker = Staker(checksum_address=staker_account, is_me=True, registry=test_registry)
-    return staker
-
-
 @pytest.mark.slow()
 def test_staker_locking_tokens(testerchain, agency, staker, token_economics):
     token_agent, staking_agent, policy_agent = agency

--- a/tests/blockchain/eth/entities/actors/test_worker.py
+++ b/tests/blockchain/eth/entities/actors/test_worker.py
@@ -3,7 +3,7 @@ import pytest_twisted
 from twisted.internet import threads
 from twisted.internet.task import Clock
 
-from nucypher.blockchain.eth.token import NU, PeriodTracker
+from nucypher.blockchain.eth.token import NU, WorkTracker
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.ursula import make_decentralized_ursulas, start_pytest_ursula_services
@@ -31,7 +31,7 @@ def test_worker_auto_confirmations(testerchain,
 
     # Control time
     clock = Clock()
-    PeriodTracker.CLOCK = clock
+    WorkTracker.CLOCK = clock
 
     # Bond the Worker and Staker
     staker.set_worker(worker_address=worker_address)
@@ -49,10 +49,8 @@ def test_worker_auto_confirmations(testerchain,
         ursula.period_tracker.start()
 
     def time_travel(_):
-        # Advance one period, and two hours, somehow separately
-        testerchain.time_travel(periods=2)
-        two_hours = (60*60) * 2
-        clock.advance(two_hours)
+        testerchain.time_travel(periods=1)
+        clock.advance(WorkTracker.REFRESH_RATE+1)
 
     def verify(_):
         # Verify that periods were confirmed on-chain automatically

--- a/tests/blockchain/eth/entities/actors/test_worker.py
+++ b/tests/blockchain/eth/entities/actors/test_worker.py
@@ -33,21 +33,23 @@ def test_worker_auto_confirmations(testerchain,
     clock = Clock()
     PeriodTracker.CLOCK = clock
 
+    # Bond the Worker and Staker
+    staker.set_worker(worker_address=worker_address)
+
+    # Make the Worker
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[worker_address],
                                         confirm_activity=False,
                                         registry=test_registry).pop()
 
-    # Bond the Worker and Staker
-    staker.set_worker(worker_address=worker_address)
-
-    # Start running the worker
     def start():
+        # Start running the worker
         start_pytest_ursula_services(ursula=ursula)
         ursula.period_tracker.start()
 
     def time_travel(_):
+        # Advance one period, and two hours, somehow separately
         testerchain.time_travel(periods=2)
         two_hours = (60*60) * 2
         clock.advance(two_hours)

--- a/tests/blockchain/eth/entities/actors/test_worker.py
+++ b/tests/blockchain/eth/entities/actors/test_worker.py
@@ -46,7 +46,7 @@ def test_worker_auto_confirmations(testerchain,
     def start():
         # Start running the worker
         start_pytest_ursula_services(ursula=ursula)
-        ursula.period_tracker.start()
+        ursula.work_tracker.start()
 
     def time_travel(_):
         testerchain.time_travel(periods=1)

--- a/tests/blockchain/eth/entities/actors/test_worker.py
+++ b/tests/blockchain/eth/entities/actors/test_worker.py
@@ -1,0 +1,66 @@
+import pytest
+import pytest_twisted
+from twisted.internet import threads
+from twisted.internet.task import Clock
+
+from nucypher.blockchain.eth.token import NU, PeriodTracker
+from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
+from nucypher.utilities.sandbox.ursula import make_decentralized_ursulas, start_pytest_ursula_services
+
+
+@pytest.mark.slow()
+@pytest_twisted.inlineCallbacks
+def test_worker_auto_confirmations(testerchain,
+                                   test_registry,
+                                   staker,
+                                   agency,
+                                   token_economics,
+                                   ursula_decentralized_test_config):
+
+    # Mock Powerup consumption (Ursula-Worker)
+    testerchain.transacting_power = TransactingPower(password=INSECURE_DEVELOPMENT_PASSWORD,
+                                                     account=staker.checksum_address)
+    testerchain.transacting_power.activate()
+
+    staker.initialize_stake(amount=NU(token_economics.minimum_allowed_locked, 'NuNit'),
+                            lock_periods=int(token_economics.minimum_locked_periods))
+
+    # Get an unused address and create a new worker
+    worker_address = testerchain.unassigned_accounts[-1]
+
+    # Control time
+    clock = Clock()
+    PeriodTracker.CLOCK = clock
+
+    ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
+                                        stakers_addresses=[staker.checksum_address],
+                                        workers_addresses=[worker_address],
+                                        confirm_activity=False,
+                                        registry=test_registry).pop()
+
+    # Bond the Worker and Staker
+    staker.set_worker(worker_address=worker_address)
+
+    # Start running the worker
+    def start():
+        start_pytest_ursula_services(ursula=ursula)
+        ursula.period_tracker.start()
+
+    def time_travel(_):
+        testerchain.time_travel(periods=2)
+        two_hours = (60*60) * 2
+        clock.advance(two_hours)
+
+    def verify(_):
+        # Verify that periods were confirmed on-chain automatically
+        last_active_period = staker.staking_agent.get_last_active_period(address=staker.checksum_address)
+        current_period = staker.staking_agent.get_current_period()
+        assert (last_active_period - current_period) == 1
+
+    # Run the callbacks
+    d = threads.deferToThread(start)
+    for i in range(5):
+        d.addCallback(time_travel)
+        d.addCallback(verify)
+    yield d

--- a/tests/characters/test_stakeholder.py
+++ b/tests/characters/test_stakeholder.py
@@ -109,7 +109,7 @@ def test_collect_inflation_rewards(software_stakeholder, manual_worker, testerch
     worker = Worker(is_me=True,
                     worker_address=manual_worker,
                     checksum_address=stake.staker_address,
-                    start_working_loop=False,
+                    start_working_now=False,
                     registry=test_registry)
 
     # Mock TransactingPower consumption (Worker-Ursula)

--- a/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
+++ b/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
@@ -51,7 +51,7 @@ def test_new_federated_ursula_announces_herself(ursula_federated_test_config):
     assert ursula_in_a_house in ursula_with_a_mouse.known_nodes
 
 
-def test_stakers_bond_to_ursulas(testerchain, stakers, ursula_decentralized_test_config):
+def test_stakers_bond_to_ursulas(testerchain, test_registry, stakers, ursula_decentralized_test_config):
 
     ursulas = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                          stakers_addresses=testerchain.stakers_accounts,
@@ -60,7 +60,7 @@ def test_stakers_bond_to_ursulas(testerchain, stakers, ursula_decentralized_test
 
     assert len(ursulas) == len(stakers)
     for ursula in ursulas:
-        ursula.validate_worker(verify_staking=True)
+        ursula.validate_worker(registry=test_registry)
         assert ursula.verified_worker
 
 

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -14,6 +14,7 @@ from nucypher.utilities.sandbox.constants import (
     MOCK_IP_ADDRESS,
     MOCK_IP_ADDRESS_2
 )
+from nucypher.utilities.sandbox.ursula import start_pytest_ursula_services
 
 
 def test_destroy_with_no_configurations(click_runner, custom_filepath):

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -20,7 +20,6 @@ from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,
     MOCK_URSULA_STARTING_PORT,
     INSECURE_DEVELOPMENT_PASSWORD,
-    MOCK_REGISTRY_FILEPATH,
     TEMPORARY_DOMAIN,
     MOCK_KNOWN_URSULAS_CACHE,
     select_test_port,

--- a/tests/config/test_storages.py
+++ b/tests/config/test_storages.py
@@ -14,19 +14,22 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+import os
 
 import pytest
 
 from nucypher.characters.lawful import Ursula
+from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.storages import (
     ForgetfulNodeStorage,
     TemporaryFileBasedNodeStorage,
-    NodeStorage
-)
-from nucypher.utilities.sandbox.constants import MOCK_URSULA_DB_FILEPATH, MOCK_URSULA_STARTING_PORT
-
-MOCK_S3_BUCKET_NAME = 'mock-seednodes'
-S3_DOMAIN_NAME = 's3.amazonaws.com'
+    NodeStorage,
+    LocalFileBasedNodeStorage)
+from nucypher.utilities.sandbox.constants import (
+    MOCK_URSULA_DB_FILEPATH,
+    MOCK_URSULA_STARTING_PORT,
+    INSECURE_DEVELOPMENT_PASSWORD,
+    TEST_PROVIDER_URI)
 
 
 class BaseTestNodeStorageBackends:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,8 @@ NucypherClickConfig.log_to_file = True
 WebEmitter._crash_on_error_default = True
 
 # Dont re-lock account in background during activity confirmations
-TransactingPower.lock_account = lambda: True
+LOCK_FUNCTION = TransactingPower.lock_account
+TransactingPower.lock_account = lambda *a, **k: True
 
 
 ##########################################

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ import pytest
 
 from nucypher.characters.control.emitters import WebEmitter
 from nucypher.cli.config import NucypherClickConfig
+from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.logging import GlobalLoggerSettings
 # Logger Configuration
 #
@@ -32,6 +33,9 @@ NucypherClickConfig.log_to_file = True
 
 # Crash on server error by default
 WebEmitter._crash_on_error_default = True
+
+# Dont re-lock account in background during activity confirmations
+TransactingPower.lock_account = lambda: True
 
 
 ##########################################

--- a/tests/crypto/test_powers.py
+++ b/tests/crypto/test_powers.py
@@ -7,6 +7,9 @@ from nucypher.crypto.api import verify_eip_191
 from nucypher.crypto.powers import (PowerUpError)
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
+from tests.conftest import LOCK_FUNCTION
+
+TransactingPower.lock_account = LOCK_FUNCTION
 
 
 def test_transacting_power_sign_message(testerchain):

--- a/tests/learning/test_fault_tolerance.py
+++ b/tests/learning/test_fault_tolerance.py
@@ -57,6 +57,7 @@ def test_blockchain_ursula_stamp_verification_tolerance(blockchain_ursulas):
 
 @pytest.mark.skip("See Issue #1075")  # TODO: Issue #1075
 def test_invalid_workers_tolerance(testerchain,
+                                   test_registry,
                                    blockchain_ursulas,
                                    agency,
                                    idle_staker,
@@ -106,8 +107,8 @@ def test_invalid_workers_tolerance(testerchain,
     # The worker is valid and can be verified (even with the force option)
     worker.verify_node(force=True, network_middleware=MockRestMiddleware(), certificate_filepath="quietorl")
     # In particular, we know that it's bonded to a staker who is really staking.
-    assert worker._worker_is_bonded_to_staker()
-    assert worker._staker_is_really_staking()
+    assert worker._worker_is_bonded_to_staker(registry=test_registry)
+    assert worker._staker_is_really_staking(registry=test_registry)
 
     # OK. Now we learn about this worker.
     lonely_blockchain_learner.remember_node(worker)


### PR DESCRIPTION
Fixes #1279 - Known nodes are now lazily loaded from the disk at Character learning-time, instead of pre-init.
Fixes #1282 - ~~Sets geth keyring unlock time to 10 Years.~~ Unlocks and Relocks keyring between confirmations.
Fixes #1281 - Uses `WorkTracker` to perform activity confirmations
Fixes #1283 - Allow staking to maximum amount per address.