### PR TITLE
Add @pytest.mark.nightly marker to specify nightly tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 6 * * *"   # Scheduled for 0800 CEST / 2300 PDT
+          cron: "0 6 * * *"   # Scheduled for 0600 UTC (0800 CEST, 2300 PDT)
           filters:
             branches:
               only:
@@ -689,5 +689,5 @@ jobs:
       - run:
           name: Statistical tests (e.g., sampling)
           command: |
-            pytest --run-nightly tests/blockchain/eth/contracts/main/staking_escrow/test_sampling_distribution.py
+            pytest --run-nightly --no-cov tests/blockchain/eth/contracts/main/staking_escrow/test_sampling_distribution.py
       - capture_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,13 +184,11 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "45 * * * *" # Just for testing configs
-          # cron: "0 6 * * *"   # Scheduled for 0800 CEST / 2300 PDT
+          cron: "0 6 * * *"   # Scheduled for 0800 CEST / 2300 PDT
           filters:
             branches:
               only:
                 - master
-                - foo
     jobs:
       - pipenv_install_36:
           filters:
@@ -212,6 +210,13 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - statistical_tests:
+          context: "Nightly Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
 
 
 python_36_base: &python_36_base
@@ -675,3 +680,14 @@ jobs:
           command: |
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
             docker push nucypher/nucypher:$CIRCLE_TAG
+
+  statistical_tests:
+      <<: *python_37_base
+      parallelism: 1
+      steps:
+      - prepare_environment
+      - run:
+          name: Statistical tests (e.g., sampling)
+          command: |
+            pytest --run-nightly tests/blockchain/eth/contracts/main/staking_escrow/test_sampling_distribution.py
+      - capture_test_results

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,2 @@
 [pytest]
 addopts = -v --runslow --junitxml=./reports/pytest-results.xml --strict-markers --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml
-markers =
-    slow: marks tests as slow (skipped by default, use '--runslow' to include these tests)

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_sampling_distribution.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_sampling_distribution.py
@@ -20,10 +20,9 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.constants import STAKING_ESCROW_CONTRACT_NAME
 
 
-# TODO: #1288 - Consider moving this test out from regular CI workflow to a scheduled workflow (e.g., nightly)
-# @pytest.mark.slow
-@pytest.mark.skip("Until SAMPLES can be raised. See #1288")
+@pytest.mark.nightly
 def test_sampling_distribution(testerchain, token, deploy_contract):
+
 
     #
     # SETUP
@@ -90,7 +89,7 @@ def test_sampling_distribution(testerchain, token, deploy_contract):
     #
 
     ERROR_TOLERANCE = 0.05  # With this tolerance, all sampling ratios should between 5% and 15% (expected is 10%)
-    SAMPLES = 100
+    SAMPLES = 300
     quantity = 3
     import random
     from collections import Counter


### PR DESCRIPTION
* Adds support in our pytest config to the `@pytest.mark.nightly` marker, similar to  `@pytest.mark.slow` but for tests that are specifically designed for nightly builds.
* Uses this marker for running a more robust statistical test for sampling (Closes #1288)
* Schedules tests to run at **06:00 UTC** (08:00 CEST, 23:00 PDT).
   * East coast nucypherinos should be sleeping
   * West coast nucypherinos should be brushing their teeth
  * European nucypherinos are snoozing the alarm for the third time
