### PR TITLE
Fix StakingEscrow state for upgrading

### DIFF
--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -90,10 +90,10 @@ contract StakingEscrow is Issuer {
         uint16 workerStartPeriod;
         // last confirmed active period
         uint16 lastActivePeriod;
-        bool measureWork;
-        uint256 completedWork;
         Downtime[] pastDowntime;
         SubStakeInfo[] subStakes;
+        bool measureWork;
+        uint256 completedWork;
     }
 
     /*
@@ -1216,6 +1216,11 @@ contract StakingEscrow is Issuer {
         bytes32 memoryAddress = delegateGetData(_target, "stakerInfo(address)", 1, _staker, 0);
         assembly {
             result := memoryAddress
+            // copy data to the right position after the array pointer place
+            // measureWork
+            mstore(add(memoryAddress, 0x140), mload(add(memoryAddress, 0x100)))
+            // completedWork
+            mstore(add(memoryAddress, 0x160), mload(add(memoryAddress, 0x120)))
         }
     }
 


### PR DESCRIPTION
Deployed in testnet:
```
struct StakerInfo {
        uint256 value;
        uint16 confirmedPeriod1;
        uint16 confirmedPeriod2;
        bool reStake;
        uint16 lockReStakeUntilPeriod;
        address worker;
        // period when worker was set
        uint16 workerStartPeriod;
        // last confirmed active period
        uint16 lastActivePeriod;
        Downtime[] pastDowntime;
        SubStakeInfo[] subStakes;
}
```
and in master:
```
struct StakerInfo {
        uint256 value;
        uint16 confirmedPeriod1;
        uint16 confirmedPeriod2;
        bool reStake;
        uint16 lockReStakeUntilPeriod;
        address worker;
        // period when worker was set
        uint16 workerStartPeriod;
        // last confirmed active period
        uint16 lastActivePeriod;
        bool measureWork;
        uint256 completedWork;
        Downtime[] pastDowntime;
        SubStakeInfo[] subStakes;
}
```
and `require` with `delegateGet(_testTarget, "getPastDowntimeLength(address)", staker)` fails in `verifyState` because `pastDowntime` in new contract in a wrong slot
`measureWork` and `completedWork` must be after `subStakes`