### PR TITLE
Glossary Page for Docs

### DIFF
--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,0 +1,78 @@
+Glossary
+========
+
+.. _Umbral: https://github.com/nucypher/umbral-doc/blob/master/umbral-doc.pdf
+
+.. glossary::
+
+    Alice
+      *"The Data Owner"* :term:`Character` - retains full control over the data encrypted for her and determines whom to share the data with.
+
+    Bob
+      *"The Data Recipient"* :term:`Character` - the data recipient that :term:`Alice` intends to share data with.
+
+    Capsule
+      Encrypted symmetric key (:term:`KEM`) that is eventually re-encrypted.
+
+    cFrag
+      A fragment of ciphertext that is a partial re-encryption produced by a :term:`kFrag` operation on a :term:`Capsule`.
+
+    Character
+      A common term for any entity fulfilling a particular role in our cryptographic narrative.
+
+    DEM
+      Data encapsulation mechanism - data encrypted with a symmetric key.
+
+    Enrico
+      *"The Encryptor"* :term:`Character` - a data source that encrypts data on behalf of :term:`Alice` and produces a :term:`MessageKit`.
+
+    Felix
+      *"The Faucet"* :term:`Character` - provides *testnet* NU tokens for nodes on the test NuCypher Network.
+
+    KEM
+      Key encapsulation mechanism - a symmetric key encrypted with an asymmetric key
+
+    kFrag
+      A fragment of a :term:`Re-encryption Key`.
+
+    Label
+      A title for a classification/categorization of data according to how it is intended to be shared.
+
+    MessageKit
+      The :term:`KEM` and :term:`DEM` encrypted data that is stored together.
+
+    Moe
+      *"The Monitor"* :term:`Character` - provides a high-level view of the NuCypher Network.
+
+    NU
+      The NuCypher token used by nodes for staking.
+
+    NuNit
+        1 NU = 10\ :sup:`18` NuNits.
+
+    PKE
+      Public-key encryption.
+
+    PRE
+      Proxy re-encryption.
+
+    Re-encryption Key
+      A key that facilitates the transformation of ciphertext from one encryption key to another.
+
+    Stake
+      A quantity of tokens and escrow duration in periods.
+
+    Staker
+      An account that holds NU tokens and performs staking-related operations on the blockchain.
+
+    Stamp
+      The public key for a :term:`Character`'s signing key pair.
+
+    Umbral
+      NuCypher's threshold proxy re-encryption scheme - it takes standard :term:`PRE` and increases the security and performance. See Umbral_.
+
+    Ursula
+      *"The Proxy in PRE"* :term:`Character` - the nodes on the NuCypher Network that stand ready to re-encrypt data in exchange for payment in fees and token rewards; they enforce the access policy created by :term:`Alice`.
+
+    Worker
+      An account that is actively doing work in the network as an :term:`Ursula` node - a worker is bonded to, and performs work on behalf of, a :term:`Staker`.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -48,7 +48,10 @@ Glossary
       The NuCypher token used by nodes for staking.
 
     NuNit
-        1 NU = 10\ :sup:`18` NuNits.
+      1 NU = 10\ :sup:`18` NuNits.
+
+    Period
+      A timeframe of approximately a day in the NuCypher Network.
 
     PKE
       Public-key encryption.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -156,6 +156,12 @@ Whitepapers
 
    release_notes/genesis_release
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Glossary
+
+   glossary
+
 
 Indices and Tables
 ==================


### PR DESCRIPTION
While I'm playing with the docs for #1365, I figured we could add some initial work on a glossary that could be updated over time.

To reference the glossary term anywhere in the docs, you can use :term:\`Glossary Term\` - see https://sublime-and-sphinx-guide.readthedocs.io/en/latest/glossary.html.

Fixes #28 .