### PR TITLE
[APPROVED - DON'T MERGE YET] Fix potential problem with EIP-1884

### DIFF
--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.5.3;
 import "zeppelin/token/ERC20/SafeERC20.sol";
 import "zeppelin/math/SafeMath.sol";
 import "zeppelin/math/Math.sol";
+import "zeppelin/utils/Address.sol";
 import "contracts/lib/AdditionalMath.sol";
 import "contracts/StakingEscrow.sol";
 import "contracts/NuCypherToken.sol";
@@ -19,6 +20,7 @@ contract PolicyManager is Upgradeable {
     using AdditionalMath for uint256;
     using AdditionalMath for int256;
     using AdditionalMath for uint16;
+    using Address for address payable;
 
     event PolicyCreated(
         bytes16 indexed policyId,
@@ -216,9 +218,7 @@ contract PolicyManager is Upgradeable {
         uint256 reward = node.reward;
         require(reward != 0);
         node.reward = 0;
-        // Transfer reward to _recipient
-        (bool success, ) = _recipient.call.value(reward)("");
-        require(success);
+        _recipient.sendValue(reward);
         emit Withdrawn(msg.sender, _recipient, reward);
         return reward;
     }
@@ -340,9 +340,7 @@ contract PolicyManager is Upgradeable {
             require(i < policy.arrangements.length);
         }
         if (refundValue > 0) {
-            // Transfer refund to creator
-            (bool success, ) = msg.sender.call.value(refundValue)("");
-            require(success);
+            msg.sender.sendValue(refundValue);
         }
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -216,6 +216,7 @@ contract PolicyManager is Upgradeable {
         uint256 reward = node.reward;
         require(reward != 0);
         node.reward = 0;
+        // Transfer reward to _recipient
         (bool success, ) = _recipient.call.value(reward)("");
         require(success);
         emit Withdrawn(msg.sender, _recipient, reward);
@@ -339,6 +340,7 @@ contract PolicyManager is Upgradeable {
             require(i < policy.arrangements.length);
         }
         if (refundValue > 0) {
+            // Transfer refund to creator
             (bool success, ) = msg.sender.call.value(refundValue)("");
             require(success);
         }

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -216,7 +216,8 @@ contract PolicyManager is Upgradeable {
         uint256 reward = node.reward;
         require(reward != 0);
         node.reward = 0;
-        _recipient.transfer(reward);
+        (bool success, ) = _recipient.call.value(reward)("");
+        require(success);
         emit Withdrawn(msg.sender, _recipient, reward);
         return reward;
     }
@@ -338,7 +339,8 @@ contract PolicyManager is Upgradeable {
             require(i < policy.arrangements.length);
         }
         if (refundValue > 0) {
-            msg.sender.transfer(refundValue);
+            (bool success, ) = msg.sender.call.value(refundValue)("");
+            require(success);
         }
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -128,7 +128,8 @@ contract WorkLock {
         completedWork = refundETH.mul(refundRate);
         info.completedWork = info.completedWork.add(completedWork);
         emit Refund(msg.sender, refundETH, completedWork);
-        msg.sender.transfer(refundETH);
+        (bool success, ) = msg.sender.call.value(refundETH)("");
+        require(success);
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.3;
 
 
 import "zeppelin/math/SafeMath.sol";
+import "zeppelin/utils/Address.sol";
 import "contracts/NuCypherToken.sol";
 import "contracts/StakingEscrow.sol";
 
@@ -11,6 +12,7 @@ import "contracts/StakingEscrow.sol";
 **/
 contract WorkLock {
     using SafeMath for uint256;
+    using Address for address payable;
 
     event Bid(address indexed staker, uint256 depositedETH, uint256 claimedTokens);
     event Claimed(address indexed staker, uint256 claimedTokens);
@@ -128,9 +130,7 @@ contract WorkLock {
         completedWork = refundETH.mul(refundRate);
         info.completedWork = info.completedWork.add(completedWork);
         emit Refund(msg.sender, refundETH, completedWork);
-        // Transfer refund to sender
-        (bool success, ) = msg.sender.call.value(refundETH)("");
-        require(success);
+        msg.sender.sendValue(refundETH);
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -128,6 +128,7 @@ contract WorkLock {
         completedWork = refundETH.mul(refundRate);
         info.completedWork = info.completedWork.add(completedWork);
         emit Refund(msg.sender, refundETH, completedWork);
+        // Transfer refund to sender
         (bool success, ) = msg.sender.call.value(refundETH)("");
         require(success);
     }

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.5.3;
 import "zeppelin/ownership/Ownable.sol";
 import "zeppelin/token/ERC20/SafeERC20.sol";
 import "zeppelin/math/SafeMath.sol";
+import "zeppelin/utils/Address.sol";
 import "contracts/NuCypherToken.sol";
 import "contracts/staking_contracts/AbstractStakingContract.sol";
 
@@ -15,6 +16,7 @@ import "contracts/staking_contracts/AbstractStakingContract.sol";
 contract PreallocationEscrow is AbstractStakingContract, Ownable {
     using SafeERC20 for NuCypherToken;
     using SafeMath for uint256;
+    using Address for address payable;
 
     event TokensDeposited(address indexed sender, uint256 value, uint256 duration);
     event TokensWithdrawn(address indexed owner, uint256 value);
@@ -73,9 +75,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     function withdrawETH() public onlyOwner {
         uint256 balance = address(this).balance;
         require(balance != 0);
-        // Transfer ETH to owner
-        (bool success, ) = msg.sender.call.value(balance)("");
-        require(success);
+        msg.sender.sendValue(balance);
         emit ETHWithdrawn(msg.sender, balance);
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -73,7 +73,8 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     function withdrawETH() public onlyOwner {
         uint256 balance = address(this).balance;
         require(balance != 0);
-        msg.sender.transfer(balance);
+        (bool success, ) = msg.sender.call.value(balance)("");
+        require(success);
         emit ETHWithdrawn(msg.sender, balance);
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -73,6 +73,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     function withdrawETH() public onlyOwner {
         uint256 balance = address(this).balance;
         require(balance != 0);
+        // Transfer ETH to owner
         (bool success, ) = msg.sender.call.value(balance)("");
         require(success);
         emit ETHWithdrawn(msg.sender, balance);

--- a/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
@@ -1,26 +1,68 @@
 pragma solidity ^0.5.3;
 
 /**
- * Utility library of inline functions on addresses
+ * @dev Collection of functions related to the address type
  */
 library Address {
     /**
-     * Returns whether the target address is a contract
-     * @dev This function will return false if invoked during the constructor of a contract,
-     * as the code is not actually created until after the constructor finishes.
-     * @param account address of the account to check
-     * @return whether the target address is a contract
+     * @dev Returns true if `account` is a contract.
+     *
+     * This test is non-exhaustive, and there may be false-negatives: during the
+     * execution of a contract's constructor, its address will be reported as
+     * not containing a contract.
+     *
+     * IMPORTANT: It is unsafe to assume that an address for which this
+     * function returns false is an externally-owned account (EOA) and not a
+     * contract.
      */
     function isContract(address account) internal view returns (bool) {
-        uint256 size;
-        // XXX Currently there is no better way to check if there is a contract in an address
-        // than to check the size of the code at that address.
-        // See https://ethereum.stackexchange.com/a/14016/36603
-        // for more details about how this works.
-        // TODO Check this again before the Serenity release, because all addresses will be
-        // contracts then.
+        // This method relies in extcodesize, which returns 0 for contracts in
+        // construction, since the code is only stored at the end of the
+        // constructor execution.
+
+        // According to EIP-1052, 0x0 is the value returned for not-yet created accounts
+        // and 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is returned
+        // for accounts without code, i.e. `keccak256('')`
+        bytes32 codehash;
+        bytes32 accountHash = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
         // solhint-disable-next-line no-inline-assembly
-        assembly { size := extcodesize(account) }
-        return size > 0;
+        assembly { codehash := extcodehash(account) }
+        return (codehash != 0x0 && codehash != accountHash);
+    }
+
+    /**
+     * @dev Converts an `address` into `address payable`. Note that this is
+     * simply a type cast: the actual underlying value is not changed.
+     *
+     * _Available since v2.4.0._
+     */
+    function toPayable(address account) internal pure returns (address payable) {
+        return address(uint160(account));
+    }
+
+    /**
+     * @dev Replacement for Solidity's `transfer`: sends `amount` wei to
+     * `recipient`, forwarding all available gas and reverting on errors.
+     *
+     * https://eips.ethereum.org/EIPS/eip-1884[EIP1884] increases the gas cost
+     * of certain opcodes, possibly making contracts go over the 2300 gas limit
+     * imposed by `transfer`, making them unable to receive funds via
+     * `transfer`. {sendValue} removes this limitation.
+     *
+     * https://diligence.consensys.net/posts/2019/09/stop-using-soliditys-transfer-now/[Learn more].
+     *
+     * IMPORTANT: because control is transferred to `recipient`, care must be
+     * taken to not create reentrancy vulnerabilities. Consider using
+     * {ReentrancyGuard} or the
+     * https://solidity.readthedocs.io/en/v0.5.11/security-considerations.html#use-the-checks-effects-interactions-pattern[checks-effects-interactions pattern].
+     *
+     * _Available since v2.4.0._
+     */
+    function sendValue(address payable recipient, uint256 amount) internal {
+        require(address(this).balance >= amount, "Address: insufficient balance");
+
+        // solhint-disable-next-line avoid-call-value
+        (bool success, ) = recipient.call.value(amount)("");
+        require(success, "Address: unable to send value, recipient may have reverted");
     }
 }

--- a/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
@@ -86,13 +86,23 @@ contract StakingEscrowForPolicyMock {
 
     /**
     * @notice Emulate mint method
+    * @param _staker Staker on behalf of whom minting will be
+    * @param _startPeriod Start period for minting
+    * @param _numberOfPeriods Number periods for minting
+    **/
+    function mint(address _staker, uint16 _startPeriod, uint16 _numberOfPeriods) public {
+        for (uint16 i = 0; i < _numberOfPeriods; i++) {
+            policyManager.updateReward(_staker, i + _startPeriod);
+        }
+    }
+
+    /**
+    * @notice Emulate mint method
     * @param _startPeriod Start period for minting
     * @param _numberOfPeriods Number periods for minting
     **/
     function mint(uint16 _startPeriod, uint16 _numberOfPeriods) external {
-        for (uint16 i = 0; i < _numberOfPeriods; i++) {
-            policyManager.updateReward(msg.sender, i + _startPeriod);
-        }
+        mint(msg.sender, _startPeriod, _numberOfPeriods);
     }
 
     /**

--- a/tests/blockchain/eth/contracts/contracts/ReentrancyTest.sol
+++ b/tests/blockchain/eth/contracts/contracts/ReentrancyTest.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.5.3;
+
+
+/**
+* @dev Contract for reentrancy protection testing
+**/
+contract ReentrancyTest {
+
+    uint256 maxDepth = 1;
+    uint256 lockCounter;
+    address target;
+    uint256 value;
+    bytes data;
+
+    function setData(uint256 _maxDepth, address _target, uint256 _value, bytes calldata _data) external {
+        maxDepth = _maxDepth;
+        target = _target;
+        value = _value;
+        data = _data;
+    }
+
+    function () payable external {
+        // call only once
+        if (lockCounter >= maxDepth) {
+            return;
+        }
+        lockCounter++;
+        (bool callSuccess,) = target.call.value(value)(data);
+        require(callSuccess);
+        lockCounter--;
+    }
+
+}


### PR DESCRIPTION
[EIP-1884](https://github.com/ethereum/EIPs/blob/dcc573e74adc0e6dd25821ddaabf862e8f85e107/EIPS/eip-1884.md)

Potential issue: 
Problem may appear in calling `someAddress.transfer(ethAmount)` because it uses fixed gas limit (2300). Transfering ETH to some contract executes fallback function which can consume more than 2300 gas and probability of exceeding gas limit becomes greater with EIP-1884. For our network it means that not every intermediary contract can withdraw ETH (policy reward, worklock refund) from our contracts.
Fix:
Instead of not adjustable `transfer()` function use `call("")` with all initial gas limit
