### PR TITLE
Auto-detect HW accounts in TransactingPower. Finalize basic staking via contract CLI functionality.

### DIFF
--- a/docs/source/guides/staking_guide.rst
+++ b/docs/source/guides/staking_guide.rst
@@ -392,30 +392,31 @@ since the contract can't perform transactions, and it's the preallocation user
 (also known as the "`beneficiary`" of the contract)
 who has to perform staking operations.
 
+As part of the preallocation process, beneficiaries receive an allocation file,
+containing the ETH addresses of their beneficiary account and corresponding
+preallocation contract.
+
 In general, preallocation users can use all staking-related operations offered
-by the CLI in the same way as described above, except that they have to include
-the ``--escrow`` flag to indicate they are acting as beneficiaries.
+by the CLI in the same way as described above, except that they have to specify
+the path to the allocation file using the option ``--allocation-filepath PATH``.
 
 For example, to create a stake:
 
 .. code:: bash
 
-    (nucypher)$ nucypher stake create --hw-wallet --escrow
+    (nucypher)$ nucypher stake create --hw-wallet --allocation-filepath PATH
 
 
 Or to set a worker:
 
 .. code:: bash
 
-    (nucypher)$ nucypher stake set-worker --hw-wallet --escrow
+    (nucypher)$ nucypher stake set-worker --hw-wallet --allocation-filepath PATH
 
 
-As an alternative to the ``--escrow`` flag, preallocation users can directly specify
-their beneficiary address with the ``--beneficiary-address ADDRESS`` flag.
-
-The CLI will automatically look for a file named ``allocation_registry.json`` in
-the default installation path, although a custom path can be used with the flag
-``--allocation-filepath /path/to/allocation_registry.json``.
+As an alternative to the ``--allocation-filepath`` flag, preallocation users
+can directly specify their beneficiary and staking contract addresses with the
+``--beneficiary-address ADDRESS`` and ``--staking-address ADDRESS``, respectively.
 
 
 Inline Method

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -606,11 +606,9 @@ class Staker(NucypherTokenActor):
     @property
     def current_stake(self) -> NU:
         """
-        The total number of staked tokens, either locked or unlocked in the current period.
+        The total number of staked tokens, i.e., tokens locked in the current period.
         """
-        stake = self.staking_agent.owned_tokens(staker_address=self.checksum_address)
-        nu_stake = NU.from_nunits(stake)
-        return nu_stake
+        return self.locked_tokens(periods=0)
 
     @only_me
     def divide_stake(self,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -827,8 +827,8 @@ class Staker(NucypherTokenActor):
         """Withdraw tokens rewarded for staking."""
         if self.is_contract:
             reward_amount = self.staking_agent.calculate_staking_reward(staker_address=self.checksum_address)
-            self.log.debug(f"Withdrawing staking reward, {reward_amount}, to {self.checksum_address}")
-            receipt = self.preallocation_escrow_agent.withdraw_as_staker(amount=reward_amount)
+            self.log.debug(f"Withdrawing staking reward ({NU.from_nunits(reward_amount)}) to {self.checksum_address}")
+            receipt = self.preallocation_escrow_agent.withdraw_as_staker(value=reward_amount)
         else:
             receipt = self.staking_agent.collect_staking_reward(staker_address=self.checksum_address)
         return receipt
@@ -838,7 +838,7 @@ class Staker(NucypherTokenActor):
     def withdraw(self, amount: NU) -> str:
         """Withdraw tokens (assuming they're unlocked)"""
         if self.is_contract:
-            receipt = self.preallocation_escrow_agent.withdraw_as_staker(amount=int(amount))
+            receipt = self.preallocation_escrow_agent.withdraw_as_staker(value=int(amount))
         else:
             receipt = self.staking_agent.withdraw(staker_address=self.checksum_address,
                                                   amount=int(amount))
@@ -861,7 +861,6 @@ class Worker(NucypherTokenActor):
                  work_tracker: WorkTracker = None,
                  worker_address: str = None,
                  start_working_now: bool = True,
-                 confirm_now: bool = True,
                  check_active_worker: bool = True,
                  *args, **kwargs):
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -374,7 +374,8 @@ class StakingEscrowAgent(EthereumContractAgent):
     def collect_staking_reward(self, staker_address: str):
         """Withdraw tokens rewarded for staking."""
         reward_amount = self.calculate_staking_reward(staker_address=staker_address)
-        self.log.debug(f"Withdrawing staking reward, {reward_amount}, to {staker_address}")
+        from nucypher.blockchain.eth.token import NU
+        self.log.debug(f"Withdrawing staking reward ({NU.from_nunits(reward_amount)}) to {staker_address}")
         return self.withdraw(staker_address=staker_address, amount=reward_amount)
 
     @validate_checksum_address

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -562,6 +562,11 @@ class PolicyManagerAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=author_address)
         return receipt
 
+    @validate_checksum_address
+    def get_reward_amount(self, staker_address: str) -> int:
+        reward_amount = self.contract.functions.nodes(staker_address).call()[0]
+        return reward_amount
+
 
 class PreallocationEscrowAgent(EthereumContractAgent):
 

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -352,6 +352,10 @@ class GethClient(Web3Client):
         rlp_encoded_transaction = result.raw
         return rlp_encoded_transaction
 
+    @property
+    def wallets(self):
+        return self.w3.manager.request_blocking("personal_listWallets", [])
+
 
 class ParityClient(Web3Client):
 

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -900,6 +900,11 @@ class PreallocationEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin
         self.deployment_receipts.update({'deployment': deploy_receipt})
         return deploy_receipt
 
+    def get_contract_abi(self):
+        contract_factory = self.blockchain.get_contract_factory(contract_name=self.contract_name)
+        abi = contract_factory.abi
+        return abi
+
 
 class AdjudicatorDeployer(BaseContractDeployer, UpgradeableContractMixin, OwnableContractMixin):
 

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -189,7 +189,7 @@ class BaseContractRegistry(ABC):
         if contract_address and len(contracts) > 1:
             m = f"Multiple records returned for address {contract_address}"
             self.log.critical(m)
-            raise self.IllegalRegistry(m.format(contract_address))
+            raise self.IllegalRegistry(m)
 
         result = tuple(contracts) if contract_name else contracts[0]
         return result
@@ -464,7 +464,9 @@ class IndividualAllocationRegistry(InMemoryAllocationRegistry):
         if not contract_abi:
             # Download individual allocation template to extract contract_abi
             individual_allocation_template = json.loads(self.fetch_latest_publication())
-            contract_data = [*individual_allocation_template.values()].pop()
+            if len(individual_allocation_template) != 1:
+                raise self.IllegalRegistry("Individual allocation template must contain a single entry")
+            contract_data = list(individual_allocation_template.values()).pop()
             contract_abi = contract_data[1]
 
         # Fill template with beneficiary and contract addresses

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -466,7 +466,11 @@ class IndividualAllocationRegistry(InMemoryAllocationRegistry):
             individual_allocation_template = json.loads(self.fetch_latest_publication())
             if len(individual_allocation_template) != 1:
                 raise self.IllegalRegistry("Individual allocation template must contain a single entry")
-            contract_data = list(individual_allocation_template.values()).pop()
+            try:
+                contract_data = individual_allocation_template["BENEFICIARY_ADDRESS"]
+            except KeyError:
+                raise self.IllegalRegistry("Bad format of individual allocation template. "
+                                           "Expected a 'BENEFICIARY_ADDRESS' key.")
             contract_abi = contract_data[1]
 
         # Fill template with beneficiary and contract addresses

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -205,9 +205,11 @@ class Stake:
 
         # Time
         self.start_datetime = datetime_at_period(period=first_locked_period,
-                                                 seconds_per_period=self.economics.seconds_per_period)
+                                                 seconds_per_period=self.economics.seconds_per_period,
+                                                 start_of_period=True)
         self.unlock_datetime = datetime_at_period(period=final_locked_period + 1,
-                                                  seconds_per_period=self.economics.seconds_per_period)
+                                                  seconds_per_period=self.economics.seconds_per_period,
+                                                  start_of_period=True)
 
         if validate_now:
             self.validate_duration()

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -220,7 +220,13 @@ class Stake:
         return r
 
     def __eq__(self, other) -> bool:
+        # TODO: Is this right? Two stakes from different accounts, durations, etc, but of the same value, are equal?
         return bool(self.value == other.value)
+
+    @property
+    def address_index_ordering_key(self):
+        """To be used as a lexicographical order key for Stakes based on the tuple (staker_address, index)."""
+        return self.staker_address, self.index
 
     #
     # Metadata

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -31,22 +31,33 @@ def datetime_to_period(datetime: maya.MayaDT, seconds_per_period: int) -> int:
     return int(future_period)
 
 
-def datetime_at_period(period: int, seconds_per_period: int) -> maya.MayaDT:
-    """Returns the datetime object at a given period, future, or past."""
+def period_to_epoch(period: int, seconds_per_period: int) -> int:
+    epoch = period * seconds_per_period
+    return epoch
 
-    now = maya.now()
-    current_period = datetime_to_period(datetime=now, seconds_per_period=seconds_per_period)
-    delta_periods = period - current_period
 
-    # +
-    if delta_periods:
-        target_period = now + maya.timedelta(days=delta_periods)
-
-    # -
+def datetime_at_period(period: int, seconds_per_period: int, start_of_period: bool = False) -> maya.MayaDT:
+    """
+    Returns the datetime object at a given period, future, or past.
+    If start_of_period, the datetime object represents the first second of said period.
+    """
+    if start_of_period:
+        datetime_at_start_of_period = maya.MayaDT(epoch=period_to_epoch(period, seconds_per_period))
+        return datetime_at_start_of_period
     else:
-        target_period = now - maya.timedelta(days=delta_periods)
+        now = maya.now()
+        current_period = datetime_to_period(datetime=now, seconds_per_period=seconds_per_period)
+        delta_periods = period - current_period
 
-    return target_period
+        # +
+        if delta_periods:
+            target_datetime = now + maya.timedelta(days=delta_periods)
+
+        # -
+        else:
+            target_datetime = now - maya.timedelta(days=delta_periods)
+
+        return target_datetime
 
 
 def calculate_period_duration(future_time: maya.MayaDT, seconds_per_period: int) -> int:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1390,7 +1390,6 @@ class StakeHolder(Staker):
                 self.__get_accounts()
                 if checksum_address not in self:
                     raise self.UnknownAccount
-            # TODO: What if cached TransactingPower is wrongly initialized? See issue #1385
             try:
                 transacting_power = self.__transacting_powers[checksum_address]
             except KeyError:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1402,7 +1402,7 @@ class StakeHolder(Staker):
         @property
         def balances(self) -> Dict[str, int]:
             balances = dict()
-            for account in self.__accounts:
+            for account in self.accounts:
                 funds = {'ETH': self.blockchain.client.get_balance(account),  # TODO: EthAgent or something?
                          'NU': self.token_agent.get_balance(account)}
                 balances.update({account: funds})

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -796,6 +796,7 @@ class Ursula(Teacher, Character, Worker):
                  checksum_address: str = None,  # Staker address
                  worker_address: str = None,
                  work_tracker: WorkTracker = None,
+                 start_working_now: bool = True,
                  client_password: str = None,
 
                  # Character
@@ -856,7 +857,8 @@ class Ursula(Teacher, Character, Worker):
                                 registry=self.registry,
                                 checksum_address=checksum_address,
                                 worker_address=worker_address,
-                                work_tracker=work_tracker)
+                                work_tracker=work_tracker,
+                                start_working_now=start_working_now)
 
         #
         # ProxyRESTServer and TLSHostingPower #

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -442,7 +442,7 @@ def confirm_enable_restaking(emitter, staking_address: str) -> bool:
 
 def establish_deployer_registry(emitter,
                                 registry_infile: str = None,
-                                registry_outfile:str = None,
+                                registry_outfile: str = None,
                                 use_existing_registry: bool = False,
                                 dev: bool = False
                                 ) -> LocalContractRegistry:

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -36,7 +36,12 @@ from nucypher.blockchain.eth.agents import NucypherTokenAgent
 from nucypher.blockchain.eth.clients import NuCypherGethGoerliProcess
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
-from nucypher.blockchain.eth.registry import BaseContractRegistry, InMemoryContractRegistry, LocalContractRegistry
+from nucypher.blockchain.eth.registry import (
+    BaseContractRegistry,
+    InMemoryContractRegistry,
+    LocalContractRegistry,
+    IndividualAllocationRegistry
+)
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.token import Stake
 from nucypher.cli import painting
@@ -363,8 +368,7 @@ def select_client_account(emitter,
 def handle_client_account_for_staking(emitter,
                                       stakeholder,
                                       staking_address: str,
-                                      is_preallocation_staker: bool,
-                                      beneficiary_address: str,
+                                      individual_allocation: IndividualAllocationRegistry,
                                       force: bool,
                                       ) -> Tuple[str, str]:
     """
@@ -376,26 +380,14 @@ def handle_client_account_for_staking(emitter,
     then the local client account is the beneficiary, and the staking address is the address of the staking contract.
     """
 
-    if is_preallocation_staker:
-        if beneficiary_address:
-            client_account = beneficiary_address
-        else:
-            client_account = select_client_account(prompt="Select beneficiary account",
-                                                   emitter=emitter,
-                                                   registry=stakeholder.registry,
-                                                   provider_uri=stakeholder.wallet.blockchain.provider_uri)
-        staking_address = stakeholder.check_if_staking_via_contract(checksum_address=client_account)
-        if staking_address:
-            message = f"Beneficiary {client_account} will use preallocation contract {staking_address} to stake."
-            emitter.echo(message, color='yellow', verbosity=1)
-            if not force:
-                click.confirm("Is this correct?", abort=True)
-        else:
-            message = (f"Beneficiary {client_account} doesn't have a preallocation contract in current registry.\n"
-                       f"Are you sure you are using the correct allocation registry?\n"
-                       f"Currently using {stakeholder.allocation_registry.filepath}")
-            emitter.echo(message, color='red', verbosity=1)
-            raise click.Abort()
+    if individual_allocation:
+        client_account = individual_allocation.beneficiary_address
+        staking_address = individual_allocation.contract_address
+
+        message = f"Beneficiary {client_account} will use preallocation contract {staking_address} to stake."
+        emitter.echo(message, color='yellow', verbosity=1)
+        if not force:
+            click.confirm("Is this correct?", abort=True)
     else:
         if staking_address:
             client_account = staking_address

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -312,8 +312,10 @@ def make_cli_character(character_config,
 
 def select_stake(stakeholder, emitter) -> Stake:
     stakes = stakeholder.all_stakes
-    enumerated_stakes = dict(enumerate(stakes))
-    painting.paint_stakes(stakes=stakes, emitter=emitter)
+    active_stakes = sorted((stake for stake in stakes if stake.is_active),
+                           key=lambda some_stake: some_stake.address_index_ordering_key)
+    enumerated_stakes = dict(enumerate(active_stakes))
+    painting.paint_stakes(stakes=active_stakes, emitter=emitter)
     choice = click.prompt("Select Stake", type=click.IntRange(min=0, max=len(enumerated_stakes)-1))
     chosen_stake = enumerated_stakes[choice]
     return chosen_stake

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -293,8 +293,9 @@ def make_cli_character(character_config,
         CHARACTER = character_config(known_nodes=teacher_nodes,
                                      network_middleware=character_config.network_middleware,
                                      **config_args)
-    except CryptoError as e:
-        raise character_config.keyring.AuthenticationFailed(str(e))
+    except CryptoError:
+        raise character_config.keyring.AuthenticationFailed("Failed keyring unlocking. "
+                                                            "Are you sure you provided the correct password?")
     #
     # Post-Init
     #

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -294,7 +294,7 @@ def make_cli_character(character_config,
                                      network_middleware=character_config.network_middleware,
                                      **config_args)
     except CryptoError:
-        raise character_config.keyring.AuthenticationFailed("Failed keyring unlocking. "
+        raise character_config.keyring.AuthenticationFailed("Failed to unlock keyring. "
                                                             "Are you sure you provided the correct password?")
     #
     # Post-Init

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -166,11 +166,10 @@ def stake(click_config,
         allocation_registry = None
         initial_address = staking_address
 
-    dummy_password = "Look Away, I'm Hideous"  # TODO: See #1385
     STAKEHOLDER = stakeholder_config.produce(initial_address=initial_address,
-                                             allocation_registry=allocation_registry,
-                                             password=dummy_password)
+                                             allocation_registry=allocation_registry)
     blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)  # Eager connection
+
     economics = STAKEHOLDER.economics
 
     # Dynamic click types (Economics)

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -63,6 +63,7 @@ from nucypher.config.characters import StakeHolderConfiguration
 @click.option('--lock-until', help="Period to release re-staking lock", type=click.IntRange(min=0))
 @click.option('--beneficiary-address', help="Address of a pre-allocation beneficiary", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--allocation-filepath', help="Path to individual allocation file", type=EXISTING_READABLE_FILE)
+@click.option('--all', help="List all stakes, including inactive", is_flag=True)
 @nucypher_click_config
 def stake(click_config,
           action,
@@ -90,6 +91,7 @@ def stake(click_config,
           staking_reward,
           enable,
           lock_until,
+          all,
 
           # Allocation stakers
           beneficiary_address,
@@ -192,7 +194,7 @@ def stake(click_config,
     #
 
     if action == 'list':
-        painting.paint_stakes(emitter=emitter, stakes=STAKEHOLDER.all_stakes)
+        painting.paint_stakes(emitter=emitter, stakes=STAKEHOLDER.all_stakes, paint_inactive=all)
         return  # Exit
 
     elif action == 'accounts':

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -200,8 +200,7 @@ def stake(click_config,
         return  # Exit
 
     elif action == 'accounts':
-        # TODO: Order accounts like shown by blockchain.client.accounts
-        for address, balances in STAKEHOLDER.wallet.balances.items():
+        for address, balances in sorted(STAKEHOLDER.wallet.balances.items()):
             emitter.echo(f"{address} | {Web3.fromWei(balances['ETH'], 'ether')} ETH | {NU.from_nunits(balances['NU'])}")
         return  # Exit
 

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -304,8 +304,8 @@ def stake(click_config,
             prompt = f"Enter stake duration ({STAKEHOLDER.economics.minimum_locked_periods} periods minimum)"
             lock_periods = click.prompt(prompt, type=stake_duration_range)
 
-        start_period = STAKEHOLDER.staking_agent.get_current_period()
-        end_period = start_period + lock_periods
+        start_period = STAKEHOLDER.staking_agent.get_current_period() + 1
+        unlock_period = start_period + lock_periods
 
         #
         # Review
@@ -318,7 +318,7 @@ def stake(click_config,
                                         stake_value=value,
                                         lock_periods=lock_periods,
                                         start_period=start_period,
-                                        end_period=end_period)
+                                        unlock_period=unlock_period)
 
             confirm_staged_stake(staker_address=staking_address, value=value, lock_periods=lock_periods)
 

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -191,6 +191,7 @@ def stake(click_config,
         return  # Exit
 
     elif action == 'accounts':
+        # TODO: Order accounts like shown by blockchain.client.accounts
         for address, balances in STAKEHOLDER.wallet.balances.items():
             emitter.echo(f"{address} | {Web3.fromWei(balances['ETH'], 'ether')} ETH | {NU.from_nunits(balances['NU'])}")
         return  # Exit
@@ -420,16 +421,22 @@ def stake(click_config,
     elif action == 'collect-reward':
         """Withdraw staking reward to the specified wallet address"""
 
-        # TODO: Missing account selection
+        # Authenticate
+        client_account, staking_address = handle_client_account_for_staking(emitter=emitter,
+                                                                            stakeholder=STAKEHOLDER,
+                                                                            staking_address=staking_address,
+                                                                            is_preallocation_staker=is_preallocation_staker,
+                                                                            beneficiary_address=beneficiary_address,
+                                                                            force=force)
 
         password = None
         if not hw_wallet and not blockchain.client.is_local:
-            password = get_client_password(checksum_address=staking_address)
+            password = get_client_password(checksum_address=client_account)
 
         if not staking_reward and not policy_reward:
             raise click.BadArgumentUsage(f"Either --staking-reward or --policy-reward must be True to collect rewards.")
 
-        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+        STAKEHOLDER.assimilate(checksum_address=client_account, password=password)
         if staking_reward:
             # Note: Sending staking / inflation rewards to another account is not allowed.
             staking_receipt = STAKEHOLDER.collect_staking_reward()

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -442,12 +442,16 @@ def stake(click_config,
         STAKEHOLDER.assimilate(checksum_address=client_account, password=password)
         if staking_reward:
             # Note: Sending staking / inflation rewards to another account is not allowed.
+            reward_amount = NU.from_nunits(STAKEHOLDER.calculate_staking_reward())
+            emitter.echo(message=f'Collecting {reward_amount} from staking rewards...')
             staking_receipt = STAKEHOLDER.collect_staking_reward()
             paint_receipt_summary(receipt=staking_receipt,
                                   chain_name=STAKEHOLDER.wallet.blockchain.client.chain_name,
                                   emitter=emitter)
 
         if policy_reward:
+            reward_amount = Web3.fromWei(STAKEHOLDER.calculate_policy_reward(), 'ether')
+            emitter.echo(message=f'Collecting {reward_amount} ETH from policy rewards...')
             policy_receipt = STAKEHOLDER.collect_policy_reward(collector_address=withdraw_address)
             paint_receipt_summary(receipt=policy_receipt,
                                   chain_name=STAKEHOLDER.wallet.blockchain.client.chain_name,

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -169,8 +169,8 @@ def stake(click_config,
             option = "--beneficiary_address" if beneficiary_address else "--staking-address"
             raise click.BadOptionUsage(option_name=option,
                                        message=f"You must specify both --beneficiary-address and --staking-address. "
-                                               f"Only {option} was provided. As an alternative you can input just an "
-                                               f"individual allocation with --allocation-file <PATH>")
+                                               f"Only {option} was provided. As an alternative, you can simply "
+                                               f"provide an individual allocation with --allocation-file <PATH>")
     else:
         individual_allocation = None
         initial_address = staking_address

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -192,16 +192,11 @@ def stake(click_config,
     #
 
     if action == 'list':
-        stakes = STAKEHOLDER.all_stakes
-        if not stakes:
-            emitter.echo(f"There are no active stakes")
-        else:
-            painting.paint_stakes(emitter=emitter, stakes=stakes)
+        painting.paint_stakes(emitter=emitter, stakes=STAKEHOLDER.all_stakes)
         return  # Exit
 
     elif action == 'accounts':
-        for address, balances in sorted(STAKEHOLDER.wallet.balances.items()):
-            emitter.echo(f"{address} | {Web3.fromWei(balances['ETH'], 'ether')} ETH | {NU.from_nunits(balances['NU'])}")
+        painting.paint_accounts(emitter=emitter, balances=STAKEHOLDER.wallet.balances)
         return  # Exit
 
     elif action == 'set-worker':

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -224,7 +224,9 @@ def stake(click_config,
         bonded_date = datetime_at_period(period=current_period, seconds_per_period=economics.seconds_per_period)
         min_worker_periods = STAKEHOLDER.staking_agent.staking_parameters()[7]
         release_period = current_period + min_worker_periods
-        release_date = datetime_at_period(period=release_period, seconds_per_period=economics.seconds_per_period)
+        release_date = datetime_at_period(period=release_period,
+                                          seconds_per_period=economics.seconds_per_period,
+                                          start_of_period=True)
 
         emitter.echo(f"\nWorker {worker_address} successfully bonded to staker {staking_address}", color='green')
         paint_receipt_summary(emitter=emitter,

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -20,7 +20,7 @@ import click
 from web3 import Web3
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
-from nucypher.blockchain.eth.registry import AllocationRegistry
+from nucypher.blockchain.eth.registry import IndividualAllocationRegistry
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.utils import datetime_at_period
 from nucypher.characters.lawful import StakeHolder
@@ -51,7 +51,7 @@ from nucypher.config.characters import StakeHolderConfiguration
 @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--poa', help="Inject POA middleware", is_flag=True)
 @click.option('--provider', 'provider_uri', help="Blockchain provider's URI i.e. 'file:///path/to/geth.ipc'", type=click.STRING)
-@click.option('--staking-address', help="Address to stake NU ERC20 tokens", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--staking-address', help="Address to stake NU tokens", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--worker-address', help="Address to assign as an Ursula-Worker", type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--staking-reward/--no-staking-reward', is_flag=True, default=False)
 @click.option('--policy-reward/--no-policy-reward', is_flag=True, default=False)
@@ -61,9 +61,8 @@ from nucypher.config.characters import StakeHolderConfiguration
 @click.option('--index', help="A specific stake index to resume", type=click.INT)
 @click.option('--enable/--disable', help="Used to enable and disable re-staking", is_flag=True, default=True)
 @click.option('--lock-until', help="Period to release re-staking lock", type=click.IntRange(min=0))
-@click.option('--escrow', help="Use a pre-allocation escrow contract", is_flag=True)  # TODO: #1351 - Refactor allocation registry?
 @click.option('--beneficiary-address', help="Address of a pre-allocation beneficiary", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--allocation-filepath', help="Custom allocation registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--allocation-filepath', help="Path to individual allocation file", type=EXISTING_READABLE_FILE)
 @nucypher_click_config
 def stake(click_config,
           action,
@@ -93,7 +92,6 @@ def stake(click_config,
           lock_until,
 
           # Allocation stakers
-          escrow,
           beneficiary_address,
           allocation_filepath,
           ) -> None:
@@ -152,22 +150,33 @@ def stake(click_config,
     #
 
     # First let's check whether we're dealing here with a regular staker or a preallocation staker
-    is_preallocation_staker = escrow or beneficiary_address
-
-    if staking_address and is_preallocation_staker:
-        raise click.BadOptionUsage("--escrow and --beneficiary-address are incompatible with --staking-address")
+    is_preallocation_staker = (beneficiary_address and staking_address) or allocation_filepath
 
     if is_preallocation_staker:
-        # This assumes the user has an allocation registry in disk,
-        # in a specified filepath or in a default location (when filepath is None)
-        allocation_registry = AllocationRegistry(allocation_filepath)
-        initial_address = beneficiary_address
+        if allocation_filepath:
+            if beneficiary_address or staking_address:
+                message = "--allocation-filepath is incompatible with --beneficiary-address and --staking-address."
+                raise click.BadOptionUsage(option_name="--allocation-filepath", message=message)
+
+            # This assumes the user has an individual allocation file in disk
+            individual_allocation = IndividualAllocationRegistry.from_allocation_file(allocation_filepath)
+            initial_address = individual_allocation.beneficiary_address
+        elif beneficiary_address and staking_address:
+            individual_allocation = IndividualAllocationRegistry(beneficiary_address=beneficiary_address,
+                                                                 contract_address=staking_address)
+            initial_address = beneficiary_address
+        else:
+            option = "--beneficiary_address" if beneficiary_address else "--staking-address"
+            raise click.BadOptionUsage(option_name=option,
+                                       message=f"You must specify both --beneficiary-address and --staking-address. "
+                                               f"Only {option} was provided. As an alternative you can input just an "
+                                               f"individual allocation with --allocation-file <PATH>")
     else:
-        allocation_registry = None
+        individual_allocation = None
         initial_address = staking_address
 
     STAKEHOLDER = stakeholder_config.produce(initial_address=initial_address,
-                                             allocation_registry=allocation_registry)
+                                             individual_allocation=individual_allocation)
     blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)  # Eager connection
 
     economics = STAKEHOLDER.economics
@@ -201,8 +210,7 @@ def stake(click_config,
         client_account, staking_address = handle_client_account_for_staking(emitter=emitter,
                                                                             stakeholder=STAKEHOLDER,
                                                                             staking_address=staking_address,
-                                                                            is_preallocation_staker=is_preallocation_staker,
-                                                                            beneficiary_address=beneficiary_address,
+                                                                            individual_allocation=individual_allocation,
                                                                             force=force)
 
         if not worker_address:
@@ -239,8 +247,7 @@ def stake(click_config,
         client_account, staking_address = handle_client_account_for_staking(emitter=emitter,
                                                                             stakeholder=STAKEHOLDER,
                                                                             staking_address=staking_address,
-                                                                            is_preallocation_staker=is_preallocation_staker,
-                                                                            beneficiary_address=beneficiary_address,
+                                                                            individual_allocation=individual_allocation,
                                                                             force=force)
 
         if worker_address:
@@ -280,8 +287,7 @@ def stake(click_config,
         client_account, staking_address = handle_client_account_for_staking(emitter=emitter,
                                                                             stakeholder=STAKEHOLDER,
                                                                             staking_address=staking_address,
-                                                                            is_preallocation_staker=is_preallocation_staker,
-                                                                            beneficiary_address=beneficiary_address,
+                                                                            individual_allocation=individual_allocation,
                                                                             force=force)
 
         password = None
@@ -338,8 +344,7 @@ def stake(click_config,
         client_account, staking_address = handle_client_account_for_staking(emitter=emitter,
                                                                             stakeholder=STAKEHOLDER,
                                                                             staking_address=staking_address,
-                                                                            is_preallocation_staker=is_preallocation_staker,
-                                                                            beneficiary_address=beneficiary_address,
+                                                                            individual_allocation=individual_allocation,
                                                                             force=force)
 
         password = None
@@ -425,8 +430,7 @@ def stake(click_config,
         client_account, staking_address = handle_client_account_for_staking(emitter=emitter,
                                                                             stakeholder=STAKEHOLDER,
                                                                             staking_address=staking_address,
-                                                                            is_preallocation_staker=is_preallocation_staker,
-                                                                            beneficiary_address=beneficiary_address,
+                                                                            individual_allocation=individual_allocation,
                                                                             force=force)
 
         password = None

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -122,7 +122,7 @@ def deploy(action,
 
     if action == "download-registry":
         if not force:
-            prompt = f"Fetch and download latest registry from {BaseContractRegistry.PUBLICATION_ENDPOINT}?"
+            prompt = f"Fetch and download latest registry from {BaseContractRegistry.get_publication_endpoint()}?"
             click.confirm(prompt, abort=True)
         registry = InMemoryContractRegistry.from_latest_publication()
         output_filepath = registry.commit(filepath=registry_outfile, overwrite=force)

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -159,8 +159,7 @@ def deploy(action,
     #
 
     if action == "inspect":
-        administrator = ContractAdministrator(registry=local_registry, deployer_address=deployer_address)
-        paint_deployer_contract_inspection(emitter=emitter, administrator=administrator)
+        paint_deployer_contract_inspection(emitter=emitter, registry=local_registry, deployer_address=deployer_address)
         return  # Exit
 
     #

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -519,16 +519,16 @@ def paint_stakers(emitter, stakers: List[str], agent) -> None:
         emitter.echo(f"{staker}  {'Nickname:':10} {nickname} {symbols}")
         tab = " " * len(staker)
 
-        stake = agent.owned_tokens(staker)
+        owned_tokens = agent.owned_tokens(staker)
         last_confirmed_period = agent.get_last_active_period(staker)
         worker = agent.get_worker_from_staker(staker)
         is_restaking = agent.is_restaking(staker)
 
         missing_confirmations = current_period - last_confirmed_period
-        stake_in_nu = round(NU.from_nunits(stake), 2)
+        owned_in_nu = round(NU.from_nunits(owned_tokens), 2)
         locked_tokens = round(NU.from_nunits(agent.get_locked_tokens(staker)), 2)
 
-        emitter.echo(f"{tab}  {'Stake:':10} {stake_in_nu}  (Locked: {locked_tokens})")
+        emitter.echo(f"{tab}  {'Owned:':10} {owned_in_nu}  (Staked: {locked_tokens})")
         if is_restaking:
             if agent.is_restaking_locked(staker):
                 unlock_period = agent.get_restake_unlock_period(staker)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -343,9 +343,11 @@ Staking address: {staking_address}
 ~ Value      -> {stake_value} ({Decimal(int(stake_value)):.2E} NuNits)
 ~ Duration   -> {lock_periods} Days ({lock_periods} Periods)
 ~ Enactment  -> {datetime_at_period(period=start_period,
-                                    seconds_per_period=stakeholder.economics.seconds_per_period)} (period #{start_period})
+                                    seconds_per_period=stakeholder.economics.seconds_per_period,
+                                    start_of_period=True)} (period #{start_period})
 ~ Expiration -> {datetime_at_period(period=end_period,
-                                    seconds_per_period=stakeholder.economics.seconds_per_period)} (period #{end_period})
+                                    seconds_per_period=stakeholder.economics.seconds_per_period,
+                                    start_of_period=True)} (period #{end_period})
     """)
 
     # TODO: periods != Days - Do we inform the user here?
@@ -367,8 +369,8 @@ or set your Ursula worker node address by running 'nucypher stake set-worker'.
 
 
 def prettify_stake(stake, index: int = None) -> str:
-    start_datetime = stake.start_datetime.local_datetime().strftime("%b %d %H:%M:%S %Z")
-    expiration_datetime = stake.unlock_datetime.local_datetime().strftime("%b %d %H:%M:%S %Z")
+    start_datetime = stake.start_datetime.local_datetime().strftime("%b %d %H:%M %Z")
+    expiration_datetime = stake.unlock_datetime.local_datetime().strftime("%b %d %H:%M %Z")
     duration = stake.duration
 
     pretty_periods = f'{duration} periods {"." if len(str(duration)) == 2 else ""}'

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -393,27 +393,37 @@ def prettify_stake(stake, index: int = None) -> str:
     return pretty
 
 
-def paint_stakes(emitter, stakes):
-    active_stakes = sorted((stake for stake in stakes if stake.is_active),
-                           key=lambda some_stake: some_stake.address_index_ordering_key)
-    if not active_stakes:
-        emitter.echo(f"There are no active stakes")
-        return
-
-    title = "======================================= Active Stakes =========================================\n"
-
+def paint_stakes(emitter, stakes, paint_inactive: bool = False):
     header = f'| ~ | Staker | Worker | # | Value    | Duration     | Enactment          '
     breaky = f'|   | ------ | ------ | - | -------- | ------------ | ----------------------------------------- '
 
-    emitter.echo(title)
-    emitter.echo(header, bold=True)
-    emitter.echo(breaky, bold=True)
+    active_stakes = sorted((stake for stake in stakes if stake.is_active),
+                           key=lambda some_stake: some_stake.address_index_ordering_key)
+    if active_stakes:
+        title = "======================================= Active Stakes =========================================\n"
+        emitter.echo(title)
+        emitter.echo(header, bold=True)
+        emitter.echo(breaky, bold=True)
 
-    for index, stake in enumerate(active_stakes):
-        row = prettify_stake(stake=stake, index=index)
-        row_color = 'yellow' if stake.worker_address == BlockchainInterface.NULL_ADDRESS else 'white'
-        emitter.echo(row, color=row_color)
-    emitter.echo('')  # newline
+        for index, stake in enumerate(active_stakes):
+            row = prettify_stake(stake=stake, index=index)
+            row_color = 'yellow' if stake.worker_address == BlockchainInterface.NULL_ADDRESS else 'white'
+            emitter.echo(row, color=row_color)
+        emitter.echo('')  # newline
+
+    if paint_inactive:
+        title = "\n====================================== Inactive Stakes ========================================\n"
+        emitter.echo(title)
+        emitter.echo(header, bold=True)
+        emitter.echo(breaky, bold=True)
+
+        for stake in sorted([s for s in stakes if s not in active_stakes],
+                            key=lambda some_stake: some_stake.address_index_ordering_key):
+            row = prettify_stake(stake=stake, index=None)
+            emitter.echo(row, color='red')
+        emitter.echo('')  # newline
+    elif not active_stakes:
+        emitter.echo(f"There are no active stakes\n")
 
 
 def paint_staged_stake_division(emitter,

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -393,7 +393,8 @@ def paint_stakes(emitter, stakes):
     emitter.echo(title)
     emitter.echo(header, bold=True)
     emitter.echo(breaky, bold=True)
-    for index, stake in enumerate(stakes):
+
+    for index, stake in enumerate(sorted(stakes, key=lambda some_stake: some_stake.address_index_ordering_key)):
         row = prettify_stake(stake=stake, index=index)
         row_color = 'yellow' if stake.worker_address == BlockchainInterface.NULL_ADDRESS else 'white'
         emitter.echo(row, color=row_color)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -329,8 +329,19 @@ def paint_staged_stake(emitter,
                        stake_value,
                        lock_periods,
                        start_period,
-                       end_period,
+                       unlock_period,
                        division_message: str = None):
+    start_datetime = datetime_at_period(period=start_period,
+                                        seconds_per_period=stakeholder.economics.seconds_per_period,
+                                        start_of_period=True)
+
+    unlock_datetime = datetime_at_period(period=unlock_period,
+                                         seconds_per_period=stakeholder.economics.seconds_per_period,
+                                         start_of_period=True)
+
+    start_datetime_pretty = start_datetime.local_datetime().strftime("%b %d %H:%M %Z")
+    unlock_datetime_pretty = unlock_datetime.local_datetime().strftime("%b %d %H:%M %Z")
+
     if division_message:
         emitter.echo(f"\n{'=' * 30} ORIGINAL STAKE {'=' * 28}", bold=True)
         emitter.echo(division_message)
@@ -340,14 +351,10 @@ def paint_staged_stake(emitter,
     emitter.echo(f"""
 Staking address: {staking_address}
 ~ Chain      -> ID # {stakeholder.wallet.blockchain.client.chain_id} | {stakeholder.wallet.blockchain.client.chain_name}
-~ Value      -> {stake_value} ({Decimal(int(stake_value)):.2E} NuNits)
+~ Value      -> {stake_value} ({int(stake_value)} NuNits)
 ~ Duration   -> {lock_periods} Days ({lock_periods} Periods)
-~ Enactment  -> {datetime_at_period(period=start_period,
-                                    seconds_per_period=stakeholder.economics.seconds_per_period,
-                                    start_of_period=True)} (period #{start_period})
-~ Expiration -> {datetime_at_period(period=end_period,
-                                    seconds_per_period=stakeholder.economics.seconds_per_period,
-                                    start_of_period=True)} (period #{end_period})
+~ Enactment  -> {start_datetime_pretty} (period #{start_period})
+~ Expiration -> {unlock_datetime_pretty} (period #{unlock_period})
     """)
 
     # TODO: periods != Days - Do we inform the user here?
@@ -429,7 +436,7 @@ Staking address: {staking_address}
                        stake_value=target_value,
                        lock_periods=new_duration_periods,
                        start_period=original_stake.start_period,
-                       end_period=new_end_period,
+                       unlock_period=new_end_period,
                        division_message=division_message)
 
 

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -387,8 +387,11 @@ def prettify_stake(stake, index: int = None) -> str:
 
 
 def paint_stakes(emitter, stakes):
-    if not stakes:
+    active_stakes = sorted((stake for stake in stakes if stake.is_active),
+                           key=lambda some_stake: some_stake.address_index_ordering_key)
+    if not active_stakes:
         emitter.echo(f"There are no active stakes")
+        return
 
     title = "======================================= Active Stakes =========================================\n"
 
@@ -399,7 +402,7 @@ def paint_stakes(emitter, stakes):
     emitter.echo(header, bold=True)
     emitter.echo(breaky, bold=True)
 
-    for index, stake in enumerate(sorted(stakes, key=lambda some_stake: some_stake.address_index_ordering_key)):
+    for index, stake in enumerate(active_stakes):
         row = prettify_stake(stake=stake, index=index)
         row_color = 'yellow' if stake.worker_address == BlockchainInterface.NULL_ADDRESS else 'white'
         emitter.echo(row, color=row_color)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import csv
 import time
 import webbrowser
 from collections import Counter
@@ -617,3 +618,16 @@ def paint_deployed_allocations(emitter, allocations, failed) -> None:
         emitter.echo(f"{beneficiary} | {name:20} | FAILED", color='red')
     emitter.echo()
 
+
+def write_deployed_allocations_to_csv(filepath: str, allocated: list, failed: list):
+    fieldnames = ['Beneficiary', 'Name', 'Contract address']
+    allocated += [(failed_allocation, "FAILED") for failed_allocation in failed]
+
+    with open(filepath, 'w', newline='') as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        for allocation, contract_address in allocated:
+            beneficiary = allocation['beneficiary_address']
+            name = allocation.get('name', 'No name provided')
+            row = (beneficiary, name, contract_address)
+            writer.writerow(dict(zip(fieldnames, row)))

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -31,9 +31,9 @@ from nucypher.blockchain.eth.agents import (
     NucypherTokenAgent,
     AdjudicatorAgent,
     PolicyManagerAgent,
-    StakingEscrowAgent
+    StakingEscrowAgent,
+    PreallocationEscrowAgent
 )
-from nucypher.blockchain.eth.agents import PreallocationEscrowAgent
 from nucypher.blockchain.eth.constants import NUCYPHER_TOKEN_CONTRACT_NAME
 from nucypher.blockchain.eth.deployers import DispatcherDeployer, StakingInterfaceRouterDeployer
 from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainInterfaceFactory
@@ -228,10 +228,10 @@ Stakers population ....... {staking_agent.get_staker_population()}
     emitter.echo(sep)
 
 
-def paint_deployer_contract_inspection(emitter, administrator) -> None:
+def paint_deployer_contract_inspection(emitter, registry, deployer_address) -> None:
 
     blockchain = BlockchainInterfaceFactory.get_interface()
-    token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=administrator.registry)
+    token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=registry)
 
     sep = '-' * 45
     emitter.echo(sep)
@@ -242,7 +242,7 @@ def paint_deployer_contract_inspection(emitter, administrator) -> None:
 ====================================================================
 
 Provider URI ............. {blockchain.provider_uri}
-Registry  ................ {administrator.registry.filepath}
+Registry  ................ {registry.filepath}
 
 * Standard Deployments
 =====================================================================
@@ -257,19 +257,20 @@ Registry  ................ {administrator.registry.filepath}
 ====================================================================="""
     emitter.echo(banner)
 
-    for contract_deployer_class in administrator.dispatched_upgradeable_deployer_classes:
+    from nucypher.blockchain.eth.actors import ContractAdministrator
+    for contract_deployer_class in ContractAdministrator.dispatched_upgradeable_deployer_classes:
         try:
             bare_contract = blockchain.get_contract_by_name(name=contract_deployer_class.contract_name,
                                                             proxy_name=DispatcherDeployer.contract_name,
-                                                            registry=administrator.registry,
+                                                            registry=registry,
                                                             use_proxy_address=False)
 
-            dispatcher_deployer = DispatcherDeployer(registry=administrator.registry,
+            dispatcher_deployer = DispatcherDeployer(registry=registry,
                                                      target_contract=bare_contract,
-                                                     deployer_address=administrator.deployer_address,
+                                                     deployer_address=deployer_address,
                                                      bare=True)  # acquire agency for the dispatcher itself.
 
-            agent = contract_deployer_class.agency(registry=administrator.registry, contract=bare_contract)
+            agent = contract_deployer_class.agency(registry=registry, contract=bare_contract)
 
             proxy_payload = f"""
 {agent.contract_name} .... {bare_contract.address}
@@ -285,7 +286,7 @@ Registry  ................ {administrator.registry.filepath}
             emitter.echo(sep, nl=False)
 
         except BaseContractRegistry.UnknownContract:
-            message = f"\n{contract_deployer_class.contract_name} is not enrolled in {administrator.registry.filepath}"
+            message = f"\n{contract_deployer_class.contract_name} is not enrolled in {registry.filepath}"
             emitter.echo(message, color='yellow')
             emitter.echo(sep, nl=False)
 
@@ -295,15 +296,15 @@ Registry  ................ {administrator.registry.filepath}
         # StakingInterface
         #
 
-        staking_interface_agent = PreallocationEscrowAgent.StakingInterfaceAgent(registry=administrator.registry)
+        staking_interface_agent = PreallocationEscrowAgent.StakingInterfaceAgent(registry=registry)
         bare_contract = blockchain.get_contract_by_name(name=staking_interface_agent.contract_name,
                                                         proxy_name=StakingInterfaceRouterDeployer.contract_name,
                                                         use_proxy_address=False,
-                                                        registry=administrator.registry)
+                                                        registry=registry)
 
-        router_deployer = StakingInterfaceRouterDeployer(registry=administrator.registry,
+        router_deployer = StakingInterfaceRouterDeployer(registry=registry,
                                                          target_contract=bare_contract,
-                                                         deployer_address=administrator.deployer_address,
+                                                         deployer_address=deployer_address,
                                                          bare=True)  # acquire agency for the dispatcher itself.
 
         preallocation_escrow_payload = f"""
@@ -315,7 +316,7 @@ Registry  ................ {administrator.registry.filepath}
         emitter.echo(sep)
 
     except BaseContractRegistry.UnknownContract:
-        message = f"\nStakingInterface is not enrolled in {administrator.registry.filepath}"
+        message = f"\nStakingInterface is not enrolled in {registry.filepath}"
         emitter.echo(message, color='yellow')
 
     return

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -385,6 +385,9 @@ def prettify_stake(stake, index: int = None) -> str:
 
 
 def paint_stakes(emitter, stakes):
+    if not stakes:
+        emitter.echo(f"There are no active stakes")
+
     title = "======================================= Active Stakes =========================================\n"
 
     header = f'| ~ | Staker | Worker | # | Value    | Duration     | Enactment          '
@@ -423,6 +426,22 @@ Staking address: {staking_address}
                        start_period=original_stake.start_period,
                        end_period=new_end_period,
                        division_message=division_message)
+
+
+def paint_accounts(emitter, balances):
+    rows = list()
+    max_eth_len, max_nu_len = 0, 0
+    for address, balances in sorted(balances.items()):
+        eth = str(Web3.fromWei(balances['ETH'], 'ether')) + " ETH"
+        nu = str(NU.from_nunits(balances['NU']))
+
+        max_eth_len = max(max_eth_len, len(eth))
+        max_nu_len = max(max_nu_len, len(nu))
+
+        rows.append((address, eth, nu))
+
+    for address, eth, nu in rows:
+        emitter.echo(f"{address} | {eth:{max_eth_len}} | {nu:{max_nu_len}}")
 
 
 def paint_receipt_summary(emitter, receipt, chain_name: str = None, transaction_type=None, provider_uri: str = None):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -45,6 +45,7 @@ from twisted.internet import task
 from twisted.internet.threads import deferToThread
 from twisted.logger import Logger
 
+from nucypher.blockchain.economics import TokenEconomicsFactory
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.registry import BaseContractRegistry
@@ -1012,9 +1013,19 @@ class Teacher:
         As a follow-up, this checks that the staker is, indeed, staking.
         """
         # Lazy agent get or create
-        staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)
-        locked_tokens = staking_agent.get_locked_tokens(staker_address=self.checksum_address)
-        return locked_tokens > 0  # TODO: Consider min stake size #1115
+        staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)  # type: StakingEscrowAgent
+
+        try:
+            economics = TokenEconomicsFactory.get_economics(registry=registry)
+        except Exception:
+            raise  # TODO: Get StandardEconomics
+
+        min_stake = economics.minimum_allowed_locked
+
+        stake_current_period = staking_agent.get_locked_tokens(staker_address=self.checksum_address, periods=0)
+        stake_next_period = staking_agent.get_locked_tokens(staker_address=self.checksum_address, periods=1)
+        is_staking = max(stake_current_period, stake_next_period) >= min_stake
+        return is_staking
 
     def validate_worker(self, registry: BaseContractRegistry = None) -> None:
 

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -123,17 +123,17 @@ BASE_TEMP_DIR = tempfile.gettempdir()
 BASE_TEMP_PREFIX = 'nucypher-tmp-'
 DATETIME_FORMAT = "%Y-%m-%d_%H-%M-%S.%f"
 
-MOCK_CUSTOM_INSTALLATION_PATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-custom-{str(datetime.now().strftime(DATETIME_FORMAT))}')
+MOCK_CUSTOM_INSTALLATION_PATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-custom-{datetime.now().strftime(DATETIME_FORMAT)}')
 
-MOCK_ALLOCATION_INFILE = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-allocations-{str(datetime.now().strftime(DATETIME_FORMAT))}.json')
+MOCK_ALLOCATION_INFILE = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-allocations-{datetime.now().strftime(DATETIME_FORMAT)}.json')
 
-MOCK_ALLOCATION_REGISTRY_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-allocation-registry-{str(datetime.now().strftime(DATETIME_FORMAT))}.json')
+MOCK_ALLOCATION_REGISTRY_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-allocation-registry-{datetime.now().strftime(DATETIME_FORMAT)}.json')
 
-MOCK_INDIVIDUAL_ALLOCATION_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-individual-allocation-{str(datetime.now().strftime(DATETIME_FORMAT))}.json')
+MOCK_INDIVIDUAL_ALLOCATION_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-individual-allocation-{datetime.now().strftime(DATETIME_FORMAT)}.json')
 
 MOCK_CUSTOM_INSTALLATION_PATH_2 = '/tmp/nucypher-tmp-test-custom-2-{}'.format(time.time())
 
-MOCK_REGISTRY_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}mock-registry-{str(datetime.now().strftime(DATETIME_FORMAT))}.json')
+MOCK_REGISTRY_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}mock-registry-{datetime.now().strftime(DATETIME_FORMAT)}.json')
 
 TEMPORARY_DOMAIN = ':TEMPORARY_DOMAIN:'  # for use with `--dev` node runtimes
 

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -129,6 +129,8 @@ MOCK_ALLOCATION_INFILE = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-al
 
 MOCK_ALLOCATION_REGISTRY_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-allocation-registry-{str(datetime.now().strftime(DATETIME_FORMAT))}.json')
 
+MOCK_INDIVIDUAL_ALLOCATION_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}test-individual-allocation-{str(datetime.now().strftime(DATETIME_FORMAT))}.json')
+
 MOCK_CUSTOM_INSTALLATION_PATH_2 = '/tmp/nucypher-tmp-test-custom-2-{}'.format(time.time())
 
 MOCK_REGISTRY_FILEPATH = os.path.join(BASE_TEMP_DIR, f'{BASE_TEMP_PREFIX}mock-registry-{str(datetime.now().strftime(DATETIME_FORMAT))}.json')

--- a/tests/blockchain/eth/entities/deployers/test_deploy_preallocations.py
+++ b/tests/blockchain/eth/entities/deployers/test_deploy_preallocations.py
@@ -41,7 +41,6 @@ def test_deploy_and_allocate(agency, token_economics, test_registry):
 
         # Ensure we have the correct assembly of address and abi
         assert escrow_deployer.contract.address == escrow_deployer.contract.address
-        # assert escrow_deployer.contract_address == user_escrow_proxy  # (address)
 
         # Ensure each deployment is unique
         if _last_deployment_address:

--- a/tests/blockchain/eth/interfaces/test_decorators.py
+++ b/tests/blockchain/eth/interfaces/test_decorators.py
@@ -23,13 +23,7 @@ from eth_utils import to_checksum_address
 from nucypher.blockchain.eth.decorators import validate_checksum_address, InvalidChecksumAddress
 
 
-def get_random_checksum_address():
-    canonical_address = os.urandom(20)
-    checksum_address = to_checksum_address(canonical_address)
-    return checksum_address
-
-
-def test_validate_checksum_address():
+def test_validate_checksum_address(get_random_checksum_address):
 
     # Simple case: just one parameter, called "checksum_address"
     @validate_checksum_address

--- a/tests/blockchain/eth/interfaces/test_registry.py
+++ b/tests/blockchain/eth/interfaces/test_registry.py
@@ -14,10 +14,33 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+import json
+import os
 import pytest
 
+from nucypher.blockchain.eth.deployers import PreallocationEscrowDeployer
 from nucypher.blockchain.eth.interfaces import BaseContractRegistry
-from nucypher.blockchain.eth.registry import LocalContractRegistry
+from nucypher.blockchain.eth.registry import LocalContractRegistry, IndividualAllocationRegistry
+
+
+@pytest.fixture(autouse=True, scope='module')
+def patch_individual_allocation_registry_fetch_latest_publication(agency, test_registry):
+    empty_allocation_escrow_deployer = PreallocationEscrowDeployer(registry=test_registry)
+    allocation_contract_abi = empty_allocation_escrow_deployer.get_contract_abi()
+    allocation_template = {
+        "BENEFICIARY_ADDRESS": ["ALLOCATION_CONTRACT_ADDRESS", allocation_contract_abi]
+    }
+    new_fetch_result = json.dumps(allocation_template).encode()
+
+    original_fetch = IndividualAllocationRegistry.fetch_latest_publication
+
+    def new_fetch(*args, **kwargs):
+        return new_fetch_result
+
+    IndividualAllocationRegistry.fetch_latest_publication = new_fetch
+    yield
+    IndividualAllocationRegistry.fetch_latest_publication = original_fetch
 
 
 def test_contract_registry(tempfile_path):
@@ -74,3 +97,38 @@ def test_contract_registry(tempfile_path):
     # Check that searching for an unknown contract raises
     with pytest.raises(BaseContractRegistry.IllegalRegistry):
         test_registry.search(contract_address=test_addr)
+
+
+def test_individual_allocation_registry(get_random_checksum_address, test_registry, tempfile_path):
+    empty_allocation_escrow_deployer = PreallocationEscrowDeployer(registry=test_registry)
+    allocation_contract_abi = empty_allocation_escrow_deployer.get_contract_abi()
+
+    beneficiary = get_random_checksum_address()
+    contract_address = get_random_checksum_address()
+    allocation_registry = IndividualAllocationRegistry(beneficiary_address=beneficiary,
+                                                       contract_address=contract_address)
+
+    registry_data = allocation_registry.read()
+    assert len(registry_data) == 1
+
+    assert allocation_registry.search(beneficiary_address=beneficiary) == [contract_address, allocation_contract_abi]
+    assert allocation_registry.search(contract_address=contract_address) == [beneficiary, allocation_contract_abi]
+
+    # Check that searching for an unknown beneficiary or unknown contract raises
+    with pytest.raises(IndividualAllocationRegistry.UnknownBeneficiary):
+        allocation_registry.search(beneficiary_address=get_random_checksum_address())
+
+    with pytest.raises(IndividualAllocationRegistry.UnknownContract):
+        allocation_registry.search(contract_address=get_random_checksum_address())
+
+    # Check that it gets the same data if using a file to create the allocation registry
+    individual_allocation_file_data = {
+        'beneficiary_address': beneficiary,
+        'contract_address': contract_address
+    }
+    with open(tempfile_path, 'w') as outfile:
+        json.dump(individual_allocation_file_data, outfile)
+
+    allocation_registry = IndividualAllocationRegistry.from_allocation_file(filepath=tempfile_path)
+    assert registry_data == allocation_registry.read()
+

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -1,7 +1,5 @@
 import os
 
-import pytest
-
 from nucypher.blockchain.eth.agents import (
     PolicyManagerAgent,
     StakingEscrowAgent,
@@ -10,7 +8,7 @@ from nucypher.blockchain.eth.agents import (
 )
 from nucypher.blockchain.eth.constants import STAKING_ESCROW_CONTRACT_NAME
 from nucypher.blockchain.eth.deployers import StakingEscrowDeployer
-from nucypher.blockchain.eth.registry import InMemoryContractRegistry, LocalContractRegistry
+from nucypher.blockchain.eth.registry import LocalContractRegistry
 from nucypher.cli.deploy import deploy
 from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -92,7 +92,7 @@ def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agenc
 
     assert re.search(f"^Current period: {staking_agent.get_current_period()}", result.output, re.MULTILINE)
     assert re.search(r"Worker:\s+" + some_dude.worker_address, result.output, re.MULTILINE)
-    assert re.search(r"Stake:\s+" + str(round(owned_tokens, 2)), result.output, re.MULTILINE)
-    assert re.search(r"Locked: " + str(round(locked_tokens, 2)), result.output, re.MULTILINE)
+    assert re.search(r"Owned:\s+" + str(round(owned_tokens, 2)), result.output, re.MULTILINE)
+    assert re.search(r"Staked: " + str(round(locked_tokens, 2)), result.output, re.MULTILINE)
 
 

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -15,19 +15,33 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import datetime
 import json
+import os
+import random
 
+import maya
 import pytest
+from twisted.logger import Logger
 from web3 import Web3
 
 from nucypher.blockchain.eth.actors import Staker
 from nucypher.blockchain.eth.agents import StakingEscrowAgent, ContractAgency, PreallocationEscrowAgent, NucypherTokenAgent
-from nucypher.blockchain.eth.token import NU, Stake
+from nucypher.blockchain.eth.token import NU, Stake, StakeList
+from nucypher.characters.lawful import Enrico, Ursula
 from nucypher.cli.main import nucypher_cli
+from nucypher.config.characters import UrsulaConfiguration
+from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,
     INSECURE_DEVELOPMENT_PASSWORD,
+    MOCK_IP_ADDRESS,
+    MOCK_URSULA_STARTING_PORT,
+    TEMPORARY_DOMAIN,
+    MOCK_KNOWN_URSULAS_CACHE,
+    select_test_port,
 )
+from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 #
 # This test module is intended to mirror tests/cli/ursula/test_stakeholder_and_ursula.py,
@@ -169,6 +183,68 @@ def test_stake_set_worker(click_runner,
     assert staker.worker_address == manual_worker
 
 
+def test_stake_detach_worker(click_runner,
+                             testerchain,
+                             token_economics,
+                             beneficiary,
+                             preallocation_escrow_agent,
+                             mock_allocation_registry,
+                             manual_worker,
+                             test_registry,
+                             stakeholder_configuration_file_location):
+
+    staker_address = preallocation_escrow_agent.principal_contract.address
+
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    assert manual_worker == staking_agent.get_worker_from_staker(staker_address=staker_address)
+
+    testerchain.time_travel(periods=token_economics.minimum_worker_periods)
+
+    init_args = ('stake', 'detach-worker',
+                 '--config-file', stakeholder_configuration_file_location,
+                 '--escrow',
+                 '--beneficiary-address', beneficiary,
+                 '--allocation-filepath', mock_allocation_registry.filepath,
+                 '--force')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    staker = Staker(is_me=True,
+                    checksum_address=beneficiary,
+                    allocation_registry=mock_allocation_registry,
+                    registry=test_registry)
+
+    assert not staker.worker_address
+
+    # Ok ok, let's set the worker again.
+
+    init_args = ('stake', 'set-worker',
+                 '--config-file', stakeholder_configuration_file_location,
+                 '--escrow',
+                 '--beneficiary-address', beneficiary,
+                 '--allocation-filepath', mock_allocation_registry.filepath,
+                 '--worker-address', manual_worker,
+                 '--force')
+
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=user_input,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    staker = Staker(is_me=True,
+                    checksum_address=beneficiary,
+                    allocation_registry=mock_allocation_registry,
+                    registry=test_registry)
+
+    assert staker.worker_address == manual_worker
+
+
 def test_stake_restake(click_runner,
                        beneficiary,
                        preallocation_escrow_agent,
@@ -253,3 +329,248 @@ def test_stake_restake(click_runner,
                     allocation_registry=mock_allocation_registry)
     assert not staker.is_restaking
     assert "Successfully disabled" in result.output
+
+
+def test_ursula_init(click_runner,
+                     custom_filepath,
+                     mock_registry_filepath,
+                     preallocation_escrow_agent,
+                     manual_worker,
+                     testerchain):
+
+    init_args = ('ursula', 'init',
+                 '--poa',
+                 '--network', TEMPORARY_DOMAIN,
+                 '--staker-address', preallocation_escrow_agent.principal_contract.address,
+                 '--worker-address', manual_worker,
+                 '--config-root', custom_filepath,
+                 '--provider', TEST_PROVIDER_URI,
+                 '--registry-filepath', mock_registry_filepath,
+                 '--rest-host', MOCK_IP_ADDRESS,
+                 '--rest-port', MOCK_URSULA_STARTING_PORT)
+
+    user_input = '{password}\n{password}'.format(password=INSECURE_DEVELOPMENT_PASSWORD)
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=user_input,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Files and Directories
+    assert os.path.isdir(custom_filepath), 'Configuration file does not exist'
+    assert os.path.isdir(os.path.join(custom_filepath, 'keyring')), 'Keyring does not exist'
+    assert os.path.isdir(os.path.join(custom_filepath, 'known_nodes')), 'known_nodes directory does not exist'
+
+    custom_config_filepath = os.path.join(custom_filepath, UrsulaConfiguration.generate_filename())
+    assert os.path.isfile(custom_config_filepath), 'Configuration file does not exist'
+
+    with open(custom_config_filepath, 'r') as config_file:
+        raw_config_data = config_file.read()
+        config_data = json.loads(raw_config_data)
+        assert config_data['provider_uri'] == TEST_PROVIDER_URI
+        assert config_data['worker_address'] == manual_worker
+        assert config_data['checksum_address'] == preallocation_escrow_agent.principal_contract.address
+        assert TEMPORARY_DOMAIN in config_data['domains']
+
+
+def test_ursula_run(click_runner,
+                    manual_worker,
+                    custom_filepath,
+                    testerchain):
+
+    custom_config_filepath = os.path.join(custom_filepath, UrsulaConfiguration.generate_filename())
+
+    # Now start running your Ursula!
+    init_args = ('ursula', 'run',
+                 '--dry-run',
+                 '--config-file', custom_config_filepath)
+
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' * 2
+    result = click_runner.invoke(nucypher_cli,
+                                 init_args,
+                                 input=user_input,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+
+def test_collect_rewards_integration(click_runner,
+                                     testerchain,
+                                     test_registry,
+                                     stakeholder_configuration_file_location,
+                                     blockchain_alice,
+                                     blockchain_bob,
+                                     random_policy_label,
+                                     beneficiary,
+                                     preallocation_escrow_agent,
+                                     mock_allocation_registry,
+                                     manual_worker,
+                                     token_economics,
+                                     stake_value,
+                                     policy_value,
+                                     policy_rate):
+
+    half_stake_time = token_economics.minimum_locked_periods // 2  # Test setup
+    logger = Logger("Test-CLI")  # Enter the Teacher's Logger, and
+    current_period = 0  # State the initial period for incrementing
+
+    staker_address = preallocation_escrow_agent.principal_contract.address
+    worker_address = manual_worker
+
+    # The staker is staking.
+    stakes = StakeList(registry=test_registry, checksum_address=staker_address)
+    stakes.refresh()
+    assert stakes
+
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    assert worker_address == staking_agent.get_worker_from_staker(staker_address=staker_address)
+
+    ursula_port = select_test_port()
+    ursula = Ursula(is_me=True,
+                    checksum_address=staker_address,
+                    worker_address=worker_address,
+                    registry=test_registry,
+                    rest_host='127.0.0.1',
+                    rest_port=ursula_port,
+                    start_working_now=False,
+                    network_middleware=MockRestMiddleware())
+
+    MOCK_KNOWN_URSULAS_CACHE[ursula_port] = ursula
+    assert ursula.worker_address == worker_address
+    assert ursula.checksum_address == staker_address
+
+    # Mock TransactingPower consumption (Worker-Ursula)
+    testerchain.transacting_power = TransactingPower(account=worker_address, password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power.activate()
+
+    # Confirm for half the first stake duration
+    for _ in range(half_stake_time):
+        logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+        ursula.confirm_activity()
+        testerchain.time_travel(periods=1)
+        current_period += 1
+
+    # Alice creates a policy and grants Bob access
+    blockchain_alice.selection_buffer = 1
+
+    M, N = 1, 1
+    expiration = maya.now() + datetime.timedelta(days=3)
+    blockchain_policy = blockchain_alice.grant(bob=blockchain_bob,
+                                               label=random_policy_label,
+                                               m=M, n=N,
+                                               value=policy_value,
+                                               expiration=expiration,
+                                               handpicked_ursulas={ursula})
+
+    # Ensure that the handpicked Ursula was selected for the policy
+    arrangement = list(blockchain_policy._accepted_arrangements)[0]
+    assert arrangement.ursula == ursula
+
+    # Bob learns about the new staker and joins the policy
+    blockchain_bob.start_learning_loop()
+    blockchain_bob.remember_node(node=ursula)
+    blockchain_bob.join_policy(random_policy_label, bytes(blockchain_alice.stamp))
+
+    # Enrico Encrypts (of course)
+    enrico = Enrico(policy_encrypting_key=blockchain_policy.public_key,
+                    network_middleware=MockRestMiddleware())
+
+    verifying_key = blockchain_alice.stamp.as_umbral_pubkey()
+
+    for index in range(half_stake_time - 5):
+        logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+        ursula.confirm_activity()
+
+        # Encrypt
+        random_data = os.urandom(random.randrange(20, 100))
+        ciphertext, signature = enrico.encrypt_message(message=random_data)
+
+        # Decrypt
+        cleartexts = blockchain_bob.retrieve(message_kit=ciphertext,
+                                             data_source=enrico,
+                                             alice_verifying_key=verifying_key,
+                                             label=random_policy_label)
+        assert random_data == cleartexts[0]
+
+        # Ursula Staying online and the clock advancing
+        testerchain.time_travel(periods=1)
+        current_period += 1
+
+    # Finish the passage of time
+    for _ in range(5 - 1):  # minus 1 because the first period was already confirmed in test_ursula_run
+        logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+        ursula.confirm_activity()
+        current_period += 1
+        testerchain.time_travel(periods=1)
+
+    #
+    # WHERES THE MONEY URSULA?? - Collecting Rewards
+    #
+
+    # The address the client wants Ursula to send policy rewards to
+    burner_wallet = testerchain.w3.eth.account.create(INSECURE_DEVELOPMENT_PASSWORD)
+
+    # The policy rewards wallet is initially empty, because it is freshly created
+    assert testerchain.client.get_balance(burner_wallet.address) == 0
+
+    # Rewards will be unlocked after the
+    # final confirmed period has passed (+1).
+    logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+    testerchain.time_travel(periods=1)
+    current_period += 1
+    logger.debug(f">>>>>>>>>>> TEST PERIOD {current_period} <<<<<<<<<<<<<<<<")
+
+    # Since we are mocking the blockchain connection, manually consume the transacting power of the Beneficiary.
+    testerchain.transacting_power = TransactingPower(account=beneficiary,
+                                                     password=INSECURE_DEVELOPMENT_PASSWORD)
+    testerchain.transacting_power.activate()
+
+    # Collect Policy Reward
+    collection_args = ('stake', 'collect-reward',
+                       '--mock-networking',
+                       '--config-file', stakeholder_configuration_file_location,
+                       '--policy-reward',
+                       '--no-staking-reward',
+                       '--withdraw-address', burner_wallet.address,
+                       '--escrow',
+                       '--beneficiary-address', beneficiary,
+                       '--allocation-filepath', mock_allocation_registry.filepath,
+                       '--force')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 collection_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Policy Reward
+    collected_policy_reward = testerchain.client.get_balance(burner_wallet.address)
+    expected_collection = policy_rate * 30
+    assert collected_policy_reward == expected_collection
+
+    #
+    # Collect Staking Reward
+    #
+    token_agent = ContractAgency.get_agent(agent_class=NucypherTokenAgent, registry=test_registry)
+    balance_before_collecting = token_agent.get_balance(address=staker_address)
+
+    collection_args = ('stake', 'collect-reward',
+                       '--mock-networking',
+                       '--config-file', stakeholder_configuration_file_location,
+                       '--no-policy-reward',
+                       '--staking-reward',
+                       '--escrow',
+                       '--beneficiary-address', beneficiary,
+                       '--allocation-filepath', mock_allocation_registry.filepath,
+                       '--force')
+
+    result = click_runner.invoke(nucypher_cli,
+                                 collection_args,
+                                 input=INSECURE_DEVELOPMENT_PASSWORD,
+                                 catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # The beneficiary has withdrawn her staking rewards, which are now in the staking contract
+    assert token_agent.get_balance(address=staker_address) >= balance_before_collecting
+
+
+

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -201,7 +201,7 @@ def test_stake_set_worker(click_runner,
                  '--worker-address', manual_worker,
                  '--force')
 
-    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(nucypher_cli,
                                  init_args,
                                  input=user_input,
@@ -261,7 +261,7 @@ def test_stake_detach_worker(click_runner,
                  '--worker-address', manual_worker,
                  '--force')
 
-    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(nucypher_cli,
                                  init_args,
                                  input=user_input,

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -128,7 +128,7 @@ def test_stake_list(click_runner,
     stake_args = ('stake', 'list',
                   '--config-file', stakeholder_configuration_file_location)
 
-    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(nucypher_cli, stake_args, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
     assert str(stake_value) in result.output
@@ -159,7 +159,7 @@ def test_staker_divide_stakes(click_runner,
                   '--config-file', stakeholder_configuration_file_location,
                   '--poa')
 
-    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(nucypher_cli, stake_args, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
     assert str(NU(token_economics.minimum_allowed_locked, 'NuNit').to_tokens()) in result.output
@@ -178,7 +178,7 @@ def test_stake_set_worker(click_runner,
                  '--worker-address', manual_worker,
                  '--force')
 
-    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(nucypher_cli,
                                  init_args,
                                  input=user_input,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -23,9 +23,8 @@ import tempfile
 
 import maya
 import pytest
-from eth_tester import PyEVMBackend
 
-from constant_sorrow.constants import NON_PAYMENT
+from eth_utils import to_checksum_address
 from sqlalchemy.engine import create_engine
 from twisted.logger import Logger
 from umbral import pre
@@ -809,3 +808,12 @@ def mock_registry_filepath(testerchain, agency, test_registry):
 
     if os.path.isfile(MOCK_REGISTRY_FILEPATH):
         os.remove(MOCK_REGISTRY_FILEPATH)
+
+
+@pytest.fixture(scope='module')
+def get_random_checksum_address():
+    def _get_random_checksum_address():
+        canonical_address = os.urandom(20)
+        checksum_address = to_checksum_address(canonical_address)
+        return checksum_address
+    return _get_random_checksum_address


### PR DESCRIPTION
* `TransactingPower` now auto-detects that the account comes from a HW, using the data provided by geth endpoint `personal_listWallets`. Fix #1385. Fix #1128 
* Check min staking size when learning. Also accepts staking for next period, which makes possible creating a stake and running a discoverable Ursula in the same period. Closes #1115 
* Fix confusion between staked and locked+rewards. Fixes #1369 
* Fix lack of client account selection for `nucypher stake collect-reward`
* Complete CLI tests for staking via contracts, except for divide.
* Revamp output files of allocation process and how allocation users stake. Closes #1351 
* Fix datetimes printed by `nucypher stake`.
* `nucypher stake list` now only prints active stakes. Fixes #1418 