### PR TITLE
Github Actions: Automatic PR labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+ETH Contracts:
+  - nucypher/blockchain/eth/sol/source/**/*
+
+CLI:
+  - nucypher/cli/**/*
+
+circleci:
+  - .circleci/**/*
+
+Demos:
+  - examples/**/*
+
+Dependencies:
+  - Pipfile
+  - Pipfile.lock
+  - setup.py
+  - dev-requirements.txt
+  - requirements.txt

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,12 @@
+name: Pull Request Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
First test of Github Actions: for the moment I'd like to try the automatic PR labeler; initially I just defined some very basic labeling rules (found [here](https://github.com/nucypher/nucypher/pull/1287/files#diff-69a161780e8c3442ad32efea8760ff94)) based on which files are modified (e.g, if contracts are modified then the label "ETH Contracts" should automatically be added to the PR).

There are other cool GH actions out there but I just wanted to start with something simple.