### PR TITLE
Refactor Alice's revoke method to accept a `TreasureMap`

### DIFF
--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -112,7 +112,8 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
 
         response_data = {'treasure_map': new_policy.treasure_map,
                          'policy_encrypting_key': new_policy.public_key,
-                         'alice_verifying_key': new_policy.alice.stamp}
+                         'alice_verifying_key': new_policy.alice.stamp,
+                         'policy_credential': new_policy.credential()}
         return response_data
 
     def revoke(self, treasure_map: bytes) -> dict:

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -120,7 +120,7 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
         Character control endpoint to allow Alice to revoke her policy.
         """
         from nucypher.policy.collections import TreasureMap
-        treasure_map = TreasureMap.from_bytes(treasure_map)
+        treasure_map = TreasureMap._TreasureMap__deserialize(treasure_map)
 
         failed_revocations = self.character.revoke(treasure_map)
         if len(failed_revocations) > 0:

--- a/nucypher/characters/control/serializers.py
+++ b/nucypher/characters/control/serializers.py
@@ -140,8 +140,8 @@ class AliceControlJSONSerializer(CharacterControlJSONSerializer, MessageHandlerM
 
     @staticmethod
     def parse_revoke_input(request: dict):
-        parsed_input = dict(label=request['label'].encode(),
-                            bob_verifying_key=bytes.fromhex(request['bob_verifying_key']))
+        treasure_map_bytes = b64decode(request['treasure_map'])
+        parsed_input = dict(treasure_map=treasure_map_bytes)
         return parsed_input
 
     @staticmethod

--- a/nucypher/characters/control/serializers.py
+++ b/nucypher/characters/control/serializers.py
@@ -134,7 +134,8 @@ class AliceControlJSONSerializer(CharacterControlJSONSerializer, MessageHandlerM
 
         response_data = {'treasure_map': treasure_map_base64,
                          'policy_encrypting_key': policy_encrypting_key_hex,
-                         'alice_verifying_key': alice_verifying_key_hex}
+                         'alice_verifying_key': alice_verifying_key_hex,
+                         'policy_credential': response['policy_credential'].to_json()}
 
         return response_data
 

--- a/nucypher/characters/control/specifications.py
+++ b/nucypher/characters/control/specifications.py
@@ -69,7 +69,7 @@ class AliceSpecification(CharacterSpecification):
     __grant = (('bob_encrypting_key', 'bob_verifying_key', 'm', 'n', 'label', 'expiration'),  # In
                ('treasure_map', 'policy_encrypting_key', 'alice_verifying_key'))              # Out
 
-    __revoke = (('label', 'bob_verifying_key', ),  # In
+    __revoke = (('treasure_map', ),  # In
                 ('failed_revocations',))     # Out
 
     __decrypt = (

--- a/nucypher/characters/control/specifications.py
+++ b/nucypher/characters/control/specifications.py
@@ -67,7 +67,7 @@ class AliceSpecification(CharacterSpecification):
                                      ('policy_encrypting_key', 'label'))   # Out
 
     __grant = (('bob_encrypting_key', 'bob_verifying_key', 'm', 'n', 'label', 'expiration'),  # In
-               ('treasure_map', 'policy_encrypting_key', 'alice_verifying_key'))              # Out
+               ('treasure_map', 'policy_encrypting_key', 'alice_verifying_key', 'policy_credential'))              # Out
 
     __revoke = (('treasure_map', ),  # In
                 ('failed_revocations',))     # Out

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -139,19 +139,6 @@ class Alice(Character, BlockchainPolicyAuthor):
         self.log = Logger(self.__class__.__name__)
         self.log.info(self.banner)
 
-        self.active_policies = dict()
-        self.revocation_kits = dict()
-
-    def add_active_policy(self, active_policy):
-        """
-        Adds a Policy object that is active on the NuCypher network to Alice's
-        `active_policies` dictionary by the policy ID.
-        The policy ID is a Keccak hash of the policy label and Bob's stamp bytes
-        """
-        if active_policy.id in self.active_policies:
-            raise KeyError("Policy already exists in active_policies.")
-        self.active_policies[active_policy.id] = active_policy
-
     def generate_kfrags(self,
                         bob: 'Bob',
                         label: bytes,

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -89,10 +89,10 @@ class UmbralMessageKit(MessageKit):
 
 class RevocationKit:
 
-    def __init__(self, policy: 'Policy', signer: 'SignatureStamp'):
+    def __init__(self, treasure_map: 'TreasureMap', signer: 'SignatureStamp'):
         from nucypher.policy.collections import Revocation
         self.revocations = dict()
-        for node_id, arrangement_id in policy.treasure_map:
+        for node_id, arrangement_id in treasure_map:
             self.revocations[node_id] = Revocation(arrangement_id, signer=signer)
 
     def __iter__(self):

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -14,8 +14,10 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-import binascii
 
+
+import binascii
+import json
 import maya
 import msgpack
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
@@ -222,6 +224,52 @@ class PolicyCredential:
         self.expiration = expiration
         self.policy_pubkey = policy_pubkey
         self.treasure_map = treasure_map
+
+    def to_json(self):
+        """
+        Serializes the PolicyCredential to JSON.
+        """
+        cred_dict = {
+            'alice_verifying_key': bytes(self.alice_verifying_key).hex(),
+            'label': self.label.hex(),
+            'expiration': self.expiration.iso8601(),
+            'policy_pubkey': bytes(self.policy_pubkey).hex()
+        }
+
+        if self.treasure_map is not None:
+            cred_dict['treasure_map'] = bytes(self.treasure_map).hex()
+
+        return json.dumps(cred_dict)
+
+    @classmethod
+    def from_json(cls, data: str):
+        """
+        Deserializes the PolicyCredential from JSON.
+        """
+        cred_json = json.loads(data)
+
+        alice_verifying_key = UmbralPublicKey.from_bytes(
+                                    cred_json['alice_verifying_key'],
+                                    decoder=bytes().fromhex)
+        label = bytes().fromhex(cred_json['label'])
+        expiration = maya.MayaDT.from_iso8601(cred_json['expiration'])
+        policy_pubkey = UmbralPublicKey.from_bytes(
+                            cred_json['policy_pubkey'],
+                            decoder=bytes().fromhex)
+        treasure_map = None
+
+        if 'treasure_map' in cred_json:
+            treasure_map = TreasureMap.from_bytes(
+                                bytes().fromhex(cred_json['treasure_map']))
+
+        return cls(alice_verifying_key, label, expiration, policy_pubkey,
+                   treasure_map)
+
+    def __eq__(self, other):
+        return ((self.alice_verifying_key == other.alice_verifying_key) and
+                (self.label == other.label) and
+                (self.expiration == other.expiration) and
+                (self.policy_pubkey == other.policy_pubkey))
 
 
 class WorkOrder:

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -209,6 +209,21 @@ class TreasureMap:
         return len(self.destinations)
 
 
+class PolicyCredential:
+    """
+    A portable structure that contains information necessary for Alice or Bob
+    to utilize the policy on the network that the credential describes.
+    """
+
+    def __init__(self, alice_verifying_key, label, expiration, policy_pubkey,
+                 treasure_map=None):
+        self.alice_verifying_key = alice_verifying_key
+        self.label = label
+        self.expiration = expiration
+        self.policy_pubkey = policy_pubkey
+        self.treasure_map = treasure_map
+
+
 class WorkOrder:
 
     class Task:

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -264,7 +264,6 @@ class PolicyCredential:
         }
 
         if self.treasure_map is not None:
-            breakpoint()
             cred_dict['treasure_map'] = self.treasure_map._TreasureMap__serialize().hex()
 
         return json.dumps(cred_dict)

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -264,7 +264,8 @@ class PolicyCredential:
         }
 
         if self.treasure_map is not None:
-            cred_dict['treasure_map'] = bytes(self.treasure_map).hex()
+            breakpoint()
+            cred_dict['treasure_map'] = self.treasure_map._TreasureMap__serialize().hex()
 
         return json.dumps(cred_dict)
 
@@ -286,7 +287,7 @@ class PolicyCredential:
         treasure_map = None
 
         if 'treasure_map' in cred_json:
-            treasure_map = TreasureMap.from_bytes(
+            treasure_map = TreasureMap._TreasureMap__deserialize(
                                 bytes().fromhex(cred_json['treasure_map']))
 
         return cls(alice_verifying_key, label, expiration, policy_pubkey,

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -277,6 +277,22 @@ class Policy(ABC):
         """
         return self.publish_treasure_map(network_middleware=network_middleware)
 
+    def credential(self, with_treasure_map=True):
+        """
+        Creates a PolicyCredential for portable access to the policy via
+        Alice or Bob. By default, it will include the treasure_map for the
+        policy unless `with_treasure_map` is False.
+        """
+        from nucypher.policy.collections import PolicyCredential
+
+        treasure_map = self.treasure_map
+        if not with_treasure_map:
+            treasure_map = None
+
+        return PolicyCredential(self.alice.stamp, self.label, self.expiration,
+                                self.public_key, treasure_map)
+
+
     def __assign_kfrags(self) -> Generator[Arrangement, None, None]:
 
         if len(self._accepted_arrangements) < self.n:

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -17,7 +17,6 @@ from nucypher.blockchain.eth.utils import calculate_period_duration
 from nucypher.characters.lawful import Alice, Ursula
 from nucypher.crypto.api import secure_random, keccak_digest
 from nucypher.crypto.constants import PUBLIC_KEY_LENGTH
-from nucypher.crypto.kits import RevocationKit
 from nucypher.crypto.powers import DecryptingPower, SigningPower
 from nucypher.crypto.utils import construct_policy_id
 from nucypher.network.exceptions import NodeSeemsToBeDown
@@ -332,10 +331,6 @@ class Policy(ABC):
             self.treasure_map.add_arrangement(arrangement)
 
         else:  # ...After *all* the policies are enacted
-            # Create Alice's revocation kit
-            self.revocation_kit = RevocationKit(self, self.alice.stamp)
-            self.alice.add_active_policy(self)
-
             if publish is True:
                 return self.publish(network_middleware=network_middleware)
 

--- a/tests/characters/control/test_web_control.py
+++ b/tests/characters/control/test_web_control.py
@@ -100,11 +100,10 @@ def test_alice_character_control_revoke(alice_web_controller_test_client, federa
     assert response.status_code == 200
 
     revoke_request_data = {
-        'label': 'test',
-        'bob_verifying_key': bytes(federated_bob.stamp).hex()
+        'treasure_map': response.json['result']['treasure_map']
     }
 
-    response = alice_web_controller_test_client.delete(f'/revoke', data=json.dumps(revoke_request_data))
+    response = alice_web_controller_test_client.delete('/revoke', data=json.dumps(revoke_request_data))
     assert response.status_code == 200
 
     response_data = json.loads(response.data)

--- a/tests/characters/control/test_web_control.py
+++ b/tests/characters/control/test_web_control.py
@@ -7,10 +7,9 @@ import pytest
 from click.testing import CliRunner
 
 import nucypher
-from nucypher.characters.control.serializers import AliceControlJSONSerializer
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import DecryptingPower
-from nucypher.policy.collections import TreasureMap
+from nucypher.policy.collections import TreasureMap, PolicyCredential
 
 click_runner = CliRunner()
 
@@ -70,6 +69,7 @@ def test_alice_web_character_control_grant(alice_web_controller_test_client, gra
     assert 'treasure_map' in response_data['result']
     assert 'policy_encrypting_key' in response_data['result']
     assert 'alice_verifying_key' in response_data['result']
+    assert 'policy_credential' in response_data['result']
 
     map_bytes = b64decode(response_data['result']['treasure_map'])
     encrypted_map = TreasureMap.from_bytes(map_bytes)
@@ -99,8 +99,12 @@ def test_alice_character_control_revoke(alice_web_controller_test_client, federa
     response = alice_web_controller_test_client.put('/grant', data=json.dumps(grant_request_data))
     assert response.status_code == 200
 
+    policy_credential = PolicyCredential.from_json(
+                                response.json['result']['policy_credential'])
+
+    treasure_map_b64 = b64encode(policy_credential.treasure_map._TreasureMap__serialize())
     revoke_request_data = {
-        'treasure_map': response.json['result']['treasure_map']
+        'treasure_map': treasure_map_b64.decode(),
     }
 
     response = alice_web_controller_test_client.delete('/revoke', data=json.dumps(revoke_request_data))

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -71,6 +71,17 @@ def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
 
         assert kfrag == retrieved_kfrag
 
+    # Check that the PolicyCredential is consistent to the new policy
+    credential = policy.credential()
+    assert credential.alice_verifying_key == policy.alice.stamp
+    assert credential.label == policy.label
+    assert credential.expiration == policy.expiration
+    assert credential.policy_pubkey == policy.public_key
+    assert credential.treasure_map == policy.treasure_map
+
+    credential = policy.credential(with_treasure_map=False)
+    assert credential.treasure_map is None
+
 
 @pytest.mark.usefixtures('federated_ursulas')
 def test_federated_grant(federated_alice, federated_bob):

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -29,7 +29,7 @@ from nucypher.characters.lawful import Bob, Enrico
 from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.powers import SigningPower, DecryptingPower
-from nucypher.policy.collections import Revocation
+from nucypher.policy.collections import Revocation, PolicyCredential
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 from nucypher.utilities.sandbox.policy import MockPolicyCreation
@@ -71,7 +71,19 @@ def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
 
         assert kfrag == retrieved_kfrag
 
-    # Check that the PolicyCredential is consistent to the new policy
+    # Test PolicyCredential w/o TreasureMap
+    credential = policy.credential(with_treasure_map=False)
+    assert credential.alice_verifying_key == policy.alice.stamp
+    assert credential.label == policy.label
+    assert credential.expiration == policy.expiration
+    assert credential.policy_pubkey == policy.public_key
+    assert credential.treasure_map is None
+
+    cred_json = credential.to_json()
+    deserialized_cred = PolicyCredential.from_json(cred_json)
+    assert credential == deserialized_cred
+
+    # Test PolicyCredential w/ TreasureMap
     credential = policy.credential()
     assert credential.alice_verifying_key == policy.alice.stamp
     assert credential.label == policy.label
@@ -79,9 +91,9 @@ def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
     assert credential.policy_pubkey == policy.public_key
     assert credential.treasure_map == policy.treasure_map
 
-    credential = policy.credential(with_treasure_map=False)
-    assert credential.treasure_map is None
-
+    cred_json = credential.to_json()
+    deserialized_cred = PolicyCredential.from_json(cred_json)
+    assert credential == deserialized_cred
 
 @pytest.mark.usefixtures('federated_ursulas')
 def test_federated_grant(federated_alice, federated_bob):

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -111,10 +111,6 @@ def test_federated_grant(federated_alice, federated_bob):
     policy_id = keccak_digest(policy.label + bytes(policy.bob.stamp))
     assert policy_id == policy.id
 
-    # Check Alice's active policies
-    assert policy_id in federated_alice.active_policies
-    assert federated_alice.active_policies[policy_id] == policy
-
     # The number of accepted arrangements at least the number of Ursulas we're using (n)
     assert len(policy._accepted_arrangements) >= n
 

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -116,7 +116,7 @@ def test_bob_joins_policy_and_retrieves(federated_alice,
     assert delivered_cleartexts == cleartexts_delivered_a_second_time
 
     # Let's try retrieve again, but Alice revoked the policy.
-    failed_revocations = federated_alice.revoke(policy)
+    failed_revocations = federated_alice.revoke(policy.treasure_map)
     assert len(failed_revocations) == 0
 
     # One thing to note here is that Bob *can* still retrieve with the cached CFrags, even though this Policy has been revoked.  #892


### PR DESCRIPTION
### What this does:

1. Refactors `Alice.revoke` to take a `TreasureMap` affiliated with an active policy instead of a `Policy` directly.
2. The `RevocationKit` now also takes a ` TreasureMap` instead of a `Policy`.
3. Removes `add_active_policy` and `active_policies`, as well as the `revocation_kits` dict.
4. Adds two methods `__serialize` and `__deserialize` to `TreasureMap`.
    - This is not super fine work, but it's a hacky way to get going in the direction that we eventually need to be in.
5. The `grant` character control method additionally returns a `PolicyCredential` for Alice (or Bob) to use as needed.