### PR TITLE
Auto-detect HW wallet accounts in TransactingPower 

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -827,8 +827,8 @@ class Staker(NucypherTokenActor):
         """Withdraw tokens rewarded for staking."""
         if self.is_contract:
             reward_amount = self.staking_agent.calculate_staking_reward(staker_address=self.checksum_address)
-            self.log.debug(f"Withdrawing staking reward, {reward_amount}, to {self.checksum_address}")
-            receipt = self.user_escrow_agent.withdraw_as_staker(amount=reward_amount)
+            self.log.debug(f"Withdrawing staking reward ({NU.from_nunits(reward_amount)}) to {self.checksum_address}")
+            receipt = self.user_escrow_agent.withdraw_as_staker(value=reward_amount)
         else:
             receipt = self.staking_agent.collect_staking_reward(staker_address=self.checksum_address)
         return receipt
@@ -838,7 +838,7 @@ class Staker(NucypherTokenActor):
     def withdraw(self, amount: NU) -> str:
         """Withdraw tokens (assuming they're unlocked)"""
         if self.is_contract:
-            receipt = self.user_escrow_agent.withdraw_as_staker(amount=int(amount))
+            receipt = self.user_escrow_agent.withdraw_as_staker(value=int(amount))
         else:
             receipt = self.staking_agent.withdraw(staker_address=self.checksum_address,
                                                   amount=int(amount))
@@ -861,7 +861,6 @@ class Worker(NucypherTokenActor):
                  work_tracker: WorkTracker = None,
                  worker_address: str = None,
                  start_working_now: bool = True,
-                 confirm_now: bool = True,
                  check_active_worker: bool = True,
                  *args, **kwargs):
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -606,11 +606,9 @@ class Staker(NucypherTokenActor):
     @property
     def current_stake(self) -> NU:
         """
-        The total number of staked tokens, either locked or unlocked in the current period.
+        The total number of staked tokens, i.e., tokens locked in the current period.
         """
-        stake = self.staking_agent.owned_tokens(staker_address=self.checksum_address)
-        nu_stake = NU.from_nunits(stake)
-        return nu_stake
+        return self.locked_tokens(periods=0)
 
     @only_me
     def divide_stake(self,

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -374,7 +374,8 @@ class StakingEscrowAgent(EthereumContractAgent):
     def collect_staking_reward(self, staker_address: str):
         """Withdraw tokens rewarded for staking."""
         reward_amount = self.calculate_staking_reward(staker_address=staker_address)
-        self.log.debug(f"Withdrawing staking reward, {reward_amount}, to {staker_address}")
+        from nucypher.blockchain.eth.token import NU
+        self.log.debug(f"Withdrawing staking reward ({NU.from_nunits(reward_amount)}) to {staker_address}")
         return self.withdraw(staker_address=staker_address, amount=reward_amount)
 
     @validate_checksum_address

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -352,6 +352,10 @@ class GethClient(Web3Client):
         rlp_encoded_transaction = result.raw
         return rlp_encoded_transaction
 
+    @property
+    def wallets(self):
+        return self.w3.manager.request_blocking("personal_listWallets", [])
+
 
 class ParityClient(Web3Client):
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1390,7 +1390,6 @@ class StakeHolder(Staker):
                 self.__get_accounts()
                 if checksum_address not in self:
                     raise self.UnknownAccount
-            # TODO: What if cached TransactingPower is wrongly initialized? See issue #1385
             try:
                 transacting_power = self.__transacting_powers[checksum_address]
             except KeyError:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -796,6 +796,7 @@ class Ursula(Teacher, Character, Worker):
                  checksum_address: str = None,  # Staker address
                  worker_address: str = None,
                  work_tracker: WorkTracker = None,
+                 start_working_now: bool = True,
                  client_password: str = None,
 
                  # Character
@@ -856,7 +857,8 @@ class Ursula(Teacher, Character, Worker):
                                 registry=self.registry,
                                 checksum_address=checksum_address,
                                 worker_address=worker_address,
-                                work_tracker=work_tracker)
+                                work_tracker=work_tracker,
+                                start_working_now=start_working_now)
 
         #
         # ProxyRESTServer and TLSHostingPower #

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -442,7 +442,7 @@ def confirm_enable_restaking(emitter, staking_address: str) -> bool:
 
 def establish_deployer_registry(emitter,
                                 registry_infile: str = None,
-                                registry_outfile:str = None,
+                                registry_outfile: str = None,
                                 use_existing_registry: bool = False,
                                 dev: bool = False
                                 ) -> LocalContractRegistry:

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -166,11 +166,10 @@ def stake(click_config,
         allocation_registry = None
         initial_address = staking_address
 
-    dummy_password = "Look Away, I'm Hideous"  # TODO: See #1385
     STAKEHOLDER = stakeholder_config.produce(initial_address=initial_address,
-                                             allocation_registry=allocation_registry,
-                                             password=dummy_password)
+                                             allocation_registry=allocation_registry)
     blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)  # Eager connection
+
     economics = STAKEHOLDER.economics
 
     # Dynamic click types (Economics)

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -191,6 +191,7 @@ def stake(click_config,
         return  # Exit
 
     elif action == 'accounts':
+        # TODO: Order accounts like shown by blockchain.client.accounts
         for address, balances in STAKEHOLDER.wallet.balances.items():
             emitter.echo(f"{address} | {Web3.fromWei(balances['ETH'], 'ether')} ETH | {NU.from_nunits(balances['NU'])}")
         return  # Exit
@@ -420,16 +421,22 @@ def stake(click_config,
     elif action == 'collect-reward':
         """Withdraw staking reward to the specified wallet address"""
 
-        # TODO: Missing account selection
+        # Authenticate
+        client_account, staking_address = handle_client_account_for_staking(emitter=emitter,
+                                                                            stakeholder=STAKEHOLDER,
+                                                                            staking_address=staking_address,
+                                                                            is_preallocation_staker=is_preallocation_staker,
+                                                                            beneficiary_address=beneficiary_address,
+                                                                            force=force)
 
         password = None
         if not hw_wallet and not blockchain.client.is_local:
-            password = get_client_password(checksum_address=staking_address)
+            password = get_client_password(checksum_address=client_account)
 
         if not staking_reward and not policy_reward:
             raise click.BadArgumentUsage(f"Either --staking-reward or --policy-reward must be True to collect rewards.")
 
-        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+        STAKEHOLDER.assimilate(checksum_address=client_account, password=password)
         if staking_reward:
             # Note: Sending staking / inflation rewards to another account is not allowed.
             staking_receipt = STAKEHOLDER.collect_staking_reward()

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -159,8 +159,7 @@ def deploy(action,
     #
 
     if action == "inspect":
-        administrator = ContractAdministrator(registry=local_registry, deployer_address=deployer_address)
-        paint_deployer_contract_inspection(emitter=emitter, administrator=administrator)
+        paint_deployer_contract_inspection(emitter=emitter, registry=local_registry, deployer_address=deployer_address)
         return  # Exit
 
     #

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -519,16 +519,16 @@ def paint_stakers(emitter, stakers: List[str], agent) -> None:
         emitter.echo(f"{staker}  {'Nickname:':10} {nickname} {symbols}")
         tab = " " * len(staker)
 
-        stake = agent.owned_tokens(staker)
+        owned_tokens = agent.owned_tokens(staker)
         last_confirmed_period = agent.get_last_active_period(staker)
         worker = agent.get_worker_from_staker(staker)
         is_restaking = agent.is_restaking(staker)
 
         missing_confirmations = current_period - last_confirmed_period
-        stake_in_nu = round(NU.from_nunits(stake), 2)
+        owned_in_nu = round(NU.from_nunits(owned_tokens), 2)
         locked_tokens = round(NU.from_nunits(agent.get_locked_tokens(staker)), 2)
 
-        emitter.echo(f"{tab}  {'Stake:':10} {stake_in_nu}  (Locked: {locked_tokens})")
+        emitter.echo(f"{tab}  {'Owned:':10} {owned_in_nu}  (Staked: {locked_tokens})")
         if is_restaking:
             if agent.is_restaking_locked(staker):
                 unlock_period = agent.get_restake_unlock_period(staker)

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -45,6 +45,7 @@ from twisted.internet import task
 from twisted.internet.threads import deferToThread
 from twisted.logger import Logger
 
+from nucypher.blockchain.economics import TokenEconomicsFactory
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.registry import BaseContractRegistry
@@ -1012,9 +1013,19 @@ class Teacher:
         As a follow-up, this checks that the staker is, indeed, staking.
         """
         # Lazy agent get or create
-        staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)
-        locked_tokens = staking_agent.get_locked_tokens(staker_address=self.checksum_address)
-        return locked_tokens > 0  # TODO: Consider min stake size #1115
+        staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)  # type: StakingEscrowAgent
+
+        try:
+            economics = TokenEconomicsFactory.get_economics(registry=registry)
+        except Exception:
+            raise  # TODO: Get StandardEconomics
+
+        min_stake = economics.minimum_allowed_locked
+
+        stake_current_period = staking_agent.get_locked_tokens(staker_address=self.checksum_address, periods=0)
+        stake_next_period = staking_agent.get_locked_tokens(staker_address=self.checksum_address, periods=1)
+        is_staking = max(stake_current_period, stake_next_period) >= min_stake
+        return is_staking
 
     def validate_worker(self, registry: BaseContractRegistry = None) -> None:
 

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 from nucypher.blockchain.eth.agents import (
     PolicyManagerAgent,
     StakingEscrowAgent,
@@ -10,7 +8,7 @@ from nucypher.blockchain.eth.agents import (
 )
 from nucypher.blockchain.eth.constants import STAKING_ESCROW_CONTRACT_NAME
 from nucypher.blockchain.eth.deployers import StakingEscrowDeployer
-from nucypher.blockchain.eth.registry import InMemoryContractRegistry, LocalContractRegistry
+from nucypher.blockchain.eth.registry import LocalContractRegistry
 from nucypher.cli.deploy import deploy
 from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -92,7 +92,7 @@ def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agenc
 
     assert re.search(f"^Current period: {staking_agent.get_current_period()}", result.output, re.MULTILINE)
     assert re.search(r"Worker:\s+" + some_dude.worker_address, result.output, re.MULTILINE)
-    assert re.search(r"Stake:\s+" + str(round(owned_tokens, 2)), result.output, re.MULTILINE)
-    assert re.search(r"Locked: " + str(round(locked_tokens, 2)), result.output, re.MULTILINE)
+    assert re.search(r"Owned:\s+" + str(round(owned_tokens, 2)), result.output, re.MULTILINE)
+    assert re.search(r"Staked: " + str(round(locked_tokens, 2)), result.output, re.MULTILINE)
 
 

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -15,19 +15,33 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import datetime
 import json
+import os
+import random
 
+import maya
 import pytest
+from twisted.logger import Logger
 from web3 import Web3
 
 from nucypher.blockchain.eth.actors import Staker
 from nucypher.blockchain.eth.agents import StakingEscrowAgent, ContractAgency, UserEscrowAgent, NucypherTokenAgent
-from nucypher.blockchain.eth.token import NU, Stake
+from nucypher.blockchain.eth.token import NU, Stake, StakeList
+from nucypher.characters.lawful import Enrico, Ursula
 from nucypher.cli.main import nucypher_cli
+from nucypher.config.characters import UrsulaConfiguration
+from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,
     INSECURE_DEVELOPMENT_PASSWORD,
+    MOCK_IP_ADDRESS,
+    MOCK_URSULA_STARTING_PORT,
+    TEMPORARY_DOMAIN,
+    MOCK_KNOWN_URSULAS_CACHE,
+    select_test_port,
 )
+from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 #
 # This test module is intended to mirror tests/cli/ursula/test_stakeholder_and_ursula.py,
@@ -169,6 +183,68 @@ def test_stake_set_worker(click_runner,
     assert staker.worker_address == manual_worker
 
 
+def test_stake_detach_worker(click_runner,
+                             testerchain,
+                             token_economics,
+                             beneficiary,
+                             user_escrow_agent,
+                             mock_allocation_registry,
+                             manual_worker,
+                             test_registry,
+                             stakeholder_configuration_file_location):
+
+    staker_address = user_escrow_agent.principal_contract.address
+
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    assert manual_worker == staking_agent.get_worker_from_staker(staker_address=staker_address)
+
+    testerchain.time_travel(periods=token_economics.minimum_worker_periods)
+
+    init_args = ('stake', 'detach-worker',
+                 '--config-file', stakeholder_configuration_file_location,
+                 '--escrow',
+                 '--beneficiary-address', beneficiary,
+                 '--allocation-filepath', mock_allocation_registry.filepath,
+                 '--force')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    staker = Staker(is_me=True,
+                    checksum_address=beneficiary,
+                    allocation_registry=mock_allocation_registry,
+                    registry=test_registry)
+
+    assert not staker.worker_address
+
+    # Ok ok, let's set the worker again.
+
+    init_args = ('stake', 'set-worker',
+                 '--config-file', stakeholder_configuration_file_location,
+                 '--escrow',
+                 '--beneficiary-address', beneficiary,
+                 '--allocation-filepath', mock_allocation_registry.filepath,
+                 '--worker-address', manual_worker,
+                 '--force')
+
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=user_input,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    staker = Staker(is_me=True,
+                    checksum_address=beneficiary,
+                    allocation_registry=mock_allocation_registry,
+                    registry=test_registry)
+
+    assert staker.worker_address == manual_worker
+
+
 def test_stake_restake(click_runner,
                        beneficiary,
                        user_escrow_agent,
@@ -253,3 +329,249 @@ def test_stake_restake(click_runner,
                     allocation_registry=mock_allocation_registry)
     assert not staker.is_restaking
     assert "Successfully disabled" in result.output
+
+
+def test_ursula_init(click_runner,
+                     custom_filepath,
+                     mock_registry_filepath,
+                     user_escrow_agent,
+                     manual_worker,
+                     testerchain):
+
+    init_args = ('ursula', 'init',
+                 '--poa',
+                 '--network', TEMPORARY_DOMAIN,
+                 '--staker-address', user_escrow_agent.principal_contract.address,
+                 '--worker-address', manual_worker,
+                 '--config-root', custom_filepath,
+                 '--provider', TEST_PROVIDER_URI,
+                 '--registry-filepath', mock_registry_filepath,
+                 '--rest-host', MOCK_IP_ADDRESS,
+                 '--rest-port', MOCK_URSULA_STARTING_PORT)
+
+    user_input = '{password}\n{password}'.format(password=INSECURE_DEVELOPMENT_PASSWORD)
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=user_input,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Files and Directories
+    assert os.path.isdir(custom_filepath), 'Configuration file does not exist'
+    assert os.path.isdir(os.path.join(custom_filepath, 'keyring')), 'Keyring does not exist'
+    assert os.path.isdir(os.path.join(custom_filepath, 'known_nodes')), 'known_nodes directory does not exist'
+
+    custom_config_filepath = os.path.join(custom_filepath, UrsulaConfiguration.generate_filename())
+    assert os.path.isfile(custom_config_filepath), 'Configuration file does not exist'
+
+    with open(custom_config_filepath, 'r') as config_file:
+        raw_config_data = config_file.read()
+        config_data = json.loads(raw_config_data)
+        assert config_data['provider_uri'] == TEST_PROVIDER_URI
+        assert config_data['worker_address'] == manual_worker
+        assert config_data['checksum_address'] == user_escrow_agent.principal_contract.address
+        assert TEMPORARY_DOMAIN in config_data['domains']
+
+
+def test_ursula_run(click_runner,
+                    manual_worker,
+                    user_escrow_agent,
+                    custom_filepath,
+                    testerchain):
+
+    custom_config_filepath = os.path.join(custom_filepath, UrsulaConfiguration.generate_filename())
+
+    # Now start running your Ursula!
+    init_args = ('ursula', 'run',
+                 '--dry-run',
+                 '--config-file', custom_config_filepath)
+
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' * 2
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=user_input,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+
+def test_collect_rewards_integration(click_runner,
+                                     testerchain,
+                                     test_registry,
+                                     stakeholder_configuration_file_location,
+                                     blockchain_alice,
+                                     blockchain_bob,
+                                     random_policy_label,
+                                     beneficiary,
+                                     user_escrow_agent,
+                                     mock_allocation_registry,
+                                     manual_worker,
+                                     token_economics,
+                                     stake_value,
+                                     policy_value,
+                                     policy_rate):
+
+    half_stake_time = token_economics.minimum_locked_periods // 2  # Test setup
+    logger = Logger("Test-CLI")  # Enter the Teacher's Logger, and
+    current_period = 0  # State the initial period for incrementing
+
+    staker_address = user_escrow_agent.principal_contract.address
+    worker_address = manual_worker
+
+    # The staker is staking.
+    stakes = StakeList(registry=test_registry, checksum_address=staker_address)
+    stakes.refresh()
+    assert stakes
+
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    assert worker_address == staking_agent.get_worker_from_staker(staker_address=staker_address)
+
+    ursula_port = select_test_port()
+    ursula = Ursula(is_me=True,
+                    checksum_address=staker_address,
+                    worker_address=worker_address,
+                    registry=test_registry,
+                    rest_host='127.0.0.1',
+                    rest_port=ursula_port,
+                    start_working_now=False,
+                    network_middleware=MockRestMiddleware())
+
+    MOCK_KNOWN_URSULAS_CACHE[ursula_port] = ursula
+    assert ursula.worker_address == worker_address
+    assert ursula.checksum_address == staker_address
+
+    # Mock TransactingPower consumption (Worker-Ursula)
+    testerchain.transacting_power = TransactingPower(account=worker_address, password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power.activate()
+
+    # Confirm for half the first stake duration
+    for _ in range(half_stake_time):
+        logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+        ursula.confirm_activity()
+        testerchain.time_travel(periods=1)
+        current_period += 1
+
+    # Alice creates a policy and grants Bob access
+    blockchain_alice.selection_buffer = 1
+
+    M, N = 1, 1
+    expiration = maya.now() + datetime.timedelta(days=3)
+    blockchain_policy = blockchain_alice.grant(bob=blockchain_bob,
+                                               label=random_policy_label,
+                                               m=M, n=N,
+                                               value=policy_value,
+                                               expiration=expiration,
+                                               handpicked_ursulas={ursula})
+
+    # Ensure that the handpicked Ursula was selected for the policy
+    arrangement = list(blockchain_policy._accepted_arrangements)[0]
+    assert arrangement.ursula == ursula
+
+    # Bob learns about the new staker and joins the policy
+    blockchain_bob.start_learning_loop()
+    blockchain_bob.remember_node(node=ursula)
+    blockchain_bob.join_policy(random_policy_label, bytes(blockchain_alice.stamp))
+
+    # Enrico Encrypts (of course)
+    enrico = Enrico(policy_encrypting_key=blockchain_policy.public_key,
+                    network_middleware=MockRestMiddleware())
+
+    verifying_key = blockchain_alice.stamp.as_umbral_pubkey()
+
+    for index in range(half_stake_time - 5):
+        logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+        ursula.confirm_activity()
+
+        # Encrypt
+        random_data = os.urandom(random.randrange(20, 100))
+        ciphertext, signature = enrico.encrypt_message(message=random_data)
+
+        # Decrypt
+        cleartexts = blockchain_bob.retrieve(message_kit=ciphertext,
+                                             data_source=enrico,
+                                             alice_verifying_key=verifying_key,
+                                             label=random_policy_label)
+        assert random_data == cleartexts[0]
+
+        # Ursula Staying online and the clock advancing
+        testerchain.time_travel(periods=1)
+        current_period += 1
+
+    # Finish the passage of time
+    for _ in range(5 - 1):  # minus 1 because the first period was already confirmed in test_ursula_run
+        logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+        ursula.confirm_activity()
+        current_period += 1
+        testerchain.time_travel(periods=1)
+
+    #
+    # WHERES THE MONEY URSULA?? - Collecting Rewards
+    #
+
+    # The address the client wants Ursula to send policy rewards to
+    burner_wallet = testerchain.w3.eth.account.create(INSECURE_DEVELOPMENT_PASSWORD)
+
+    # The policy rewards wallet is initially empty, because it is freshly created
+    assert testerchain.client.get_balance(burner_wallet.address) == 0
+
+    # Rewards will be unlocked after the
+    # final confirmed period has passed (+1).
+    logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+    testerchain.time_travel(periods=1)
+    current_period += 1
+    logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+
+    # Since we are mocking the blockchain connection, manually consume the transacting power of the Beneficiary.
+    testerchain.transacting_power = TransactingPower(account=beneficiary,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power.activate()
+
+    # Collect Policy Reward
+    collection_args = ('stake', 'collect-reward',
+                       '--mock-networking',
+                       '--config-file', stakeholder_configuration_file_location,
+                       '--policy-reward',
+                       '--no-staking-reward',
+                       '--withdraw-address', burner_wallet.address,
+                       '--escrow',
+                       '--beneficiary-address', beneficiary,
+                       '--allocation-filepath', mock_allocation_registry.filepath,
+                       '--force')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 collection_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Policy Reward
+    collected_policy_reward = testerchain.client.get_balance(burner_wallet.address)
+    expected_collection = policy_rate * 30
+    assert collected_policy_reward == expected_collection
+
+    #
+    # Collect Staking Reward
+    #
+    token_agent = ContractAgency.get_agent(agent_class=NucypherTokenAgent, registry=test_registry)
+    balance_before_collecting = token_agent.get_balance(address=staker_address)
+
+    collection_args = ('stake', 'collect-reward',
+                       '--mock-networking',
+                       '--config-file', stakeholder_configuration_file_location,
+                       '--no-policy-reward',
+                       '--staking-reward',
+                       '--escrow',
+                       '--beneficiary-address', beneficiary,
+                       '--allocation-filepath', mock_allocation_registry.filepath,
+                       '--force')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 collection_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # The beneficiary has withdrawn her staking rewards, which are now in the staking contract
+    assert token_agent.get_balance(address=staker_address) >= balance_before_collecting
+
+
+


### PR DESCRIPTION
* `TransactingPower` now auto-detects that the account comes from a HW, using the data provided by geth endpoint `personal_listWallets`. Fix #1385. Fix #1128 
* Check min staking size when learning. Also accepts staking for next period, which makes possible creating a stake and running a discoverable Ursula in the same period. Closes #1115 
* Fix confusion between staked and locked+rewards. Fixes #1369 
* Fix lack of client account selection for `nucypher stake collect-reward`
* Complete CLI tests for staking via contracts, except for divide.