### PR TITLE
[EPIC] Birdcage: A PR for people who want to pretend to like Bob.

### DIFF
--- a/examples/finnegans_wake_demo/finnegans-wake-demo.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo.py
@@ -142,7 +142,7 @@ for counter, plaintext in enumerate(finnegans_wake):
 
     # Now Bob can retrieve the original message.
     alice_pubkey_restored_from_ancient_scroll = UmbralPublicKey.from_bytes(alices_pubkey_bytes_saved_for_posterity)
-    delivered_cleartexts = BOB.retrieve(message_kit=single_passage_ciphertext,
+    delivered_cleartexts = BOB.retrieve(single_passage_ciphertext,
                                         enrico=enrico_as_understood_by_bob,
                                         alice_verifying_key=alice_pubkey_restored_from_ancient_scroll,
                                         label=label)

--- a/examples/populate_mario_box.py
+++ b/examples/populate_mario_box.py
@@ -5,54 +5,56 @@ import json
 import os
 
 import click
-import libnacl.secret
 
 from nucypher.characters.lawful import Enrico
 from nucypher.cli.actions import make_cli_character
 from nucypher.config.characters import AliceConfiguration
+from nucypher.crypto.powers import SigningPower
 
 
 @click.command()
-# @click.option('--plaintext-pass-through', type=click.BOOL, required=True)  # FIXME
 @click.option('--plaintext-dir', type=click.STRING, required=True)
+@click.option('--outfile', type=click.STRING)
 @click.option('--alice-config', type=click.STRING)
 @click.option('--label', type=click.STRING, required=True)
-def mario_box_cli(plaintext_dir, alice_config, label):
-    click.secho("Starting Up...", fg='green')
+def mario_box_cli(plaintext_dir, alice_config, label, outfile):
 
     # Derive Policy Encrypting Key
     alice_configuration = AliceConfiguration.from_configuration_file(filepath=alice_config)
     alice = make_cli_character(character_config=alice_configuration)
+    alice_signing_key = alice.public_keys(SigningPower)
     policy_encrypting_key = alice.get_policy_encrypting_key_from_label(label=label.encode())
+    policy_encrypting_key_hex = bytes(policy_encrypting_key).hex()
 
-    message_kits = list()
+    output = list()
     paths = list(os.listdir(plaintext_dir))
-    for path in paths:
-        filepath = os.path.join(plaintext_dir, path)
-        click.secho(f'Processing {filepath}...')
-        with open(filepath, 'rb') as file:
-            plaintext = file.read()
-            encoded_plaintext = base64.b64encode(plaintext)
+    click.secho(f"Encrypting {len(paths)} files for policy {policy_encrypting_key_hex}", fg='blue')
 
-            # Make the Box
-            box = libnacl.secret.SecretBox()
+    with click.progressbar(paths) as bar:
+        for path in bar:
+            filepath = os.path.join(plaintext_dir, path)
+            with open(filepath, 'rb') as file:
+                plaintext = file.read()
+                encoded_plaintext = base64.b64encode(plaintext)
 
-            # Encrypt file contents symmetrically
-            ciphertext = box.encrypt(encoded_plaintext)
-            base64_ciphertext = base64.b64encode(ciphertext).decode()
+                enrico = Enrico(policy_encrypting_key=policy_encrypting_key)
+                message_kit, _signature = enrico.encrypt_message(message=encoded_plaintext)
+                base64_message_kit = base64.b64encode(bytes(message_kit)).decode()
 
-            # Encrypt the symmetric key
-            enrico = Enrico(policy_encrypting_key=policy_encrypting_key)
-            message_kit, _signature = enrico.encrypt_message(message=box.sk)
-            base64_message_kit = base64.b64encode(bytes(message_kit)).decode()
+                # Collect Bob Retrieve JSON Requests
+                retrieve_payload = {'label': label,
+                                    'policy-encrypting-key': policy_encrypting_key_hex,
+                                    'alice-verifying-key': bytes(alice_signing_key).hex(),
+                                    'message-kit': base64_message_kit}
 
-            # Collect ciphertext-message-kit pairs.
-            message_kits.append((base64_ciphertext, base64_message_kit))
-            click.secho(f"Encrypted {filepath}...")
+                output.append(retrieve_payload)
 
-    # Generate the output
-    output = {'ciphertexts': message_kits, 'pek': bytes(policy_encrypting_key).hex()}
-    click.secho(json.dumps(output))
+    if not outfile:
+        outfile = f'{policy_encrypting_key_hex}.json'
+
+    with open(outfile, 'w') as file:
+        file.write(json.dumps(output, indent=2))
+    click.secho(f"Successfully wrote output to {outfile}", fg='green')
 
 
 if __name__ == '__main__':

--- a/examples/populate_mario_box.py
+++ b/examples/populate_mario_box.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import base64
+import json
+import os
+
+import click
+import libnacl.secret
+
+from nucypher.characters.lawful import Enrico
+from nucypher.cli.actions import make_cli_character
+from nucypher.config.characters import AliceConfiguration
+
+
+@click.command()
+# @click.option('--plaintext-pass-through', type=click.BOOL, required=True)  # FIXME
+@click.option('--plaintext-dir', type=click.STRING, required=True)
+@click.option('--alice-config', type=click.STRING)
+@click.option('--label', type=click.STRING, required=True)
+def mario_box_cli(plaintext_dir, alice_config, label):
+    click.secho("Starting Up...", fg='green')
+
+    # Derive Policy Encrypting Key
+    alice_configuration = AliceConfiguration.from_configuration_file(filepath=alice_config)
+    alice = make_cli_character(character_config=alice_configuration)
+    policy_encrypting_key = alice.get_policy_encrypting_key_from_label(label=label.encode())
+
+    message_kits = list()
+    paths = list(os.listdir(plaintext_dir))
+    for path in paths:
+        filepath = os.path.join(plaintext_dir, path)
+        click.secho(f'Processing {filepath}...')
+        with open(filepath, 'rb') as file:
+            plaintext = file.read()
+            encoded_plaintext = base64.b64encode(plaintext)
+
+            # Make the Box
+            box = libnacl.secret.SecretBox()
+
+            # Encrypt file contents symmetrically
+            ciphertext = box.encrypt(encoded_plaintext)
+            base64_ciphertext = base64.b64encode(ciphertext).decode()
+
+            # Encrypt the symmetric key
+            enrico = Enrico(policy_encrypting_key=policy_encrypting_key)
+            message_kit, _signature = enrico.encrypt_message(message=box.sk)
+            base64_message_kit = base64.b64encode(bytes(message_kit)).decode()
+
+            # Collect ciphertext-message-kit pairs.
+            message_kits.append((base64_ciphertext, base64_message_kit))
+            click.secho(f"Encrypted {filepath}...")
+
+    # Generate the output
+    output = {'ciphertexts': message_kits, 'pek': bytes(policy_encrypting_key).hex()}
+    click.secho(json.dumps(output))
+
+
+if __name__ == '__main__':
+    mario_box_cli()

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -217,7 +217,9 @@ class Character(Learner):
             if registry is not None:
                 raise TypeError("Registry cannot be attached to stranger-Characters.")
 
-            self._stamp = StrangerStamp(self.public_keys(SigningPower))
+            verifying_key = self.public_keys(SigningPower)
+            self._stamp = StrangerStamp(verifying_key)
+            self.keyring_root = STRANGER
             self.network_middleware = STRANGER
 
         #

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -4,6 +4,7 @@ import json
 from collections.abc import Mapping
 
 import maya
+from typing import Union
 
 from nucypher.characters.control.specifications import alice, bob, enrico
 from umbral.keys import UmbralPublicKey
@@ -189,7 +190,7 @@ class BobInterface(CharacterPublicInterface):
                  policy_encrypting_key: bytes,
                  alice_verifying_key: bytes,
                  message_kit: bytes,
-                 treasure_map: bytes = None):
+                 treasure_map: Union[bytes, 'TreasureMap'] = None):
         """
         Character control endpoint for re-encrypting and decrypting policy data.
         """

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -1,14 +1,11 @@
 import functools
-import click
-import json
-from collections.abc import Mapping
-
-import maya
+from base64 import b64decode
 from typing import Union
 
-from nucypher.characters.control.specifications import alice, bob, enrico
+import maya
 from umbral.keys import UmbralPublicKey
 
+from nucypher.characters.control.specifications import alice, bob, enrico
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import DecryptingPower, SigningPower
 from nucypher.crypto.utils import construct_policy_id
@@ -16,14 +13,13 @@ from nucypher.network.middleware import NotFound
 
 
 def attach_schema(schema):
-
     def callable(func):
         func._schema = schema()
 
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-
             return func(*args, **kwargs)
+
         return wrapped
 
     return callable
@@ -37,7 +33,6 @@ class CharacterPublicInterface:
 
     @classmethod
     def connect_cli(cls, action):
-
         schema = getattr(cls, action)._schema
 
         def callable(func):
@@ -48,6 +43,7 @@ class CharacterPublicInterface:
             @functools.wraps(func)
             def wrapped(*args, **kwargs):
                 return c(*args, **kwargs)
+
             return wrapped
 
         return callable
@@ -129,9 +125,9 @@ class AliceInterface(CharacterPublicInterface):
             for node_id, attempt in failed_revocations.items():
                 revocation, fail_reason = attempt
                 if fail_reason == NotFound:
-                    del(failed_revocations[node_id])
+                    del (failed_revocations[node_id])
         if len(failed_revocations) <= (policy.n - policy.treasure_map.m + 1):
-            del(self.character.active_policies[policy_id])
+            del (self.character.active_policies[policy_id])
 
         response_data = {'failed_revocations': len(failed_revocations)}
         return response_data
@@ -190,7 +186,7 @@ class BobInterface(CharacterPublicInterface):
                  policy_encrypting_key: bytes,
                  alice_verifying_key: bytes,
                  message_kit: bytes,
-                 treasure_map: Union[bytes, 'TreasureMap'] = None):
+                 treasure_map: Union[bytes, str, 'TreasureMap'] = None):
         """
         Character control endpoint for re-encrypting and decrypting policy data.
         """
@@ -198,7 +194,8 @@ class BobInterface(CharacterPublicInterface):
 
         policy_encrypting_key = UmbralPublicKey.from_bytes(policy_encrypting_key)
         alice_verifying_key = UmbralPublicKey.from_bytes(alice_verifying_key)
-        message_kit = UmbralMessageKit.from_bytes(message_kit)  # TODO #846: May raise UnknownOpenSSLError and InvalidTag.
+        message_kit = UmbralMessageKit.from_bytes(
+            message_kit)  # TODO #846: May raise UnknownOpenSSLError and InvalidTag.
 
         enrico = Enrico.from_public_keys(verifying_key=message_kit.sender_verifying_key,
                                               policy_encrypting_key=policy_encrypting_key,

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -188,7 +188,8 @@ class BobInterface(CharacterPublicInterface):
                  label: bytes,
                  policy_encrypting_key: bytes,
                  alice_verifying_key: bytes,
-                 message_kit: bytes):
+                 message_kit: bytes,
+                 treasure_map: bytes = None):
         """
         Character control endpoint for re-encrypting and decrypting policy data.
         """

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -202,8 +202,8 @@ class BobInterface(CharacterPublicInterface):
                                               label=label)
 
         self.character.join_policy(label=label, alice_verifying_key=alice_verifying_key)
-        plaintexts = self.character.retrieve(message_kit=message_kit,
-                                             data_source=enrico,
+        plaintexts = self.character.retrieve(message_kit,
+                                             enrico=enrico,
                                              alice_verifying_key=alice_verifying_key,
                                              label=label)
 

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -202,10 +202,13 @@ class BobInterface(CharacterPublicInterface):
                                               label=label)
 
         self.character.join_policy(label=label, alice_verifying_key=alice_verifying_key)
+
+
         plaintexts = self.character.retrieve(message_kit,
                                              enrico=enrico,
                                              alice_verifying_key=alice_verifying_key,
-                                             label=label)
+                                             label=label,
+                                             treasure_map=treasure_map)
 
         response_data = {'cleartexts': plaintexts}
         return response_data

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -585,19 +585,18 @@ class Bob(Character):
 
     def work_orders_for_capsules(self,
                                  *capsules,
-                                 map_or_id: Union['TreasureMap', str],  # XXX or bytes?
                                  alice_verifying_key: UmbralPublicKey,
+                                 map_id: str = None,  # XXX or bytes?
+                                 treasure_map: 'TreasureMap' = None,
                                  num_ursulas: int = None,
                                  ):
 
         from nucypher.policy.collections import WorkOrder  # Prevent circular import
-        from nucypher.policy.collections import TreasureMap
 
-        if isinstance(map_or_id, TreasureMap):
-            map_id = map_or_id.public_id()
-            treasure_map_to_use = map_or_id
+        if treasure_map:
+            map_id = treasure_map.public_id()
+            treasure_map_to_use = treasure_map
         else:
-            map_id = map_or_id
             try:
                 treasure_map_to_use = self.treasure_maps[map_id]
             except KeyError:
@@ -727,7 +726,8 @@ class Bob(Character):
             capsule.set_correctness_keys(verifying=alice_verifying_key)
 
             new_work_orders, complete_work_orders = self.work_orders_for_capsules(
-                map_or_id=treasure_map or map_id,
+                map_id=map_id,
+                treasure_map=treasure_map,
                 alice_verifying_key=alice_verifying_key,
                 *capsules_to_activate)
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -664,7 +664,8 @@ class Bob(Character):
                  enrico: "Enrico" = None,
                  retain_cfrags: bool=False,
                  use_attached_cfrags: bool=False,
-                 use_precedent_work_orders: bool=False):
+                 use_precedent_work_orders: bool=False,
+                 policy_encrypting_key: UmbralPublicKey=None):
         # Try our best to get an UmbralPublicKey from input
         alice_verifying_key = UmbralPublicKey.from_bytes(bytes(alice_verifying_key))
 
@@ -681,6 +682,10 @@ class Bob(Character):
                     raise ValueError
             elif enrico:
                 message.sender = enrico
+            elif message.sender_verifying_key and policy_encrypting_key:
+                # Well, after all, this is all we *really* need.
+                message.sender = Enrico.from_public_keys(verifying_key=message.sender_verifying_key,
+                                                         policy_encrypting_key=policy_encrypting_key)
             else:
                 raise TypeError
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1213,15 +1213,6 @@ class Ursula(Teacher, Character, Worker):
                 raise Learner.NotATeacher(
                     f"{checksum_address} is staking less than the specified minimum stake value ({minimum_stake}).")
 
-        # Verify the node's TLS certificate
-        try:
-            potential_seed_node.verify_node(network_middleware=network_middleware,
-                                            registry=registry,
-                                            certificate_filepath=temp_certificate_filepath)
-        except potential_seed_node.InvalidNode:
-            # TODO: What if our seed node fails verification?
-            raise
-
         # OK - everyone get out
         temp_node_storage.forget()
         return potential_seed_node

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -700,8 +700,8 @@ class Bob(Character):
             hrac, map_id = self.construct_hrac_and_map_id(alice_verifying_key, label)
             _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(map_id=map_id, block=True)
 
-            capsule.set_cfrag_correctness_key("receiving", self.public_keys(DecryptingPower))
-            capsule.set_cfrag_correctness_key("verifying", alice_verifying_key)
+            capsule.set_correctness_keys("receiving", self.public_keys(DecryptingPower))
+            capsule.set_correctness_keys("verifying", alice_verifying_key)
 
             new_work_orders, complete_work_orders = self.work_orders_for_capsules(
                 map_id=map_id,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -585,7 +585,7 @@ class Bob(Character):
 
     def work_orders_for_capsules(self,
                                  *capsules,
-                                 map_or_id: Union['TreasureMap', str],
+                                 map_or_id: Union['TreasureMap', str],  # XXX or bytes?
                                  alice_verifying_key: UmbralPublicKey,
                                  num_ursulas: int = None,
                                  ):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -443,11 +443,11 @@ class Bob(Character):
         self.log.info(self.banner)
 
     def _pick_treasure_map(self, treasure_map=None, map_id=None):
-        if not treasure_map:
+        if treasure_map is None:
             if map_id:
                 treasure_map = self.treasure_maps[map_id]
             else:
-                raise ValueError("You need to pass either treasure_map or map_id.")
+                 raise ValueError("You need to pass either treasure_map or map_id.")
         elif map_id:
             raise ValueError("Don't pass both treasure_map and map_id - pick one or the other.")
         return treasure_map

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -723,7 +723,6 @@ class Bob(Character):
                 else:
                     self.log.warn("Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")
 
-
         # Part II: Getting the cleartexts.
         cleartexts = []
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -700,8 +700,8 @@ class Bob(Character):
             hrac, map_id = self.construct_hrac_and_map_id(alice_verifying_key, label)
             _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(map_id=map_id, block=True)
 
-            capsule.set_correctness_keys("receiving", self.public_keys(DecryptingPower))
-            capsule.set_correctness_keys("verifying", alice_verifying_key)
+            capsule.set_correctness_keys(receiving=self.public_keys(DecryptingPower))
+            capsule.set_correctness_keys(verifying=alice_verifying_key)
 
             new_work_orders, complete_work_orders = self.work_orders_for_capsules(
                 map_id=map_id,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -658,7 +658,7 @@ class Bob(Character):
         self.follow_treasure_map(treasure_map=treasure_map, block=block)
 
     def retrieve(self,
-                 message_kits: UmbralMessageKit,
+                 *message_kits: UmbralMessageKit,
                  alice_verifying_key: UmbralPublicKey,
                  label: bytes,
                  enrico: "Enrico" = None,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -32,8 +32,6 @@ from eth_utils import to_checksum_address
 from flask import request, Response
 from twisted.internet import threads
 from twisted.logger import Logger
-
-from nucypher.characters.control.interfaces import AliceInterface, BobInterface, EnricoInterface
 from umbral import pre
 from umbral.keys import UmbralPublicKey
 from umbral.kfrags import KFrag
@@ -52,9 +50,9 @@ from nucypher.blockchain.eth.token import WorkTracker
 from nucypher.characters.banners import ALICE_BANNER, BOB_BANNER, ENRICO_BANNER, URSULA_BANNER
 from nucypher.characters.base import Character, Learner
 from nucypher.characters.control.controllers import (
-    CLIController,
     WebController
 )
+from nucypher.characters.control.interfaces import AliceInterface, BobInterface, EnricoInterface
 from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage
 from nucypher.crypto.api import keccak_digest, encrypt_and_sign
 from nucypher.crypto.constants import PUBLIC_KEY_LENGTH, PUBLIC_ADDRESS_LENGTH
@@ -667,11 +665,11 @@ class Bob(Character):
                  alice_verifying_key: UmbralPublicKey,
                  label: bytes,
                  enrico: "Enrico" = None,
-                 retain_cfrags: bool=False,
-                 use_attached_cfrags: bool=False,
-                 use_precedent_work_orders: bool=False,
-                 policy_encrypting_key: UmbralPublicKey=None,
-                 treasure_map: Union['TreasureMap', bytes]=None):
+                 retain_cfrags: bool = False,
+                 use_attached_cfrags: bool = False,
+                 use_precedent_work_orders: bool = False,
+                 policy_encrypting_key: UmbralPublicKey = None,
+                 treasure_map: Union['TreasureMap', bytes] = None):
 
         # Try our best to get an UmbralPublicKey from input
         alice_verifying_key = UmbralPublicKey.from_bytes(bytes(alice_verifying_key))
@@ -739,7 +737,8 @@ class Bob(Character):
                         cfrag_in_question = work_order.tasks[capsule].cfrag
                         capsule.attach_cfrag(cfrag_in_question)
                 else:
-                    self.log.warn("Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")
+                    self.log.warn(
+                        "Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")
 
         # Part II: Getting the cleartexts.
         cleartexts = []

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -731,7 +731,6 @@ class Bob(Character):
             # TODO Optimization: Block here (or maybe even later) until map is done being followed (instead of blocking above). #1114
             the_airing_of_grievances = []
 
-
             for work_order in new_work_orders.values():
                 for capsule in work_order.tasks:
                     work_order_is_useful = False
@@ -752,7 +751,7 @@ class Bob(Character):
                 # We don't have enough CFrags yet.  Let's get another one from a WorkOrder.
                 try:
                     self.get_reencrypted_cfrags(work_order, retain_cfrags=retain_cfrags)
-                except NodeSeemsToBeDown:
+                except NodeSeemsToBeDown as e:
                     # TODO: What to do here?  Ursula isn't supposed to be down.
                     self.log.info(
                         f"Ursula ({work_order.ursula}) seems to be down while trying to complete WorkOrder: {work_order}")
@@ -1396,8 +1395,8 @@ class Enrico(Character):
     _interface_class = EnricoInterface
     _default_crypto_powerups = [SigningPower]
 
-    def __init__(self, policy_encrypting_key, controller: bool = True, *args, **kwargs):
-        self.policy_pubkey = policy_encrypting_key
+    def __init__(self, policy_encrypting_key=None, controller: bool = True, *args, **kwargs):
+        self._policy_pubkey = policy_encrypting_key
 
         # Encrico never uses the blockchain, hence federated_only)
         kwargs['federated_only'] = True
@@ -1407,7 +1406,7 @@ class Enrico(Character):
         if controller:
             self.make_cli_controller()
 
-        self.log = Logger(f'{self.__class__.__name__}-{bytes(policy_encrypting_key).hex()[:6]}')
+        self.log = Logger(f'{self.__class__.__name__}-{bytes(self.public_keys(SigningPower)).hex()[:6]}')
         self.log.info(self.banner.format(policy_encrypting_key))
 
     def encrypt_message(self,
@@ -1429,6 +1428,12 @@ class Enrico(Character):
         policy_pubkey_enc = alice.get_policy_encrypting_key_from_label(label)
         return cls(crypto_power_ups={SigningPower: alice.stamp.as_umbral_pubkey()},
                    policy_encrypting_key=policy_pubkey_enc)
+
+    @property
+    def policy_pubkey(self):
+        if not self._policy_pubkey:
+            raise TypeError("This Enrico doesn't know which policy encrypting key he used.  Oh well.")
+        return self._policy_pubkey
 
     def make_web_controller(drone_enrico, crash_on_error: bool = False):
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -700,10 +700,9 @@ class Bob(Character):
             hrac, map_id = self.construct_hrac_and_map_id(alice_verifying_key, label)
             _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(map_id=map_id, block=True)
 
-            capsule.set_correctness_keys(
-                delegating=enrico.policy_pubkey,
-                receiving=self.public_keys(DecryptingPower),
-                verifying=alice_verifying_key)
+            capsule.set_cfrag_correctness_key("receiving", self.public_keys(DecryptingPower))
+            capsule.set_cfrag_correctness_key("verifying", alice_verifying_key)
+
             new_work_orders, complete_work_orders = self.work_orders_for_capsules(
                 map_id=map_id,
                 alice_verifying_key=alice_verifying_key,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -586,7 +586,7 @@ class Bob(Character):
     def work_orders_for_capsules(self,
                                  *capsules,
                                  alice_verifying_key: UmbralPublicKey,
-                                 map_id: str = None,  # XXX or bytes?
+                                 map_id: str = None,
                                  treasure_map: 'TreasureMap' = None,
                                  num_ursulas: int = None,
                                  ):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -658,13 +658,13 @@ class Bob(Character):
         self.follow_treasure_map(treasure_map=treasure_map, block=block)
 
     def retrieve(self,
-                 enrico: "Enrico",
                  message_kits: UmbralMessageKit,
                  alice_verifying_key: UmbralPublicKey,
                  label: bytes,
-                 retain_cfrags: bool = False,
-                 use_attached_cfrags: bool = False,
-                 use_precedent_work_orders: bool = False):
+                 enrico: "Enrico" = None,
+                 retain_cfrags: bool=False,
+                 use_attached_cfrags: bool=False,
+                 use_precedent_work_orders: bool=False):
         # Try our best to get an UmbralPublicKey from input
         alice_verifying_key = UmbralPublicKey.from_bytes(bytes(alice_verifying_key))
 
@@ -788,7 +788,7 @@ class Bob(Character):
                 #  - This line is unreachable when NotEnoughUrsulas
 
             for message in message_kits:
-                delivered_cleartext = self.verify_from(enrico, message, decrypt=True)
+                delivered_cleartext = self.verify_from(message.sender, message, decrypt=True)
                 cleartexts.append(delivered_cleartext)
         finally:
             if not retain_cfrags:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -448,7 +448,7 @@ class Bob(Character):
             if map_id:
                 treasure_map = self.treasure_maps[map_id]
             else:
-                 raise ValueError("You need to pass either treasure_map or map_id.")
+                raise ValueError("You need to pass either treasure_map or map_id.")
         elif map_id:
             raise ValueError("Don't pass both treasure_map and map_id - pick one or the other.")
         return treasure_map
@@ -693,7 +693,6 @@ class Bob(Character):
 
             if isinstance(treasure_map, str):
                 tmap_bytes = treasure_map.encode()
-                b64decode(tmap_bytes)
                 treasure_map = TreasureMap.from_bytes(b64decode(tmap_bytes))
 
             treasure_map.orient(compass)

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -46,6 +46,7 @@ from nucypher.blockchain.eth.registry import (
 )
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.token import Stake
+from nucypher.characters.control.emitters import StdoutEmitter
 from nucypher.cli import painting
 from nucypher.cli.types import IPV4_ADDRESS
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, NUCYPHER_ENVVAR_KEYRING_PASSWORD

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -46,7 +46,6 @@ from nucypher.blockchain.eth.registry import (
 )
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.token import Stake
-from nucypher.characters.control.emitters import StdoutEmitter
 from nucypher.cli import painting
 from nucypher.cli.types import IPV4_ADDRESS
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, NUCYPHER_ENVVAR_KEYRING_PASSWORD

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -70,8 +70,8 @@ class MessageKit(CryptoKit):
     @classmethod
     def splitter(cls, *args, **kwargs):
         return BytestringKwargifier(cls,
-                                    capsule=(capsule_splitter, {'single': True}),
-                                    sender_verifying_key=(key_splitter, {'single': True}),
+                                    capsule=capsule_splitter,
+                                    sender_verifying_key=key_splitter,
                                     ciphertext=VariableLengthBytestring)
 
     @property

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -96,12 +96,11 @@ class PolicyMessageKit(MessageKit):
         self.capsule.set_cfrag_correctness_key("delegating", enrico.policy_pubkey)
         self._sender = enrico
 
+    def __bytes__(self):
+        return super().to_bytes(include_alice_pubkey=True)
 
-    # def __init__(self, *args, **kwargs) -> None:
-    #     super().__init__(*args, **kwargs)
-    #     self.policy_pubkey = None
 
-UmbralMessageKit = PolicyMessageKit
+UmbralMessageKit = PolicyMessageKit  # Temporarily, until serialization w/ Enrico's
 
 
 class RevocationKit:

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -93,7 +93,7 @@ class PolicyMessageKit(MessageKit):
     @sender.setter
     def sender(self, enrico):
         # Here we set the delegating correctness key to the policy public key (which happens to be composed on enrico, but for which of course he doesn't have the corresponding private key).
-        self.capsule.set_cfrag_correctness_key("delegating", enrico.policy_pubkey)
+        self.capsule.set_correctness_keys("delegating", enrico.policy_pubkey)
         self._sender = enrico
 
     def __bytes__(self):

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -82,7 +82,9 @@ class PolicyMessageKit(MessageKit):
     """
     A MessageKit which includes sufficient additional information to be retrieved on the NuCypher Network.
     """
-    splitter = capsule_splitter + key_splitter * 2
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._sender = UNKNOWN_SENDER.bool_value(False)
 
     @property
     def sender(self):
@@ -90,6 +92,7 @@ class PolicyMessageKit(MessageKit):
 
     @sender.setter
     def sender(self, enrico):
+        # Here we set the delegating correctness key to the policy public key (which happens to be composed on enrico, but for which of course he doesn't have the corresponding private key).
         self.capsule.set_cfrag_correctness_key("delegating", enrico.policy_pubkey)
         self._sender = enrico
 

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -93,7 +93,7 @@ class PolicyMessageKit(MessageKit):
     @sender.setter
     def sender(self, enrico):
         # Here we set the delegating correctness key to the policy public key (which happens to be composed on enrico, but for which of course he doesn't have the corresponding private key).
-        self.capsule.set_correctness_keys("delegating", enrico.policy_pubkey)
+        self.capsule.set_correctness_keys(delegating=enrico.policy_pubkey)
         self._sender = enrico
 
     def __bytes__(self):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -660,6 +660,8 @@ class Learner:
             if (round_finish - start).seconds > timeout:
                 if not self._learning_task.running:
                     raise RuntimeError("Learning loop is not running.  Start it with start_learning().")
+                elif not reactor.running and not learn_on_this_thread:
+                    raise RuntimeError(f"The reactor isn't running, but you're trying to use it for discovery.  You need to start the Reactor in order to use {self} this way.")
                 else:
                     raise self.NotEnoughNodes("After {} seconds and {} rounds, didn't find {} nodes".format(
                         timeout, rounds_undertaken, number_of_nodes_to_know))

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -158,6 +158,7 @@ class TreasureMap:
         Ursula will refuse to propagate this if it she can't prove the payload is signed by Alice's public key,
         which is included in it,
         """
+        # TODO: No reason to keccak this over and over again.  Turn into set-once property pattern.
         _id = keccak_digest(bytes(self._verifying_key) + bytes(self._hrac)).hex()
         return _id
 

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -201,8 +201,12 @@ class TreasureMap:
             raise self.InvalidSignature(
                 "This TreasureMap does not contain the correct signature from Alice to Bob.")
         else:
+            m = map_in_the_clear[0]
             self._m = map_in_the_clear[0]
-            self._destinations = dict(self.node_id_splitter.repeat(map_in_the_clear[1:]))
+            if self._m > 0:
+                self._destinations = dict(self.node_id_splitter.repeat(map_in_the_clear[1:]))
+            else:
+                self._destinations = {}
 
     def __eq__(self, other):
         return bytes(self) == bytes(other)

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -282,10 +282,9 @@ class WorkOrder:
         return len(self.tasks)
 
     @classmethod
-    def construct_by_bob(cls, arrangement_id, capsules, ursula, bob):
+    def construct_by_bob(cls, arrangement_id, alice_verifying, capsules, ursula, bob):
         ursula.mature()
-        alice_verifying_key = capsules[0].get_correctness_keys()["verifying"]  # TODO: What if the different capsules have different correctness keys?
-        alice_address = canonical_address_from_umbral_key(alice_verifying_key)
+        alice_address = canonical_address_from_umbral_key(alice_verifying)
 
         # TODO: Bob's input to prove freshness for this work order
         blockhash = b'\x00' * 32
@@ -296,9 +295,6 @@ class WorkOrder:
 
         tasks, tasks_bytes = {}, []
         for capsule in capsules:
-            if alice_verifying_key != capsule.get_correctness_keys()["verifying"]:
-                raise ValueError("Capsules in this work order are inconsistent.")
-
             task = cls.PRETask(capsule, signature=None)
             specification = task.get_specification(ursula.stamp, alice_address, blockhash, ursula_identity_evidence)
             task.signature = bob.stamp(specification)

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 import binascii
+from collections import OrderedDict
 from typing import List, Optional, Tuple
 
 import maya
@@ -294,16 +295,15 @@ class WorkOrder:
         if ursula._stamp_has_valid_signature_by_worker():
             ursula_identity_evidence = ursula.decentralized_identity_evidence
 
-        tasks, tasks_bytes = {}, []
+        tasks = OrderedDict()
         for capsule in capsules:
             task = cls.PRETask(capsule, signature=None)
             specification = task.get_specification(ursula.stamp, alice_address, blockhash, ursula_identity_evidence)
             task.signature = bob.stamp(specification)
             tasks[capsule] = task
-            tasks_bytes.append(bytes(task))
 
         # TODO: What's the goal of the receipt? Should it include only the capsules?
-        receipt_bytes = b"wo:" + bytes(ursula.stamp) + msgpack.dumps(tasks_bytes)
+        receipt_bytes = b"wo:" + bytes(ursula.stamp) + keccak_digest(*[bytes(task.capsule) for task in tasks.values()])
         receipt_signature = bob.stamp(receipt_bytes)
 
         return cls(bob=bob, arrangement_id=arrangement_id, tasks=tasks,
@@ -320,11 +320,6 @@ class WorkOrder:
         signature, bob_verifying_key, (tasks_bytes, blockhash) = payload_elements
 
         # TODO: check freshness of blockhash?
-
-        # Check receipt
-        receipt_bytes = b"wo:" + bytes(ursula.stamp) + msgpack.dumps(tasks_bytes)
-        if not signature.verify(receipt_bytes, bob_verifying_key):
-            raise InvalidSignature()
 
         ursula_identity_evidence = b''
         if ursula._stamp_has_valid_signature_by_worker():
@@ -343,6 +338,11 @@ class WorkOrder:
 
             if not task.signature.verify(specification, bob_verifying_key):
                 raise InvalidSignature()
+
+        # Check receipt
+        receipt_bytes = b"wo:" + bytes(ursula.stamp) + keccak_digest(*[bytes(task.capsule) for task in tasks])
+        if not signature.verify(receipt_bytes, bob_verifying_key):
+            raise InvalidSignature()
 
         bob = Bob.from_public_keys(verifying_key=bob_verifying_key)
         return cls(bob=bob,

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -302,6 +302,22 @@ class Policy(ABC):
         """
         return self.publish_treasure_map(network_middleware=network_middleware)
 
+    def credential(self, with_treasure_map=True):
+        """
+        Creates a PolicyCredential for portable access to the policy via
+        Alice or Bob. By default, it will include the treasure_map for the
+        policy unless `with_treasure_map` is False.
+        """
+        from nucypher.policy.collections import PolicyCredential
+
+        treasure_map = self.treasure_map
+        if not with_treasure_map:
+            treasure_map = None
+
+        return PolicyCredential(self.alice.stamp, self.label, self.expiration,
+                                self.public_key, treasure_map)
+
+
     def __assign_kfrags(self) -> Generator[Arrangement, None, None]:
 
         if len(self._accepted_arrangements) < self.n:

--- a/nucypher/utilities/sandbox/middleware.py
+++ b/nucypher/utilities/sandbox/middleware.py
@@ -146,13 +146,19 @@ class NodeIsDownMiddleware(MockRestMiddleware):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.client = _MiddlewareClientWithConnectionProblems()
-        self.ports_that_are_down = []
 
     def node_is_down(self, node):
         self.client.ports_that_are_down.add(node.rest_interface.port)
 
     def node_is_up(self, node):
         self.client.ports_that_are_down.remove(node.rest_interface.port)
+
+    def all_nodes_up(self):
+        self.client.ports_that_are_down = set()
+
+    def all_nodes_down(self):
+        self.client.ports_that_are_down = set(MOCK_KNOWN_URSULAS_CACHE)
+
 
 
 class EvilMiddleWare(MockRestMiddleware):

--- a/tests/characters/control/blockchain/conftest.py
+++ b/tests/characters/control/blockchain/conftest.py
@@ -113,6 +113,7 @@ def join_control_request(blockchain_bob, enacted_blockchain_policy):
 
 @pytest.fixture(scope='function')
 def retrieve_control_request(blockchain_bob, enacted_blockchain_policy, capsule_side_channel_blockchain):
+    capsule_side_channel_blockchain.reset()
     method_name = 'retrieve'
     message_kit, data_source = capsule_side_channel_blockchain()
 

--- a/tests/characters/control/blockchain/conftest.py
+++ b/tests/characters/control/blockchain/conftest.py
@@ -111,7 +111,7 @@ def join_control_request(blockchain_bob, enacted_blockchain_policy):
     return method_name, params
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def retrieve_control_request(blockchain_bob, enacted_blockchain_policy, capsule_side_channel_blockchain):
     method_name = 'retrieve'
     message_kit, data_source = capsule_side_channel_blockchain()

--- a/tests/characters/control/blockchain/test_rpc_control_blockchain.py
+++ b/tests/characters/control/blockchain/test_rpc_control_blockchain.py
@@ -1,7 +1,6 @@
 import pytest
 
 from base64 import b64encode
-from nucypher.characters.control.specifications import AliceSpecification, BobSpecification, EnricoSpecification
 from nucypher.policy.collections import TreasureMap
 from nucypher.crypto.powers import DecryptingPower, SigningPower
 from nucypher.characters.lawful import Ursula
@@ -135,9 +134,6 @@ def test_bob_rpc_character_control_retrieve_with_tmap(
     params['treasure_map'] = tmap_64
     request_data = {'method': method_name, 'params': params}
     response = bob_rpc_controller.send(request_data)
-    assert validate_json_rpc_response_data(response=response,
-                                           method_name=method_name,
-                                           specification=bob_specification)
     assert response.data['result']['cleartexts'][0] == 'Welcome to flippering number 1.'
 
     # Make a wrong (empty) treasure map

--- a/tests/characters/control/blockchain/test_rpc_control_blockchain.py
+++ b/tests/characters/control/blockchain/test_rpc_control_blockchain.py
@@ -146,5 +146,5 @@ def test_bob_rpc_character_control_retrieve_with_tmap(
             b'Wrong!')
     tmap_64 = b64encode(bytes(wrong_tmap)).decode()
     params['treasure_map'] = tmap_64
-    with pytest.raises(Ursula.NotEnoughUrsulas):
+    with pytest.raises(TreasureMap.IsDisorienting):
         bob_rpc_controller.send(request_data)

--- a/tests/characters/control/blockchain/test_rpc_control_blockchain.py
+++ b/tests/characters/control/blockchain/test_rpc_control_blockchain.py
@@ -1,5 +1,10 @@
 import pytest
 
+from base64 import b64encode
+from nucypher.characters.control.specifications import AliceSpecification, BobSpecification, EnricoSpecification
+from nucypher.policy.collections import TreasureMap
+from nucypher.crypto.powers import DecryptingPower, SigningPower
+from nucypher.characters.lawful import Ursula
 from nucypher.characters.control.interfaces import AliceInterface, BobInterface, EnricoInterface
 
 
@@ -120,3 +125,30 @@ def test_bob_rpc_character_control_retrieve(bob_rpc_controller, retrieve_control
     assert validate_json_rpc_response_data(response=response,
                                            method_name=method_name,
                                            interface=BobInterface)
+
+
+def test_bob_rpc_character_control_retrieve_with_tmap(
+        enacted_blockchain_policy, blockchain_bob, blockchain_alice,
+        bob_rpc_controller, retrieve_control_request):
+    tmap_64 = b64encode(bytes(enacted_blockchain_policy.treasure_map)).decode()
+    method_name, params = retrieve_control_request
+    params['treasure_map'] = tmap_64
+    request_data = {'method': method_name, 'params': params}
+    response = bob_rpc_controller.send(request_data)
+    assert validate_json_rpc_response_data(response=response,
+                                           method_name=method_name,
+                                           specification=bob_specification)
+    assert response.data['result']['cleartexts'][0] == 'Welcome to flippering number 1.'
+
+    # Make a wrong (empty) treasure map
+
+    wrong_tmap = TreasureMap(m=0)
+    wrong_tmap.prepare_for_publication(
+            blockchain_bob.public_keys(DecryptingPower),
+            blockchain_bob.public_keys(SigningPower),
+            blockchain_alice.stamp,
+            b'Wrong!')
+    tmap_64 = b64encode(bytes(wrong_tmap)).decode()
+    params['treasure_map'] = tmap_64
+    with pytest.raises(Ursula.NotEnoughUrsulas):
+        bob_rpc_controller.send(request_data)

--- a/tests/characters/control/blockchain/test_rpc_control_blockchain.py
+++ b/tests/characters/control/blockchain/test_rpc_control_blockchain.py
@@ -145,6 +145,6 @@ def test_bob_rpc_character_control_retrieve_with_tmap(
             blockchain_alice.stamp,
             b'Wrong!')
     tmap_64 = b64encode(bytes(wrong_tmap)).decode()
-    params['treasure_map'] = tmap_64
+    request_data['params']['treasure_map'] = tmap_64
     with pytest.raises(TreasureMap.IsDisorienting):
         bob_rpc_controller.send(request_data)

--- a/tests/characters/control/blockchain/test_web_control_blockchain.py
+++ b/tests/characters/control/blockchain/test_web_control_blockchain.py
@@ -147,7 +147,7 @@ def test_alice_character_control_decrypt(alice_web_controller_test_client,
     assert 'cleartexts' in response_data['result']
 
     response_message = response_data['result']['cleartexts'][0]
-    assert response_message == 'Welcome to flippering number 1.'  # This is the first message - in a test below, we'll show retrieving a second one.
+    assert response_message == 'Welcome to flippering number 1.'
 
     # Send bad data to assert error returns
     response = alice_web_controller_test_client.post('/decrypt', data=json.dumps({'bad': 'input'}))
@@ -192,7 +192,7 @@ def test_bob_web_character_control_retrieve(bob_web_controller_test_client, retr
     assert 'cleartexts' in response_data['result']
 
     response_message = response_data['result']['cleartexts'][0]
-    assert response_message == 'Welcome to flippering number 2.'  # This is the second message - the first is in the test above.
+    assert response_message == 'Welcome to flippering number 1.'
 
     # Send bad data to assert error returns
     response = bob_web_controller_test_client.post(endpoint, data=json.dumps({'bad': 'input'}))

--- a/tests/characters/control/blockchain/test_web_control_blockchain.py
+++ b/tests/characters/control/blockchain/test_web_control_blockchain.py
@@ -14,7 +14,8 @@ from nucypher.policy.collections import TreasureMap
 click_runner = CliRunner()
 
 
-def test_label_whose_b64_representation_is_invalid_utf8(alice_web_controller_test_client, create_policy_control_request):
+def test_label_whose_b64_representation_is_invalid_utf8(alice_web_controller_test_client,
+                                                        create_policy_control_request):
     # In our Discord, user robin#2324 (github username @robin-thomas) reported certain labels
     # break Bob's retrieve endpoint.
     # convo starts here: https://ptb.discordapp.com/channels/411401661714792449/411401661714792451/564353305887637517
@@ -128,7 +129,6 @@ def test_alice_character_control_revoke(alice_web_controller_test_client, blockc
 def test_alice_character_control_decrypt(alice_web_controller_test_client,
                                          enacted_blockchain_policy,
                                          capsule_side_channel_blockchain):
-
     message_kit, data_source = capsule_side_channel_blockchain()
 
     label = enacted_blockchain_policy.label.decode()
@@ -153,7 +153,7 @@ def test_alice_character_control_decrypt(alice_web_controller_test_client,
     response = alice_web_controller_test_client.post('/decrypt', data=json.dumps({'bad': 'input'}))
     assert response.status_code == 400
 
-    del(request_data['message_kit'])
+    del (request_data['message_kit'])
     response = alice_web_controller_test_client.put('/decrypt', data=json.dumps(request_data))
     assert response.status_code == 405
 
@@ -176,7 +176,7 @@ def test_bob_character_control_join_policy(bob_web_controller_test_client, enact
     assert response.status_code == 400
 
     # Missing Key results in bad request
-    del(request_data['alice_verifying_key'])
+    del (request_data['alice_verifying_key'])
     response = bob_web_controller_test_client.post('/join_policy', data=json.dumps(request_data))
     assert response.status_code == 400
 
@@ -198,8 +198,19 @@ def test_bob_web_character_control_retrieve(bob_web_controller_test_client, retr
     response = bob_web_controller_test_client.post(endpoint, data=json.dumps({'bad': 'input'}))
     assert response.status_code == 400
 
-    del(params['alice_verifying_key'])
+    del (params['alice_verifying_key'])
     response = bob_web_controller_test_client.put(endpoint, data=json.dumps(params))
+
+
+def test_bob_web_character_control_retrieve_with_tmap(
+        enacted_blockchain_policy, bob_web_controller_test_client, retrieve_control_request):
+    tmap_64 = b64encode(bytes(enacted_blockchain_policy.treasure_map)).decode()
+    method_name, params = retrieve_control_request
+    params['treasure_map'] = tmap_64
+    endpoint = f'/{method_name}'
+
+    response = bob_web_controller_test_client.post(endpoint, data=json.dumps(params))
+    assert response.status_code == 200
 
 
 def test_enrico_web_character_control_encrypt_message(enrico_web_controller_test_client, encrypt_control_request):
@@ -220,7 +231,7 @@ def test_enrico_web_character_control_encrypt_message(enrico_web_controller_test
     response = enrico_web_controller_test_client.post('/encrypt_message', data=json.dumps({'bad': 'input'}))
     assert response.status_code == 400
 
-    del(params['message'])
+    del (params['message'])
     response = enrico_web_controller_test_client.post('/encrypt_message', data=params)
     assert response.status_code == 400
 
@@ -232,7 +243,6 @@ def test_web_character_control_lifecycle(alice_web_controller_test_client,
                                          blockchain_bob,
                                          blockchain_ursulas,
                                          random_policy_label):
-
     random_label = random_policy_label.decode()  # Unicode string
 
     bob_keys_response = bob_web_controller_test_client.get('/public_keys')

--- a/tests/characters/control/federated/conftest.py
+++ b/tests/characters/control/federated/conftest.py
@@ -22,8 +22,8 @@ def bob_web_controller_test_client(federated_bob):
 
 @pytest.fixture(scope='module')
 def enrico_web_controller_test_client(capsule_side_channel):
-    _message_kit, enrico = capsule_side_channel()
-    web_controller = enrico.make_web_controller(crash_on_error=True)
+    _message_kit = capsule_side_channel()
+    web_controller = capsule_side_channel.enrico.make_web_controller(crash_on_error=True)
     yield web_controller.test_client()
 
 
@@ -54,10 +54,10 @@ def bob_rpc_controller(federated_bob):
 def enrico_rpc_controller_test_client(capsule_side_channel):
 
     # Side Channel
-    _message_kit, enrico = capsule_side_channel()
+    _message_kit = capsule_side_channel()
 
     # RPC Controler
-    rpc_controller = enrico.make_rpc_controller(crash_on_error=True)
+    rpc_controller = capsule_side_channel.enrico.make_rpc_controller(crash_on_error=True)
     yield rpc_controller.test_client()
 
 
@@ -112,7 +112,7 @@ def join_control_request(federated_bob, enacted_federated_policy):
 @pytest.fixture(scope='module')
 def retrieve_control_request(federated_bob, enacted_federated_policy, capsule_side_channel):
     method_name = 'retrieve'
-    message_kit, data_source = capsule_side_channel()
+    message_kit = capsule_side_channel()
 
     params = {
         'label': enacted_federated_policy.label.decode(),

--- a/tests/characters/control/federated/test_web_control_federated.py
+++ b/tests/characters/control/federated/test_web_control_federated.py
@@ -122,7 +122,7 @@ def test_alice_character_control_decrypt(alice_web_controller_test_client,
                                          enacted_federated_policy,
                                          capsule_side_channel):
 
-    message_kit, data_source = capsule_side_channel()
+    message_kit = capsule_side_channel()
 
     label = enacted_federated_policy.label.decode()
     policy_encrypting_key = bytes(enacted_federated_policy.public_key).hex()

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -71,6 +71,17 @@ def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
 
         assert kfrag == retrieved_kfrag
 
+    # Check that the PolicyCredential is consistent to the new policy
+    credential = policy.credential()
+    assert credential.alice_verifying_key == policy.alice.stamp
+    assert credential.label == policy.label
+    assert credential.expiration == policy.expiration
+    assert credential.policy_pubkey == policy.public_key
+    assert credential.treasure_map == policy.treasure_map
+
+    credential = policy.credential(with_treasure_map=False)
+    assert credential.treasure_map is None
+
 
 @pytest.mark.usefixtures('federated_ursulas')
 def test_federated_grant(federated_alice, federated_bob):

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -29,7 +29,7 @@ from nucypher.characters.lawful import Bob, Enrico
 from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.powers import SigningPower, DecryptingPower
-from nucypher.policy.collections import Revocation
+from nucypher.policy.collections import Revocation, PolicyCredential
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 from nucypher.utilities.sandbox.policy import MockPolicyCreation
@@ -71,7 +71,19 @@ def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
 
         assert kfrag == retrieved_kfrag
 
-    # Check that the PolicyCredential is consistent to the new policy
+    # Test PolicyCredential w/o TreasureMap
+    credential = policy.credential(with_treasure_map=False)
+    assert credential.alice_verifying_key == policy.alice.stamp
+    assert credential.label == policy.label
+    assert credential.expiration == policy.expiration
+    assert credential.policy_pubkey == policy.public_key
+    assert credential.treasure_map is None
+
+    cred_json = credential.to_json()
+    deserialized_cred = PolicyCredential.from_json(cred_json)
+    assert credential == deserialized_cred
+
+    # Test PolicyCredential w/ TreasureMap
     credential = policy.credential()
     assert credential.alice_verifying_key == policy.alice.stamp
     assert credential.label == policy.label
@@ -79,9 +91,9 @@ def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
     assert credential.policy_pubkey == policy.public_key
     assert credential.treasure_map == policy.treasure_map
 
-    credential = policy.credential(with_treasure_map=False)
-    assert credential.treasure_map is None
-
+    cred_json = credential.to_json()
+    deserialized_cred = PolicyCredential.from_json(cred_json)
+    assert credential == deserialized_cred
 
 @pytest.mark.usefixtures('federated_ursulas')
 def test_federated_grant(federated_alice, federated_bob):

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -22,6 +22,7 @@ from umbral import pre
 from umbral.cfrags import CapsuleFrag
 from umbral.kfrags import KFrag
 
+from nucypher.crypto.kits import PolicyMessageKit
 from nucypher.utilities.sandbox.middleware import NodeIsDownMiddleware
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
@@ -657,13 +658,23 @@ def test_bob_retrieves_multiple_messages_in_a_single_adventure(federated_bob,
     message2, enrico2 = capsule_side_channel.reset()  # Second message
     message3, enrico3 = capsule_side_channel.reset()  # Third message
 
+    # We'll cast the kits to bytes as if to pretend that Bob has stored them to disk or is accessing them via the web extension.
+    # This is meaningful as a regression test (as distinct from the single-Capsule tests) because it shows that we are
+    # properly adhering the three different sender_verifying_keys.
+    message1_bytes = bytes(message1)
+    message2_bytes = bytes(message2)
+    message3_bytes = bytes(message3)
+
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message1,
-                                                  message2,
-                                                  message3,
+    delivered_cleartexts = federated_bob.retrieve(PolicyMessageKit.from_bytes(message1_bytes),
+                                                  PolicyMessageKit.from_bytes(message2_bytes),
+                                                  PolicyMessageKit.from_bytes(message3_bytes),
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
-                                                  use_precedent_work_orders=True)
+                                                  use_precedent_work_orders=True,
+                                                  policy_encrypting_key=enacted_federated_policy.public_key)
 
-    assert False
+    assert b"Welcome to flippering number 0." == delivered_cleartexts[0]
+    assert b"Welcome to flippering number 0." == delivered_cleartexts[1]
+    assert b"Welcome to flippering number 0." == delivered_cleartexts[2]

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -362,7 +362,7 @@ def test_federated_bob_retrieves_a_single_message(federated_bob,
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label)
@@ -385,7 +385,7 @@ def test_federated_bob_retrieves_multiple_messages_from_same_enrico(federated_bo
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=three_message_kits,
+    delivered_cleartexts = federated_bob.retrieve(*three_message_kits,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label)
@@ -412,7 +412,9 @@ def test_federated_bob_retrieves_multiple_messages_from_different_enricos(federa
     message2.sender = enrico2
     message3.sender = enrico3
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(message1, message2, message3),
+    delivered_cleartexts = federated_bob.retrieve(message1,
+                                                  message2,
+                                                  message3,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label)
 
@@ -434,7 +436,7 @@ def test_federated_bob_retrieves_twice_without_retaining_cfrags(federated_bob,
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label)
@@ -442,7 +444,7 @@ def test_federated_bob_retrieves_twice_without_retaining_cfrags(federated_bob,
     # We show that indeed this is the passage originally encrypted by the Enrico.
     assert b"Welcome to flippering number 1." == delivered_cleartexts[0]
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
@@ -461,7 +463,7 @@ def test_federated_bob_retrieves_twice_by_retaining_cfrags(federated_bob,
     the_message_kit = capsule_side_channel()
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
@@ -471,13 +473,13 @@ def test_federated_bob_retrieves_twice_by_retaining_cfrags(federated_bob,
     # Can't retrieve this message again.
     # Bob needs to either instantiate the message_kit again or use use_attached_cfrags=True.
     with pytest.raises(TypeError):
-        federated_bob.retrieve(message_kits=(the_message_kit,),
+        federated_bob.retrieve(the_message_kit,
                                enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label,
                                )
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
@@ -521,7 +523,7 @@ def test_federated_bob_cannot_resume_retrieval_without_caching(federated_bob,
 
     # Since 8 Ursulas are down, Bob can only get 2 CFrags; not enough to complete retrieval.
     with pytest.raises(ursula1.NotEnoughUrsulas):
-        federated_bob.retrieve(message_kits=(the_message_kit,),
+        federated_bob.retrieve(the_message_kit,
                                enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label)
@@ -539,7 +541,7 @@ def test_federated_bob_cannot_resume_retrieval_without_caching(federated_bob,
     federated_bob.network_middleware.node_is_up(ursula4)
 
     with pytest.raises(ursula1.NotEnoughUrsulas):
-        federated_bob.retrieve(message_kits=(the_message_kit,),
+        federated_bob.retrieve(the_message_kit,
                                enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label)
@@ -579,7 +581,7 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
 
     # Bob can't retrieve; there aren't enough Ursulas up.
     with pytest.raises(ursula1.NotEnoughUrsulas):
-        federated_bob.retrieve(message_kits=(the_message_kit,),
+        federated_bob.retrieve(the_message_kit,
                                enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label,
@@ -599,14 +601,14 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
 
     # We're not allowed to try again with a Capsule with cached CFrags if we set cache to False.
     with pytest.raises(TypeError):
-        federated_bob.retrieve(message_kits=(the_message_kit,),
+        federated_bob.retrieve(the_message_kit,
                                enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label,
                                retain_cfrags=False)
 
     # But now, with just one Ursula up, we can use the cached CFrags to get the message.
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
@@ -620,7 +622,7 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
     for ursula in federated_ursulas:
         federated_bob.network_middleware.node_is_down(ursula)
 
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
@@ -633,7 +635,7 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
     the_message_kit.capsule.clear_cfrags()
 
     # ...we can still get the message with the network being down because Bob has the properly completed WorkOrders cached in state.
-    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
                                                   enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -147,11 +147,15 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
 
     # We'll test against just a single Ursula - here, we make a WorkOrder for just one.
     # We can pass any number of capsules as args; here we pass just one.
-    capsule = capsule_side_channel()[0].capsule
+    capsule = capsule_side_channel().capsule
     capsule.set_correctness_keys(delegating=enacted_federated_policy.public_key,
                                  receiving=federated_bob.public_keys(DecryptingPower),
                                  verifying=federated_alice.stamp.as_umbral_pubkey())
-    work_orders, _ = federated_bob.work_orders_for_capsule(map_id, capsule, num_ursulas=1)
+    work_orders, _ = federated_bob.work_orders_for_capsules(
+        capsule,
+        map_id=map_id,
+        alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
+        num_ursulas=1)
 
     # Again: one Ursula, one work_order.
     assert len(work_orders) == 1
@@ -160,7 +164,11 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     assert len(federated_bob._completed_work_orders) == 0
 
     # This time, we'll tell Bob to cache it.
-    retained_work_orders, _ = federated_bob.work_orders_for_capsule(map_id, capsule, num_ursulas=1)
+    retained_work_orders, _ = federated_bob.work_orders_for_capsules(
+        capsule,
+        map_id=map_id,
+        alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
+        num_ursulas=1)
 
     # The work order we just made is not yet complete, of course.
     address, work_order = list(retained_work_orders.items())[0]
@@ -208,8 +216,11 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     assert work_orders_from_bob[0].bob_signature == work_order.receipt_signature
 
 
-def test_bob_can_use_cfrag_attached_to_completed_workorder(enacted_federated_policy, federated_bob,
-                                                           federated_ursulas, capsule_side_channel):
+def test_bob_can_use_cfrag_attached_to_completed_workorder(enacted_federated_policy,
+                                                           federated_alice,
+                                                           federated_bob,
+                                                           federated_ursulas,
+                                                           capsule_side_channel):
     # In our last episode, Bob made a single WorkOrder...
     work_orders = list(federated_bob._completed_work_orders.by_ursula.values())
     assert len(work_orders) == 1
@@ -218,11 +229,12 @@ def test_bob_can_use_cfrag_attached_to_completed_workorder(enacted_federated_pol
     last_capsule_on_side_channel = capsule_side_channel.messages[-1][0].capsule
     old_work_order = work_orders[0][last_capsule_on_side_channel]
 
-    incomplete_work_orders, complete_work_orders = federated_bob.work_orders_for_capsule(
-        enacted_federated_policy.treasure_map.public_id(),
+    incomplete_work_orders, complete_work_orders = federated_bob.work_orders_for_capsules(
         last_capsule_on_side_channel,
+        map_id=enacted_federated_policy.treasure_map.public_id(),
+        alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=1,
-        )
+    )
 
     # Here we show that this WorkOrder is still saved, replete with the CFrag.
     work_orders_for_this_capsule = federated_bob._completed_work_orders._latest_replete[last_capsule_on_side_channel]
@@ -237,7 +249,8 @@ def test_bob_can_use_cfrag_attached_to_completed_workorder(enacted_federated_pol
         federated_bob.get_reencrypted_cfrags(new_work_order)
 
 
-def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_federated_policy, federated_bob,
+def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_federated_policy, federated_alice,
+                                                                   federated_bob,
                                                                    federated_ursulas, capsule_side_channel):
     # In our last episode, Bob made a single WorkOrder...
     work_orders = list(federated_bob._completed_work_orders.by_ursula.values())
@@ -263,9 +276,10 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_feder
     saved_work_order = list(work_orders_by_capsule.values())[0]
 
     # The rest of this test will show that if Bob generates another WorkOrder, it's for a *different* Ursula.
-    incomplete_work_orders, complete_work_orders = federated_bob.work_orders_for_capsule(
-        enacted_federated_policy.treasure_map.public_id(),
+    incomplete_work_orders, complete_work_orders = federated_bob.work_orders_for_capsules(
         last_capsule_on_side_channel,
+        map_id=enacted_federated_policy.treasure_map.public_id(),
+        alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=1)
     id_of_this_new_ursula, new_work_order = list(incomplete_work_orders.items())[0]
 
@@ -314,9 +328,10 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
         receiving=federated_bob.public_keys(DecryptingPower),
         verifying=federated_alice.stamp.as_umbral_pubkey())
 
-    new_incomplete_work_orders, _ = federated_bob.work_orders_for_capsule(
-        enacted_federated_policy.treasure_map.public_id(),
+    new_incomplete_work_orders, _ = federated_bob.work_orders_for_capsules(
         the_message_kit.capsule,
+        map_id=enacted_federated_policy.treasure_map.public_id(),
+        alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=number_left_to_collect)
     _id_of_yet_another_ursula, new_work_order = list(new_incomplete_work_orders.items())[0]
 
@@ -334,51 +349,75 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
     assert cleartext == b'Welcome to flippering number 1.'
 
 
-def test_federated_bob_retrieves(federated_bob,
-                                 federated_alice,
-                                 capsule_side_channel,
-                                 enacted_federated_policy,
-                                 ):
+def test_federated_bob_retrieves_a_single_message(federated_bob,
+                                                  federated_alice,
+                                                  capsule_side_channel,
+                                                  enacted_federated_policy,
+                                                  ):
     # The side channel delivers all that Bob needs at this point:
     # - A single MessageKit, containing a Capsule
     # - A representation of the data source
     capsule_side_channel.reset()
-    the_message_kit, the_data_source = capsule_side_channel()
+    the_message_kit = capsule_side_channel()
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label)
 
     # We show that indeed this is the passage originally encrypted by the Enrico.
     assert b"Welcome to flippering number 1." == delivered_cleartexts[0]
+
+
+def test_federated_bob_retrieves_multiple_messages(federated_bob,
+                                                   federated_alice,
+                                                   capsule_side_channel,
+                                                   enacted_federated_policy,
+                                                   ):
+    # The side channel delivers all that Bob needs at this point:
+    # - A single MessageKit, containing a Capsule
+    # - A representation of the data source
+    capsule_side_channel.reset()
+
+    three_message_kits = [capsule_side_channel(), capsule_side_channel(), capsule_side_channel()]
+
+    alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
+
+    delivered_cleartexts = federated_bob.retrieve(message_kits=three_message_kits,
+                                                  enrico=capsule_side_channel.enrico,
+                                                  alice_verifying_key=alices_verifying_key,
+                                                  label=enacted_federated_policy.label)
+
+    assert b"Welcome to flippering number 1." == delivered_cleartexts[0]
+    assert b"Welcome to flippering number 2." == delivered_cleartexts[1]
+    assert b"Welcome to flippering number 3." == delivered_cleartexts[2]
 
 
 def test_federated_bob_retrieves_twice_without_retaining_cfrags(federated_bob,
-                                 federated_alice,
-                                 capsule_side_channel,
-                                 enacted_federated_policy,
-                                 ):
+                                                                federated_alice,
+                                                                capsule_side_channel,
+                                                                enacted_federated_policy,
+                                                                ):
     # The side channel delivers all that Bob needs at this point:
     # - A single MessageKit, containing a Capsule
     # - A representation of the data source
     capsule_side_channel.reset()
-    the_message_kit, the_data_source = capsule_side_channel()
+    the_message_kit = capsule_side_channel()
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label)
 
     # We show that indeed this is the passage originally encrypted by the Enrico.
     assert b"Welcome to flippering number 1." == delivered_cleartexts[0]
 
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
                                                   use_precedent_work_orders=True)
@@ -388,16 +427,16 @@ def test_federated_bob_retrieves_twice_without_retaining_cfrags(federated_bob,
 
 
 def test_federated_bob_retrieves_twice_by_retaining_cfrags(federated_bob,
-                                       federated_alice,
-                                       capsule_side_channel,
-                                       enacted_federated_policy,
-                                       ):
+                                                           federated_alice,
+                                                           capsule_side_channel,
+                                                           enacted_federated_policy,
+                                                           ):
     capsule_side_channel.reset()
-    the_message_kit, the_data_source = capsule_side_channel()
+    the_message_kit = capsule_side_channel()
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
                                                   retain_cfrags=True)
@@ -406,14 +445,14 @@ def test_federated_bob_retrieves_twice_by_retaining_cfrags(federated_bob,
     # Can't retrieve this message again.
     # Bob needs to either instantiate the message_kit again or use use_attached_cfrags=True.
     with pytest.raises(TypeError):
-        federated_bob.retrieve(message_kit=the_message_kit,
-                               enrico=the_data_source,
+        federated_bob.retrieve(message_kits=(the_message_kit,),
+                               enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label,
                                )
 
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
                                                   use_attached_cfrags=True)
@@ -428,7 +467,7 @@ def test_federated_bob_cannot_resume_retrieval_without_caching(federated_bob,
                                                                federated_ursulas
                                                                ):
     capsule_side_channel.reset()
-    the_message_kit, the_data_source = capsule_side_channel()
+    the_message_kit = capsule_side_channel()
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
@@ -456,8 +495,8 @@ def test_federated_bob_cannot_resume_retrieval_without_caching(federated_bob,
 
     # Since 8 Ursulas are down, Bob can only get 2 CFrags; not enough to complete retrieval.
     with pytest.raises(ursula1.NotEnoughUrsulas):
-        federated_bob.retrieve(message_kit=the_message_kit,
-                               enrico=the_data_source,
+        federated_bob.retrieve(message_kits=(the_message_kit,),
+                               enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label)
 
@@ -474,8 +513,8 @@ def test_federated_bob_cannot_resume_retrieval_without_caching(federated_bob,
     federated_bob.network_middleware.node_is_up(ursula4)
 
     with pytest.raises(ursula1.NotEnoughUrsulas):
-        federated_bob.retrieve(message_kit=the_message_kit,
-                               enrico=the_data_source,
+        federated_bob.retrieve(message_kits=(the_message_kit,),
+                               enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label)
 
@@ -488,7 +527,7 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
                                                      ):
     # Same setup as last time.
     capsule_side_channel.reset()
-    the_message_kit, the_data_source = capsule_side_channel()
+    the_message_kit = capsule_side_channel()
 
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
     ursula1 = list(federated_ursulas)[0]
@@ -514,8 +553,8 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
 
     # Bob can't retrieve; there aren't enough Ursulas up.
     with pytest.raises(ursula1.NotEnoughUrsulas):
-        federated_bob.retrieve(message_kit=the_message_kit,
-                               enrico=the_data_source,
+        federated_bob.retrieve(message_kits=(the_message_kit,),
+                               enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label,
                                retain_cfrags=True)
@@ -534,15 +573,15 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
 
     # We're not allowed to try again with a Capsule with cached CFrags if we set cache to False.
     with pytest.raises(TypeError):
-        federated_bob.retrieve(message_kit=the_message_kit,
-                               enrico=the_data_source,
+        federated_bob.retrieve(message_kits=(the_message_kit,),
+                               enrico=capsule_side_channel.enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=enacted_federated_policy.label,
                                retain_cfrags=False)
 
     # But now, with just one Ursula up, we can use the cached CFrags to get the message.
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
                                                   retain_cfrags=True,
@@ -555,8 +594,8 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
     for ursula in federated_ursulas:
         federated_bob.network_middleware.node_is_down(ursula)
 
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
                                                   retain_cfrags=True,
@@ -568,8 +607,8 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
     the_message_kit.capsule.clear_cfrags()
 
     # ...we can still get the message with the network being down because Bob has the properly completed WorkOrders cached in state.
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(the_message_kit,),
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label,
                                                   use_precedent_work_orders=True)

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -642,3 +642,28 @@ def test_federated_retrieves_partially_then_finishes(federated_bob,
                                                   use_precedent_work_orders=True)
 
     assert b"Welcome to flippering number 1." == delivered_cleartexts[0]
+    federated_bob.network_middleware.all_nodes_up()
+
+
+def test_bob_retrieves_multiple_messages_in_a_single_adventure(federated_bob,
+                                                   federated_alice,
+                                                   capsule_side_channel,
+                                                   enacted_federated_policy,
+                                                   ):
+    # The side channel delivers all that Bob needs at this point:
+    # - A single MessageKit, containing a Capsule
+    # - A representation of the data source
+    message1, enrico1 = capsule_side_channel.reset()  # First message
+    message2, enrico2 = capsule_side_channel.reset()  # Second message
+    message3, enrico3 = capsule_side_channel.reset()  # Third message
+
+    alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
+
+    delivered_cleartexts = federated_bob.retrieve(message1,
+                                                  message2,
+                                                  message3,
+                                                  alice_verifying_key=alices_verifying_key,
+                                                  label=enacted_federated_policy.label,
+                                                  use_precedent_work_orders=True)
+
+    assert False

--- a/tests/characters/test_bob_handles_frags.py
+++ b/tests/characters/test_bob_handles_frags.py
@@ -371,7 +371,7 @@ def test_federated_bob_retrieves_a_single_message(federated_bob,
     assert b"Welcome to flippering number 1." == delivered_cleartexts[0]
 
 
-def test_federated_bob_retrieves_multiple_messages(federated_bob,
+def test_federated_bob_retrieves_multiple_messages_from_same_enrico(federated_bob,
                                                    federated_alice,
                                                    capsule_side_channel,
                                                    enacted_federated_policy,
@@ -393,6 +393,32 @@ def test_federated_bob_retrieves_multiple_messages(federated_bob,
     assert b"Welcome to flippering number 1." == delivered_cleartexts[0]
     assert b"Welcome to flippering number 2." == delivered_cleartexts[1]
     assert b"Welcome to flippering number 3." == delivered_cleartexts[2]
+
+
+def test_federated_bob_retrieves_multiple_messages_from_different_enricos(federated_bob,
+                                                   federated_alice,
+                                                   capsule_side_channel,
+                                                   enacted_federated_policy,
+                                                   ):
+    # The side channel delivers all that Bob needs at this point:
+    # - A single MessageKit, containing a Capsule
+    # - A representation of the data source
+    message1, enrico1 = capsule_side_channel.reset()  # First message
+    message2, enrico2 = capsule_side_channel.reset()  # Second message
+    message3, enrico3 = capsule_side_channel.reset()  # Third message
+
+    alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
+    message1.sender = enrico1
+    message2.sender = enrico2
+    message3.sender = enrico3
+
+    delivered_cleartexts = federated_bob.retrieve(message_kits=(message1, message2, message3),
+                                                  alice_verifying_key=alices_verifying_key,
+                                                  label=enacted_federated_policy.label)
+
+    assert b"Welcome to flippering number 0." == delivered_cleartexts[0]
+    assert b"Welcome to flippering number 0." == delivered_cleartexts[1]
+    assert b"Welcome to flippering number 0." == delivered_cleartexts[2]
 
 
 def test_federated_bob_retrieves_twice_without_retaining_cfrags(federated_bob,

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -171,7 +171,8 @@ def test_treasure_map_serialization(enacted_federated_policy, federated_bob):
 def test_bob_retrieves_with_treasure_map(
         federated_bob, federated_ursulas,
         enacted_federated_policy, capsule_side_channel):
-    message_kit, data_source = capsule_side_channel()
+    enrico = capsule_side_channel.enrico
+    message_kit = capsule_side_channel()
     treasure_map = enacted_federated_policy.treasure_map
     alice_verifying_key = enacted_federated_policy.alice.stamp
 
@@ -181,13 +182,19 @@ def test_bob_retrieves_with_treasure_map(
 
     # Deserialized treasure map
     text1 = federated_bob.retrieve(
-        message_kit, data_source, alice_verifying_key,
-        enacted_federated_policy.label, treasure_map=treasure_map)
+        message_kit,
+        enrico=enrico,
+        alice_verifying_key=alice_verifying_key,
+        label=enacted_federated_policy.label,
+        treasure_map=treasure_map)
 
     message_kit.capsule.clear_cfrags()  # Return back to a non re-encrypted state
     # Serialized treasure map
     text2 = federated_bob.retrieve(
-        message_kit, data_source, alice_verifying_key,
-        enacted_federated_policy.label, treasure_map=bytes(treasure_map))
+        message_kit,
+        enrico=enrico,
+        alice_verifying_key=alice_verifying_key,
+        label=enacted_federated_policy.label,
+        treasure_map=bytes(treasure_map))
 
     assert text1[0] == text2[0] == b'Welcome to flippering number 2.'

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -180,12 +180,14 @@ def test_bob_retrieves_with_treasure_map(
     federated_bob.learn_from_teacher_node(eager=True)
 
     # Deserialized treasure map
-    federated_bob.retrieve(
+    text1 = federated_bob.retrieve(
         message_kit, data_source, alice_verifying_key,
         enacted_federated_policy.label, treasure_map=treasure_map)
 
     message_kit.capsule.clear_cfrags()  # Return back to a non re-encrypted state
     # Serialized treasure map
-    federated_bob.retrieve(
+    text2 = federated_bob.retrieve(
         message_kit, data_source, alice_verifying_key,
         enacted_federated_policy.label, treasure_map=bytes(treasure_map))
+
+    assert text1[0] == text2[0] == b'Welcome to flippering number 2.'

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -179,6 +179,13 @@ def test_bob_retrieves_with_treasure_map(
     federated_bob.remember_node(list(federated_ursulas)[0])
     federated_bob.learn_from_teacher_node(eager=True)
 
+    # Deserialized treasure map
     federated_bob.retrieve(
         message_kit, data_source, alice_verifying_key,
         enacted_federated_policy.label, treasure_map=treasure_map)
+
+    message_kit.capsule.clear_cfrags()  # Return back to a non re-encrypted state
+    # Serialized treasure map
+    federated_bob.retrieve(
+        message_kit, data_source, alice_verifying_key,
+        enacted_federated_policy.label, treasure_map=bytes(treasure_map))

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -166,3 +166,19 @@ def test_treasure_map_serialization(enacted_federated_policy, federated_bob):
     deserialized_map.orient(compass)
     assert deserialized_map.m == treasure_map.m
     assert deserialized_map.destinations == treasure_map.destinations
+
+
+def test_bob_retrieves_with_treasure_map(
+        federated_bob, federated_ursulas,
+        enacted_federated_policy, capsule_side_channel):
+    message_kit, data_source = capsule_side_channel()
+    treasure_map = enacted_federated_policy.treasure_map
+    alice_verifying_key = enacted_federated_policy.alice.stamp
+
+    # Teach Bob about the network
+    federated_bob.remember_node(list(federated_ursulas)[0])
+    federated_bob.learn_from_teacher_node(eager=True)
+
+    federated_bob.retrieve(
+        message_kit, data_source, alice_verifying_key,
+        enacted_federated_policy.label, treasure_map=treasure_map)

--- a/tests/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/characters/test_bob_joins_policy_and_retrieves.py
@@ -31,11 +31,11 @@ def test_federated_bob_full_retrieve_flow(federated_ursulas,
     # The side channel delivers all that Bob needs at this point:
     # - A single MessageKit, containing a Capsule
     # - A representation of the data source
-    the_message_kit, the_data_source = capsule_side_channel()
+    the_message_kit = capsule_side_channel()
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
-    delivered_cleartexts = federated_bob.retrieve(message_kit=the_message_kit,
-                                                  enrico=the_data_source,
+    delivered_cleartexts = federated_bob.retrieve(the_message_kit,
+                                                  enrico=capsule_side_channel.enrico,
                                                   alice_verifying_key=alices_verifying_key,
                                                   label=enacted_federated_policy.label)
 
@@ -96,26 +96,26 @@ def test_bob_joins_policy_and_retrieves(federated_alice,
     alices_verifying_key = federated_alice.stamp.as_umbral_pubkey()
 
     # Bob takes the message_kit and retrieves the message within
-    delivered_cleartexts = bob.retrieve(message_kit=message_kit,
+    delivered_cleartexts = bob.retrieve(message_kit,
                                         enrico=enrico,
                                         alice_verifying_key=alices_verifying_key,
-                                        label=policy.label)
+                                        label=policy.label,
+                                        retain_cfrags=True)
 
     assert plaintext == delivered_cleartexts[0]
 
     # Bob tries to retrieve again, but without using the cached CFrags, it fails.
     with pytest.raises(TypeError):
-        delivered_cleartexts = bob.retrieve(message_kit=message_kit,
+        delivered_cleartexts = bob.retrieve(message_kit,
                                             enrico=enrico,
                                             alice_verifying_key=alices_verifying_key,
                                             label=policy.label)
 
-    # Bob can retrieve again if he sets cache=True.
-    cleartexts_delivered_a_second_time = bob.retrieve(message_kit=message_kit,
+    cleartexts_delivered_a_second_time = bob.retrieve(message_kit,
                                                       enrico=enrico,
                                                       alice_verifying_key=alices_verifying_key,
                                                       label=policy.label,
-                                                      retain_cfrags=True)
+                                                      use_attached_cfrags=True)
 
     # Indeed, they're the same cleartexts.
     assert delivered_cleartexts == cleartexts_delivered_a_second_time
@@ -125,11 +125,11 @@ def test_bob_joins_policy_and_retrieves(federated_alice,
     assert len(failed_revocations) == 0
 
     # One thing to note here is that Bob *can* still retrieve with the cached CFrags, even though this Policy has been revoked.  #892
-    _cleartexts = bob.retrieve(message_kit=message_kit,
+    _cleartexts = bob.retrieve(message_kit,
                                enrico=enrico,
                                alice_verifying_key=alices_verifying_key,
                                label=policy.label,
-                               retain_cfrags=True,
+                               use_precedent_work_orders=True,
                                )
     assert _cleartexts == delivered_cleartexts  # TODO: 892
 
@@ -137,7 +137,7 @@ def test_bob_joins_policy_and_retrieves(federated_alice,
     message_kit.capsule.clear_cfrags()
 
     with pytest.raises(Ursula.NotEnoughUrsulas):
-        _cleartexts = bob.retrieve(message_kit=message_kit,
+        _cleartexts = bob.retrieve(message_kit,
                                    enrico=enrico,
                                    alice_verifying_key=alices_verifying_key,
                                    label=policy.label,

--- a/tests/characters/test_specifications.py
+++ b/tests/characters/test_specifications.py
@@ -1,3 +1,5 @@
+from base64 import b64encode
+
 import pytest
 from marshmallow import validates_schema
 import maya
@@ -51,7 +53,7 @@ def test_various_field_validations_by_way_of_alice_grant(federated_bob):
         GrantPolicy().load(data)
 
 
-def test_treasuremap_validation():
+def test_treasuremap_validation(enacted_federated_policy):
     """Tell people exactly what's wrong with their treasuremaps"""
 
     class TreasureMapsOnly(BaseSchema):
@@ -74,7 +76,9 @@ def test_treasuremap_validation():
     assert "Can't split a message with more bytes than the original splittable" in str(e)
 
     # a valid treasuremap for once...
-    result = TreasureMapsOnly().load({'tmap': "dAYjo1M+OWFWXS/EkRGGBUJ6ywgGczmbELGbncfYT1W51k/EBO6y/LwSIeoQcrT/NzE25OXnsnnwOzwoZxT5oE7fhO+HbJPiGTt1Fl4iCvVrwxuJWIk0Nrw9WslSNBzAAAABHAM2ndUrO/67tZnGmF8ca1U8h09k2Qsn3gohnEP2M4aIfwPxG9F2jOqSS7OVoBsNnziS0qdYqMXmPPMnNrUPyR4PfB+9RmvtufpZ1DbbP4MEyxL1qL4xrmNhr6AYSMbnJD6FA3Qb0AGzgLrvTrO7qaWSJ2mxKMyGNnC/FeZhjg4AeuTfuEGEkogqeL/uMTNrl5vG3JwNIXFVsPY3sXR743ZKpP4ypu8HFj8BoqSfxleRmcwbANHQlSdwBd+/NJLcdqQCVuB1UdFDJPCJ3HxvjHIRhxWHTtuQ4L/HIjxTHoRsS/CFwjembIWhqpxqfswnxmKRQ5hCosO6iqK3aRYkDpOQMPwqgkv0diRBx5AC7Fj1nSfuXlpJix8PLxcy"})
+    tmap_bytes = bytes(enacted_federated_policy.treasure_map)
+    tmap_b64 = b64encode(tmap_bytes)
+    result = TreasureMapsOnly().load({'tmap': tmap_b64.decode()})
     assert isinstance(result['tmap'], bytes)
 
 

--- a/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
+++ b/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
@@ -53,7 +53,6 @@ def test_new_federated_ursula_announces_herself(ursula_federated_test_config):
 
 
 def test_stakers_bond_to_ursulas(testerchain, test_registry, stakers, ursula_decentralized_test_config):
-
     ursulas = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                          stakers_addresses=testerchain.stakers_accounts,
                                          workers_addresses=testerchain.ursulas_accounts,
@@ -88,7 +87,7 @@ def test_blockchain_ursula_verifies_stamp(blockchain_ursulas):
     assert first_ursula.verified_stamp
 
 
-@pytest.mark.skip("See Issue #1075")    # TODO: Issue #1075
+@pytest.mark.skip("See Issue #1075")  # TODO: Issue #1075
 def test_vladimir_cannot_verify_interface_with_ursulas_signing_key(blockchain_ursulas):
     his_target = list(blockchain_ursulas)[4]
 
@@ -119,7 +118,7 @@ def test_vladimir_cannot_verify_interface_with_ursulas_signing_key(blockchain_ur
         vladimir.validate_metadata()
 
 
-@pytest.mark.skip("See Issue #1075")    # TODO: Issue #1075
+@pytest.mark.skip("See Issue #1075")  # TODO: Issue #1075
 def test_vladimir_invalidity_without_stake(testerchain, blockchain_ursulas, blockchain_alice):
     his_target = list(blockchain_ursulas)[4]
     vladimir = Vladimir.from_target_ursula(target_ursula=his_target)
@@ -134,7 +133,7 @@ def test_vladimir_invalidity_without_stake(testerchain, blockchain_ursulas, bloc
         vladimir.verify_node(blockchain_alice.network_middleware, certificate_filepath="doesn't matter")
 
 
-@pytest.mark.skip("See Issue #1075")    # TODO: Issue #1075
+@pytest.mark.skip("See Issue #1075")  # TODO: Issue #1075
 def test_vladimir_uses_his_own_signing_key(blockchain_alice, blockchain_ursulas):
     """
     Similar to the attack above, but this time Vladimir makes his own interface signature
@@ -162,7 +161,6 @@ def test_vladimir_uses_his_own_signing_key(blockchain_alice, blockchain_ursulas)
 
 # TODO: Change name of this file, extract this test
 def test_blockchain_ursulas_reencrypt(blockchain_ursulas, blockchain_alice, blockchain_bob, policy_value):
-
     label = b'bbo'
 
     # TODO: Make sample selection buffer configurable - #1061
@@ -184,7 +182,8 @@ def test_blockchain_ursulas_reencrypt(blockchain_ursulas, blockchain_alice, bloc
 
     blockchain_bob.join_policy(label, bytes(blockchain_alice.stamp))
 
-    plaintext = blockchain_bob.retrieve(enrico, message_kit, blockchain_alice.stamp, label)
+    plaintext = blockchain_bob.retrieve(message_kit, alice_verifying_key=blockchain_alice.stamp, label=label,
+                                        enrico=enrico)
     assert plaintext[0] == message
 
     # Let's consider also that a node may be down when granting

--- a/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
+++ b/tests/characters/test_ursula_prepares_to_act_as_mining_node.py
@@ -184,7 +184,7 @@ def test_blockchain_ursulas_reencrypt(blockchain_ursulas, blockchain_alice, bloc
 
     blockchain_bob.join_policy(label, bytes(blockchain_alice.stamp))
 
-    plaintext = blockchain_bob.retrieve(message_kit, enrico, blockchain_alice.stamp, label)
+    plaintext = blockchain_bob.retrieve(enrico, message_kit, blockchain_alice.stamp, label)
     assert plaintext[0] == message
 
     # Let's consider also that a node may be down when granting

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -32,6 +32,7 @@ def test_bob_public_keys(click_runner):
     assert "bob_verifying_key" in result.output
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import SigningPower
+from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, TEMPORARY_DOMAIN
 from nucypher.utilities.sandbox.constants import MOCK_IP_ADDRESS, MOCK_CUSTOM_INSTALLATION_PATH
 
@@ -177,13 +178,19 @@ def test_bob_retrieves_twice_via_cli(click_runner,
         this_fuckin_guy.controller.emitter = JSONRPCStdoutEmitter()
         return this_fuckin_guy
 
+
     _old_make_character_function = actions.make_cli_character
     try:
+
         log.info("Patching make_cli_character with substitute_bob")
         actions.make_cli_character = substitute_bob
 
         # Once...
+        # TODO: Add invocation wrapper #1353
+        GlobalLoggerSettings.stop_console_logging()
         retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+        GlobalLoggerSettings.start_console_logging()
+
         log.info(f"First retrieval response: {retrieve_response.output}")
         assert retrieve_response.exit_code == 0
 
@@ -192,7 +199,11 @@ def test_bob_retrieves_twice_via_cli(click_runner,
             assert cleartext.encode() == capsule_side_channel.plaintexts[1]
 
         # and again!
+        # TODO: Add invocation wrapper #1353
+        GlobalLoggerSettings.stop_console_logging()
         retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+        GlobalLoggerSettings.start_console_logging()
+
         log.info(f"Second retrieval response: {retrieve_response.output}")
         assert retrieve_response.exit_code == 0
 

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -186,10 +186,8 @@ def test_bob_retrieves_twice_via_cli(click_runner,
         actions.make_cli_character = substitute_bob
 
         # Once...
-        # TODO: Add invocation wrapper #1353
-        GlobalLoggerSettings.stop_console_logging()
-        retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
-        GlobalLoggerSettings.start_console_logging()
+        with GlobalLoggerSettings.pause_console_logging_while():
+            retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
 
         log.info(f"First retrieval response: {retrieve_response.output}")
         assert retrieve_response.exit_code == 0
@@ -199,10 +197,8 @@ def test_bob_retrieves_twice_via_cli(click_runner,
             assert cleartext.encode() == capsule_side_channel.plaintexts[1]
 
         # and again!
-        # TODO: Add invocation wrapper #1353
-        GlobalLoggerSettings.stop_console_logging()
-        retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
-        GlobalLoggerSettings.start_console_logging()
+        with GlobalLoggerSettings.pause_console_logging_while():
+            retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
 
         log.info(f"Second retrieval response: {retrieve_response.output}")
         assert retrieve_response.exit_code == 0

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -3,6 +3,8 @@ import os
 from base64 import b64encode
 from unittest import mock
 
+from twisted.logger import Logger
+
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.main import nucypher_cli
@@ -32,6 +34,8 @@ from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import SigningPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, TEMPORARY_DOMAIN
 from nucypher.utilities.sandbox.constants import MOCK_IP_ADDRESS, MOCK_CUSTOM_INSTALLATION_PATH
+
+log = Logger()
 
 
 def test_initialize_bob_with_custom_configuration_root(custom_filepath, click_runner):
@@ -114,18 +118,15 @@ def test_bob_destroy(click_runner, custom_filepath):
     assert result.exit_code == 0
     assert SUCCESSFUL_DESTRUCTION in result.output
     assert not os.path.exists(custom_config_filepath), "Bob config file was deleted"
-    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
-    assert result.exit_code == 2
-    assert 'Cannot create a persistent development character' in result.output, 'Missing or invalid error message was produced.'
 
 
 def test_bob_retrieves_twice_via_cli(click_runner,
-                           capsule_side_channel,
-                           enacted_federated_policy,
-                           federated_ursulas,
-                           custom_filepath_2,
-                           federated_alice
-                           ):
+                                     capsule_side_channel,
+                                     enacted_federated_policy,
+                                     federated_ursulas,
+                                     custom_filepath_2,
+                                     federated_alice
+                                     ):
     teacher = list(federated_ursulas)[0]
 
     first_message = capsule_side_channel.reset(plaintext_passthrough=True)
@@ -145,6 +146,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
 
     envvars = {'NUCYPHER_KEYRING_PASSWORD': INSECURE_DEVELOPMENT_PASSWORD}
 
+    log.info("Init'ing a normal Bob; we'll substitute the Policy Bob in shortly.")
     bob_init_response = click_runner.invoke(nucypher_cli, bob_init_args, catch_exceptions=False, env=envvars)
 
     message_kit_bytes = bytes(three_message_kits[0])
@@ -165,6 +167,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
     from nucypher.cli import actions
 
     def substitute_bob(*args, **kwargs):
+        log.info("Substituting the Policy's Bob in CLI runtime.")
         this_fuckin_guy = enacted_federated_policy.bob
         somebody_else = Ursula.from_teacher_uri(teacher_uri=kwargs['teacher_uri'],
                                                 min_stake=0,
@@ -176,6 +179,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
 
     _old_make_character_function = actions.make_cli_character
     try:
+        log.info("Patching make_cli_character with substitute_bob")
         actions.make_cli_character = substitute_bob
 
         # Once...
@@ -194,4 +198,5 @@ def test_bob_retrieves_twice_via_cli(click_runner,
         for cleartext in retrieve_response['result']['cleartexts']:
             assert cleartext.encode() == capsule_side_channel.plaintexts[1]
     finally:
+        log.info("un-patching make_cli_character")
         actions.make_cli_character = _old_make_character_function

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -186,7 +186,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
         actions.make_cli_character = substitute_bob
 
         # Once...
-        with GlobalLoggerSettings.pause_console_logging_while():
+        with GlobalLoggerSettings.pause_all_logging_while():
             retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
 
         log.info(f"First retrieval response: {retrieve_response.output}")
@@ -197,7 +197,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
             assert cleartext.encode() == capsule_side_channel.plaintexts[1]
 
         # and again!
-        with GlobalLoggerSettings.pause_console_logging_while():
+        with GlobalLoggerSettings.pause_all_logging_while():
             retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
 
         log.info(f"Second retrieval response: {retrieve_response.output}")

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -184,6 +184,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
 
         # Once...
         retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+        log.info(f"First retrieval response: {retrieve_response.output}")
         assert retrieve_response.exit_code == 0
 
         retrieve_response = json.loads(retrieve_response.output)
@@ -192,6 +193,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
 
         # and again!
         retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+        log.info(f"Second retrieval response: {retrieve_response.output}")
         assert retrieve_response.exit_code == 0
 
         retrieve_response = json.loads(retrieve_response.output)

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -164,7 +164,7 @@ def test_bob_retrieves_twice_via_cli(click_runner,
 
     from nucypher.cli import actions
 
-    def substitue_bob(*args, **kwargs):
+    def substitute_bob(*args, **kwargs):
         this_fuckin_guy = enacted_federated_policy.bob
         somebody_else = Ursula.from_teacher_uri(teacher_uri=kwargs['teacher_uri'],
                                                 min_stake=0,
@@ -174,20 +174,24 @@ def test_bob_retrieves_twice_via_cli(click_runner,
         this_fuckin_guy.controller.emitter = JSONRPCStdoutEmitter()
         return this_fuckin_guy
 
-    actions.make_cli_character = substitue_bob
+    _old_make_character_function = actions.make_cli_character
+    try:
+        actions.make_cli_character = substitute_bob
 
-    # Once...
-    retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
-    assert retrieve_response.exit_code == 0
+        # Once...
+        retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+        assert retrieve_response.exit_code == 0
 
-    retrieve_response = json.loads(retrieve_response.output)
-    for cleartext in retrieve_response['result']['cleartexts']:
-        assert cleartext.encode() == capsule_side_channel.plaintexts[1]
+        retrieve_response = json.loads(retrieve_response.output)
+        for cleartext in retrieve_response['result']['cleartexts']:
+            assert cleartext.encode() == capsule_side_channel.plaintexts[1]
 
-    # and again!
-    retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
-    assert retrieve_response.exit_code == 0
+        # and again!
+        retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+        assert retrieve_response.exit_code == 0
 
-    retrieve_response = json.loads(retrieve_response.output)
-    for cleartext in retrieve_response['result']['cleartexts']:
-        assert cleartext.encode() == capsule_side_channel.plaintexts[1]
+        retrieve_response = json.loads(retrieve_response.output)
+        for cleartext in retrieve_response['result']['cleartexts']:
+            assert cleartext.encode() == capsule_side_channel.plaintexts[1]
+    finally:
+        actions.make_cli_character = _old_make_character_function

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -119,7 +119,7 @@ def test_bob_destroy(click_runner, custom_filepath):
     assert 'Cannot create a persistent development character' in result.output, 'Missing or invalid error message was produced.'
 
 
-def test_bob_retrieve_args(click_runner,
+def test_bob_retrieves_twice_via_cli(click_runner,
                            capsule_side_channel,
                            enacted_federated_policy,
                            federated_ursulas,
@@ -176,6 +176,15 @@ def test_bob_retrieve_args(click_runner,
 
     actions.make_cli_character = substitue_bob
 
+    # Once...
+    retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+    assert retrieve_response.exit_code == 0
+
+    retrieve_response = json.loads(retrieve_response.output)
+    for cleartext in retrieve_response['result']['cleartexts']:
+        assert cleartext.encode() == capsule_side_channel.plaintexts[1]
+
+    # and again!
     retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
     assert retrieve_response.exit_code == 0
 

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -1,10 +1,12 @@
+import json
 import os
+from base64 import b64encode
 from unittest import mock
 
+from nucypher.characters.control.emitters import JSONRPCStdoutEmitter
+from nucypher.characters.lawful import Ursula
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import BobConfiguration
-from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, \
-    MOCK_IP_ADDRESS, MOCK_CUSTOM_INSTALLATION_PATH, TEMPORARY_DOMAIN
 from nucypher.cli.actions import SUCCESSFUL_DESTRUCTION
 
 
@@ -26,6 +28,10 @@ def test_bob_public_keys(click_runner):
     assert result.exit_code == 0
     assert "bob_encrypting_key" in result.output
     assert "bob_verifying_key" in result.output
+from nucypher.crypto.kits import UmbralMessageKit
+from nucypher.crypto.powers import SigningPower
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, TEMPORARY_DOMAIN
+from nucypher.utilities.sandbox.constants import MOCK_IP_ADDRESS, MOCK_CUSTOM_INSTALLATION_PATH
 
 
 def test_initialize_bob_with_custom_configuration_root(custom_filepath, click_runner):
@@ -87,6 +93,16 @@ def test_bob_view_with_preexisting_configuration(click_runner, custom_filepath):
     assert custom_filepath in result.output
 
 
+def test_bob_public_keys(click_runner):
+    derive_key_args = ('bob', 'public-keys', '--dev')
+
+    result = click_runner.invoke(nucypher_cli, derive_key_args, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "bob_encrypting_key" in result.output
+    assert "bob_verifying_key" in result.output
+
+
 # Should be the last test since it deletes the configuration file
 def test_bob_destroy(click_runner, custom_filepath):
     custom_config_filepath = os.path.join(custom_filepath, BobConfiguration.generate_filename())
@@ -98,3 +114,71 @@ def test_bob_destroy(click_runner, custom_filepath):
     assert result.exit_code == 0
     assert SUCCESSFUL_DESTRUCTION in result.output
     assert not os.path.exists(custom_config_filepath), "Bob config file was deleted"
+    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
+    assert result.exit_code == 2
+    assert 'Cannot create a persistent development character' in result.output, 'Missing or invalid error message was produced.'
+
+
+def test_bob_retrieve_args(click_runner,
+                           capsule_side_channel,
+                           enacted_federated_policy,
+                           federated_ursulas,
+                           custom_filepath_2,
+                           federated_alice
+                           ):
+    teacher = list(federated_ursulas)[0]
+
+    first_message = capsule_side_channel.reset(plaintext_passthrough=True)
+    three_message_kits = [capsule_side_channel(), capsule_side_channel(), capsule_side_channel()]
+
+    bob_config_root = custom_filepath_2
+    bob_configuration_file_location = os.path.join(bob_config_root, BobConfiguration.generate_filename())
+    label = enacted_federated_policy.label
+
+    # I already have a Bob.
+
+    # Need to init so that the config file is made, even though we won't use this Bob.
+    bob_init_args = ('bob', 'init',
+                     '--network', TEMPORARY_DOMAIN,
+                     '--config-root', bob_config_root,
+                     '--federated-only')
+
+    envvars = {'NUCYPHER_KEYRING_PASSWORD': INSECURE_DEVELOPMENT_PASSWORD}
+
+    bob_init_response = click_runner.invoke(nucypher_cli, bob_init_args, catch_exceptions=False, env=envvars)
+
+    message_kit_bytes = bytes(three_message_kits[0])
+    message_kit_b64_bytes = b64encode(message_kit_bytes)
+    UmbralMessageKit.from_bytes(message_kit_bytes)
+
+    retrieve_args = ('bob', 'retrieve',
+                     '--mock-networking',
+                     '--json-ipc',
+                     '--teacher', teacher.seed_node_metadata(as_teacher_uri=True),
+                     '--config-file', bob_configuration_file_location,
+                     '--message-kit', message_kit_b64_bytes,
+                     '--label', label,
+                     '--policy-encrypting-key', federated_alice.get_policy_encrypting_key_from_label(label).hex(),
+                     '--alice-verifying-key', federated_alice.public_keys(SigningPower).hex()
+                     )
+
+    from nucypher.cli import actions
+
+    def substitue_bob(*args, **kwargs):
+        this_fuckin_guy = enacted_federated_policy.bob
+        somebody_else = Ursula.from_teacher_uri(teacher_uri=kwargs['teacher_uri'],
+                                                min_stake=0,
+                                                federated_only=True,
+                                                network_middleware=this_fuckin_guy.network_middleware)
+        this_fuckin_guy.remember_node(somebody_else)
+        this_fuckin_guy.controller.emitter = JSONRPCStdoutEmitter()
+        return this_fuckin_guy
+
+    actions.make_cli_character = substitue_bob
+
+    retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
+    assert retrieve_response.exit_code == 0
+
+    retrieve_response = json.loads(retrieve_response.output)
+    for cleartext in retrieve_response['result']['cleartexts']:
+        assert cleartext.encode() == capsule_side_channel.plaintexts[1]

--- a/tests/cli/test_felix.py
+++ b/tests/cli/test_felix.py
@@ -2,6 +2,8 @@ import os
 from unittest import mock
 
 import pytest_twisted
+
+from nucypher.blockchain.eth.registry import LocalContractRegistry
 from nucypher.cli.actions import SUCCESSFUL_DESTRUCTION
 from twisted.internet import threads
 from twisted.internet.task import Clock
@@ -55,8 +57,15 @@ def test_run_felix(click_runner, testerchain, agency_local_registry, deploy_user
                  '--config-root', MOCK_CUSTOM_INSTALLATION_PATH_2,
                  '--network', TEMPORARY_DOMAIN,
                  '--provider', TEST_PROVIDER_URI)
+    _original_read_function = LocalContractRegistry.read
 
-    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False, env=envvars)
+    try:
+        # Mock live contract registry reads
+        LocalContractRegistry.read = lambda *a, **kw: test_registry.read()
+        result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False, env=envvars)
+    finally:
+        # Restore original read function.
+        LocalContractRegistry.read = _original_read_function
     assert result.exit_code == 0
 
     configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH_2, FelixConfiguration.generate_filename())

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -566,11 +566,11 @@ def test_collect_rewards_integration(click_runner,
 
         # Encrypt
         random_data = os.urandom(random.randrange(20, 100))
-        ciphertext, signature = enrico.encrypt_message(message=random_data)
+        message_kit, signature = enrico.encrypt_message(message=random_data)
 
         # Decrypt
-        cleartexts = blockchain_bob.retrieve(message_kit=ciphertext,
-                                             data_source=enrico,
+        cleartexts = blockchain_bob.retrieve(message_kit,
+                                             enrico=enrico,
                                              alice_verifying_key=verifying_key,
                                              label=random_policy_label)
         assert random_data == cleartexts[0]

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -486,7 +486,7 @@ def test_collect_rewards_integration(click_runner,
         ciphertext, signature = enrico.encrypt_message(message=random_data)
 
         # Decrypt
-        cleartexts = blockchain_bob.retrieve(message_kit=ciphertext,
+        cleartexts = blockchain_bob.retrieve(ciphertext,
                                              enrico=enrico,
                                              alice_verifying_key=verifying_key,
                                              label=random_policy_label)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -151,8 +151,7 @@ def ursula_federated_test_config():
                                         federated_only=True,
                                         network_middleware=MockRestMiddleware(),
                                         save_metadata=False,
-                                        reload_metadata=False,
-                                        download_registry=False)
+                                        reload_metadata=False,)
     yield ursula_config
     ursula_config.cleanup()
 
@@ -183,8 +182,7 @@ def alice_federated_test_config(federated_ursulas):
                                 federated_only=True,
                                 abort_on_learning_error=True,
                                 save_metadata=False,
-                                reload_metadata=False,
-                                download_registry=False)
+                                reload_metadata=False,)
     yield config
     config.cleanup()
 
@@ -214,8 +212,7 @@ def bob_federated_test_config():
                               abort_on_learning_error=True,
                               federated_only=True,
                               save_metadata=False,
-                              reload_metadata=False,
-                              download_registry=False)
+                              reload_metadata=False,)
     yield config
     config.cleanup()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -151,7 +151,8 @@ def ursula_federated_test_config():
                                         federated_only=True,
                                         network_middleware=MockRestMiddleware(),
                                         save_metadata=False,
-                                        reload_metadata=False, )
+                                        reload_metadata=False,
+                                        download_registry=False)
     yield ursula_config
     ursula_config.cleanup()
 
@@ -182,7 +183,8 @@ def alice_federated_test_config(federated_ursulas):
                                 federated_only=True,
                                 abort_on_learning_error=True,
                                 save_metadata=False,
-                                reload_metadata=False)
+                                reload_metadata=False,
+                                download_registry=False)
     yield config
     config.cleanup()
 
@@ -212,7 +214,8 @@ def bob_federated_test_config():
                               abort_on_learning_error=True,
                               federated_only=True,
                               save_metadata=False,
-                              reload_metadata=False)
+                              reload_metadata=False,
+                              download_registry=False)
     yield config
     config.cleanup()
 
@@ -312,13 +315,13 @@ def capsule_side_channel(enacted_federated_policy):
             self.reset()
 
         def __call__(self):
-            enrico = Enrico(policy_encrypting_key=enacted_federated_policy.public_key)
             message = "Welcome to flippering number {}.".format(len(self.messages)).encode()
-            message_kit, _signature = enrico.encrypt_message(message)
-            self.messages.append((message_kit, enrico))
-            return message_kit, enrico
+            message_kit, _signature = self.enrico.encrypt_message(message)
+            self.messages.append((message_kit, self.enrico))
+            return message_kit
 
         def reset(self):
+            self.enrico = Enrico(policy_encrypting_key=enacted_federated_policy.public_key)
             self.messages = []
             self()
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -315,11 +315,15 @@ def capsule_side_channel(enacted_federated_policy):
             message = "Welcome to flippering number {}.".format(len(self.messages)).encode()
             message_kit, _signature = self.enrico.encrypt_message(message)
             self.messages.append((message_kit, self.enrico))
+            if self.plaintext_passthrough:
+                self.plaintexts.append(message)
             return message_kit
 
-        def reset(self):
+        def reset(self, plaintext_passthrough=False):
             self.enrico = Enrico(policy_encrypting_key=enacted_federated_policy.public_key)
             self.messages = []
+            self.plaintexts = []
+            self.plaintext_passthrough = plaintext_passthrough
             return self(), self.enrico
 
     return _CapsuleSideChannel()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -320,7 +320,7 @@ def capsule_side_channel(enacted_federated_policy):
         def reset(self):
             self.enrico = Enrico(policy_encrypting_key=enacted_federated_policy.public_key)
             self.messages = []
-            self()
+            return self(), self.enrico
 
     return _CapsuleSideChannel()
 


### PR DESCRIPTION
*Summary*: Bob's adventure is now consistent with the assumptions throughout much of the rest of the codebase.  Specifically, in a single adventure: Bob can retrieve messages in any number of capsules, he can leave CFrags attached to Capsules either after activation or after an adventure that does not result in activation, and he can save WorkOrders in a replete form, both with completion metadata and the CFrag attached.

### Multiple Capsule adventure
* Fixes #1359: `retrieve` now takes `*message_kits` and accounts for `Bob` adventuring with multiple `capsules`.
* Fixes #999: Bob can now learn "later" (instead of crashing) if a subsequent adventure leads him to a new Ursula.
* Fixes #934: If Bob has all the CFrags he needs (or an already activated Capsule), he does not engage in any network I/O at all (and thus, does not re-follow the `TreasureMap`).

### The "KMS" use case
* Fixes #1197: Bob no longer retains unused WorkOrders after activation.
* Fixes #1195: Bob can now create a new WorkOrder even if he has a complete WorkOrder for a given Capsule (encouraging him to discard them in favor of using the network while still optionally keeping track of his engagement with Ursula)

Advanced but not closed:
* #892: Behavior following revocation is now consistent, and includes a better error message than "unable to snag...", but can still probably use UI touch-
* #1234 
* #1176 

New issues:
* #1578 


** Note: This branch was previously based on a WIP variant of #1555 - for that history, see d8aebfd700a7e041d6eefc1ab37f05b337209d68.

** Note: This branch also previously included the supermariobox demo, which was initially removed [here](07e08df12bc27d004b54eac16b9de4f861a093be), but has since been pulled out.  For the history including the mariobox, see 93fa93733.  To add mariobox to a future branch, consider `git cherry-pick 3ba48e14d9bd52e89733262a1721ebe84a6e5c38..56b4b1c3e1f0c76a4da221105b81273b7f6f4c67`.