### PR TITLE
Bare Deployment and Retargeting Workflow

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -239,6 +239,15 @@ class ContractAdministrator(NucypherTokenActor):
                                     new_secret_hash=new_secret_hash)
         return txhashes
 
+    def retarget_proxy(self, contract_name: str, target_address: str, existing_plaintext_secret: str, new_plaintext_secret: str):
+        Deployer = self.__get_deployer(contract_name=contract_name)
+        deployer = Deployer(registry=self.registry, deployer_address=self.deployer_address)
+        new_secret_hash = keccak(bytes(new_plaintext_secret, encoding='utf-8'))
+        txhash = deployer.retarget(target_address=target_address,
+                                   existing_secret_plaintext=bytes(existing_plaintext_secret, encoding='utf-8'),
+                                   new_secret_hash=new_secret_hash)
+        return txhash
+
     def rollback_contract(self, contract_name: str, existing_plaintext_secret: str, new_plaintext_secret: str):
         Deployer = self.__get_deployer(contract_name=contract_name)
         deployer = Deployer(registry=self.registry, deployer_address=self.deployer_address)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -224,10 +224,12 @@ class ContractAdministrator(NucypherTokenActor):
 
         if Deployer._upgradeable:
             is_initial_deployment = not bare
-            if is_initial_deployment:
+            if is_initial_deployment and not plaintext_secret:
                 raise ValueError("An upgrade secret must be passed to perform an initial deployment series"
                                  "on an upgradeable contract.")
-            secret_hash = keccak(bytes(plaintext_secret, encoding='utf-8'))
+            secret_hash = None
+            if plaintext_secret:
+                secret_hash = keccak(bytes(plaintext_secret, encoding='utf-8'))
             txhashes = deployer.deploy(secret_hash=secret_hash,
                                        gas_limit=gas_limit,
                                        initial_deployment=is_initial_deployment,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -225,45 +225,44 @@ class ContractAdministrator(NucypherTokenActor):
         if Deployer._upgradeable:
             is_initial_deployment = not bare
             if is_initial_deployment and not plaintext_secret:
-                raise ValueError("An upgrade secret must be passed to perform an initial deployment series"
-                                 "on an upgradeable contract.")
+                raise ValueError("An upgrade secret must be passed to perform initial deployment of a Dispatcher.")
             secret_hash = None
             if plaintext_secret:
                 secret_hash = keccak(bytes(plaintext_secret, encoding='utf-8'))
-            txhashes = deployer.deploy(secret_hash=secret_hash,
+            receipts = deployer.deploy(secret_hash=secret_hash,
                                        gas_limit=gas_limit,
                                        initial_deployment=is_initial_deployment,
                                        progress=progress)
         else:
-            txhashes = deployer.deploy(gas_limit=gas_limit, progress=progress)
-        return txhashes, deployer
+            receipts = deployer.deploy(gas_limit=gas_limit, progress=progress)
+        return receipts, deployer
 
     def upgrade_contract(self, contract_name: str, existing_plaintext_secret: str, new_plaintext_secret: str) -> dict:
         Deployer = self.__get_deployer(contract_name=contract_name)
         deployer = Deployer(registry=self.registry, deployer_address=self.deployer_address)
         new_secret_hash = keccak(bytes(new_plaintext_secret, encoding='utf-8'))
-        txhashes = deployer.upgrade(existing_secret_plaintext=bytes(existing_plaintext_secret, encoding='utf-8'),
+        receipts = deployer.upgrade(existing_secret_plaintext=bytes(existing_plaintext_secret, encoding='utf-8'),
                                     new_secret_hash=new_secret_hash)
-        return txhashes
+        return receipts
 
     def retarget_proxy(self, contract_name: str, target_address: str, existing_plaintext_secret: str, new_plaintext_secret: str):
         Deployer = self.__get_deployer(contract_name=contract_name)
         deployer = Deployer(registry=self.registry, deployer_address=self.deployer_address)
         new_secret_hash = keccak(bytes(new_plaintext_secret, encoding='utf-8'))
-        txhash = deployer.retarget(target_address=target_address,
-                                   existing_secret_plaintext=bytes(existing_plaintext_secret, encoding='utf-8'),
-                                   new_secret_hash=new_secret_hash)
-        return txhash
+        receipts = deployer.retarget(target_address=target_address,
+                                     existing_secret_plaintext=bytes(existing_plaintext_secret, encoding='utf-8'),
+                                     new_secret_hash=new_secret_hash)
+        return receipts
 
     def rollback_contract(self, contract_name: str, existing_plaintext_secret: str, new_plaintext_secret: str):
         Deployer = self.__get_deployer(contract_name=contract_name)
         deployer = Deployer(registry=self.registry, deployer_address=self.deployer_address)
         new_secret_hash = keccak(bytes(new_plaintext_secret, encoding='utf-8'))
-        txhash = deployer.rollback(existing_secret_plaintext=bytes(existing_plaintext_secret, encoding='utf-8'),
-                                   new_secret_hash=new_secret_hash)
-        return txhash
+        receipts = deployer.rollback(existing_secret_plaintext=bytes(existing_plaintext_secret, encoding='utf-8'),
+                                     new_secret_hash=new_secret_hash)
+        return receipts
 
-    def deploy_user_escrow(self, allocation_registry: AllocationRegistry):
+    def deploy_user_escrow(self, allocation_registry: AllocationRegistry) -> UserEscrowDeployer:
         user_escrow_deployer = UserEscrowDeployer(registry=self.registry,
                                                   deployer_address=self.deployer_address,
                                                   allocation_registry=allocation_registry)

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -26,6 +26,9 @@ from web3 import Web3
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, DEPLOY_DIR, USER_LOG_DIR
 
 
+UNKNOWN_DEVELOPMENT_CHAIN_ID.bool_value(True)
+
+
 class Web3ClientError(Exception):
     pass
 
@@ -138,7 +141,7 @@ class Web3Client:
             'node_technology': node_technology,
             'version': client_data[1],
             'backend': client_data[-1],
-            'platform': client_data[2] if len(client_data) == 4 else None  # Plaftorm is optional
+            'platform': client_data[2] if len(client_data) == 4 else None  # Platform is optional
         }
 
         instance = ClientSubclass._get_variant(w3)(w3, **client_kwargs)

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -642,10 +642,10 @@ class BlockchainDeployerInterface(BlockchainInterface):
                                                        ContractFactoryClass=self._contract_factory)
         return wrapped_contract
 
-    def get_proxy(self,
-                  registry: BaseContractRegistry,
-                  target_address: str,
-                  proxy_name: str) -> Contract:
+    def get_proxy_contract(self,
+                           registry: BaseContractRegistry,
+                           target_address: str,
+                           proxy_name: str) -> Contract:
 
         # Lookup proxies; Search for a registered proxy that targets this contract record
         records = registry.search(contract_name=proxy_name)

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -481,7 +481,7 @@ class BlockchainInterface:
                 if version is None:
                     m = f"{len(target_contract_records)} records enrolled for contract {name} " \
                         f"and no version index was supplied."
-                    raise self.InterfaceError(m.format(name))
+                    raise self.InterfaceError(m)
                 version = self.__get_version_index(name=name,
                                                    version_index=version,
                                                    enrollments=len(target_contract_records))
@@ -508,7 +508,7 @@ class BlockchainInterface:
                 version = int(version_index)
             except ValueError:
                 what_is_this = version_index
-                raise ValueError(f"'{what_is_this}' is a valid version number")
+                raise ValueError(f"'{what_is_this}' is not a valid version number")
             else:
                 if version > enrollments - 1:
                     message = f"Version index '{version}' is larger than the number of enrollments for {name}."

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -22,11 +22,12 @@ import tempfile
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
 from os.path import dirname, abspath
-from typing import Union
+from typing import Union, Iterator
 
 import requests
 from constant_sorrow.constants import REGISTRY_COMMITTED
 from twisted.logger import Logger
+from web3.contract import Contract
 
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 
@@ -129,16 +130,16 @@ class BaseContractRegistry(ABC):
         return instance
 
     @property
-    def enrolled_names(self):
+    def enrolled_names(self) -> Iterator:
         entries = iter(record[0] for record in self.read())
         return entries
 
     @property
-    def enrolled_addresses(self):
+    def enrolled_addresses(self) -> Iterator:
         entries = iter(record[1] for record in self.read())
         return entries
 
-    def enroll(self, contract_name, contract_address, contract_abi):
+    def enroll(self, contract_name, contract_address, contract_abi) -> None:
         """
         Enrolls a contract to the chain registry by writing the name, address,
         and abi information to the filesystem as JSON.
@@ -157,7 +158,7 @@ class BaseContractRegistry(ABC):
         self.write(registry_data)
         self.log.info("Enrolled {}:{} into registry.".format(contract_name, contract_address))
 
-    def search(self, contract_name: str = None, contract_address: str = None):
+    def search(self, contract_name: str = None, contract_address: str = None) -> tuple:
         """
         Searches the registry for a contract with the provided name or address
         and returns the contracts component data.
@@ -185,7 +186,8 @@ class BaseContractRegistry(ABC):
             self.log.critical(m)
             raise self.IllegalRegistry(m.format(contract_address))
 
-        return contracts if contract_name else contracts[0]
+        result = tuple(contracts) if contract_name else contracts[0]
+        return result
 
 
 class LocalContractRegistry(BaseContractRegistry):

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -48,6 +48,7 @@ class BaseContractRegistry(ABC):
 
     # Registry
     REGISTRY_NAME = 'contract_registry.json'  # TODO: Save registry with ID-time-based filename
+    DEVELOPMENT_REGISTRY_NAME = 'dev_contract_registry.json'
 
     __PUBLICATION_USER = "nucypher"
     __PUBLICATION_REPO = f"{__PUBLICATION_USER}/ethereum-contract-registry"

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -53,7 +53,7 @@ class BaseContractRegistry(ABC):
     __PUBLICATION_USER = "nucypher"
     __PUBLICATION_REPO = f"{__PUBLICATION_USER}/ethereum-contract-registry"
     __PUBLICATION_BRANCH = 'goerli'          # TODO: Allow other branches to be used
-    _PUBLICATION_ENDPOINT = f'https://raw.githubusercontent.com/{__PUBLICATION_REPO}/{__PUBLICATION_BRANCH}/{REGISTRY_NAME}'
+    PUBLICATION_ENDPOINT = f'https://raw.githubusercontent.com/{__PUBLICATION_REPO}/{__PUBLICATION_BRANCH}/{REGISTRY_NAME}'
 
     class RegistryError(Exception):
         pass
@@ -112,12 +112,12 @@ class BaseContractRegistry(ABC):
         """
 
         # Setup
-        cls.logger.debug(f"Downloading contract registry from {cls._PUBLICATION_ENDPOINT}")
-        response = requests.get(cls._PUBLICATION_ENDPOINT)
+        cls.logger.debug(f"Downloading contract registry from {cls.PUBLICATION_ENDPOINT}")
+        response = requests.get(cls.PUBLICATION_ENDPOINT)
 
         # Fetch
         if response.status_code != 200:
-            error = f"Failed to fetch registry from {cls._PUBLICATION_ENDPOINT} with status code {response.status_code}"
+            error = f"Failed to fetch registry from {cls.PUBLICATION_ENDPOINT} with status code {response.status_code}"
             raise cls.RegistrySourceUnavailable(error)
 
         registry_data = response.content

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -90,10 +90,10 @@ contract StakingEscrow is Issuer {
         uint16 workerStartPeriod;
         // last confirmed active period
         uint16 lastActivePeriod;
-        bool measureWork;
-        uint256 completedWork;
         Downtime[] pastDowntime;
         SubStakeInfo[] subStakes;
+        bool measureWork;
+        uint256 completedWork;
     }
 
     /*
@@ -1216,6 +1216,11 @@ contract StakingEscrow is Issuer {
         bytes32 memoryAddress = delegateGetData(_target, "stakerInfo(address)", 1, _staker, 0);
         assembly {
             result := memoryAddress
+            // copy data to the right position after the array pointer place
+            // measureWork
+            mstore(add(memoryAddress, 0x140), mload(add(memoryAddress, 0x100)))
+            // completedWork
+            mstore(add(memoryAddress, 0x160), mload(add(memoryAddress, 0x120)))
         }
     }
 

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -417,4 +417,5 @@ def establish_deployer_registry(emitter,
     # All Done.
     registry = LocalContractRegistry(filepath=registry_filepath)
     emitter.message(f"Configured to registry filepath {registry_filepath}")
+
     return registry

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -407,7 +407,7 @@ def establish_deployer_registry(emitter,
             try:
                 _result = shutil.copyfile(registry_infile, registry_outfile)
             except shutil.SameFileError:
-                raise click.BadArgumentUsage("--registry-infile and --registry-outfile must not be the same path.")
+                raise click.BadArgumentUsage(f"--registry-infile and --registry-outfile must not be the same path '{registry_infile}'.")
         filepath = registry_outfile
     if dev:
         # TODO: Need a way to detect a geth --dev registry filepath here. (then deprecate the --dev flag)

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -48,7 +48,7 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 @click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)
 @click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
 @click.option('--deployer-address', help="Deployer's checksum address", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--retarget', '-d', help="Retarget a contract;s proxy.", is_flag=True)
+@click.option('--retarget', '-d', help="Retarget a contract's proxy.", is_flag=True)
 @click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--registry-infile', help="Input path for contract registry file", type=EXISTING_READABLE_FILE)
 @click.option('--value', help="Amount of tokens to transfer in the smallest denomination", type=click.INT)

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -122,7 +122,7 @@ def deploy(action,
 
     if action == "download-registry":
         if not force:
-            prompt = f"Fetch and download latest registry from {BaseContractRegistry._PUBLICATION_ENDPOINT}?"
+            prompt = f"Fetch and download latest registry from {BaseContractRegistry.PUBLICATION_ENDPOINT}?"
             click.confirm(prompt, abort=True)
         registry = InMemoryContractRegistry.from_latest_publication()
         output_filepath = registry.commit(filepath=registry_outfile, overwrite=force)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -422,7 +422,7 @@ Staking address: {staking_address}
                        division_message=division_message)
 
 
-def paint_receipt_summary(emitter, receipt, chain_name, transaction_type=None):
+def paint_receipt_summary(emitter, receipt, chain_name: str = None, transaction_type=None, provider_uri: str = None):
     tx_hash = receipt['transactionHash'].hex()
     emitter.echo("OK", color='green', nl=False, bold=True)
     if transaction_type:
@@ -431,6 +431,10 @@ def paint_receipt_summary(emitter, receipt, chain_name, transaction_type=None):
         emitter.echo(f" | {tx_hash}", color='yellow', nl=False)
     emitter.echo(f" ({receipt['gasUsed']} gas)")
     emitter.echo(f"Block #{receipt['blockNumber']} | {receipt['blockHash'].hex()}")
+
+    if not chain_name:
+        blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)
+        chain_name = blockchain.client.chain_name
     try:
         url = etherscan_url(item=tx_hash, network=chain_name)
     except ValueError as e:

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -19,6 +19,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import contextlib
 import os
 import socket
+import string
 import tempfile
 import time
 from datetime import datetime
@@ -96,7 +97,9 @@ NUMBER_OF_ALLOCATIONS_IN_TESTS = 100  # TODO: Move to constants
 # Insecure Secrets
 #
 
-INSECURE_DEVELOPMENT_PASSWORD = ''.join(SystemRandom().choice(ascii_uppercase + digits) for _ in range(16))
+__valid_password_chars = string.ascii_uppercase + string.ascii_lowercase + string.digits
+
+INSECURE_DEVELOPMENT_PASSWORD = ''.join(SystemRandom().choice(__valid_password_chars) for _ in range(16))
 
 STAKING_ESCROW_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urandom(16))
 
@@ -105,6 +108,10 @@ POLICY_MANAGER_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urando
 USER_ESCROW_PROXY_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urandom(16))
 
 ADJUDICATOR_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urandom(16))
+
+INSECURE_DEPLOYMENT_SECRET_PLAINTEXT = bytes(''.join(SystemRandom().choice(__valid_password_chars) for _ in range(16)), encoding='utf-8')
+
+INSECURE_DEPLOYMENT_SECRET_HASH = keccak_digest(INSECURE_DEPLOYMENT_SECRET_PLAINTEXT)
 
 
 #
@@ -155,5 +162,3 @@ TEST_GAS_LIMIT = 8_000_000  # gas
 
 PYEVM_GAS_LIMIT = TEST_GAS_LIMIT  # TODO: move elsewhere (used to set pyevm gas limit in tests)?
 
-INSECURE_DEPLOYMENT_SECRET_PLAINTEXT = os.urandom(32)
-INSECURE_DEPLOYMENT_SECRET_HASH = keccak_digest(INSECURE_DEPLOYMENT_SECRET_PLAINTEXT)

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -13,7 +13,8 @@ from web3 import Web3
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import AliceConfiguration, BobConfiguration
 from nucypher.crypto.kits import UmbralMessageKit
-from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, TEMPORARY_DOMAIN, TEST_PROVIDER_URI
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, TEMPORARY_DOMAIN, TEST_PROVIDER_URI, \
+    MOCK_REGISTRY_FILEPATH
 from nucypher.utilities.sandbox.ursula import start_pytest_ursula_services
 
 PLAINTEXT = "I'm bereaved, not a sap!"
@@ -92,10 +93,9 @@ def test_decentralized_cli_lifecycle(click_runner,
                                      blockchain_ursulas,
                                      custom_filepath,
                                      custom_filepath_2,
-                                     test_registry,
-                                     mock_primary_registry_filepath):
+                                     test_registry):
 
-    registry_filepath = test_registry.commit(filepath=mock_primary_registry_filepath, overwrite=True)
+    registry_filepath = test_registry.commit(filepath=MOCK_REGISTRY_FILEPATH, overwrite=True)
     yield _cli_lifecycle(click_runner,
                          testerchain,
                          random_policy_label,

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -95,7 +95,7 @@ def test_decentralized_cli_lifecycle(click_runner,
                                      test_registry,
                                      mock_primary_registry_filepath):
 
-    registry_filepath = test_registry.commit(filepath=mock_primary_registry_filepath)
+    registry_filepath = test_registry.commit(filepath=mock_primary_registry_filepath, overwrite=True)
     yield _cli_lifecycle(click_runner,
                          testerchain,
                          random_policy_label,

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -39,7 +39,7 @@ INSECURE_SECRETS = {v: generate_insecure_secret() for v in range(1, PLANNED_UPGR
 @pytest.fixture(scope="module")
 def registry_filepath(test_registry):
     # TODO: Use temp module
-    registry_filepath = os.path.join('tmp', 'nucypher-deploy-test.json')
+    registry_filepath = os.path.join('/', 'tmp', 'nucypher-deploy-test.json')
     if os.path.exists(registry_filepath):
         os.remove(registry_filepath)
     yield registry_filepath

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -234,11 +234,12 @@ def test_upgrade_contracts(click_runner, registry_filepath, testerchain):
         # Select upgrade interactive input scenario
         current_version = version_tracker[contract_name]
         new_version = current_version + 1
-        user_input = upgrade_inputs[new_version]
+        user_input = upgrade_inputs[new_version] + f'Y\n'  # Yes to confirm
 
         # Execute upgrade (Meat)
         result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
-        assert result.exit_code == 0  # TODO: Console painting
+        assert result.exit_code == 0
+        assert "Successfully deployed" in result.output
 
         # Mutate the version tracking
         version_tracker[contract_name] += 1

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -219,9 +219,9 @@ def test_upgrade_contracts(click_runner, registry_filepath, testerchain):
                                                              use_proxy_address=False)
 
         # Ensure the proxy targets the current deployed contract
-        proxy = testerchain.get_proxy(registry=registry,
-                                      target_address=real_old_contract.address,
-                                      proxy_name=proxy_name)
+        proxy = testerchain.get_proxy_contract(registry=registry,
+                                               target_address=real_old_contract.address,
+                                               proxy_name=proxy_name)
         targeted_address = proxy.functions.target().call()
         assert targeted_address == real_old_contract.address
 
@@ -274,9 +274,9 @@ def test_upgrade_contracts(click_runner, registry_filepath, testerchain):
         assert old_address != new_address
 
         # Ensure the proxy now targets the new deployment
-        proxy = testerchain.get_proxy(registry=registry,
-                                      target_address=new_address,
-                                      proxy_name=proxy_name)
+        proxy = testerchain.get_proxy_contract(registry=registry,
+                                               target_address=new_address,
+                                               proxy_name=proxy_name)
         targeted_address = proxy.functions.target().call()
         assert targeted_address != old_address
         assert targeted_address == new_address
@@ -323,13 +323,13 @@ def test_rollback(click_runner, testerchain, registry_filepath):
 
         # Ensure the proxy targets the rollback target (previous version)
         with pytest.raises(BlockchainInterface.UnknownContract):
-            testerchain.get_proxy(registry=registry,
-                                  target_address=current_target_address,
-                                  proxy_name='Dispatcher')
+            testerchain.get_proxy_contract(registry=registry,
+                                           target_address=current_target_address,
+                                           proxy_name='Dispatcher')
 
-        proxy = testerchain.get_proxy(registry=registry,
-                                      target_address=rollback_target_address,
-                                      proxy_name='Dispatcher')
+        proxy = testerchain.get_proxy_contract(registry=registry,
+                                               target_address=rollback_target_address,
+                                               proxy_name='Dispatcher')
 
         # Deeper - Ensure the proxy targets the old deployment on-chain
         targeted_address = proxy.functions.target().call()

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -32,19 +32,19 @@ def generate_insecure_secret() -> str:
     return formatted_secret
 
 
+# TODO: Use temp module
+DEPLOYMENT_REGISTRY_FILEPATH = os.path.join('/', 'tmp', f'nucypher-test-autodeploy.json')
 PLANNED_UPGRADES = 4
 INSECURE_SECRETS = {v: generate_insecure_secret() for v in range(1, PLANNED_UPGRADES+1)}
 
 
 @pytest.fixture(scope="module")
-def registry_filepath(test_registry):
-    # TODO: Use temp module
-    registry_filepath = os.path.join('/', 'tmp', 'nucypher-deploy-test.json')
-    if os.path.exists(registry_filepath):
-        os.remove(registry_filepath)
-    yield registry_filepath
-    if os.path.exists(registry_filepath):
-        os.remove(registry_filepath)
+def registry_filepath():
+    if os.path.exists(DEPLOYMENT_REGISTRY_FILEPATH):
+        os.remove(DEPLOYMENT_REGISTRY_FILEPATH)
+    yield DEPLOYMENT_REGISTRY_FILEPATH
+    if os.path.exists(DEPLOYMENT_REGISTRY_FILEPATH):
+        os.remove(DEPLOYMENT_REGISTRY_FILEPATH)
 
 
 def test_nucypher_deploy_contracts(click_runner,
@@ -55,6 +55,9 @@ def test_nucypher_deploy_contracts(click_runner,
     #
     # Main
     #
+
+    assert not os.path.exists(registry_filepath), f"Registry File '{registry_filepath}' Exists."
+    assert not os.path.lexists(registry_filepath), f"Registry File '{registry_filepath}' Exists."
 
     command = ['contracts',
                '--registry-outfile', registry_filepath,

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -33,7 +33,7 @@ def generate_insecure_secret() -> str:
 
 
 # TODO: Use temp module
-DEPLOYMENT_REGISTRY_FILEPATH = os.path.join('/', 'tmp', f'nucypher-test-autodeploy.json')
+DEPLOYMENT_REGISTRY_FILEPATH = os.path.join('/', 'tmp', 'nucypher-test-autodeploy.json')
 PLANNED_UPGRADES = 4
 INSECURE_SECRETS = {v: generate_insecure_secret() for v in range(1, PLANNED_UPGRADES+1)}
 

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -2,7 +2,6 @@ import os
 
 import pytest
 
-from nucypher.cli import deploy
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import FelixConfiguration, UrsulaConfiguration, AliceConfiguration
 from nucypher.config.keyring import NucypherKeyring
@@ -12,9 +11,9 @@ from nucypher.utilities.sandbox.constants import (
     INSECURE_DEVELOPMENT_PASSWORD,
     TEST_PROVIDER_URI,
     MOCK_IP_ADDRESS,
-    MOCK_IP_ADDRESS_2
+    MOCK_IP_ADDRESS_2,
+    MOCK_REGISTRY_FILEPATH
 )
-from nucypher.utilities.sandbox.ursula import start_pytest_ursula_services
 
 
 def test_destroy_with_no_configurations(click_runner, custom_filepath):
@@ -29,7 +28,6 @@ def test_destroy_with_no_configurations(click_runner, custom_filepath):
 
 def test_coexisting_configurations(click_runner,
                                    custom_filepath,
-                                   mock_primary_registry_filepath,
                                    testerchain,
                                    test_registry,
                                    agency):
@@ -78,7 +76,7 @@ def test_coexisting_configurations(click_runner,
                        '--network', TEMPORARY_DOMAIN,
                        '--provider', TEST_PROVIDER_URI,
                        '--checksum-address', felix,
-                       '--registry-filepath', mock_primary_registry_filepath,
+                       '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                        '--debug')
 
     result = click_runner.invoke(nucypher_cli, felix_init_args, catch_exceptions=False, env=envvars)
@@ -95,7 +93,7 @@ def test_coexisting_configurations(click_runner,
                        '--network', TEMPORARY_DOMAIN,
                        '--provider', TEST_PROVIDER_URI,
                        '--pay-with', alice,
-                       '--registry-filepath', mock_primary_registry_filepath,
+                       '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                        '--config-root', custom_filepath)
 
     result = click_runner.invoke(nucypher_cli, alice_init_args, catch_exceptions=False, env=envvars)
@@ -113,7 +111,7 @@ def test_coexisting_configurations(click_runner,
                  '--worker-address', ursula,
                  '--staker-address', staker,
                  '--rest-host', MOCK_IP_ADDRESS,
-                 '--registry-filepath', mock_primary_registry_filepath,
+                 '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                  '--config-root', custom_filepath)
 
     result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False, env=envvars)
@@ -131,7 +129,7 @@ def test_coexisting_configurations(click_runner,
                  '--worker-address', another_ursula,
                  '--staker-address', staker,
                  '--rest-host', MOCK_IP_ADDRESS_2,
-                 '--registry-filepath', mock_primary_registry_filepath,
+                 '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                  '--provider', TEST_PROVIDER_URI,
                  '--config-root', custom_filepath)
 
@@ -204,8 +202,7 @@ def test_coexisting_configurations(click_runner,
 
 def test_corrupted_configuration(click_runner,
                                  custom_filepath,
-                                 testerchain,
-                                 mock_primary_registry_filepath):
+                                 testerchain):
     alice, ursula, another_ursula, felix, staker, *all_yall = testerchain.unassigned_accounts
 
     init_args = ('ursula', 'init',
@@ -241,7 +238,7 @@ def test_corrupted_configuration(click_runner,
                  '--worker-address', another_ursula,
                  '--staker-address', staker,
                  '--rest-host', MOCK_IP_ADDRESS,
-                 '--registry-filepath', mock_primary_registry_filepath,
+                 '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                  '--config-root', custom_filepath)
 
     envvars = {'NUCYPHER_KEYRING_PASSWORD': INSECURE_DEVELOPMENT_PASSWORD}
@@ -258,7 +255,7 @@ def test_corrupted_configuration(click_runner,
         assert field in top_level_config_root
 
     # "Corrupt" the configuration by removing the contract registry
-    os.remove(mock_primary_registry_filepath)
+    os.remove(MOCK_REGISTRY_FILEPATH)
 
     # Attempt destruction with invalid configuration (missing registry)
     ursula_file_location = os.path.join(custom_filepath, default_filename)

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -30,22 +30,13 @@ from nucypher.blockchain.eth.agents import (
 from nucypher.blockchain.eth.registry import InMemoryContractRegistry
 from nucypher.blockchain.eth.token import NU
 from nucypher.cli.status import status
-from nucypher.utilities.sandbox.constants import TEST_PROVIDER_URI
-
-registry_filepath = '/tmp/nucypher-test-registry.json'
-
-
-@pytest.fixture(scope='module', autouse=True)
-def temp_registry(testerchain, test_registry, agency):
-    # Disable registry fetching, use the mock one instead
-    InMemoryContractRegistry.download_latest_publication = lambda: registry_filepath
-    test_registry.commit(filepath=registry_filepath)
+from nucypher.utilities.sandbox.constants import TEST_PROVIDER_URI, MOCK_REGISTRY_FILEPATH
 
 
 def test_nucypher_status_network(click_runner, testerchain, test_registry, agency):
 
     network_command = ('network',
-                       '--registry-filepath', registry_filepath,
+                       '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                        '--provider', TEST_PROVIDER_URI,
                        '--poa')
 
@@ -71,7 +62,7 @@ def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agenc
 
     # Get all stakers info
     stakers_command = ('stakers',
-                       '--registry-filepath', registry_filepath,
+                       '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                        '--provider', TEST_PROVIDER_URI,
                        '--poa')
 
@@ -89,7 +80,7 @@ def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agenc
     some_dude = random.choice(stakers)
     staking_address = some_dude.checksum_address
     stakers_command = ('stakers', '--staking-address', staking_address,
-                       '--registry-filepath', registry_filepath,
+                       '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                        '--provider', TEST_PROVIDER_URI,
                        '--poa')
 

--- a/tests/cli/ursula/test_run_ursula.py
+++ b/tests/cli/ursula/test_run_ursula.py
@@ -32,7 +32,7 @@ from nucypher.utilities.sandbox.constants import (
     INSECURE_DEVELOPMENT_PASSWORD,
     MOCK_URSULA_STARTING_PORT,
     TEMPORARY_DOMAIN,
-    TEST_PROVIDER_URI, MOCK_IP_ADDRESS)
+    TEST_PROVIDER_URI, MOCK_IP_ADDRESS, MOCK_REGISTRY_FILEPATH)
 from nucypher.utilities.sandbox.ursula import start_pytest_ursula_services
 
 
@@ -114,8 +114,7 @@ def test_persistent_node_storage_integration(click_runner,
                                              custom_filepath,
                                              testerchain,
                                              blockchain_ursulas,
-                                             agency,
-                                             mock_primary_registry_filepath):
+                                             agency):
 
     alice, ursula, another_ursula, felix, staker, *all_yall = testerchain.unassigned_accounts
     filename = UrsulaConfiguration.generate_filename()
@@ -128,7 +127,7 @@ def test_persistent_node_storage_integration(click_runner,
                  '--network', TEMPORARY_DOMAIN,
                  '--rest-host', MOCK_IP_ADDRESS,
                  '--config-root', custom_filepath,
-                 '--registry-filepath', mock_primary_registry_filepath,
+                 '--registry-filepath', MOCK_REGISTRY_FILEPATH,
                  )
 
     envvars = {'NUCYPHER_KEYRING_PASSWORD': INSECURE_DEVELOPMENT_PASSWORD}


### PR DESCRIPTION
##### Motivation

Deployment tooling and UX response to state verification failures experienced during `StakingEscrow` upgrade.  Provides a workflow to help mitigate a *partially* completed contract upgrade.

##### Points of Interest

- Engagement of `_deploy_essential` without deploying a proxy any additional transactions via CLI (`--bare`).
- Proxy contract upgrade / retargeting without contract re-deployment (nucypher upgrade --retarget ...).
- Adds deployer methods for better direct-access to contracts both targeted and, untargeted by proxies.
- Allows for an alternate registry output file path to be used via depolyment CLI (`--registry-outfile`).
- Clean-up registry mocking and fixture usage.  (always use `MOCK_REGISTRY_FILEPATH`)

Based on #1345  and #1350 

##### Re-Attempt at Upgrade/Re-Target

without gas limit -> <https://gist.github.com/KPrasch/58b26d20dc2fef7505e4634e5680f49e>
with gas limit -> <https://gist.github.com/KPrasch/5977b5ce353c4ea832219d1a76f2faab>

##### Successful Upgrade

```
(nucypher) kieran@pegasus:~/Git/nucypher$ nucypher-deploy upgrade --contract-name StakingEscrow --provider ~/.ethereum/goerli/geth.ipc --poa --hw-wallet 
WARNING: --etherscan is disabled. If you want to see deployed contracts and TXs in your browser, activate --etherscan.
Configured to registry filepath /home/kieran/.local/share/nucypher/contract_registry.json
0 | 0xb3aD00CB3fEcbfe729cb496C70aC420FDc229AAC 
1 | 0xcC0678E51a8237b762c09d6548d2d07285609e98 
Select deployer account [0]: 0
Selected 0xb3aD00CB3fEcbfe729cb496C70aC420FDc229AAC - Continue? [y/N]: y


Deployer ETH balance: 4.266476613
Enter existing contract upgrade secret: 
Enter new contract upgrade secret: 
Repeat for confirmation: 
Confirm deploy new version of StakingEscrow and retarget proxy? [y/N]: y
Successfully deployed and upgraded StakingEscrow
OK | 0xcb45d757ada0bcb6680dd612e32801abbe6e229a50f813cce95871b8ba14eabe (6198413 gas)
Block #1331807 | 0x20e4b2a612adb87a04a58862c0ed65c331e1ae6dc67633730577a2cb97ba7886
 See https://goerli.etherscan.io/tx/0xcb45d757ada0bcb6680dd612e32801abbe6e229a50f813cce95871b8ba14eabe

OK | 0xc412091ff584e97dbd7d4d48293cfc0e598305a9e99bd44940f4e9fb845be38a (309496 gas)
Block #1331808 | 0xb11804c63bbfa97459385685b83f1f7573e5055fb1f35b4a8a075201a6bfc1e2
 See https://goerli.etherscan.io/tx/0xc412091ff584e97dbd7d4d48293cfc0e598305a9e99bd44940f4e9fb845be38a

```

