### PR TITLE
Restaking Control

### DIFF
--- a/docs/source/guides/staking_guide.rst
+++ b/docs/source/guides/staking_guide.rst
@@ -43,7 +43,7 @@ All staking-related operations done by StakeHolder are performed through the ``n
 +----------------------+-------------------------------------------------------------------------------+
 |  ``divide``          | Create a new stake from part of an existing one                               |
 +----------------------+-------------------------------------------------------------------------------+
-|  ``restke``          | Manage automatic reward re-staking                                            |
+|  ``restake``          | Manage automatic reward re-staking                                            |
 +----------------------+-------------------------------------------------------------------------------+
 
 **Stake Command Options**
@@ -62,17 +62,15 @@ All staking-related operations done by StakeHolder are performed through the ``n
 
 **ReStake Command Options**
 
-+-------------------------+--------------------------------------------+
-| Option                  |  Description                               |
-+=========================+============================================+
-|  ``--enable``           | Enable restaking (default)                 |
-+-------------------------+--------------------------------------------+
-|  ``--disable``          | Disable restaking                          |
-+-------------------------+--------------------------------------------+
-|  ``--lock ``            | Enable restaking lock                      |
-+-------------------------+--------------------------------------------+
-|  ``--release-period``   | Expiration period of restaking lock        |
-+-------------------------+--------------------------------------------+
++-------------------------+---------------------------------------------+
+| Option                  |  Description                                |
++=========================+=============================================+
+|  ``--enable``           | Enable re-staking                           |
++-------------------------+---------------------------------------------+
+|  ``--disable``          | Disable re-staking                          |
++-------------------------+---------------------------------------------+
+|  ``--lock-until``       | Enable re-staking lock until release period |
++-------------------------+---------------------------------------------+
 
 
 Staking Overview
@@ -87,7 +85,7 @@ Most stakers on the Goerli testnet will complete the following steps:
 4) Stake tokens (See Below)
 5) Install another Ethereum node at the Worker instance
 6) Initialize a Worker node [:ref:`ursula-config-guide`] and bond it to your Staker (``set-worker``)
-7) Optoinally, enable restaking
+7) Optionally, enable re-staking
 8) Configure and run the Worker, and keep it online [:ref:`ursula-config-guide`]!
 
 Interactive Method
@@ -253,8 +251,8 @@ the address to checksum format in geth console:
 After this step, you're finished with the Staker, and you can proceed to :ref:`ursula-config-guide`.
 
 
-Manage automatic reward restaking
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Manage automatic reward re-staking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As your Ursula performs work, you can optionally enable the automatic addition of
 all rewards to your existing stake to optimize earnings.  By default this feature is disabled,
@@ -277,7 +275,7 @@ allow **restaking** to be disabled until the release period begins, even if you 
 
 .. code:: bash
 
-    (nucypher)$ nucypher stake restake --lock --release-period 12345
+    (nucypher)$ nucypher stake restake --lock-until 12345
 
 No action is needed to release the restaking lock once the release period begins.
 

--- a/docs/source/guides/staking_guide.rst
+++ b/docs/source/guides/staking_guide.rst
@@ -43,7 +43,8 @@ All staking-related operations done by StakeHolder are performed through the ``n
 +----------------------+-------------------------------------------------------------------------------+
 |  ``divide``          | Create a new stake from part of an existing one                               |
 +----------------------+-------------------------------------------------------------------------------+
-
+|  ``restke``          | Manage automatic reward re-staking                                            |
++----------------------+-------------------------------------------------------------------------------+
 
 **Stake Command Options**
 
@@ -59,6 +60,20 @@ All staking-related operations done by StakeHolder are performed through the ``n
 | ``--hw-wallet`` | Use a hardware wallet                      |
 +-----------------+--------------------------------------------+
 
+**ReStake Command Options**
+
++-------------------------+--------------------------------------------+
+| Option                  |  Description                               |
++=========================+============================================+
+|  ``--enable``           | Enable restaking (default)                 |
++-------------------------+--------------------------------------------+
+|  ``--disable``          | Disable restaking                          |
++-------------------------+--------------------------------------------+
+|  ``--lock ``            | Enable restaking lock                      |
++-------------------------+--------------------------------------------+
+|  ``--release-period``   | Expiration period of restaking lock        |
++-------------------------+--------------------------------------------+
+
 
 Staking Overview
 -----------------
@@ -72,7 +87,8 @@ Most stakers on the Goerli testnet will complete the following steps:
 4) Stake tokens (See Below)
 5) Install another Ethereum node at the Worker instance
 6) Initialize a Worker node [:ref:`ursula-config-guide`] and bond it to your Staker (``set-worker``)
-7) Configure and run the Worker, and keep it online [:ref:`ursula-config-guide`]!
+7) Optoinally, enable restaking
+8) Configure and run the Worker, and keep it online [:ref:`ursula-config-guide`]!
 
 Interactive Method
 ------------------
@@ -235,6 +251,35 @@ the address to checksum format in geth console:
     "0x287A817426DD1AE78ea23e9918e2273b6733a43D"
 
 After this step, you're finished with the Staker, and you can proceed to :ref:`ursula-config-guide`.
+
+
+Manage automatic reward restaking
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As your Ursula performs work, you can optionally enable the automatic addition of
+all rewards to your existing stake to optimize earnings.  By default this feature is disabled,
+to enable it run:
+
+.. code:: bash
+
+    (nucypher)$ nucypher stake restake --enable
+
+To disable restaking:
+
+.. code:: bash
+
+    (nucypher)$ nucypher stake restake --disable
+
+
+Additionally, you can enable **restake locking**, an on-chain commitment to continue restaking
+until a future period (`release_period`). Once enabled, the `StakingEscrow` contract will not
+allow **restaking** to be disabled until the release period begins, even if you are the stake owner.
+
+.. code:: bash
+
+    (nucypher)$ nucypher stake restake --lock --release-period 12345
+
+No action is needed to release the restaking lock once the release period begins.
 
 
 Collect rewards earned by the staker

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -564,6 +564,27 @@ class Staker(NucypherTokenActor):
 
         return new_stake
 
+    def enable_restaking(self) -> dict:
+        receipt = self.staking_agent.set_restaking(staker_address=self.checksum_address, value=True)
+        return receipt
+
+    def enable_restaking_lock(self, release_period: int):
+        current_period = self.staking_agent.get_current_period()
+        if release_period < current_period:
+            raise ValueError(f"Terminal restaking period must be in the future.  "
+                             f"Current period is {current_period}, got '{release_period}'.")
+        receipt = self.staking_agent.lock_restaking(staker_address=self.checksum_address,
+                                                    release_period=release_period)
+        return receipt
+
+    @property
+    def restaking_lock_enabled(self) -> bool:
+        status = self.staking_agent.get_restaking_lock_status(staker_address=self.checksum_address)
+        return status
+
+    def disable_restaking(self) -> dict:
+        receipt = self.staking_agent.set_restaking(staker_address=self.checksum_address, value=False)
+        return receipt
     #
     # Reward and Collection
     #

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -510,7 +510,7 @@ class Staker(NucypherTokenActor):
 
         # Calculate stake duration in periods
         if expiration:
-            additional_periods = datetime_to_period(datetime=expiration) - current_stake.final_locked_period
+            additional_periods = datetime_to_period(datetime=expiration, seconds_per_period=self.economics.seconds_per_period) - current_stake.final_locked_period
             if additional_periods <= 0:
                 raise Stake.StakingError(f"New expiration {expiration} must be at least 1 period from the "
                                          f"current stake's end period ({current_stake.final_locked_period}).")
@@ -537,7 +537,8 @@ class Staker(NucypherTokenActor):
         if lock_periods and expiration:
             raise ValueError("Pass the number of lock periods or an expiration MayaDT; not both.")
         if expiration:
-            lock_periods = calculate_period_duration(future_time=expiration)
+            lock_periods = calculate_period_duration(future_time=expiration,
+                                                     seconds_per_period=self.economics.seconds_per_period)
 
         # Value
         if entire_balance and amount:

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -589,7 +589,7 @@ class Staker(NucypherTokenActor):
 
     @property
     def restaking_lock_enabled(self) -> bool:
-        status = self.staking_agent.get_restaking_lock_status(staker_address=self.checksum_address)
+        status = self.staking_agent.is_restaking_locked(staker_address=self.checksum_address)
         return status
 
     def disable_restaking(self) -> dict:

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -564,10 +564,19 @@ class Staker(NucypherTokenActor):
 
         return new_stake
 
+    @property
+    def is_restaking(self) -> bool:
+        restaking = self.staking_agent.is_restaking(staker_address=self.checksum_address)
+        return restaking
+
+    @only_me
+    @save_receipt
     def enable_restaking(self) -> dict:
         receipt = self.staking_agent.set_restaking(staker_address=self.checksum_address, value=True)
         return receipt
 
+    @only_me
+    @save_receipt
     def enable_restaking_lock(self, release_period: int):
         current_period = self.staking_agent.get_current_period()
         if release_period < current_period:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -363,6 +363,26 @@ class StakingEscrowAgent(EthereumContractAgent):
                                                    sender_address=staker_address)
         return receipt
 
+    def get_restaking_lock_status(self, staker_address: str) -> bool:
+        status = self.contract.functions.isReStakeLocked(staker_address).call()
+        return status
+
+    def set_restaking(self, staker_address: str, value: bool) -> dict:
+        """
+        Enable automatic restaking for a fixed duration of lock periods.
+        If set to True, then all staking rewards will be automatically added to locked stake.
+        """
+        contract_function = self.contract.functions.setReStake(value)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                   sender_address=staker_address)
+        return receipt
+
+    def lock_restaking(self, staker_address: str, termination_period: int) -> dict:
+        contract_function = self.contract.functions.lockReStake(termination_period)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                   sender_address=staker_address)
+        return receipt
+
     def staking_parameters(self) -> Tuple:
         parameter_signatures = (
             # Period

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -288,6 +288,22 @@ class StakingEscrowAgent(EthereumContractAgent):
         for stake_index in range(stakes_length):
             yield self.get_substake_info(staker_address=staker_address, stake_index=stake_index)
 
+    @validate_checksum_address
+    def is_restaking(self, staker_address: str) -> bool:
+        staker_info = self.get_staker_info(staker_address)
+        restake_flag = bool(staker_info[3])
+        return restake_flag
+
+    @validate_checksum_address
+    def is_restake_locked(self, staker_address: str) -> bool:
+        return self.contract.functions.isReStakeLocked(staker_address).call()
+
+    @validate_checksum_address
+    def get_restake_unlock_period(self, staker_address: str) -> int:
+        staker_info = self.get_staker_info(staker_address)
+        restake_unlock_period = int(staker_info[4])
+        return restake_unlock_period
+
     def deposit_tokens(self, amount: int, lock_periods: int, sender_address: str):
         """Send tokens to the escrow from the staker's address"""
         contract_function = self.contract.functions.deposit(amount, lock_periods)
@@ -363,10 +379,12 @@ class StakingEscrowAgent(EthereumContractAgent):
                                                    sender_address=staker_address)
         return receipt
 
+    @validate_checksum_address
     def get_restaking_lock_status(self, staker_address: str) -> bool:
         status = self.contract.functions.isReStakeLocked(staker_address).call()
         return status
 
+    @validate_checksum_address
     def set_restaking(self, staker_address: str, value: bool) -> dict:
         """
         Enable automatic restaking for a fixed duration of lock periods.
@@ -375,12 +393,15 @@ class StakingEscrowAgent(EthereumContractAgent):
         contract_function = self.contract.functions.setReStake(value)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    sender_address=staker_address)
+        # TODO: Handle ReStakeSet event (see #1193)
         return receipt
 
+    @validate_checksum_address
     def lock_restaking(self, staker_address: str, release_period: int) -> dict:
         contract_function = self.contract.functions.lockReStake(release_period)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    sender_address=staker_address)
+        # TODO: Handle ReStakeLocked event (see #1193)
         return receipt
 
     def staking_parameters(self) -> Tuple:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -288,22 +288,6 @@ class StakingEscrowAgent(EthereumContractAgent):
         for stake_index in range(stakes_length):
             yield self.get_substake_info(staker_address=staker_address, stake_index=stake_index)
 
-    @validate_checksum_address
-    def is_restaking(self, staker_address: str) -> bool:
-        staker_info = self.get_staker_info(staker_address)
-        restake_flag = bool(staker_info[3])
-        return restake_flag
-
-    @validate_checksum_address
-    def is_restake_locked(self, staker_address: str) -> bool:
-        return self.contract.functions.isReStakeLocked(staker_address).call()
-
-    @validate_checksum_address
-    def get_restake_unlock_period(self, staker_address: str) -> int:
-        staker_info = self.get_staker_info(staker_address)
-        restake_unlock_period = int(staker_info[4])
-        return restake_unlock_period
-
     def deposit_tokens(self, amount: int, lock_periods: int, sender_address: str):
         """Send tokens to the escrow from the staker's address"""
         contract_function = self.contract.functions.deposit(amount, lock_periods)
@@ -380,9 +364,14 @@ class StakingEscrowAgent(EthereumContractAgent):
         return receipt
 
     @validate_checksum_address
-    def get_restaking_lock_status(self, staker_address: str) -> bool:
-        status = self.contract.functions.isReStakeLocked(staker_address).call()
-        return status
+    def is_restaking(self, staker_address: str) -> bool:
+        staker_info = self.get_staker_info(staker_address)
+        restake_flag = bool(staker_info[3])  # TODO: #1348 Use constant or enum
+        return restake_flag
+
+    @validate_checksum_address
+    def is_restaking_locked(self, staker_address: str) -> bool:
+        return self.contract.functions.isReStakeLocked(staker_address).call()
 
     @validate_checksum_address
     def set_restaking(self, staker_address: str, value: bool) -> dict:
@@ -403,6 +392,12 @@ class StakingEscrowAgent(EthereumContractAgent):
                                                    sender_address=staker_address)
         # TODO: Handle ReStakeLocked event (see #1193)
         return receipt
+
+    @validate_checksum_address
+    def get_restake_unlock_period(self, staker_address: str) -> int:
+        staker_info = self.get_staker_info(staker_address)
+        restake_unlock_period = int(staker_info[4])  # TODO: #1348 Use constant or enum
+        return restake_unlock_period
 
     def staking_parameters(self) -> Tuple:
         parameter_signatures = (

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -377,8 +377,8 @@ class StakingEscrowAgent(EthereumContractAgent):
                                                    sender_address=staker_address)
         return receipt
 
-    def lock_restaking(self, staker_address: str, termination_period: int) -> dict:
-        contract_function = self.contract.functions.lockReStake(termination_period)
+    def lock_restaking(self, staker_address: str, release_period: int) -> dict:
+        contract_function = self.contract.functions.lockReStake(release_period)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    sender_address=staker_address)
         return receipt

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -78,7 +78,7 @@ class BaseContractRegistry(ABC):
         return bool(self.id == other.id)
 
     def __repr__(self) -> str:
-        r = f"{self.__class__.__name__}"
+        r = f"{self.__class__.__name__}(id={self.id[:6]})"
         return r
 
     @property

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -369,3 +369,21 @@ def confirm_deployment(emitter, deployer_interface) -> bool:
         raise click.Abort()
 
     return True
+
+
+def confirm_enable_restaking_lock(emitter, staking_address: str, release_period: int) -> bool:
+    restaking_lock_agreement = f"""
+By enabling the re-staking lock for {staking_address}, you are committing to automatically 
+re-stake all rewards until period a future period.  You will not be able to disable re-staking until {release_period}.
+    """
+    emitter.message(restaking_lock_agreement)
+    click.confirm(f"Confirm enable re-staking lock for staker {staking_address} until {release_period}?", abort=True)
+    return True
+
+
+def confirm_enable_restaking(emitter, staking_address: str) -> bool:
+    restaking_lock_agreement = f"By enabling the re-staking for {staking_address}, " \
+                               f"All staking rewards will be automatically added to your existing stake."
+    emitter.message(restaking_lock_agreement)
+    click.confirm(f"Confirm enable automatic re-staking for staker {staking_address}?", abort=True)
+    return True

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -298,6 +298,16 @@ def stake(click_config,
         return  # Exit
 
     elif action == "restake":
+
+        # Authenticate
+        if not staking_address:
+            staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).staker_address
+        password = None
+        if not hw_wallet and not blockchain.client.is_local:
+            password = get_client_password(checksum_address=staking_address)
+        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+
+        # Inner Switch
         if lock:
             if not force:
                 click.confirm(f"Confirm enable restaking lock for staker {staking_address} until {release_period}?", abort=True)
@@ -309,10 +319,13 @@ def stake(click_config,
             if not force:
                 click.confirm(f"Confirm enable restaking for staker {staking_address}?", abort=True)
             receipt = STAKEHOLDER.enable_restaking()
+            emitter.echo(f'Successfully enabled restaking for {staking_address}', color='green', verbosity=1)
         else:
             if not force:
                 click.confirm(f"Confirm disable restaking for staker {staking_address}?", abort=True)
             receipt = STAKEHOLDER.enable_restaking()
+            emitter.echo(f'Successfully disabled restaking for {staking_address}', color='green', verbosity=1)
+
         paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=blockchain.client.chain_name)
         return  # Exit
 

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -19,12 +19,19 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import click
 from web3 import Web3
 
-from nucypher.characters.lawful import StakeHolder
 from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainInterfaceFactory
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.utils import datetime_at_period
+from nucypher.characters.lawful import StakeHolder
 from nucypher.cli import painting, actions
-from nucypher.cli.actions import confirm_staged_stake, get_client_password, select_stake, select_client_account
+from nucypher.cli.actions import (
+    confirm_staged_stake,
+    get_client_password,
+    select_stake,
+    select_client_account,
+    confirm_enable_restaking_lock,
+    confirm_enable_restaking
+)
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.painting import paint_receipt_summary
 from nucypher.cli.types import (
@@ -308,13 +315,13 @@ def stake(click_config,
         # Inner Exclusive Switch
         if lock_until:
             if not force:
-                click.confirm(f"Confirm enable re-staking lock for staker {staking_address} until {lock_until}?", abort=True)
+                confirm_enable_restaking_lock(emitter, staking_address=staking_address, release_period=lock_until)
             receipt = STAKEHOLDER.enable_restaking_lock(release_period=lock_until)
             emitter.echo(f'Successfully enabled re-staking lock for {staking_address} until {lock_until}',
                          color='green', verbosity=1)
         elif enable:
             if not force:
-                click.confirm(f"Confirm enable re-staking for staker {staking_address}?", abort=True)
+                confirm_enable_restaking(emitter, staking_address=staking_address)
             receipt = STAKEHOLDER.enable_restaking()
             emitter.echo(f'Successfully enabled re-staking for {staking_address}', color='green', verbosity=1)
         else:

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -307,7 +307,7 @@ def stake(click_config,
             password = get_client_password(checksum_address=staking_address)
         STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
 
-        # Inner Switch
+        # Inner Exclusive Switch
         if lock:
             if not force:
                 click.confirm(f"Confirm enable restaking lock for staker {staking_address} until {release_period}?", abort=True)
@@ -315,6 +315,8 @@ def stake(click_config,
                 current_period = STAKEHOLDER.staking_agent.get_current_period()
                 release_period = click.prompt("Enter release period", type=click.IntRange(min=current_period+1))
             receipt = STAKEHOLDER.enable_restaking_lock(release_period=release_period)
+            emitter.echo(f'Successfully enabled restaking lock for {staking_address} until {release_period}',
+                         color='green', verbosity=1)
         elif enable:
             if not force:
                 click.confirm(f"Confirm enable restaking for staker {staking_address}?", abort=True)
@@ -323,7 +325,7 @@ def stake(click_config,
         else:
             if not force:
                 click.confirm(f"Confirm disable restaking for staker {staking_address}?", abort=True)
-            receipt = STAKEHOLDER.enable_restaking()
+            receipt = STAKEHOLDER.disable_restaking()
             emitter.echo(f'Successfully disabled restaking for {staking_address}', color='green', verbosity=1)
 
         paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=blockchain.client.chain_name)

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -53,9 +53,8 @@ from nucypher.config.characters import StakeHolderConfiguration
 @click.option('--value', help="Token value of stake", type=click.INT)
 @click.option('--lock-periods', help="Duration of stake in periods.", type=click.INT)
 @click.option('--index', help="A specific stake index to resume", type=click.INT)
-@click.option('--enable/--disable', help="Used to enable and disable restaking", is_flag=True, default=True)
-@click.option('--lock', help="Used with restake to enable restaking lock", is_flag=True)
-@click.option('--release-period', help="Period to release restaking lock", type=click.IntRange(min=0))
+@click.option('--enable/--disable', help="Used to enable and disable re-staking", is_flag=True, default=True)
+@click.option('--lock-until', help="Period to release re-staking lock", type=click.IntRange(min=0))
 @nucypher_click_config
 def stake(click_config,
           action,
@@ -84,8 +83,7 @@ def stake(click_config,
           policy_reward,
           staking_reward,
           enable,
-          lock,
-          release_period
+          lock_until,
 
           ) -> None:
     """
@@ -101,7 +99,7 @@ def stake(click_config,
     set-worker        Bond a worker to a staker
     detach-worker     Detach worker currently bonded to a staker
     init              Create a new stake
-    restake           Manage restaking with --enable or --disable
+    restake           Manage re-staking with --enable or --disable
     divide            Create a new stake from part of an existing one
     collect-reward    Withdraw staking reward
 
@@ -308,25 +306,22 @@ def stake(click_config,
         STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
 
         # Inner Exclusive Switch
-        if lock:
+        if lock_until:
             if not force:
-                click.confirm(f"Confirm enable restaking lock for staker {staking_address} until {release_period}?", abort=True)
-            if not release_period:
-                current_period = STAKEHOLDER.staking_agent.get_current_period()
-                release_period = click.prompt("Enter release period", type=click.IntRange(min=current_period+1))
-            receipt = STAKEHOLDER.enable_restaking_lock(release_period=release_period)
-            emitter.echo(f'Successfully enabled restaking lock for {staking_address} until {release_period}',
+                click.confirm(f"Confirm enable re-staking lock for staker {staking_address} until {lock_until}?", abort=True)
+            receipt = STAKEHOLDER.enable_restaking_lock(release_period=lock_until)
+            emitter.echo(f'Successfully enabled re-staking lock for {staking_address} until {lock_until}',
                          color='green', verbosity=1)
         elif enable:
             if not force:
-                click.confirm(f"Confirm enable restaking for staker {staking_address}?", abort=True)
+                click.confirm(f"Confirm enable re-staking for staker {staking_address}?", abort=True)
             receipt = STAKEHOLDER.enable_restaking()
-            emitter.echo(f'Successfully enabled restaking for {staking_address}', color='green', verbosity=1)
+            emitter.echo(f'Successfully enabled re-staking for {staking_address}', color='green', verbosity=1)
         else:
             if not force:
-                click.confirm(f"Confirm disable restaking for staker {staking_address}?", abort=True)
+                click.confirm(f"Confirm disable re-staking for staker {staking_address}?", abort=True)
             receipt = STAKEHOLDER.disable_restaking()
-            emitter.echo(f'Successfully disabled restaking for {staking_address}', color='green', verbosity=1)
+            emitter.echo(f'Successfully disabled re-staking for {staking_address}', color='green', verbosity=1)
 
         paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=blockchain.client.chain_name)
         return  # Exit

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -517,12 +517,21 @@ def paint_stakers(emitter, stakers: List[str], agent) -> None:
         stake = agent.owned_tokens(staker)
         last_confirmed_period = agent.get_last_active_period(staker)
         worker = agent.get_worker_from_staker(staker)
+        is_restaking = agent.is_restaking(staker)
 
         missing_confirmations = current_period - last_confirmed_period
         stake_in_nu = round(NU.from_nunits(stake), 2)
         locked_tokens = round(NU.from_nunits(agent.get_locked_tokens(staker)), 2)
 
         emitter.echo(f"{tab}  {'Stake:':10} {stake_in_nu}  (Locked: {locked_tokens})")
+        if is_restaking:
+            if agent.is_restake_locked(staker):
+                unlock_period = agent.get_restake_unlock_period(staker)
+                emitter.echo(f"{tab}  {'Re-staking:':10} Yes  (Locked until period: {unlock_period})")
+            else:
+                emitter.echo(f"{tab}  {'Re-staking:':10} Yes  (Unlocked)")
+        else:
+            emitter.echo(f"{tab}  {'Re-staking:':10} No")
         emitter.echo(f"{tab}  {'Activity:':10} ", nl=False)
         if missing_confirmations == -1:
             emitter.echo(f"Next period confirmed (#{last_confirmed_period})", color='green')

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -525,7 +525,7 @@ def paint_stakers(emitter, stakers: List[str], agent) -> None:
 
         emitter.echo(f"{tab}  {'Stake:':10} {stake_in_nu}  (Locked: {locked_tokens})")
         if is_restaking:
-            if agent.is_restake_locked(staker):
+            if agent.is_restaking_locked(staker):
                 unlock_period = agent.get_restake_unlock_period(staker)
                 emitter.echo(f"{tab}  {'Re-staking:':10} Yes  (Locked until period: {unlock_period})")
             else:

--- a/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
@@ -238,7 +238,7 @@ def test_lock_restaking(agency, testerchain):
     staker_account, worker_account, *other = testerchain.unassigned_accounts
     current_period = staking_agent.get_current_period()
     terminal_period = current_period + 2
-    receipt = staking_agent.lock_restaking(staker_account, termination_period=terminal_period)
+    receipt = staking_agent.lock_restaking(staker_account, release_period=terminal_period)
     assert receipt['status'] == 1, "Transaction Rejected"
 
 

--- a/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_staking_escrow_agent.py
@@ -225,6 +225,35 @@ def test_divide_stake(agency, token_economics):
 
 
 @pytest.mark.slow()
+def test_enable_restaking(agency, testerchain):
+    token_agent, staking_agent, _policy_agent = agency
+    staker_account, worker_account, *other = testerchain.unassigned_accounts
+    receipt = staking_agent.set_restaking(staker_account, value=True)
+    assert receipt['status'] == 1, "Transaction Rejected"
+
+
+@pytest.mark.slow()
+def test_lock_restaking(agency, testerchain):
+    token_agent, staking_agent, _policy_agent = agency
+    staker_account, worker_account, *other = testerchain.unassigned_accounts
+    current_period = staking_agent.get_current_period()
+    terminal_period = current_period + 2
+    receipt = staking_agent.lock_restaking(staker_account, termination_period=terminal_period)
+    assert receipt['status'] == 1, "Transaction Rejected"
+
+
+@pytest.mark.slow()
+def test_disable_restaking(agency, testerchain):
+    token_agent, staking_agent, _policy_agent = agency
+    staker_account, worker_account, *other = testerchain.unassigned_accounts
+    assert staking_agent.get_restaking_lock_status(staker_account)
+    testerchain.time_travel(periods=2)  # Wait for restake lock to be released.
+    receipt = staking_agent.set_restaking(staker_account, value=False)
+    assert receipt['status'] == 1, "Transaction Rejected"
+    assert not staking_agent.get_restaking_lock_status(staker_account)
+
+
+@pytest.mark.slow()
 def test_collect_staking_reward(agency, testerchain):
     token_agent, staking_agent, _policy_agent = agency
 

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -7,7 +7,7 @@ from nucypher.blockchain.eth.agents import (
     ContractAgency
 )
 from nucypher.blockchain.eth.constants import STAKING_ESCROW_CONTRACT_NAME
-from nucypher.blockchain.eth.registry import InMemoryContractRegistry
+from nucypher.blockchain.eth.registry import InMemoryContractRegistry, LocalContractRegistry
 from nucypher.cli.deploy import deploy
 from nucypher.utilities.sandbox.constants import TEST_PROVIDER_URI, MOCK_REGISTRY_FILEPATH
 
@@ -32,11 +32,12 @@ def test_nucypher_deploy_inspect_no_deployments(click_runner, testerchain):
     assert result.exit_code == 0
 
 
-def test_nucypher_deploy_inspect_fully_deployed(click_runner, testerchain, test_registry, agency):
+def test_nucypher_deploy_inspect_fully_deployed(click_runner, testerchain, agency):
 
-    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
-    policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=test_registry)
-    adjudicator_agent = ContractAgency.get_agent(AdjudicatorAgent, registry=test_registry)
+    local_registry = LocalContractRegistry(filepath=registry_filepath)
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=local_registry)
+    policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=local_registry)
+    adjudicator_agent = ContractAgency.get_agent(AdjudicatorAgent, registry=local_registry)
 
     status_command = ('inspect',
                       '--registry-infile', MOCK_REGISTRY_FILEPATH,
@@ -52,11 +53,12 @@ def test_nucypher_deploy_inspect_fully_deployed(click_runner, testerchain, test_
     assert adjudicator_agent.owner in result.output
 
 
-def test_transfer_ownership(click_runner, testerchain, test_registry, agency):
+def test_transfer_ownership(click_runner, testerchain, agency):
 
-    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
-    policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=test_registry)
-    adjudicator_agent = ContractAgency.get_agent(AdjudicatorAgent, registry=test_registry)
+    local_registry = LocalContractRegistry(filepath=registry_filepath)
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=local_registry)
+    policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=local_registry)
+    adjudicator_agent = ContractAgency.get_agent(AdjudicatorAgent, registry=local_registry)
 
     assert staking_agent.owner == testerchain.etherbase_account
     assert policy_agent.owner == testerchain.etherbase_account
@@ -65,7 +67,7 @@ def test_transfer_ownership(click_runner, testerchain, test_registry, agency):
     maclane = testerchain.unassigned_accounts[0]
 
     ownership_command = ('transfer-ownership',
-                         '--registry-infile', MOCK_REGISTRY_FILEPATH,
+                         '--registry-infile', registry_filepath,
                          '--provider', TEST_PROVIDER_URI,
                          '--target-address', maclane,
                          '--poa')

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -304,8 +304,7 @@ def test_stake_restake(click_runner,
     current_period = staking_agent.get_current_period()
     release_period = current_period + 1
     lock_args = ('stake', 'restake',
-                 '--lock',
-                 '--release-period', release_period,
+                 '--lock-until', release_period,
                  '--config-file', stakeholder_configuration_file_location,
                  '--staking-address', manual_staker,
                  '--force',
@@ -316,13 +315,19 @@ def test_stake_restake(click_runner,
                                  input=INSECURE_DEVELOPMENT_PASSWORD,
                                  catch_exceptions=False)
     assert result.exit_code == 0
+
+    # Still staking and the lock is enabled
+    assert staker.is_restaking
     assert staker.restaking_lock_enabled
+
+    # CLI Output includes success message
     assert "Successfully enabled" in result.output
     assert str(release_period) in result.output
 
     # Wait until release period
     testerchain.time_travel(periods=1)
     assert not staker.restaking_lock_enabled
+    assert staker.is_restaking
 
     disable_args = ('stake', 'restake',
                     '--disable',

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -275,6 +275,39 @@ def test_ursula_run(click_runner,
     assert result.exit_code == 0
 
 
+def test_stake_restake(click_runner,
+                       manual_staker,
+                       custom_filepath,
+                       testerchain,
+                       stakeholder_configuration_file_location):
+
+    restake_args = ('stake', 'restake',
+                    '--enable',
+                    '--config-file', stakeholder_configuration_file_location,
+                    '--staking-address', manual_staker,
+                    '--force',
+                    '--debug')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 restake_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    restake_args = ('stake', 'restake',
+                    '--disable',
+                    '--config-file', stakeholder_configuration_file_location,
+                    '--staking-address', manual_staker,
+                    '--force',
+                    '--debug')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 restake_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+
 def test_collect_rewards_integration(click_runner,
                                      testerchain,
                                      test_registry,
@@ -397,8 +430,8 @@ def test_collect_rewards_integration(click_runner,
     current_period += 1
     logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
 
-    # Half of the tokens are unlocked.
-    assert staker.locked_tokens() == token_economics.minimum_allowed_locked
+    # At least half of the tokens are unlocked (restaking was enabled for some prior periods)
+    assert staker.locked_tokens() >= token_economics.minimum_allowed_locked
 
     # Since we are mocking the blockchain connection, manually consume the transacting power of the Staker.
     testerchain.transacting_power = TransactingPower(account=staker_address,


### PR DESCRIPTION
Co-Author: @cygnusv 

Fixes #1269, Includes extracted changes from #1227 

##### New Staker CLI Commands

`nucypher stake restake --enable`
`nucypher stake restake --disable`
`nucypher stake restake --lock-until <PERIOD>`

##### Example 

```
$ nucypher stake restake --enable
 ____    __            __                      
/\  _`\ /\ \__        /\ \                     
\ \,\L\_\ \ ,_\    __ \ \ \/'\      __   _ __  
 \/_\__ \\ \ \/  /'__`\\ \ , <    /'__`\/\`'__\
   /\ \L\ \ \ \_/\ \L\.\\ \ \\`\ /\  __/\ \ \/ 
   \ `\____\ \__\ \__/.\_\ \_\ \_\ \____\\ \_\ 
    \/_____/\/__/\/__/\/_/\/_/\/_/\/____/ \/_/ 
   
The Holder of Stakes.                                      

======================================= Active Stakes =========================================

| ~ | Staker | Worker | # | Value    | Duration     | Enactment          
|   | ------ | ------ | - | -------- | ------------ | ----------------------------------------- 
| 0 | 0xEc39 | 0x985a | 0 | 45000 NU | 103 periods  | Aug 27 23:47:06 PDT - Dec 08 22:47:06 PST 

Select Stake: 0
Enter password to unlock account 0xEc391142E1007787101F328837C3ffa9eef767A2: 
Confirm enable restaking for staker 0xEc391142E1007787101F328837C3ffa9eef767A2? [y/N]: y
Successfully enabled restaking for 0xEc391142E1007787101F328837C3ffa9eef767A2
OK | 0x279c03b0bade60b0e499d85cce090d35bae2472aaa3f63250291f5b255086476 (31953 gas)
Block #1312292 | 0x7eab515f7a2e9ed98cbdbe6f2d4ff637e07274be1b9fd11bde7d0bbedc14a829
 See https://goerli.etherscan.io/tx/0x279c03b0bade60b0e499d85cce090d35bae2472aaa3f63250291f5b255086476

```