### PR TITLE
Darth-Moe Status Page Cleanup

### DIFF
--- a/nucypher/network/status_app/base.py
+++ b/nucypher/network/status_app/base.py
@@ -118,17 +118,19 @@ class NetworkStatusPage:
         Update this depending on which columns you want to show links for
         and what you want those links to be.
         """
-        identity = html.Td(children=html.Div([html.Span(f'{node_info["icon_details"]["first_symbol"]}',
-                                                        className='single-symbol',
-                                                        style={'color': node_info["icon_details"]['first_color']}),
-                                              html.Span(f'{node_info["icon_details"]["second_symbol"]}',
-                                                        className='single-symbol',
-                                                        style={'color': node_info["icon_details"]['second_color']}),
-                                              html.A(node_info['nickname'],
-                                                     href=f'https://{node_info["rest_url"]}/status',
-                                                     target='_blank')
-                                              ],
-                                             className='symbols'))
+        identity = html.Td(children=html.Div([
+            html.Div([
+                html.Span(f'{node_info["icon_details"]["first_symbol"]}',
+                          className='single-symbol',
+                          style={'color': node_info["icon_details"]['first_color']}),
+                html.Span(f'{node_info["icon_details"]["second_symbol"]}',
+                          className='single-symbol',
+                          style={'color': node_info["icon_details"]['second_color']}),
+            ], className='symbols'),
+            html.A(node_info['nickname'],
+                   href=f'https://{node_info["rest_url"]}/status',
+                   target='_blank')
+        ]))
 
         # Fleet State
         fleet_state_div = []

--- a/nucypher/network/status_app/moe.py
+++ b/nucypher/network/status_app/moe.py
@@ -156,20 +156,19 @@ class MoeStatusApp(NetworkStatusPage):
         def prev_locked_tokens(pathname):
             prior_periods = 30
             locked_tokens_dict = self.moe_db_client.get_historical_locked_tokens_over_range(prior_periods)
-            marker_color = 'rgb(0, 163, 239)'
-
+            token_values = list(locked_tokens_dict.values())
             fig = go.Figure(data=[
                                 go.Bar(
                                     textposition='auto',
                                     x=list(locked_tokens_dict.keys()),
-                                    y=list(locked_tokens_dict.values()),
+                                    y=token_values,
                                     name='Locked Stake',
-                                    marker=go.bar.Marker(color=marker_color)
+                                    marker=go.bar.Marker(color=token_values, colorscale='Viridis')
                                 )
                             ],
                             layout=go.Layout(
                                 title=f'Staked NU over the previous {prior_periods} days.',
-                                xaxis={'title': 'Date', 'nticks': len(locked_tokens_dict)},
+                                xaxis={'title': 'Date', 'nticks': len(locked_tokens_dict) + 1},
                                 yaxis={'title': 'NU Tokens', 'zeroline': False},
                                 showlegend=False,
                                 paper_bgcolor='rgba(0,0,0,0)',
@@ -196,8 +195,8 @@ class MoeStatusApp(NetworkStatusPage):
                             ],
                             layout=go.Layout(
                                 title=f'Num Stakers over the previous {prior_periods} days.',
-                                xaxis={'title': 'Date', 'nticks': len(num_stakers_dict)},
-                                yaxis={'title': 'Stakers', 'zeroline': False},
+                                xaxis={'title': 'Date', 'nticks': len(num_stakers_dict) + 1, 'showgrid': False},
+                                yaxis={'title': 'Stakers', 'zeroline': False, 'showgrid': False},
                                 showlegend=False,
                                 paper_bgcolor='rgba(0,0,0,0)',
                                 plot_bgcolor='rgba(0,0,0,0)'
@@ -212,15 +211,14 @@ class MoeStatusApp(NetworkStatusPage):
             token_counter = self.moe_crawler.snapshot['future_locked_tokens']
             periods = len(token_counter)
             period_range = list(range(1, periods + 1))
-            marker_color = 'rgb(230, 234, 232)'
-
+            token_counter_values = list(token_counter.values())
             fig = go.Figure(data=[
                                 go.Bar(
                                     textposition='auto',
                                     x=period_range,
-                                    y=list(token_counter.values()),
+                                    y=token_counter_values,
                                     name='Stake',
-                                    marker=go.bar.Marker(color=marker_color)
+                                    marker=go.bar.Marker(color=token_counter_values, colorscale='Viridis')
                                 )
                             ],
                             layout=go.Layout(


### PR DESCRIPTION
1. Improve colouring of graphs - uses auto-colour scaling based on values
2. Number of ticks for x-axis was wrong - one less than what was needed
3. Improved layout of nickname in the nodes table

<img width="1429" alt="Screen Shot 2019-10-03 at 10 54 23 AM" src="https://user-images.githubusercontent.com/19150641/66138658-fe0f1080-e5cc-11e9-9a12-b27da6e0c4b9.png">

<img width="1439" alt="Screen Shot 2019-10-03 at 10 27 40 AM" src="https://user-images.githubusercontent.com/19150641/66138686-05ceb500-e5cd-11e9-8bdc-0273e33e567a.png">
