### PR TITLE
Improve `nucypher-deploy allocations`

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -55,7 +55,7 @@ from nucypher.blockchain.eth.registry import AllocationRegistry, BaseContractReg
 from nucypher.blockchain.eth.token import NU, Stake, StakeList, WorkTracker
 from nucypher.blockchain.eth.utils import datetime_to_period, calculate_period_duration, datetime_at_period
 from nucypher.characters.control.emitters import StdoutEmitter
-from nucypher.cli.painting import paint_contract_deployment, paint_allocation_data
+from nucypher.cli.painting import paint_contract_deployment, paint_input_allocation_file
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.powers import TransactingPower
 
@@ -245,11 +245,11 @@ class ContractAdministrator(NucypherTokenActor):
                                    new_secret_hash=new_secret_hash)
         return txhash
 
-    def deploy_user_escrow(self, allocation_registry: AllocationRegistry):
+    def deploy_user_escrow(self, allocation_registry: AllocationRegistry, progress=None):
         user_escrow_deployer = UserEscrowDeployer(registry=self.registry,
                                                   deployer_address=self.deployer_address,
                                                   allocation_registry=allocation_registry)
-        user_escrow_deployer.deploy()
+        user_escrow_deployer.deploy(progress=progress)
         principal_address = user_escrow_deployer.contract.address
         self.user_escrow_deployers[principal_address] = user_escrow_deployer
         return user_escrow_deployer
@@ -347,45 +347,85 @@ class ContractAdministrator(NucypherTokenActor):
                                      allocation_outfile: str = None,
                                      allocation_registry: AllocationRegistry = None,
                                      crash_on_failure: bool = True,
+                                     interactive: bool = True,
+                                     emitter: StdoutEmitter = None,
                                      ) -> Dict[str, dict]:
         """
-
         Example allocation dataset (one year is 31536000 seconds):
 
         data = [{'beneficiary_address': '0xdeadbeef', 'amount': 100, 'duration_seconds': 31536000},
                 {'beneficiary_address': '0xabced120', 'amount': 133432, 'duration_seconds': 31536000*2},
                 {'beneficiary_address': '0xf7aefec2', 'amount': 999, 'duration_seconds': 31536000*3}]
         """
+
+        if interactive and not emitter:
+            raise ValueError("'emitter' is a required keyword argument when interactive is True.")
+
         if allocation_registry and allocation_outfile:
             raise self.ActorError("Pass either allocation registry or allocation_outfile, not both.")
         if allocation_registry is None:
             allocation_registry = AllocationRegistry(filepath=allocation_outfile)
 
+        if emitter:
+            paint_input_allocation_file(emitter, allocations)
+
+        if interactive:
+            click.confirm("Continue with the allocation process?", abort=True)
+
         allocation_receipts, failed = dict(), list()
-        for allocation in allocations:
-            deployer = self.deploy_user_escrow(allocation_registry=allocation_registry)
+        total_deployment_transactions = len(allocations) * 4
 
-            beneficiary = allocation['beneficiary_address']
-            amount = allocation['amount']
-            try:
-                receipts = deployer.deliver(value=amount,
-                                            duration=allocation['duration_seconds'],
-                                            beneficiary_address=beneficiary)
-            except TransactionFailed:
-                if crash_on_failure:
-                    raise
-                self.log.debug(f"Failed allocation transaction for {NU.from_nunits(amount)} to {beneficiary}")
-                failed.append(allocation)
-                continue
+        with click.progressbar(length=total_deployment_transactions,
+                               label="Allocation progress",
+                               show_eta=False) as bar:
+            bar.short_limit = 0
+            for allocation in allocations:
 
-            else:
-                allocation_receipts[beneficiary] = receipts
-                principal_address = deployer.contract_address
-                self.log.info(f"Created UserEscrow contract at {principal_address} for beneficiary {beneficiary}.")
+                # TODO: Check if allocation already exists in allocation registry
 
-        if failed:
-            # TODO: More with these failures: send to isolated logfile, and reattempt
-            self.log.critical(f"FAILED TOKEN ALLOCATION - {len(failed)} Allocations failed.")
+                beneficiary = allocation['beneficiary_address']
+
+                if interactive:
+                    click.pause(info=f"\nPress any key to continue with allocation for beneficiary {beneficiary}")
+
+                if emitter:
+                    emitter.echo(f"\nDeploying UserEscrow contract for beneficiary {beneficiary}...")
+                    bar._last_line = None
+                    bar.render_progress()
+
+                deployer = self.deploy_user_escrow(allocation_registry=allocation_registry,
+                                                   progress=bar)
+
+                amount = allocation['amount']
+                duration = allocation['duration_seconds']
+                try:
+                    receipts = deployer.deliver(value=amount,
+                                                duration=duration,
+                                                beneficiary_address=beneficiary,
+                                                progress=bar)
+                except TransactionFailed:
+                    if crash_on_failure:
+                        raise
+                    self.log.debug(f"Failed allocation transaction for {NU.from_nunits(amount)} to {beneficiary}")
+                    failed.append(allocation)
+                    continue
+
+                else:
+                    allocation_receipts[beneficiary] = receipts
+                    principal_address = deployer.contract_address
+                    self.log.info(f"Created UserEscrow contract at {principal_address} for beneficiary {beneficiary}.")
+                    if emitter:
+                        blockchain = BlockchainInterfaceFactory.get_interface()
+                        paint_contract_deployment(contract_name=deployer.contract_name,
+                                                  receipts=receipts,
+                                                  contract_address=deployer.contract_address,
+                                                  emitter=emitter,
+                                                  chain_name=blockchain.client.chain_name,
+                                                  open_in_browser=False)
+
+            if failed:
+                # TODO: More with these failures: send to isolated logfile, and reattempt
+                self.log.critical(f"FAILED TOKEN ALLOCATION - {len(failed)} Allocations failed.")
 
         return allocation_receipts
 
@@ -406,14 +446,6 @@ class ContractAdministrator(NucypherTokenActor):
                                        interactive=None) -> dict:
 
         allocations = self.__read_allocation_data(filepath=allocation_data_filepath)
-
-        # TODO: Print allocation data before deploying and ask for confirmation
-        if emitter:
-            paint_allocation_data(emitter, allocations)
-
-        if interactive:
-            click.confirm("Continue with the allocation process?", abort=True)
-
         receipts = self.deploy_beneficiary_contracts(allocations=allocations,
                                                      allocation_outfile=allocation_outfile,
                                                      emitter=emitter,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -55,7 +55,7 @@ from nucypher.blockchain.eth.registry import AllocationRegistry, BaseContractReg
 from nucypher.blockchain.eth.token import NU, Stake, StakeList, WorkTracker
 from nucypher.blockchain.eth.utils import datetime_to_period, calculate_period_duration, datetime_at_period
 from nucypher.characters.control.emitters import StdoutEmitter
-from nucypher.cli.painting import paint_contract_deployment
+from nucypher.cli.painting import paint_contract_deployment, paint_allocation_data
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.powers import TransactingPower
 
@@ -401,10 +401,23 @@ class ContractAdministrator(NucypherTokenActor):
 
     def deploy_beneficiaries_from_file(self,
                                        allocation_data_filepath: str,
-                                       allocation_outfile: str = None) -> dict:
+                                       allocation_outfile: str = None,
+                                       emitter=None,
+                                       interactive=None) -> dict:
 
         allocations = self.__read_allocation_data(filepath=allocation_data_filepath)
-        receipts = self.deploy_beneficiary_contracts(allocations=allocations, allocation_outfile=allocation_outfile)
+
+        # TODO: Print allocation data before deploying and ask for confirmation
+        if emitter:
+            paint_allocation_data(emitter, allocations)
+
+        if interactive:
+            click.confirm("Continue with the allocation process?", abort=True)
+
+        receipts = self.deploy_beneficiary_contracts(allocations=allocations,
+                                                     allocation_outfile=allocation_outfile,
+                                                     emitter=emitter,
+                                                     interactive=interactive)
         return receipts
 
     def save_deployment_receipts(self, receipts: dict) -> str:

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -417,10 +417,10 @@ class ContractAdministrator(NucypherTokenActor):
                                                 duration=duration,
                                                 beneficiary_address=beneficiary,
                                                 progress=bar)
-                except TransactionFailed:
+                except TransactionFailed as e:
                     if crash_on_failure:
                         raise
-                    self.log.debug(f"Failed allocation transaction for {NU.from_nunits(amount)} to {beneficiary}")
+                    self.log.debug(f"Failed allocation transaction for {NU.from_nunits(amount)} to {beneficiary}: {e}")
                     failed.append(allocation)
                     continue
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -379,6 +379,11 @@ class ContractAdministrator(NucypherTokenActor):
         if interactive:
             click.confirm("Continue with the allocation process?", abort=True)
 
+        total_to_allocate = NU.from_nunits(sum(allocation['amount'] for allocation in allocations))
+        balance = ContractAgency.get_agent(NucypherTokenAgent, self.registry).get_balance(self.deployer_address)
+        if balance < total_to_allocate:
+            raise ValueError("Not enough tokens to allocate. We need at least {total_to_allocate}.")
+
         allocation_receipts, failed, allocated = dict(), list(), list()
         total_deployment_transactions = len(allocations) * 4
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -464,10 +464,13 @@ class ContractAdministrator(NucypherTokenActor):
                                                      allocation_outfile=allocation_outfile,
                                                      emitter=emitter,
                                                      interactive=interactive)
+        # Save transaction metadata
+        receipts_filepath = self.save_deployment_receipts(receipts=receipts, filename_prefix='allocation')
+        emitter.echo(f"Saved allocation receipts to {receipts_filepath}", color='blue', bold=True)
         return receipts
 
-    def save_deployment_receipts(self, receipts: dict) -> str:
-        filename = f'deployment-receipts-{self.deployer_address[:6]}-{maya.now().epoch}.json'
+    def save_deployment_receipts(self, receipts: dict, filename_prefix: str = 'deployment') -> str:
+        filename = f'{filename_prefix}-receipts-{self.deployer_address[:6]}-{maya.now().epoch}.json'
         filepath = os.path.join(DEFAULT_CONFIG_ROOT, filename)
         # TODO: Do not assume default config root
         os.makedirs(DEFAULT_CONFIG_ROOT, exist_ok=True)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -351,11 +351,18 @@ class ContractAdministrator(NucypherTokenActor):
                                      emitter: StdoutEmitter = None,
                                      ) -> Dict[str, dict]:
         """
-        Example allocation dataset (one year is 31536000 seconds):
+        The allocation file is a JSON file containing a list of allocations. Each allocation has a:
+          * 'beneficiary_address': Checksum address of the beneficiary
+          * 'name': User-friendly name of the beneficiary (Optional)
+          * 'amount': Amount of tokens locked, in NuNits
+          * 'duration_seconds': Lock duration expressed in seconds
 
-        data = [{'beneficiary_address': '0xdeadbeef', 'amount': 100, 'duration_seconds': 31536000},
-                {'beneficiary_address': '0xabced120', 'amount': 133432, 'duration_seconds': 31536000*2},
-                {'beneficiary_address': '0xf7aefec2', 'amount': 999, 'duration_seconds': 31536000*3}]
+        Example allocation file:
+
+        [ {'beneficiary_address': '0xdeadbeef', 'name': 'H. E. Pennypacker', 'amount': 100, 'duration_seconds': 31536000},
+          {'beneficiary_address': '0xabced120', 'amount': 133432, 'duration_seconds': 31536000},
+          {'beneficiary_address': '0xf7aefec2', 'amount': 999, 'duration_seconds': 31536000}]
+
         """
 
         if interactive and not emitter:
@@ -384,12 +391,14 @@ class ContractAdministrator(NucypherTokenActor):
                 # TODO: Check if allocation already exists in allocation registry
 
                 beneficiary = allocation['beneficiary_address']
+                name = allocation.get('name', 'No name provided')
 
                 if interactive:
-                    click.pause(info=f"\nPress any key to continue with allocation for beneficiary {beneficiary}")
+                    click.pause(info=f"\nPress any key to continue with allocation for "
+                                     f"beneficiary {beneficiary} ({name})")
 
                 if emitter:
-                    emitter.echo(f"\nDeploying UserEscrow contract for beneficiary {beneficiary}...")
+                    emitter.echo(f"\nDeploying UserEscrow contract for beneficiary {beneficiary} ({name})...")
                     bar._last_line = None
                     bar.render_progress()
 
@@ -414,7 +423,7 @@ class ContractAdministrator(NucypherTokenActor):
                     allocation_receipts[beneficiary] = receipts
                     principal_address = deployer.contract_address
                     self.log.info(f"Created UserEscrow contract at {principal_address} for beneficiary {beneficiary}.")
-                    allocated.append((beneficiary, principal_address))
+                    allocated.append((allocation, principal_address))
 
                     if emitter:
                         blockchain = BlockchainInterfaceFactory.get_interface()

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -361,29 +361,33 @@ class ContractAdministrator(NucypherTokenActor):
         if allocation_registry is None:
             allocation_registry = AllocationRegistry(filepath=allocation_outfile)
 
-        allocation_txhashes, failed = dict(), list()
+        allocation_receipts, failed = dict(), list()
         for allocation in allocations:
             deployer = self.deploy_user_escrow(allocation_registry=allocation_registry)
 
+            beneficiary = allocation['beneficiary_address']
+            amount = allocation['amount']
             try:
-                txhashes = deployer.deliver(value=allocation['amount'],
+                receipts = deployer.deliver(value=amount,
                                             duration=allocation['duration_seconds'],
-                                            beneficiary_address=allocation['beneficiary_address'])
+                                            beneficiary_address=beneficiary)
             except TransactionFailed:
                 if crash_on_failure:
                     raise
-                self.log.debug(f"Failed allocation transaction for {allocation['amount']} to {allocation['beneficiary_address']}")
+                self.log.debug(f"Failed allocation transaction for {NU.from_nunits(amount)} to {beneficiary}")
                 failed.append(allocation)
                 continue
 
             else:
-                allocation_txhashes[allocation['beneficiary_address']] = txhashes
+                allocation_receipts[beneficiary] = receipts
+                principal_address = deployer.contract_address
+                self.log.info(f"Created UserEscrow contract at {principal_address} for beneficiary {beneficiary}.")
 
         if failed:
             # TODO: More with these failures: send to isolated logfile, and reattempt
             self.log.critical(f"FAILED TOKEN ALLOCATION - {len(failed)} Allocations failed.")
 
-        return allocation_txhashes
+        return allocation_receipts
 
     @staticmethod
     def __read_allocation_data(filepath: str) -> list:
@@ -400,8 +404,8 @@ class ContractAdministrator(NucypherTokenActor):
                                        allocation_outfile: str = None) -> dict:
 
         allocations = self.__read_allocation_data(filepath=allocation_data_filepath)
-        txhashes = self.deploy_beneficiary_contracts(allocations=allocations, allocation_outfile=allocation_outfile)
-        return txhashes
+        receipts = self.deploy_beneficiary_contracts(allocations=allocations, allocation_outfile=allocation_outfile)
+        return receipts
 
     def save_deployment_receipts(self, receipts: dict) -> str:
         filename = f'deployment-receipts-{self.deployer_address[:6]}-{maya.now().epoch}.json'

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -791,7 +791,6 @@ class UserEscrowDeployer(ContractDeployer):
     @validate_checksum_address
     def assign_beneficiary(self, checksum_address: str) -> dict:
         """Relinquish ownership of a UserEscrow deployment to the beneficiary"""
-        checksum_address = checksum_address
         # TODO: #413, #842 - Gas Management
         payload = {'gas': 500_000}
         transfer_owner_function = self.contract.functions.transferOwnership(checksum_address)

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -19,7 +19,6 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 from typing import Tuple, Dict
 
 from constant_sorrow.constants import CONTRACT_NOT_DEPLOYED, NO_DEPLOYER_CONFIGURED, NO_BENEFICIARY
-from eth_utils import is_checksum_address
 from web3.contract import Contract
 
 from nucypher.blockchain.economics import StandardTokenEconomics

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -841,10 +841,10 @@ class UserEscrowDeployer(ContractDeployer):
 
         """
 
-        deposit_txhash = self.initial_deposit(value=value, duration_seconds=duration)
-        assign_txhash = self.assign_beneficiary(beneficiary_address=beneficiary_address)
+        deposit_receipt = self.initial_deposit(value=value, duration_seconds=duration)
+        assign_receipt = self.assign_beneficiary(beneficiary_address=beneficiary_address)
         self.enroll_principal_contract()
-        return dict(deposit_txhash=deposit_txhash, assign_txhash=assign_txhash)
+        return dict(deposit_receipt=deposit_receipt, assign_receipt=assign_receipt)
 
     def deploy(self, gas_limit: int = None, progress=None) -> dict:
         """Deploy a new instance of UserEscrow to the blockchain."""

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -33,7 +33,7 @@ from nucypher.blockchain.eth.agents import (
     AdjudicatorAgent
 )
 from nucypher.blockchain.eth.constants import DISPATCHER_CONTRACT_NAME
-from nucypher.blockchain.eth.decorators import validate_secret
+from nucypher.blockchain.eth.decorators import validate_secret, validate_checksum_address
 from nucypher.blockchain.eth.interfaces import BlockchainDeployerInterface, BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import AllocationRegistry, BaseContractRegistry
 
@@ -789,17 +789,17 @@ class UserEscrowDeployer(ContractDeployer):
     def allocation_registry(self):
         return self.__allocation_registry
 
-    def assign_beneficiary(self, beneficiary_address: str) -> dict: 
+    @validate_checksum_address
+    def assign_beneficiary(self, checksum_address: str) -> dict:
         """Relinquish ownership of a UserEscrow deployment to the beneficiary"""
-        if not is_checksum_address(beneficiary_address):
-            raise self.ContractDeploymentError("{} is not a valid checksum address.".format(beneficiary_address))
+        checksum_address = checksum_address
         # TODO: #413, #842 - Gas Management
         payload = {'gas': 500_000}
-        transfer_owner_function = self.contract.functions.transferOwnership(beneficiary_address)
+        transfer_owner_function = self.contract.functions.transferOwnership(checksum_address)
         transfer_owner_receipt = self.blockchain.send_transaction(contract_function=transfer_owner_function,
                                                                   payload=payload,
                                                                   sender_address=self.deployer_address)
-        self.__beneficiary_address = beneficiary_address
+        self.__beneficiary_address = checksum_address
         return transfer_owner_receipt
 
     def initial_deposit(self, value: int, duration_seconds: int) -> dict:
@@ -842,7 +842,7 @@ class UserEscrowDeployer(ContractDeployer):
         """
 
         deposit_receipt = self.initial_deposit(value=value, duration_seconds=duration)
-        assign_receipt = self.assign_beneficiary(beneficiary_address=beneficiary_address)
+        assign_receipt = self.assign_beneficiary(checksum_address=beneficiary_address)
         self.enroll_principal_contract()
         return dict(deposit_receipt=deposit_receipt, assign_receipt=assign_receipt)
 

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -351,7 +351,7 @@ class AllocationRegistry(LocalContractRegistry):
 
     def search(self, beneficiary_address: str = None, contract_address: str = None):
         if not (bool(beneficiary_address) ^ bool(contract_address)):
-            raise ValueError("Pass contract_owner or contract_address, not both.")
+            raise ValueError("Pass either beneficiary_address or contract_address.")
 
         try:
             allocation_data = self.read()
@@ -373,9 +373,6 @@ class AllocationRegistry(LocalContractRegistry):
                 raise self.RegistryError("Multiple {} deployments for beneficiary {}".format(self._contract_name, beneficiary_address))
             else:
                 contract_data = records[0]
-
-        else:
-            raise ValueError("Beneficiary address or contract address must be supplied.")
 
         return contract_data
 

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -384,7 +384,7 @@ class AllocationRegistry(LocalContractRegistry):
         try:
             allocation_data = self.read()
         except self.RegistryError:
-            self.log.info("Blank allocation registry encountered: enrolling {}:{}".format(beneficiary_address, contract_address))
+            self.log.info(f"Blank allocation registry encountered: enrolling {beneficiary_address}:{contract_address}")
             allocation_data = list() if self._multi_contract else dict()  # empty registry
 
         if beneficiary_address in allocation_data:

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -356,7 +356,8 @@ class AllocationRegistry(LocalContractRegistry):
 
     def search(self, beneficiary_address: str = None, contract_address: str = None):
         if not (bool(beneficiary_address) ^ bool(contract_address)):
-            raise ValueError("Pass either beneficiary_address or contract_address.")
+            raise ValueError(f"Pass either beneficiary_address or contract_address. "
+                             f"Got {beneficiary_address} and {contract_address}.")
 
         try:
             allocation_data = self.read()
@@ -385,8 +386,9 @@ class AllocationRegistry(LocalContractRegistry):
         contract_data = [contract_address, contract_abi]
         try:
             allocation_data = self.read()
-        except self.RegistryError:
-            self.log.info(f"Blank allocation registry encountered: enrolling {beneficiary_address}:{contract_address}")
+        except self.RegistryError as e:
+            self.log.info(f"Failure while reading allocation registry when "
+                          f"enrolling {beneficiary_address} ({contract_address}): {e}")
             allocation_data = list() if self._multi_contract else dict()  # empty registry
 
         if beneficiary_address in allocation_data:

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -102,6 +102,11 @@ class BaseContractRegistry(ABC):
         raise NotImplementedError
 
     @classmethod
+    def get_latest_publication_url(cls, branch: str = 'goerli') -> str:
+        github_endpoint = f'https://raw.githubusercontent.com/{cls.__PUBLICATION_REPO}/{branch}/{cls.REGISTRY_NAME}'
+        return github_endpoint
+
+    @classmethod
     def fetch_latest_publication(cls, branch: str = 'goerli') -> bytes:
         """
         Get the latest published contract registry from github and save it on the local file system.
@@ -109,7 +114,7 @@ class BaseContractRegistry(ABC):
         """
 
         # Setup
-        github_endpoint = f'https://raw.githubusercontent.com/{cls.__PUBLICATION_REPO}/{branch}/{cls.REGISTRY_NAME}'
+        github_endpoint = cls.get_latest_publication_url(branch=branch)
         cls.logger.debug(f"Downloading contract registry from {github_endpoint}")
         response = requests.get(github_endpoint)
 

--- a/nucypher/blockchain/eth/sol/source/contracts/UserEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/UserEscrow.sol
@@ -76,7 +76,7 @@ contract UserEscrow is Ownable {
     /**
     * @notice Initial tokens deposit
     * @param _value Amount of token to deposit
-    * @param _duration Duration of tokens locking
+    * @param _duration Duration of tokens locking (in seconds)
     **/
     function initialDeposit(uint256 _value, uint256 _duration) public {
         require(lockedValue == 0 && _value > 0);

--- a/nucypher/characters/control/emitters.py
+++ b/nucypher/characters/control/emitters.py
@@ -39,7 +39,7 @@ class StdoutEmitter:
         self.log.debug(message)
 
     def echo(self,
-             message: str,
+             message: str = None,
              color: str = None,
              bold: bool = False,
              nl: bool = True,

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -366,6 +366,8 @@ def stake(click_config,
 
         return  # Exit
 
+    # TODO: Action "mint"
+    
     # Catch-All for unknown actions
     else:
         ctx = click.get_current_context()

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -274,7 +274,9 @@ def deploy(action,
             allocation_infile = click.prompt("Enter allocation data filepath")
         click.confirm("Continue deploying and allocating?", abort=True)
         ADMINISTRATOR.deploy_beneficiaries_from_file(allocation_data_filepath=allocation_infile,
-                                                     allocation_outfile=allocation_outfile)
+                                                     allocation_outfile=allocation_outfile,
+                                                     emitter=emitter,
+                                                     interactive=not force)
         return  # Exit
 
     elif action == "transfer-tokens":

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -272,7 +272,6 @@ def deploy(action,
     elif action == "allocations":
         if not allocation_infile:
             allocation_infile = click.prompt("Enter allocation data filepath")
-        click.confirm("Continue deploying and allocating?", abort=True)
         ADMINISTRATOR.deploy_beneficiaries_from_file(allocation_data_filepath=allocation_infile,
                                                      allocation_outfile=allocation_outfile,
                                                      emitter=emitter,

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -573,3 +573,14 @@ def paint_locked_tokens_status(emitter, agent, periods) -> None:
         emitter.echo(f"{bucket_range:>9}: {box_plot:60}"
                      f"Min: {NU.from_nunits(bucket_min)} - Max: {NU.from_nunits(bucket_max)}")
 
+
+def paint_allocation_data(emitter, allocations) -> None:
+    emitter.echo(f"\n{'Beneficiary':42} | {'Duration':20} | {'Amount':20}", bold=True)
+    emitter.echo("-"*(42+20+20+6), bold=True)
+    for allocation in allocations:
+        beneficiary = allocation['address']
+        amount = str(NU.from_nunits(allocation['amount']))
+        duration = (maya.now() + maya.timedelta(seconds=allocation['duration'])).slang_date()
+        emitter.echo(f"{beneficiary:24} | {duration:20} | {amount:20}")
+    emitter.echo()
+

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -574,9 +574,9 @@ def paint_locked_tokens_status(emitter, agent, periods) -> None:
                      f"Min: {NU.from_nunits(bucket_min)} - Max: {NU.from_nunits(bucket_max)}")
 
 
-def paint_allocation_data(emitter, allocations) -> None:
+def paint_input_allocation_file(emitter, allocations) -> None:
     emitter.echo(f"\n{'Beneficiary':42} | {'Duration':20} | {'Amount':20}", bold=True)
-    emitter.echo("-"*(42+20+20+6), bold=True)
+    emitter.echo("-"*(42+3+20+3+20), bold=True)
     for allocation in allocations:
         beneficiary = allocation['address']
         amount = str(NU.from_nunits(allocation['amount']))

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -575,6 +575,8 @@ def paint_locked_tokens_status(emitter, agent, periods) -> None:
 
 
 def paint_input_allocation_file(emitter, allocations) -> None:
+    num_allocations = len(allocations)
+    emitter.echo(f"Found {num_allocations} allocations:")
     emitter.echo(f"\n{'='*46} STAGED ALLOCATIONS {'='*45}", bold=True)
     emitter.echo(f"\n{'Beneficiary':42} | {'Name':20} | {'Duration':20} | {'Amount':20}", bold=True)
     emitter.echo("-"*(42+3+20+3+20+3+20), bold=True)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -247,7 +247,7 @@ Registry  ................ {administrator.registry.filepath}
 * Standard Deployments
 =====================================================================
 
-NucypherToken ........... {token_agent.contract_address}
+{token_agent.contract_name} ........... {token_agent.contract_address}
     ~ Ethers ............ {Web3.fromWei(blockchain.client.get_balance(token_agent.contract_address), 'ether')} ETH
     ~ Tokens ............ {NU.from_nunits(token_agent.get_balance(token_agent.contract_address))}"""
     emitter.echo(contract_payload)
@@ -307,7 +307,7 @@ NucypherToken ........... {token_agent.contract_address}
                                                 bare=True)  # acquire agency for the dispatcher itself.
 
         user_escrow_payload = f"""
-UserEscrowProxy .......... {bare_contract.address}
+{user_escrow_proxy_agent.contract_name} .......... {bare_contract.address}
     ~ LibraryLinker ...... {linker_deployer.contract.address}
         ~ Owner .......... {linker_deployer.contract.functions.owner().call()}
         ~ Target ......... {linker_deployer.contract.functions.target().call()}"""

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -575,24 +575,29 @@ def paint_locked_tokens_status(emitter, agent, periods) -> None:
 
 
 def paint_input_allocation_file(emitter, allocations) -> None:
-    emitter.echo(f"\n{'='*34} STAGED ALLOCATIONS {'='*34}", bold=True)
-    emitter.echo(f"\n{'Beneficiary':42} | {'Duration':20} | {'Amount':20}", bold=True)
-    emitter.echo("-"*(42+3+20+3+20), bold=True)
+    emitter.echo(f"\n{'='*46} STAGED ALLOCATIONS {'='*45}", bold=True)
+    emitter.echo(f"\n{'Beneficiary':42} | {'Name':20} | {'Duration':20} | {'Amount':20}", bold=True)
+    emitter.echo("-"*(42+3+20+3+20+3+20), bold=True)
     for allocation in allocations:
-        beneficiary = allocation['address']
+        beneficiary = allocation['beneficiary_address']
         amount = str(NU.from_nunits(allocation['amount']))
-        duration = (maya.now() + maya.timedelta(seconds=allocation['duration'])).slang_date()
-        emitter.echo(f"{beneficiary} | {duration:20} | {amount:20}")
+        duration = (maya.now() + maya.timedelta(seconds=allocation['duration_seconds'])).slang_date()
+        name = allocation.get('name', 'No name provided')
+        emitter.echo(f"{beneficiary} | {name:20} | {duration:20} | {amount:20}")
     emitter.echo()
 
 
 def paint_deployed_allocations(emitter, allocations, failed) -> None:
-    emitter.echo(f"\n{'='*33} DEPLOYED ALLOCATIONS {'='*32}", bold=True)
-    emitter.echo(f"\n{'Beneficiary':42} | {'UserEscrow contract':42} ", bold=True)
-    emitter.echo("-"*(42+3+42), bold=True)
-    for beneficiary, contract_address in allocations:
-        emitter.echo(f"{beneficiary} | {contract_address}")
-    for beneficiary in failed:
-        emitter.echo(f"{beneficiary} | FAILED", color='red')
+    emitter.echo(f"\n{'='*45} DEPLOYED ALLOCATIONS {'='*44}", bold=True)
+    emitter.echo(f"\n{'Beneficiary':42} | {'Name':20} | {'UserEscrow contract':42} ", bold=True)
+    emitter.echo("-"*(42+3+20+3+42), bold=True)
+    for allocation, contract_address in allocations:
+        beneficiary = allocation['beneficiary_address']
+        name = allocation.get('name', 'No name provided')
+        emitter.echo(f"{beneficiary} | {name:20} | {contract_address}")
+    for allocation in failed:
+        beneficiary = allocation['beneficiary_address']
+        name = allocation.get('name', 'No name provided')
+        emitter.echo(f"{beneficiary} | {name:20} | FAILED", color='red')
     emitter.echo()
 

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -575,12 +575,24 @@ def paint_locked_tokens_status(emitter, agent, periods) -> None:
 
 
 def paint_input_allocation_file(emitter, allocations) -> None:
+    emitter.echo(f"\n{'='*34} STAGED ALLOCATIONS {'='*34}", bold=True)
     emitter.echo(f"\n{'Beneficiary':42} | {'Duration':20} | {'Amount':20}", bold=True)
     emitter.echo("-"*(42+3+20+3+20), bold=True)
     for allocation in allocations:
         beneficiary = allocation['address']
         amount = str(NU.from_nunits(allocation['amount']))
         duration = (maya.now() + maya.timedelta(seconds=allocation['duration'])).slang_date()
-        emitter.echo(f"{beneficiary:24} | {duration:20} | {amount:20}")
+        emitter.echo(f"{beneficiary} | {duration:20} | {amount:20}")
+    emitter.echo()
+
+
+def paint_deployed_allocations(emitter, allocations, failed) -> None:
+    emitter.echo(f"\n{'='*33} DEPLOYED ALLOCATIONS {'='*32}", bold=True)
+    emitter.echo(f"\n{'Beneficiary':42} | {'UserEscrow contract':42} ", bold=True)
+    emitter.echo("-"*(42+3+42), bold=True)
+    for beneficiary, contract_address in allocations:
+        emitter.echo(f"{beneficiary} | {contract_address}")
+    for beneficiary in failed:
+        emitter.echo(f"{beneficiary} | FAILED", color='red')
     emitter.echo()
 

--- a/tests/blockchain/eth/entities/actors/test_deployer.py
+++ b/tests/blockchain/eth/entities/actors/test_deployer.py
@@ -87,4 +87,6 @@ def test_rapid_deployment(token_economics, test_registry):
         random_allocation = {'beneficiary_address': beneficiary_address, 'amount': amount, 'duration_seconds': duration}
         allocation_data.append(random_allocation)
 
-    deployer.deploy_beneficiary_contracts(allocations=allocation_data, allocation_registry=allocation_registry)
+    deployer.deploy_beneficiary_contracts(allocations=allocation_data,
+                                          allocation_registry=allocation_registry,
+                                          interactive=False)

--- a/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_user_escrow_agent.py
@@ -56,7 +56,7 @@ def agent(testerchain, test_registry, allocation_value, agency) -> UserEscrowAge
 
     escrow_deployer.initial_deposit(value=allocation_value, duration_seconds=TEST_DURATION)
     assert escrow_deployer.contract.functions.getLockedTokens().call() == allocation_value
-    escrow_deployer.assign_beneficiary(beneficiary_address=beneficiary_address)
+    escrow_deployer.assign_beneficiary(checksum_address=beneficiary_address)
     escrow_deployer.enroll_principal_contract()
     assert escrow_deployer.contract.functions.getLockedTokens().call() == allocation_value
     _agent = escrow_deployer.make_agent()

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -363,6 +363,8 @@ def test_nucypher_deploy_allocation_contracts(click_runner,
                                  input=user_input,
                                  catch_exceptions=False)
     assert result.exit_code == 0
+    for allocation_address in testerchain.unassigned_accounts:
+        assert allocation_address in result.output
 
     # ensure that a pre-allocation recipient has the allocated token quantity.
     beneficiary = testerchain.client.accounts[-1]

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -109,7 +109,6 @@ def test_nucypher_deploy_contracts(click_runner,
     assert PolicyManagerAgent(registry=registry)
 
     # This agent wasn't instantiated before, so we have to supply the blockchain
-    blockchain = staking_agent.blockchain
     assert AdjudicatorAgent(registry=registry)
 
 


### PR DESCRIPTION
Provides a minimal UX for `nucypher-deploy allocations`. Here's an [example of the allocation process](https://gist.github.com/cygnusv/611d5d2a54b64c9bd718cebc1593f7dd).

Steps to reproduce:
```
# 1. Inspect published registry
nucypher-deploy --provider /path/to/geth.ipc --poa inspect

# 2. Deploy UserEscrowProxy
(Download registry manually first and use it as input next)
nucypher-deploy --provider /path/to/geth.ipc --poa contracts --deployer-address 0xfoobar --contract-name UserEscrowProxy --registry-infile contract_registry.json

# 3. Inspect new registry
nucypher-deploy --provider /path/to/geth.ipc --poa inspect --registry-infile contract_registry.json

# 4. Deploy allocations
nucypher-deploy --provider /path/to/geth.ipc --poa allocations --allocation-infile allocations.json --registry-infile contract_registry.json
```

Steps 1 and 2 are needed only because our current testnet doesn't have a `UserEscrowProxy`. 
You can skip these by using [this registry](https://gist.github.com/cygnusv/dfe16e5cb6a6570164eec78287dfaaf4), and go directly to steps 3 and 4, to try allocations. Here's an [example of allocation file](https://gist.github.com/cygnusv/87155ed5ef04159f98b16762a55ae4db). 