### PR TITLE
Bump version: 0.1.0-alpha.27 → 0.1.0-alpha.28

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0-alpha.27
+current_version = 0.1.0-alpha.28
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.1.0-alpha.27'
+release = '0.1.0-alpha.28'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "0.1.0-alpha.27"
+__version__ = "0.1.0-alpha.28"
 
 __author__ = "NuCypher"
 


### PR DESCRIPTION
Publication Build <https://circleci.com/workflow-run/04f7439b-0b82-4aae-8c02-7f40eda9e448>