### PR TITLE
WorkLock updates

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -182,7 +182,8 @@ class ContractAdministrator(NucypherTokenActor):
                  registry: BaseContractRegistry,
                  deployer_address: str = None,
                  client_password: str = None,
-                 economics: TokenEconomics = None):
+                 economics: TokenEconomics = None,
+                 staking_escrow_test_mode: bool = False):
         """
         Note: super() is not called here to avoid setting the token agent.
         TODO: Review this logic ^^ "bare mode".  #1510
@@ -199,6 +200,7 @@ class ContractAdministrator(NucypherTokenActor):
 
         self.transacting_power = TransactingPower(password=client_password, account=deployer_address, cache=True)
         self.transacting_power.activate()
+        self.staking_escrow_test_mode = staking_escrow_test_mode
 
     def __repr__(self):
         r = '{name} - {deployer_address})'.format(name=self.__class__.__name__, deployer_address=self.deployer_address)
@@ -235,6 +237,9 @@ class ContractAdministrator(NucypherTokenActor):
                         ) -> Tuple[dict, BaseContractDeployer]:
 
         Deployer = self.__get_deployer(contract_name=contract_name)
+        if Deployer is StakingEscrowDeployer:
+            kwargs.update({"test_mode": self.staking_escrow_test_mode})
+
         deployer = Deployer(registry=self.registry,
                             deployer_address=self.deployer_address,
                             economics=self.economics,

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -598,8 +598,8 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
         the_escrow_contract = wrapped_escrow_contract
 
         # 3 - Transfer the reward supply tokens to StakingEscrow #
-        reward_function = self.token_contract.functions.transfer(the_escrow_contract.address,
-                                                                 self.economics.erc20_reward_supply)
+        reward_function = self.token_contract.functions.approve(the_escrow_contract.address,
+                                                                self.economics.erc20_reward_supply)
 
         # TODO: Confirmations / Successful Transaction Indicator / Events ??  - #1193, #1194
         reward_receipt = self.blockchain.send_transaction(contract_function=reward_function,
@@ -609,7 +609,7 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
             progress.update(1)
 
         # 4 - Initialize the StakingEscrow contract
-        init_function = the_escrow_contract.functions.initialize()
+        init_function = the_escrow_contract.functions.initialize(self.economics.erc20_reward_supply)
 
         init_receipt = self.blockchain.send_transaction(contract_function=init_function,
                                                         sender_address=self.deployer_address,

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -598,14 +598,14 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
         # Switch the contract for the wrapped one
         the_escrow_contract = wrapped_escrow_contract
 
-        # 3 - Transfer the reward supply tokens to StakingEscrow #
-        reward_function = self.token_contract.functions.approve(the_escrow_contract.address,
-                                                                self.economics.erc20_reward_supply)
+        # 3 - Approve transfer the reward supply tokens to StakingEscrow #
+        approve_reward_function = self.token_contract.functions.approve(the_escrow_contract.address,
+                                                                        self.economics.erc20_reward_supply)
 
         # TODO: Confirmations / Successful Transaction Indicator / Events ??  - #1193, #1194
-        reward_receipt = self.blockchain.send_transaction(contract_function=reward_function,
-                                                          sender_address=self.deployer_address,
-                                                          payload=origin_args)
+        approve_reward_receipt = self.blockchain.send_transaction(contract_function=approve_reward_function,
+                                                                  sender_address=self.deployer_address,
+                                                                  payload=origin_args)
         if progress:
             progress.update(1)
 
@@ -619,7 +619,7 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
             progress.update(1)
 
         # Gather the transaction receipts
-        ordered_receipts = (deploy_receipt, dispatcher_deploy_receipt, reward_receipt, init_receipt)
+        ordered_receipts = (deploy_receipt, dispatcher_deploy_receipt, approve_reward_receipt, init_receipt)
         deployment_receipts = dict(zip(self.deployment_steps, ordered_receipts))
 
         # Set the contract and transaction receipts #

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -483,7 +483,7 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
 
     agency = StakingEscrowAgent
     contract_name = agency.registry_contract_name
-    deployment_steps = ('contract_deployment', 'dispatcher_deployment', 'reward_transfer', 'initialize')
+    deployment_steps = ('contract_deployment', 'dispatcher_deployment', 'approve_reward_transfer', 'initialize')
     _proxy_deployer = DispatcherDeployer
 
     def __init__(self, test_mode: bool = False, *args, **kwargs):

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -509,7 +509,8 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
             "_minLockedPeriods": args[4],
             "_minAllowableLockedTokens": args[5],
             "_maxAllowableLockedTokens": args[6],
-            "_minWorkerPeriods": args[7]
+            "_minWorkerPeriods": args[7],
+            "_isTestContract": False
         }
         constructor_kwargs.update(overrides)
         constructor_kwargs = {k: v for k, v in constructor_kwargs.items() if v is not None}

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -486,13 +486,14 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
     deployment_steps = ('contract_deployment', 'dispatcher_deployment', 'reward_transfer', 'initialize')
     _proxy_deployer = DispatcherDeployer
 
-    def __init__(self,  *args, **kwargs):
+    def __init__(self, test_mode: bool = False, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.__dispatcher_contract = None
 
         token_contract_name = NucypherTokenDeployer.contract_name
         self.token_contract = self.blockchain.get_contract_by_name(registry=self.registry,
                                                                    contract_name=token_contract_name)
+        self.test_mode = test_mode
 
     def __check_policy_manager(self):
         result = self.contract.functions.policyManager().call()
@@ -510,7 +511,7 @@ class StakingEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
             "_minAllowableLockedTokens": args[5],
             "_maxAllowableLockedTokens": args[6],
             "_minWorkerPeriods": args[7],
-            "_isTestContract": False
+            "_isTestContract": self.test_mode
         }
         constructor_kwargs.update(overrides)
         constructor_kwargs = {k: v for k, v in constructor_kwargs.items() if v is not None}

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -238,6 +238,7 @@ class BaseContractRegistry(ABC):
     def id(self) -> str:
         """Returns a hexstr of the registry contents."""
         blake = hashlib.blake2b()
+        blake.update(self.__class__.__name__.encode())
         blake.update(json.dumps(self.read()).encode())
         digest = blake.digest().hex()
         return digest

--- a/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
@@ -6,6 +6,7 @@ import "zeppelin/math/SafeMath.sol";
 import "zeppelin/math/Math.sol";
 import "contracts/proxy/Upgradeable.sol";
 import "contracts/lib/AdditionalMath.sol";
+import "zeppelin/token/ERC20/SafeERC20.sol";
 
 
 /**
@@ -13,9 +14,11 @@ import "contracts/lib/AdditionalMath.sol";
 * @dev |v1.1.2|
 */
 contract Issuer is Upgradeable {
+    using SafeERC20 for NuCypherToken;
     using SafeMath for uint256;
     using AdditionalMath for uint32;
 
+    event Burnt(address indexed sender, uint256 value);
     /// Issuer is initialized with a reserved reward
     event Initialized(uint256 reservedReward);
 
@@ -97,14 +100,14 @@ contract Issuer is Upgradeable {
     /**
     * @notice Initialize reserved tokens for reward
     */
-    function initialize() public onlyOwner {
+    function initialize(uint256 _reservedReward) public onlyOwner {
         require(currentSupply1 == 0);
+        token.safeTransferFrom(msg.sender, address(this), _reservedReward);
         currentMintingPeriod = getCurrentPeriod();
-        uint256 reservedReward = token.balanceOf(address(this));
-        uint256 currentTotalSupply = totalSupply - reservedReward;
+        uint256 currentTotalSupply = totalSupply - _reservedReward;
         currentSupply1 = currentTotalSupply;
         currentSupply2 = currentTotalSupply;
-        emit Initialized(reservedReward);
+        emit Initialized(_reservedReward);
     }
 
     /**
@@ -167,6 +170,16 @@ contract Issuer is Upgradeable {
     function unMint(uint256 _amount) internal {
         currentSupply1 = currentSupply1 - _amount;
         currentSupply2 = currentSupply2 - _amount;
+    }
+
+    /**
+    * @notice Burn sender's tokens. Amount of tokens will be returned for future minting
+    * @param _value Amount to burn
+    */
+    function burn(uint256 _value) public {
+        token.safeTransferFrom(msg.sender, address(this), _value);
+        unMint(_value);
+        emit Burnt(msg.sender, _value);
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -1215,7 +1215,7 @@ contract StakingEscrow is Issuer {
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
     function verifyState(address _testTarget) public {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "isTestContract()") == 0 ? !isTestContract : isTestContract);
+        require((delegateGet(_testTarget, "isTestContract()") == 0) == !isTestContract);
         require(uint16(delegateGet(_testTarget, "minWorkerPeriods()")) == minWorkerPeriods);
         require(delegateGet(_testTarget, "minAllowableLockedTokens()") == minAllowableLockedTokens);
         require(delegateGet(_testTarget, "maxAllowableLockedTokens()") == maxAllowableLockedTokens);

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.5.3;
 
 
-import "zeppelin/token/ERC20/SafeERC20.sol";
 import "contracts/Issuer.sol";
 
 
@@ -37,7 +36,6 @@ contract WorkLockInterface {
 * @dev |v1.4.1|
 */
 contract StakingEscrow is Issuer {
-    using SafeERC20 for NuCypherToken;
     using AdditionalMath for uint256;
     using AdditionalMath for uint16;
 

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -33,7 +33,7 @@ contract WorkLockInterface {
 /**
 * @notice Contract holds and locks stakers tokens.
 * Each staker that locks their tokens will receive some compensation
-* @dev |v1.4.1|
+* @dev |v1.5.1|
 */
 contract StakingEscrow is Issuer {
     using AdditionalMath for uint256;

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -166,7 +166,7 @@ contract WorkLock {
     * @notice Cancel bid and refund deposited ETH
     */
     function cancelBid() external {
-        // TODO check date? check minimum amount of tokens?
+        // TODO check date? check minimum amount of tokens? (#1508)
         WorkInfo storage info = workInfo[msg.sender];
         require(info.depositedETH > 0, "No bid to cancel");
         require(address(info.preallocationEscrow) == address(0), "Tokens are already claimed");

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -55,7 +55,7 @@ contract WorkLock {
     uint256 public tokenSupply;
     uint256 public ethSupply;
     uint256 public unclaimedTokens;
-    uint16 public lockedDuration;
+    uint256 public lockingDuration;
     mapping(address => WorkInfo) public workInfo;
     mapping(address => address) public depositors;
 
@@ -66,7 +66,7 @@ contract WorkLock {
     * @param _startBidDate Timestamp when bidding starts
     * @param _endBidDate Timestamp when bidding will end
     * @param _boostingRefund Coefficient to boost refund ETH
-    * @param _lockedDuration Duration of tokens locking
+    * @param _lockingDuration Duration of tokens locking
     */
     constructor(
         NuCypherToken _token,
@@ -75,7 +75,7 @@ contract WorkLock {
         uint256 _startBidDate,
         uint256 _endBidDate,
         uint256 _boostingRefund,
-        uint16 _lockedDuration
+        uint256 _lockingDuration
     )
         public
     {
@@ -86,7 +86,7 @@ contract WorkLock {
             _endBidDate > _startBidDate &&
             _endBidDate > block.timestamp &&
             _boostingRefund > 0 &&
-            _lockedDuration > 0);
+            _lockingDuration > 0);
         // worst case for `ethToWork()` and `workToETH()`,
         // when ethSupply == MAX_ETH_SUPPLY and tokenSupply == totalSupply
         require(MAX_ETH_SUPPLY * totalSupply * SLOWING_REFUND / MAX_ETH_SUPPLY / totalSupply == SLOWING_REFUND &&
@@ -98,7 +98,7 @@ contract WorkLock {
         startBidDate = _startBidDate;
         endBidDate = _endBidDate;
         boostingRefund = _boostingRefund;
-        lockedDuration = _lockedDuration;
+        lockingDuration = _lockingDuration;
     }
 
     /**
@@ -193,7 +193,7 @@ contract WorkLock {
 
         preallocationEscrow = new PreallocationEscrow(router, token);
         token.approve(address(preallocationEscrow), claimedTokens);
-        preallocationEscrow.initialDeposit(claimedTokens, lockedDuration);
+        preallocationEscrow.initialDeposit(claimedTokens, lockingDuration);
         preallocationEscrow.transferOwnership(msg.sender);
         depositors[address(preallocationEscrow)] = msg.sender;
         info.preallocationEscrow = preallocationEscrow;

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.3;
 
 import "zeppelin/math/SafeMath.sol";
 import "zeppelin/utils/Address.sol";
+import "zeppelin/token/ERC20/SafeERC20.sol";
 import "contracts/NuCypherToken.sol";
 import "contracts/StakingEscrow.sol";
 
@@ -11,12 +12,15 @@ import "contracts/StakingEscrow.sol";
 * @notice The WorkLock distribution contract
 */
 contract WorkLock {
+    using SafeERC20 for NuCypherToken;
     using SafeMath for uint256;
     using Address for address payable;
 
+    event Deposited(address indexed sender, uint256 value);
     event Bid(address indexed staker, uint256 depositedETH, uint256 claimedTokens);
     event Claimed(address indexed staker, uint256 claimedTokens);
     event Refund(address indexed staker, uint256 refundETH, uint256 completedWork);
+    event Burn(address indexed sender, uint256 value);
 
     struct WorkInfo {
         uint256 depositedETH;
@@ -34,7 +38,7 @@ contract WorkLock {
     uint256 public refundRate;
     uint256 public minAllowableLockedTokens;
     uint256 public maxAllowableLockedTokens;
-    uint256 public allClaimedTokens;
+    uint256 public remainingTokens;
     uint16 public lockedPeriods;
     mapping(address => WorkInfo) public workInfo;
 
@@ -77,6 +81,16 @@ contract WorkLock {
     }
 
     /**
+    * @notice Deposit tokens to contract
+    * @param _value Amount of tokens to transfer
+    **/
+    function deposit(uint256 _value) public {
+        token.safeTransferFrom(msg.sender, address(this), _value);
+        remainingTokens += _value;
+        emit Deposited(msg.sender, _value);
+    }
+
+    /**
     * @notice Bid for tokens by transferring ETH
     */
     function bid() public payable returns (uint256 newClaimedTokens) {
@@ -88,9 +102,7 @@ contract WorkLock {
         require(claimedTokens >= minAllowableLockedTokens && claimedTokens <= maxAllowableLockedTokens,
             "Claimed tokens must be within the allowed limits");
         newClaimedTokens = msg.value.mul(depositRate);
-        allClaimedTokens = allClaimedTokens.add(newClaimedTokens);
-        require(allClaimedTokens <= token.balanceOf(address(this)),
-            "Not enough tokens in the contract");
+        remainingTokens = remainingTokens.sub(newClaimedTokens);
         emit Bid(msg.sender, msg.value, newClaimedTokens);
     }
 
@@ -144,6 +156,17 @@ contract WorkLock {
             return 0;
         }
         return remainingWork.sub(completedWork);
+    }
+
+    /**
+    * @notice Burn unclaimed tokens
+    **/
+    function burnRemaining() public {
+        require(block.timestamp >= endBidDate, "Burning tokens allowed when bidding is over");
+        require(remainingTokens > 0, "There are no tokens that can be burned");
+        token.approve(address(escrow), remainingTokens);
+        escrow.burn(remainingTokens);
+        emit Burn(msg.sender, remainingTokens);
     }
 
 }

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -50,7 +50,7 @@ contract WorkLock {
     */
     uint256 public boostingRefund;
     uint16 public constant SLOWING_REFUND = 100;
-    uint256 private constant MAX_ETH_SUPPLY = 200000000000000000000000000;
+    uint256 private constant MAX_ETH_SUPPLY = 2e10 ether;
 
     uint256 public tokenSupply;
     uint256 public ethSupply;

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -191,7 +191,7 @@ contract WorkLock {
         claimedTokens = ethToTokens(info.depositedETH);
         require(claimedTokens > 0, "Nothing to claim");
 
-        preallocationEscrow = new PreallocationEscrow(router, token);
+        preallocationEscrow = new PreallocationEscrow(router, token, StakingEscrowInterface(address(escrow)));
         token.approve(address(preallocationEscrow), claimedTokens);
         preallocationEscrow.initialDeposit(claimedTokens, lockingDuration);
         preallocationEscrow.transferOwnership(msg.sender);

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -20,7 +20,7 @@ contract WorkLock {
     event Bid(address indexed staker, uint256 depositedETH, uint256 claimedTokens);
     event Claimed(address indexed staker, uint256 claimedTokens);
     event Refund(address indexed staker, uint256 refundETH, uint256 completedWork);
-    event Burn(address indexed sender, uint256 value);
+    event Burnt(address indexed sender, uint256 value);
 
     struct WorkInfo {
         uint256 depositedETH;
@@ -166,7 +166,8 @@ contract WorkLock {
         require(remainingTokens > 0, "There are no tokens that can be burned");
         token.approve(address(escrow), remainingTokens);
         escrow.burn(remainingTokens);
-        emit Burn(msg.sender, remainingTokens);
+        emit Burnt(msg.sender, remainingTokens);
+        remainingTokens = 0;
     }
 
 }

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -220,7 +220,8 @@ class TesterBlockchain(BlockchainDeployerInterface):
         origin = testerchain.client.etherbase
         deployer = ContractAdministrator(deployer_address=origin, 
                                          registry=registry, 
-                                         economics=economics or cls._default_token_economics)
+                                         economics=economics or cls._default_token_economics,
+                                         staking_escrow_test_mode=True)
         secrets = dict()
         for deployer_class in deployer.upgradeable_deployer_classes:
             secrets[deployer_class.contract_name] = INSECURE_DEVELOPMENT_PASSWORD

--- a/tests/blockchain/eth/contracts/contracts/IssuerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/IssuerTestSet.sol
@@ -45,8 +45,8 @@ contract IssuerMock is Issuer {
         token.transfer(msg.sender, amount);
     }
 
-    function testUnMint(uint256 _amount) public {
-        unMint(_amount);
+    function testBurn(uint256 _value) public {
+        burn(_value);
     }
 
 }

--- a/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
@@ -19,7 +19,8 @@ contract StakingEscrowBad is StakingEscrow {
         uint16 _minLockedPeriods,
         uint256 _minAllowableLockedTokens,
         uint256 _maxAllowableLockedTokens,
-        uint16 _minWorkerPeriods
+        uint16 _minWorkerPeriods,
+        bool _isTestContract
     )
         public
         StakingEscrow(
@@ -31,7 +32,8 @@ contract StakingEscrowBad is StakingEscrow {
             _minLockedPeriods,
             _minAllowableLockedTokens,
             _maxAllowableLockedTokens,
-            _minWorkerPeriods
+            _minWorkerPeriods,
+            _isTestContract
         )
     {
     }
@@ -60,6 +62,7 @@ contract StakingEscrowV2Mock is StakingEscrow {
         uint256 _minAllowableLockedTokens,
         uint256 _maxAllowableLockedTokens,
         uint16 _minWorkerPeriods,
+        bool _isTestContract,
         uint256 _valueToCheck
     )
         public
@@ -72,7 +75,8 @@ contract StakingEscrowV2Mock is StakingEscrow {
             _minLockedPeriods,
             _minAllowableLockedTokens,
             _maxAllowableLockedTokens,
-            _minWorkerPeriods
+            _minWorkerPeriods,
+            _isTestContract
         )
     {
         valueToCheck = _valueToCheck;
@@ -90,6 +94,7 @@ contract StakingEscrowV2Mock is StakingEscrow {
     function finishUpgrade(address _target) public onlyWhileUpgrading {
         StakingEscrowV2Mock escrow = StakingEscrowV2Mock(_target);
         valueToCheck = escrow.valueToCheck();
+        isTestContract = escrow.isTestContract();
         emit UpgradeFinished(_target, msg.sender);
     }
 }

--- a/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
@@ -61,3 +61,9 @@ contract StakingEscrowForWorkLockMock {
     }
 
 }
+
+
+/**
+* @notice Contract for using in WorkLock tests
+**/
+contract StakingInterfaceMock {}

--- a/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
@@ -56,4 +56,8 @@ contract StakingEscrowForWorkLockMock {
         stakerInfo[_staker].completedWork = _completedWork;
     }
 
+    function burn(uint256 _value) public {
+        token.transferFrom(msg.sender, address(this), _value);
+    }
+
 }

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -317,7 +317,7 @@ def test_all(testerchain,
     execute_multisig_transaction(testerchain, multisig, [contracts_owners[0], contracts_owners[1]], tx)
 
     # Initialize worklock
-    initial_supply = 1000
+    initial_supply = 2000
     tx = token.functions.approve(worklock.address, initial_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = worklock.functions.deposit(initial_supply).transact({'from': creator})
@@ -348,7 +348,8 @@ def test_all(testerchain,
     assert testerchain.w3.eth.getBalance(worklock.address) == 0
     tx = worklock.functions.bid().transact({'from': ursula2, 'value': deposited_eth, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.remainingTokens().call() == 0
+    remaining_tokens = initial_supply // 2
+    assert worklock.functions.remainingTokens().call() == remaining_tokens
     assert worklock.functions.workInfo(ursula2).call()[0] == deposited_eth
     assert testerchain.w3.eth.getBalance(worklock.address) == deposited_eth
 
@@ -368,8 +369,9 @@ def test_all(testerchain,
     # Ursula claims tokens
     tx = worklock.functions.claim().transact({'from': ursula2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
+    escrow_balance = token_economics.erc20_reward_supply + 1000
     assert worklock.functions.getRemainingWork(ursula2).call() == deposit_rate * deposited_eth
-    assert token_economics.erc20_reward_supply + 1000 == token.functions.balanceOf(escrow.address).call()
+    assert escrow_balance == token.functions.balanceOf(escrow.address).call()
     assert 1000 == escrow.functions.getAllTokens(ursula2).call()
     assert 0 == escrow.functions.getLockedTokens(ursula2, 0).call()
     assert 1000 == escrow.functions.getLockedTokens(ursula2, 1).call()
@@ -379,6 +381,15 @@ def test_all(testerchain,
 
     tx = escrow.functions.setWorker(ursula2).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
+
+    # Burn remaining tokens in WorkLock
+    tx = worklock.functions.burnRemaining().transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+    escrow_balance += remaining_tokens
+    assert 0 == worklock.functions.remainingTokens().call()
+    assert 0 == token.functions.balanceOf(worklock.address).call()
+    assert escrow_balance == token.functions.balanceOf(escrow.address).call()
+    assert token_economics.erc20_reward_supply + remaining_tokens == escrow.functions.getReservedReward().call()
 
     # Ursula prolongs lock duration
     tx = escrow.functions.prolongStake(0, 3).transact({'from': ursula2, 'gas_price': 0})
@@ -482,7 +493,8 @@ def test_all(testerchain,
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.confirmActivity().transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
-    assert token_economics.erc20_reward_supply + 2000 == token.functions.balanceOf(escrow.address).call()
+    escrow_balance += 1000
+    assert escrow_balance == token.functions.balanceOf(escrow.address).call()
     assert 9000 == token.functions.balanceOf(ursula1).call()
     assert 0 == escrow.functions.getLockedTokens(ursula1, 0).call()
     assert 1000 == escrow.functions.getLockedTokens(ursula1, 1).call()
@@ -497,12 +509,13 @@ def test_all(testerchain,
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.confirmActivity().transact({'from': ursula3})
     testerchain.wait_for_receipt(tx)
+    escrow_balance += 1000
     assert 1000 == escrow.functions.getAllTokens(preallocation_escrow_1.address).call()
     assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_1.address, 0).call()
     assert 1000 == escrow.functions.getLockedTokens(preallocation_escrow_1.address, 1).call()
     assert 1000 == escrow.functions.getLockedTokens(preallocation_escrow_1.address, 10).call()
     assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_1.address, 11).call()
-    assert token_economics.erc20_reward_supply + 3000 == token.functions.balanceOf(escrow.address).call()
+    assert escrow_balance == token.functions.balanceOf(escrow.address).call()
     assert 9000 == token.functions.balanceOf(preallocation_escrow_1.address).call()
 
     # Only owner can deposit tokens to the staking escrow

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -271,7 +271,7 @@ def test_all(testerchain,
 
     # Create the first preallocation escrow
     preallocation_escrow_1, _ = deploy_contract(
-        'PreallocationEscrow', staking_interface_router.address, token.address)
+        'PreallocationEscrow', staking_interface_router.address, token.address, escrow.address)
     preallocation_escrow_interface_1 = testerchain.client.get_contract(
         abi=staking_interface.abi,
         address=preallocation_escrow_1.address,

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -20,7 +20,7 @@ import os
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from eth_utils import to_canonical_address
+from eth_utils import to_canonical_address, to_wei
 from web3.contract import Contract
 
 from nucypher.blockchain.economics import TokenEconomics
@@ -134,34 +134,6 @@ def adjudicator(testerchain, escrow, token_economics, deploy_contract):
     return contract, dispatcher
 
 
-@pytest.fixture()
-def worklock(testerchain, token, escrow, deploy_contract):
-    escrow, _ = escrow
-    creator = testerchain.w3.eth.accounts[0]
-
-    # Creator deploys the worklock using test values
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
-    start_bid_date = ((now + 3600) // 3600 + 1) * 3600  # beginning of the next hour plus 1 hour
-    end_bid_date = start_bid_date + 3600
-    deposit_rate = 2
-    refund_rate = deposit_rate
-    contract, _ = deploy_contract(
-        contract_name='WorkLock',
-        _token=token.address,
-        _escrow=escrow.address,
-        _startBidDate=start_bid_date,
-        _endBidDate=end_bid_date,
-        _depositRate=deposit_rate,
-        _refundRate=refund_rate,
-        _lockedPeriods=6
-    )
-
-    tx = escrow.functions.setWorkLock(contract.address).transact({'from': creator})
-    testerchain.wait_for_receipt(tx)
-
-    return contract
-
-
 def mock_ursula(testerchain, account, mocker):
     ursula_privkey = UmbralPrivateKey.gen_key()
     ursula_stamp = SignatureStamp(verifying_key=ursula_privkey.pubkey,
@@ -193,6 +165,35 @@ def staking_interface(testerchain, token, escrow, policy_manager, deploy_contrac
     router, _ = deploy_contract(
         'StakingInterfaceRouter', staking_interface.address, secret_hash)
     return staking_interface, router
+
+
+@pytest.fixture()
+def worklock(testerchain, token, escrow, staking_interface, deploy_contract):
+    escrow, _ = escrow
+    creator = testerchain.w3.eth.accounts[0]
+    _, router = staking_interface
+
+    # Creator deploys the worklock using test values
+    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    start_bid_date = ((now + 3600) // 3600 + 1) * 3600  # beginning of the next hour plus 1 hour
+    end_bid_date = start_bid_date + 3600
+    boosting_refund = 100
+    locking_duration = 20 * 60 * 60
+    contract, _ = deploy_contract(
+        contract_name='WorkLock',
+        _token=token.address,
+        _escrow=escrow.address,
+        _router=router.address,
+        _startBidDate=start_bid_date,
+        _endBidDate=end_bid_date,
+        _boostingRefund=boosting_refund,
+        _lockingDuration=locking_duration
+    )
+
+    tx = escrow.functions.setWorkLock(contract.address).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+
+    return contract
 
 
 @pytest.fixture()
@@ -268,6 +269,14 @@ def test_all(testerchain,
         testerchain.client.accounts
     contracts_owners = sorted(contracts_owners)
 
+    # Create the first preallocation escrow
+    preallocation_escrow_1, _ = deploy_contract(
+        'PreallocationEscrow', staking_interface_router.address, token.address)
+    preallocation_escrow_interface_1 = testerchain.client.get_contract(
+        abi=staking_interface.abi,
+        address=preallocation_escrow_1.address,
+        ContractFactoryClass=Contract)
+
     # We'll need this later for slashing these Ursulas
     ursula1_with_stamp = mock_ursula(testerchain, ursula1, mocker=mocker)
     ursula2_with_stamp = mock_ursula(testerchain, ursula2, mocker=mocker)
@@ -317,46 +326,50 @@ def test_all(testerchain,
     execute_multisig_transaction(testerchain, multisig, [contracts_owners[0], contracts_owners[1]], tx)
 
     # Initialize worklock
-    initial_supply = 2000
-    tx = token.functions.approve(worklock.address, initial_supply).transact({'from': creator})
+    worklock_supply = 1980
+    tx = token.functions.approve(worklock.address, worklock_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = worklock.functions.deposit(initial_supply).transact({'from': creator})
+    tx = worklock.functions.tokenDeposit(worklock_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Can't do anything before start date
-    deposit_rate = 2
-    refund_rate = 2
-    deposited_eth = 1000 // deposit_rate
+    deposited_eth_1 = to_wei(18, 'ether')
+    deposited_eth_2 = to_wei(1, 'ether')
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.bid().transact({'from': ursula2, 'value': deposited_eth, 'gas_price': 0})
+        tx = worklock.functions.bid().transact({'from': ursula2, 'value': deposited_eth_1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Wait for the start of the bidding
     testerchain.time_travel(hours=1)
 
-    # Can't bid with too low or too high ETH
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.bid().transact({'from': ursula2, 'value': 1, 'gas_price': 0})
-        testerchain.wait_for_receipt(tx)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.bid().transact({'from': ursula2, 'value': 10**10, 'gas_price': 0})
-        testerchain.wait_for_receipt(tx)
-
     # Ursula does bid
-    assert worklock.functions.remainingTokens().call() == initial_supply
     assert worklock.functions.workInfo(ursula2).call()[0] == 0
     assert testerchain.w3.eth.getBalance(worklock.address) == 0
-    tx = worklock.functions.bid().transact({'from': ursula2, 'value': deposited_eth, 'gas_price': 0})
+    tx = worklock.functions.bid().transact({'from': ursula2, 'value': deposited_eth_1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    remaining_tokens = initial_supply // 2
-    assert worklock.functions.remainingTokens().call() == remaining_tokens
-    assert worklock.functions.workInfo(ursula2).call()[0] == deposited_eth
-    assert testerchain.w3.eth.getBalance(worklock.address) == deposited_eth
+    assert worklock.functions.workInfo(ursula2).call()[0] == deposited_eth_1
+    assert testerchain.w3.eth.getBalance(worklock.address) == deposited_eth_1
+    assert worklock.functions.ethToTokens(deposited_eth_1).call() == worklock_supply
 
     # Can't claim while bidding phase
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.claim().transact({'from': ursula2, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
+
+    # Other Ursula do bid
+    assert worklock.functions.workInfo(ursula1).call()[0] == 0
+    tx = worklock.functions.bid().transact({'from': ursula1, 'value': deposited_eth_2, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.workInfo(ursula1).call()[0] == deposited_eth_2
+    assert testerchain.w3.eth.getBalance(worklock.address) == deposited_eth_1 + deposited_eth_2
+    assert worklock.functions.ethToTokens(deposited_eth_2).call() == worklock_supply // 19
+
+    assert worklock.functions.workInfo(ursula4).call()[0] == 0
+    tx = worklock.functions.bid().transact({'from': ursula4, 'value': deposited_eth_2, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.workInfo(ursula4).call()[0] == deposited_eth_2
+    assert testerchain.w3.eth.getBalance(worklock.address) == deposited_eth_1 + 2 * deposited_eth_2
+    assert worklock.functions.ethToTokens(deposited_eth_2).call() == worklock_supply // 20
 
     # Wait for the end of the bidding
     testerchain.time_travel(hours=1)
@@ -366,39 +379,81 @@ def test_all(testerchain,
         tx = worklock.functions.bid().transact({'from': ursula2, 'value': 1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
+    # One of Ursulas cancels bid
+    tx = worklock.functions.cancelBid().transact({'from': ursula1, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.workInfo(ursula1).call()[0] == 0
+    assert testerchain.w3.eth.getBalance(worklock.address) == deposited_eth_1 + deposited_eth_2
+    assert worklock.functions.ethToTokens(deposited_eth_2).call() == worklock_supply // 20
+    assert worklock.functions.unclaimedTokens().call() == worklock_supply // 20
+
     # Ursula claims tokens
     tx = worklock.functions.claim().transact({'from': ursula2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    escrow_balance = token_economics.erc20_reward_supply + 1000
-    assert worklock.functions.getRemainingWork(ursula2).call() == deposit_rate * deposited_eth
-    assert escrow_balance == token.functions.balanceOf(escrow.address).call()
-    assert 1000 == escrow.functions.getAllTokens(ursula2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula2, 6).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 7).call()
-    assert 0 == escrow.functions.getCompletedWork(ursula2).call()
+    preallocation_escrow_2 = testerchain.client.get_contract(
+        abi=preallocation_escrow_1.abi,
+        address=worklock.functions.workInfo(ursula2).call()[2],
+        ContractFactoryClass=Contract)
 
-    tx = escrow.functions.setWorker(ursula2).transact({'from': ursula2})
+    ursula2_tokens = worklock_supply * 9 // 10
+    assert token.functions.balanceOf(ursula2).call() == 0
+    assert token.functions.balanceOf(preallocation_escrow_2.address).call() == ursula2_tokens
+    assert preallocation_escrow_2.functions.owner().call() == ursula2
+    assert preallocation_escrow_2.functions.getLockedTokens().call() == ursula2_tokens
+    ursula2_remaining_work = ursula2_tokens
+    assert worklock.functions.ethToWork(deposited_eth_1).call() == ursula2_remaining_work
+    assert worklock.functions.workToETH(ursula2_remaining_work).call() == deposited_eth_1
+    assert worklock.functions.getRemainingWork(preallocation_escrow_2.address).call() == ursula2_remaining_work
+    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - ursula2_tokens
+
+    preallocation_escrow_interface_2 = testerchain.client.get_contract(
+        abi=staking_interface.abi,
+        address=preallocation_escrow_2.address,
+        ContractFactoryClass=Contract)
+    tx = preallocation_escrow_interface_2.functions.depositAsStaker(1000, 6).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
+    tx = preallocation_escrow_interface_2.functions.setWorker(ursula2).transact({'from': ursula2})
+    testerchain.wait_for_receipt(tx)
+    escrow_balance = token_economics.erc20_reward_supply + 1000
+    assert 1000 == escrow.functions.getAllTokens(preallocation_escrow_2.address).call()
+    assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 0).call()
+    assert 1000 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 1).call()
+    assert 1000 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 6).call()
+    assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 7).call()
+    assert 0 == escrow.functions.getCompletedWork(preallocation_escrow_2.address).call()
+
+    # Another Ursula claims tokens
+    tx = worklock.functions.claim().transact({'from': ursula4, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    preallocation_escrow_3 = testerchain.client.get_contract(
+        abi=preallocation_escrow_1.abi,
+        address=worklock.functions.workInfo(ursula4).call()[2],
+        ContractFactoryClass=Contract)
+
+    ursula4_tokens = worklock_supply // 20
+    assert token.functions.balanceOf(ursula4).call() == 0
+    assert token.functions.balanceOf(preallocation_escrow_3.address).call() == ursula4_tokens
+    assert preallocation_escrow_3.functions.owner().call() == ursula4
+    assert preallocation_escrow_3.functions.getLockedTokens().call() == ursula4_tokens
+    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - ursula2_tokens - ursula4_tokens
 
     # Burn remaining tokens in WorkLock
-    tx = worklock.functions.burnRemaining().transact({'from': creator})
+    tx = worklock.functions.burnUnclaimed().transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    escrow_balance += remaining_tokens
-    assert 0 == worklock.functions.remainingTokens().call()
+    escrow_balance += worklock_supply // 20
+    assert 0 == worklock.functions.unclaimedTokens().call()
     assert 0 == token.functions.balanceOf(worklock.address).call()
     assert escrow_balance == token.functions.balanceOf(escrow.address).call()
-    assert token_economics.erc20_reward_supply + remaining_tokens == escrow.functions.getReservedReward().call()
+    assert token_economics.erc20_reward_supply + worklock_supply // 20 == escrow.functions.getReservedReward().call()
 
     # Ursula prolongs lock duration
-    tx = escrow.functions.prolongStake(0, 3).transact({'from': ursula2, 'gas_price': 0})
+    tx = preallocation_escrow_interface_2.functions.prolongStake(0, 3).transact({'from': ursula2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula2, 9).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 10).call()
-    assert 0 == escrow.functions.getCompletedWork(ursula2).call()
+    assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 0).call()
+    assert 1000 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 1).call()
+    assert 1000 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 9).call()
+    assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 10).call()
+    assert 0 == escrow.functions.getCompletedWork(preallocation_escrow_2.address).call()
 
     # Can't claim more than once
     with pytest.raises((TransactionFailed, ValueError)):
@@ -406,16 +461,10 @@ def test_all(testerchain,
         testerchain.wait_for_receipt(tx)
     # Can't refund without work
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.refund().transact({'from': ursula2, 'gas_price': 0})
+        tx = worklock.functions.refund(preallocation_escrow_2.address).transact({'from': ursula2, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
-    # Create the first preallocation escrow, set and lock re-stake parameter
-    preallocation_escrow_1, _ = deploy_contract(
-        'PreallocationEscrow', staking_interface_router.address, token.address, escrow.address)
-    preallocation_escrow_interface_1 = testerchain.client.get_contract(
-        abi=staking_interface.abi,
-        address=preallocation_escrow_1.address,
-        ContractFactoryClass=Contract)
+    # Set and lock re-stake parameter in first preallocation escrow
     tx = preallocation_escrow_1.functions.transferOwnership(ursula3).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     assert not escrow.functions.stakerInfo(preallocation_escrow_1.address).call()[RE_STAKE_FIELD]
@@ -436,22 +485,10 @@ def test_all(testerchain,
     tx = preallocation_escrow_1.functions.initialDeposit(10000, 20 * 60 * 60).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
-    preallocation_escrow_2, _ = deploy_contract(
-        'PreallocationEscrow', staking_interface_router.address, token.address, escrow.address)
-    tx = preallocation_escrow_2.functions.transferOwnership(ursula4).transact({'from': creator})
-    testerchain.wait_for_receipt(tx)
-    tx = token.functions.approve(preallocation_escrow_2.address, 10000).transact({'from': creator})
-    testerchain.wait_for_receipt(tx)
-    tx = preallocation_escrow_2.functions.initialDeposit(10000, 20 * 60 * 60).transact({'from': creator})
-    testerchain.wait_for_receipt(tx)
     assert 10000 == token.functions.balanceOf(preallocation_escrow_1.address).call()
     assert ursula3 == preallocation_escrow_1.functions.owner().call()
     assert 10000 >= preallocation_escrow_1.functions.getLockedTokens().call()
     assert 9500 <= preallocation_escrow_1.functions.getLockedTokens().call()
-    assert 10000 == token.functions.balanceOf(preallocation_escrow_2.address).call()
-    assert ursula4 == preallocation_escrow_2.functions.owner().call()
-    assert 10000 >= preallocation_escrow_2.functions.getLockedTokens().call()
-    assert 9500 <= preallocation_escrow_2.functions.getLockedTokens().call()
 
     # Ursula's withdrawal attempt won't succeed because nothing to withdraw
     with pytest.raises((TransactionFailed, ValueError)):
@@ -470,6 +507,7 @@ def test_all(testerchain,
     assert 0 == escrow.functions.getLockedTokens(ursula4, 0).call()
     assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_1.address, 0).call()
     assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 0).call()
+    assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_3.address, 0).call()
     assert 0 == escrow.functions.getLockedTokens(contracts_owners[0], 0).call()
 
     # Ursula can't deposit and lock too low value
@@ -528,7 +566,7 @@ def test_all(testerchain,
         testerchain.wait_for_receipt(tx)
 
     # Divide stakes
-    tx = escrow.functions.divideStake(0, 500, 6).transact({'from': ursula2})
+    tx = preallocation_escrow_interface_2.functions.divideStake(0, 500, 6).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.divideStake(0, 500, 9).transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
@@ -563,12 +601,13 @@ def test_all(testerchain,
 
     # Create policies
     policy_id_1 = os.urandom(16)
-    tx = policy_manager.functions.createPolicy(policy_id_1, 5, 44, [ursula1, ursula2]) \
+    tx = policy_manager.functions.createPolicy(policy_id_1, 5, 44, [ursula1, preallocation_escrow_2.address]) \
         .transact({'from': alice1, 'value': 2 * 1000 + 2 * 44, 'gas_price': 0})
 
     testerchain.wait_for_receipt(tx)
     policy_id_2 = os.urandom(16)
-    tx = policy_manager.functions.createPolicy(policy_id_2, 5, 44, [ursula2, preallocation_escrow_1.address]) \
+    tx = policy_manager.functions\
+        .createPolicy(policy_id_2, 5, 44, [preallocation_escrow_2.address, preallocation_escrow_1.address]) \
         .transact({'from': alice1, 'value': 2 * 1000 + 2 * 44, 'gas_price': 0})
 
     testerchain.wait_for_receipt(tx)
@@ -578,12 +617,13 @@ def test_all(testerchain,
 
     testerchain.wait_for_receipt(tx)
     policy_id_4 = os.urandom(16)
-    tx = policy_manager.functions.createPolicy(policy_id_4, 5, 44, [ursula2, preallocation_escrow_1.address]) \
+    tx = policy_manager.functions\
+        .createPolicy(policy_id_4, 5, 44, [preallocation_escrow_2.address, preallocation_escrow_1.address]) \
         .transact({'from': alice2, 'value': 2 * 1000 + 2 * 44, 'gas_price': 0})
 
     testerchain.wait_for_receipt(tx)
     policy_id_5 = os.urandom(16)
-    tx = policy_manager.functions.createPolicy(policy_id_5, 5, 44, [ursula1, ursula2]) \
+    tx = policy_manager.functions.createPolicy(policy_id_5, 5, 44, [ursula1, preallocation_escrow_2.address]) \
         .transact({'from': alice2, 'value': 2 * 1000 + 2 * 44, 'gas_price': 0})
 
     testerchain.wait_for_receipt(tx)
@@ -608,8 +648,8 @@ def test_all(testerchain,
         testerchain.wait_for_receipt(tx)
 
     alice1_balance = testerchain.client.get_balance(alice1)
-    tx = policy_manager.functions.revokeArrangement(policy_id_2, ursula2).transact({'from': alice1, 'gas_price': 0})
-
+    tx = policy_manager.functions.revokeArrangement(policy_id_2, preallocation_escrow_2.address)\
+        .transact({'from': alice1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 7440 == testerchain.client.get_balance(policy_manager.address)
     assert alice1_balance + 1000 == testerchain.client.get_balance(alice1)
@@ -617,7 +657,8 @@ def test_all(testerchain,
 
     # Can't revoke again
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, ursula2).transact({'from': alice1})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, preallocation_escrow_2.address)\
+            .transact({'from': alice1})
         testerchain.wait_for_receipt(tx)
 
     # Wait, confirm activity, mint
@@ -630,8 +671,8 @@ def test_all(testerchain,
     testerchain.wait_for_receipt(tx)
 
     # Check work measurement
-    work_done = escrow.functions.getCompletedWork(ursula2).call()
-    assert 0 < work_done
+    completed_work = escrow.functions.getCompletedWork(preallocation_escrow_2.address).call()
+    assert 0 < completed_work
     assert 0 == escrow.functions.getCompletedWork(preallocation_escrow_1.address).call()
     assert 0 == escrow.functions.getCompletedWork(ursula1).call()
 
@@ -668,7 +709,7 @@ def test_all(testerchain,
     testerchain.wait_for_receipt(tx)
     assert ursula1_balance < testerchain.client.get_balance(ursula1)
     ursula2_balance = testerchain.client.get_balance(ursula2)
-    tx = policy_manager.functions.withdraw().transact({'from': ursula2, 'gas_price': 0})
+    tx = preallocation_escrow_interface_2.functions.withdrawPolicyReward(ursula2).transact({'from': ursula2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert ursula2_balance < testerchain.client.get_balance(ursula2)
     ursula3_balance = testerchain.client.get_balance(ursula3)
@@ -701,7 +742,7 @@ def test_all(testerchain,
     policy_manager_v1 = policy_manager.functions.target().call()
     # Creator deploys the contracts as the second versions
     escrow_v2, _ = deploy_contract(
-        'StakingEscrow', token.address, *token_economics.staking_deployment_parameters
+        'StakingEscrow', token.address, *token_economics.staking_deployment_parameters, False
     )
     policy_manager_v2, _ = deploy_contract('PolicyManager', escrow.address)
     # Ursula and Alice can't upgrade contracts, only owner can
@@ -869,22 +910,22 @@ def test_all(testerchain,
     assert alice1_balance + base_penalty / reward_coefficient == token.functions.balanceOf(alice1).call()
 
     # Slash part of the one sub stake
-    tokens_amount = escrow.functions.getAllTokens(ursula2).call()
-    unlocked_amount = tokens_amount - escrow.functions.getLockedTokens(ursula2, 0).call()
-    tx = escrow.functions.withdraw(unlocked_amount).transact({'from': ursula2})
+    tokens_amount = escrow.functions.getAllTokens(preallocation_escrow_2.address).call()
+    unlocked_amount = tokens_amount - escrow.functions.getLockedTokens(preallocation_escrow_2.address, 0).call()
+    tx = preallocation_escrow_interface_2.functions.withdrawAsStaker(unlocked_amount).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
-    previous_lock = escrow.functions.getLockedTokensInPast(ursula2, 1).call()
-    lock = escrow.functions.getLockedTokens(ursula2, 0).call()
-    next_lock = escrow.functions.getLockedTokens(ursula2, 1).call()
+    previous_lock = escrow.functions.getLockedTokensInPast(preallocation_escrow_2.address, 1).call()
+    lock = escrow.functions.getLockedTokens(preallocation_escrow_2.address, 0).call()
+    next_lock = escrow.functions.getLockedTokens(preallocation_escrow_2.address, 1).call()
     data_hash, slashing_args = generate_args_for_slashing(mock_ursula_reencrypts, ursula2_with_stamp)
     assert not adjudicator.functions.evaluatedCFrags(data_hash).call()
     tx = adjudicator.functions.evaluateCFrag(*slashing_args).transact({'from': alice1})
     testerchain.wait_for_receipt(tx)
     assert adjudicator.functions.evaluatedCFrags(data_hash).call()
-    assert lock - base_penalty == escrow.functions.getAllTokens(ursula2).call()
-    assert previous_lock == escrow.functions.getLockedTokensInPast(ursula2, 1).call()
-    assert lock - base_penalty == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert next_lock - base_penalty == escrow.functions.getLockedTokens(ursula2, 1).call()
+    assert lock - base_penalty == escrow.functions.getAllTokens(preallocation_escrow_2.address).call()
+    assert previous_lock == escrow.functions.getLockedTokensInPast(preallocation_escrow_2.address, 1).call()
+    assert lock - base_penalty == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 0).call()
+    assert next_lock - base_penalty == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 1).call()
     assert total_previous_lock == escrow.functions.lockedPerPeriod(current_period - 1).call()
     assert total_lock - base_penalty == escrow.functions.lockedPerPeriod(current_period).call()
     assert 0 == escrow.functions.lockedPerPeriod(current_period + 1).call()
@@ -1005,7 +1046,7 @@ def test_all(testerchain,
 
     # Can't prolong stake by too low duration
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.prolongStake(0, 1).transact({'from': ursula2, 'gas_price': 0})
+        tx = preallocation_escrow_interface_2.functions.prolongStake(0, 1).transact({'from': ursula2, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Unlock and withdraw all tokens
@@ -1031,7 +1072,7 @@ def test_all(testerchain,
 
     tx = escrow.functions.mint().transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.mint().transact({'from': ursula2})
+    tx = preallocation_escrow_interface_2.functions.mint().transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     tx = preallocation_escrow_interface_1.functions.mint().transact({'from': ursula3})
     testerchain.wait_for_receipt(tx)
@@ -1042,51 +1083,51 @@ def test_all(testerchain,
     assert 0 == escrow.functions.getLockedTokens(ursula4, 0).call()
     assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_1.address, 0).call()
     assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_2.address, 0).call()
+    assert 0 == escrow.functions.getLockedTokens(preallocation_escrow_3.address, 0).call()
 
     ursula1_balance = token.functions.balanceOf(ursula1).call()
-    ursula2_balance = token.functions.balanceOf(ursula2).call()
+    ursula2_balance = token.functions.balanceOf(preallocation_escrow_2.address).call()
     preallocation_escrow_1_balance = token.functions.balanceOf(preallocation_escrow_1.address).call()
     tokens_amount = escrow.functions.getAllTokens(ursula1).call()
     tx = escrow.functions.withdraw(tokens_amount).transact({'from': ursula1})
     testerchain.wait_for_receipt(tx)
-    tokens_amount = escrow.functions.getAllTokens(ursula2).call()
-    tx = escrow.functions.withdraw(tokens_amount).transact({'from': ursula2})
+    tokens_amount = escrow.functions.getAllTokens(preallocation_escrow_2.address).call()
+    tx = preallocation_escrow_interface_2.functions.withdrawAsStaker(tokens_amount).transact({'from': ursula2})
     testerchain.wait_for_receipt(tx)
     tokens_amount = escrow.functions.getAllTokens(preallocation_escrow_1.address).call()
     tx = preallocation_escrow_interface_1.functions.withdrawAsStaker(tokens_amount).transact({'from': ursula3})
     testerchain.wait_for_receipt(tx)
     assert ursula1_balance < token.functions.balanceOf(ursula1).call()
-    assert ursula2_balance < token.functions.balanceOf(ursula2).call()
+    assert ursula2_balance < token.functions.balanceOf(preallocation_escrow_2.address).call()
     assert preallocation_escrow_1_balance < token.functions.balanceOf(preallocation_escrow_1.address).call()
 
     # Unlock and withdraw all tokens in PreallocationEscrow
     testerchain.time_travel(hours=1)
     assert 0 == preallocation_escrow_1.functions.getLockedTokens().call()
-    assert 0 == preallocation_escrow_2.functions.getLockedTokens().call()
+    assert 0 == preallocation_escrow_3.functions.getLockedTokens().call()
     ursula3_balance = token.functions.balanceOf(ursula3).call()
     ursula4_balance = token.functions.balanceOf(ursula4).call()
     tokens_amount = token.functions.balanceOf(preallocation_escrow_1.address).call()
     tx = preallocation_escrow_1.functions.withdrawTokens(tokens_amount).transact({'from': ursula3})
     testerchain.wait_for_receipt(tx)
-    tokens_amount = token.functions.balanceOf(preallocation_escrow_2.address).call()
-    tx = preallocation_escrow_2.functions.withdrawTokens(tokens_amount).transact({'from': ursula4})
+    tokens_amount = token.functions.balanceOf(preallocation_escrow_3.address).call()
+    tx = preallocation_escrow_3.functions.withdrawTokens(tokens_amount).transact({'from': ursula4})
     testerchain.wait_for_receipt(tx)
     assert ursula3_balance < token.functions.balanceOf(ursula3).call()
     assert ursula4_balance < token.functions.balanceOf(ursula4).call()
 
     # Partial refund for Ursula
-    new_work_done = escrow.functions.getCompletedWork(ursula2).call()
-    assert work_done < new_work_done
-    remaining_work = worklock.functions.getRemainingWork(ursula2).call()
+    new_completed_work = escrow.functions.getCompletedWork(preallocation_escrow_2.address).call()
+    assert completed_work < new_completed_work
+    remaining_work = worklock.functions.getRemainingWork(preallocation_escrow_2.address).call()
     assert 0 < remaining_work
-    assert deposited_eth == worklock.functions.workInfo(ursula2).call()[0]
+    assert deposited_eth_1 == worklock.functions.workInfo(ursula2).call()[0]
     ursula2_balance = testerchain.w3.eth.getBalance(ursula2)
-    tx = worklock.functions.refund().transact({'from': ursula2, 'gas_price': 0})
+    tx = worklock.functions.refund(preallocation_escrow_2.address).transact({'from': ursula2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    refund = new_work_done // refund_rate
-    assert deposited_eth - refund == worklock.functions.workInfo(ursula2).call()[0]
+    refund = worklock.functions.workToETH(new_completed_work).call()
+    assert deposited_eth_1 - refund == worklock.functions.workInfo(ursula2).call()[0]
     assert refund + ursula2_balance == testerchain.w3.eth.getBalance(ursula2)
-    assert remaining_work == worklock.functions.getRemainingWork(ursula2).call()
-    assert deposited_eth - refund == testerchain.w3.eth.getBalance(worklock.address)
+    assert deposited_eth_1 + deposited_eth_2 - refund == testerchain.w3.eth.getBalance(worklock.address)
     assert 0 == escrow.functions.getCompletedWork(ursula1).call()
     assert 0 == escrow.functions.getCompletedWork(preallocation_escrow_1.address).call()

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -70,7 +70,7 @@ def token(token_economics, deploy_contract):
 def escrow(testerchain, token, token_economics, deploy_contract):
     # Creator deploys the escrow
     contract, _ = deploy_contract(
-        'StakingEscrow', token.address, *token_economics.staking_deployment_parameters
+        'StakingEscrow', token.address, *token_economics.staking_deployment_parameters, True
     )
 
     secret_hash = testerchain.w3.keccak(escrow_secret)

--- a/tests/blockchain/eth/contracts/main/staking_escrow/conftest.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/conftest.py
@@ -55,6 +55,7 @@ def escrow_contract(testerchain, token, token_economics, request, deploy_contrac
         # Creator deploys the escrow
         deploy_parameters = list(token_economics.staking_deployment_parameters)
         deploy_parameters[-2] = max_allowed_locked_tokens
+        deploy_parameters.append(True)
         contract, _ = deploy_contract('StakingEscrow', token.address, *deploy_parameters)
 
         if request.param:

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking.py
@@ -49,9 +49,9 @@ def test_mining(testerchain, token, escrow_contract, token_economics):
     withdraw_log = escrow.events.Withdrawn.createFilter(fromBlock='latest')
 
     # Give Escrow tokens for reward and initialize contract
-    tx = token.functions.transfer(escrow.address, token_economics.erc20_reward_supply).transact({'from': creator})
+    tx = token.functions.approve(escrow.address, token_economics.erc20_reward_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.initialize().transact({'from': creator})
+    tx = escrow.functions.initialize(token_economics.erc20_reward_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Give Ursula and Ursula(2) some coins
@@ -366,9 +366,9 @@ def test_slashing(testerchain, token, escrow_contract, token_economics, deploy_c
     slashing_log = escrow.events.Slashed.createFilter(fromBlock='latest')
 
     # Give Escrow tokens for reward and initialize contract
-    tx = token.functions.transfer(escrow.address, token_economics.erc20_reward_supply).transact({'from': creator})
+    tx = token.functions.approve(escrow.address, token_economics.erc20_reward_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.initialize().transact({'from': creator})
+    tx = escrow.functions.initialize(token_economics.erc20_reward_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Give Ursula deposit some tokens

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow.py
@@ -77,7 +77,7 @@ def test_staking(testerchain, token, escrow_contract):
         testerchain.wait_for_receipt(tx)
 
     # Initialize Escrow contract
-    tx = escrow.functions.initialize().transact({'from': creator})
+    tx = escrow.functions.initialize(0).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Ursula can't deposit and lock too low value (less than _minAllowableLockedTokens coefficient)
@@ -550,7 +550,7 @@ def test_max_sub_stakes(testerchain, token, escrow_contract):
     ursula = testerchain.client.accounts[1]
 
     # Initialize Escrow contract
-    tx = escrow.functions.initialize().transact({'from': creator})
+    tx = escrow.functions.initialize(0).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Prepare before deposit

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow_additional.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow_additional.py
@@ -42,7 +42,7 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
 
     # Deploy contract
     contract_library_v1, _ = deploy_contract(
-        'StakingEscrow', token.address, *token_economics.staking_deployment_parameters
+        'StakingEscrow', token.address, *token_economics.staking_deployment_parameters, True
     )
     dispatcher, _ = deploy_contract('Dispatcher', contract_library_v1.address, secret_hash)
 
@@ -58,6 +58,7 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
         _minAllowableLockedTokens=2,
         _maxAllowableLockedTokens=2,
         _minWorkerPeriods=2,
+        _isTestContract=False,
         _valueToCheck=2
     )
 
@@ -66,6 +67,7 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
         address=dispatcher.address,
         ContractFactoryClass=Contract)
     assert token_economics.maximum_allowed_locked == contract.functions.maxAllowableLockedTokens().call()
+    assert contract.functions.isTestContract().call()
 
     # Can't call `finishUpgrade` and `verifyState` methods outside upgrade lifecycle
     with pytest.raises((TransactionFailed, ValueError)):
@@ -119,6 +121,10 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
     tx = contract.functions.confirmActivity().transact({'from': worker})
     testerchain.wait_for_receipt(tx)
 
+    # Can set WorkLock twice, because isTestContract == True
+    tx = contract.functions.setWorkLock(worklock.address).transact()
+    testerchain.wait_for_receipt(tx)
+
     # Upgrade to the second version
     tx = dispatcher.functions.upgrade(contract_library_v2.address, secret, secret2_hash).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
@@ -127,6 +133,10 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
     assert token_economics.maximum_allowed_locked == contract.functions.maxAllowableLockedTokens().call()
     assert policy_manager.address == contract.functions.policyManager().call()
     assert 2 == contract.functions.valueToCheck().call()
+    assert not contract.functions.isTestContract().call()
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = contract.functions.setWorkLock(worklock.address).transact()
+        testerchain.wait_for_receipt(tx)
     # Check new ABI
     tx = contract.functions.setValueToCheck(3).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
@@ -143,7 +153,8 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
         _minLockedPeriods=2,
         _minAllowableLockedTokens=2,
         _maxAllowableLockedTokens=2,
-        _minWorkerPeriods=2
+        _minWorkerPeriods=2,
+        _isTestContract=False
     )
     with pytest.raises((TransactionFailed, ValueError)):
         tx = dispatcher.functions.upgrade(contract_library_v1.address, secret2, secret_hash)\
@@ -159,6 +170,9 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
     testerchain.wait_for_receipt(tx)
     assert contract_library_v1.address == dispatcher.functions.target().call()
     assert policy_manager.address == contract.functions.policyManager().call()
+    assert contract.functions.isTestContract().call()
+    tx = contract.functions.setWorkLock(worklock.address).transact()
+    testerchain.wait_for_receipt(tx)
     # After rollback new ABI is unavailable
     with pytest.raises((TransactionFailed, ValueError)):
         tx = contract.functions.setValueToCheck(2).transact({'from': creator})

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow_additional.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow_additional.py
@@ -94,9 +94,9 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
     tx = contract.functions.setWorkLock(worklock.address).transact()
     testerchain.wait_for_receipt(tx)
 
-    tx = token.functions.transfer(contract.address, token_economics.erc20_reward_supply).transact({'from': creator})
+    tx = token.functions.approve(contract.address, token_economics.erc20_reward_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = contract.functions.initialize().transact({'from': creator})
+    tx = contract.functions.initialize(token_economics.erc20_reward_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = token.functions.transfer(staker, 1000).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
@@ -207,9 +207,10 @@ def test_re_stake(testerchain, token, escrow_contract):
     re_stake_lock_log = escrow.events.ReStakeLocked.createFilter(fromBlock='latest')
 
     # Give Escrow tokens for reward and initialize contract
-    tx = token.functions.transfer(escrow.address, 10 ** 9).transact({'from': creator})
+    reward = 10 ** 9
+    tx = token.functions.approve(escrow.address, reward).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.initialize().transact({'from': creator})
+    tx = escrow.functions.initialize(reward).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Set re-stake parameter even before initialization
@@ -469,7 +470,7 @@ def test_worker(testerchain, token, escrow_contract, deploy_contract):
     worker_log = escrow.events.WorkerSet.createFilter(fromBlock='latest')
 
     # Initialize escrow contract
-    tx = escrow.functions.initialize().transact({'from': creator})
+    tx = escrow.functions.initialize(0).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Deploy intermediary contracts
@@ -710,9 +711,10 @@ def test_measure_work(testerchain, token, escrow_contract, deploy_contract):
     work_measurement_log = escrow.events.WorkMeasurementSet.createFilter(fromBlock='latest')
 
     # Initialize escrow contract
-    tx = token.functions.transfer(escrow.address, int(NU(10 ** 9, 'NuNit'))).transact({'from': creator})
+    reward = 10 ** 9
+    tx = token.functions.approve(escrow.address, int(NU(reward, 'NuNit'))).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.initialize().transact({'from': creator})
+    tx = escrow.functions.initialize(reward).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Deploy WorkLock mock

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -70,7 +70,9 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
 
     # Transfer tokens to WorkLock
     worklock_supply = 2 * token_economics.maximum_allowed_locked - 1
-    tx = token.functions.transfer(worklock.address, worklock_supply).transact({'from': creator})
+    tx = token.functions.approve(worklock.address, worklock_supply).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+    tx = worklock.functions.deposit(worklock_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Give Ursulas some ETH
@@ -108,12 +110,12 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
         testerchain.wait_for_receipt(tx)
 
     # Ursula does first bid
-    assert worklock.functions.allClaimedTokens().call() == 0
+    assert worklock.functions.remainingTokens().call() == worklock_supply
     assert worklock.functions.workInfo(ursula1).call()[0] == 0
     assert testerchain.w3.eth.getBalance(worklock.address) == 0
     tx = worklock.functions.bid().transact({'from': ursula1, 'value': minimum_deposit_eth, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.allClaimedTokens().call() == token_economics.minimum_allowed_locked
+    assert worklock.functions.remainingTokens().call() == worklock_supply - token_economics.minimum_allowed_locked
     assert worklock.functions.workInfo(ursula1).call()[0] == minimum_deposit_eth
     assert testerchain.w3.eth.getBalance(worklock.address) == minimum_deposit_eth
 
@@ -128,8 +130,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert worklock.functions.workInfo(ursula2).call()[0] == 0
     tx = worklock.functions.bid().transact({'from': ursula2, 'value': maximum_deposit_eth, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.allClaimedTokens().call() == \
-           token_economics.minimum_allowed_locked + token_economics.maximum_allowed_locked
+    assert worklock.functions.remainingTokens().call() == worklock_supply - \
+           token_economics.minimum_allowed_locked - token_economics.maximum_allowed_locked
     assert worklock.functions.workInfo(ursula2).call()[0] == maximum_deposit_eth
     assert testerchain.w3.eth.getBalance(worklock.address) == maximum_deposit_eth + minimum_deposit_eth
 
@@ -152,8 +154,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     # Ursula does second bid
     tx = worklock.functions.bid().transact({'from': ursula1, 'value': minimum_deposit_eth, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.allClaimedTokens().call() == \
-           2 * token_economics.minimum_allowed_locked + token_economics.maximum_allowed_locked
+    assert worklock.functions.remainingTokens().call() == worklock_supply - \
+           2 * token_economics.minimum_allowed_locked - token_economics.maximum_allowed_locked
     assert worklock.functions.workInfo(ursula1).call()[0] == 2 * minimum_deposit_eth
     assert testerchain.w3.eth.getBalance(worklock.address) == maximum_deposit_eth + 2 * minimum_deposit_eth
 

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -39,7 +39,7 @@ def escrow(testerchain, token_economics, deploy_contract, token):
 
 @pytest.mark.slow
 def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
-    creator, ursula1, ursula2, *everyone_else = testerchain.w3.eth.accounts
+    creator, ursula1, ursula2, ursula3, *everyone_else = testerchain.w3.eth.accounts
 
     # Deploy WorkLock
     now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
@@ -64,16 +64,33 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert worklock.functions.depositRate().call() == deposit_rate
     assert worklock.functions.refundRate().call() == refund_rate
 
+    deposit_log = worklock.events.Deposited.createFilter(fromBlock='latest')
     bidding_log = worklock.events.Bid.createFilter(fromBlock='latest')
     claim_log = worklock.events.Claimed.createFilter(fromBlock='latest')
     refund_log = worklock.events.Refund.createFilter(fromBlock='latest')
+    burning_log = worklock.events.Burnt.createFilter(fromBlock='latest')
 
     # Transfer tokens to WorkLock
-    worklock_supply = 2 * token_economics.maximum_allowed_locked - 1
+    worklock_supply_1 = 2 * token_economics.maximum_allowed_locked
+    worklock_supply_2 = token_economics.maximum_allowed_locked - 1
+    worklock_supply = worklock_supply_1 + worklock_supply_2
     tx = token.functions.approve(worklock.address, worklock_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = worklock.functions.deposit(worklock_supply).transact({'from': creator})
+    tx = worklock.functions.deposit(worklock_supply_1).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
+    assert worklock.functions.remainingTokens().call() == worklock_supply_1
+    tx = worklock.functions.deposit(worklock_supply_2).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.remainingTokens().call() == worklock_supply
+
+    events = deposit_log.get_all_entries()
+    assert 2 == len(events)
+    event_args = events[0]['args']
+    assert event_args['sender'] == creator
+    assert event_args['value'] == worklock_supply_1
+    event_args = events[1]['args']
+    assert event_args['sender'] == creator
+    assert event_args['value'] == worklock_supply_2
 
     # Give Ursulas some ETH
     minimum_deposit_eth = token_economics.minimum_allowed_locked // deposit_rate
@@ -86,6 +103,10 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     tx = testerchain.w3.eth.sendTransaction(
         {'from': testerchain.etherbase_account, 'to': ursula2, 'value': ursula2_balance})
     testerchain.wait_for_receipt(tx)
+    ursula3_balance = maximum_deposit_eth
+    tx = testerchain.w3.eth.sendTransaction(
+        {'from': testerchain.etherbase_account, 'to': ursula3, 'value': ursula3_balance})
+    testerchain.wait_for_receipt(tx)
 
     # Can't do anything before start date
     with pytest.raises((TransactionFailed, ValueError)):
@@ -96,6 +117,9 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.burnRemaining().transact({'from': ursula1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Wait for the start of bidding
@@ -115,7 +139,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert testerchain.w3.eth.getBalance(worklock.address) == 0
     tx = worklock.functions.bid().transact({'from': ursula1, 'value': minimum_deposit_eth, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.remainingTokens().call() == worklock_supply - token_economics.minimum_allowed_locked
+    remaining_tokens = worklock_supply - token_economics.minimum_allowed_locked
+    assert worklock.functions.remainingTokens().call() == remaining_tokens
     assert worklock.functions.workInfo(ursula1).call()[0] == minimum_deposit_eth
     assert testerchain.w3.eth.getBalance(worklock.address) == minimum_deposit_eth
 
@@ -130,8 +155,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert worklock.functions.workInfo(ursula2).call()[0] == 0
     tx = worklock.functions.bid().transact({'from': ursula2, 'value': maximum_deposit_eth, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.remainingTokens().call() == worklock_supply - \
-           token_economics.minimum_allowed_locked - token_economics.maximum_allowed_locked
+    remaining_tokens -= token_economics.maximum_allowed_locked
+    assert worklock.functions.remainingTokens().call() == remaining_tokens
     assert worklock.functions.workInfo(ursula2).call()[0] == maximum_deposit_eth
     assert testerchain.w3.eth.getBalance(worklock.address) == maximum_deposit_eth + minimum_deposit_eth
 
@@ -139,6 +164,22 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert 2 == len(events)
     event_args = events[1]['args']
     assert event_args['staker'] == ursula2
+    assert event_args['depositedETH'] == maximum_deposit_eth
+    assert event_args['claimedTokens'] == token_economics.maximum_allowed_locked
+
+    # Third Ursula does first bid
+    assert worklock.functions.workInfo(ursula3).call()[0] == 0
+    tx = worklock.functions.bid().transact({'from': ursula3, 'value': maximum_deposit_eth, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    remaining_tokens -= token_economics.maximum_allowed_locked
+    assert worklock.functions.remainingTokens().call() == remaining_tokens
+    assert worklock.functions.workInfo(ursula3).call()[0] == maximum_deposit_eth
+    assert testerchain.w3.eth.getBalance(worklock.address) == 2 * maximum_deposit_eth + minimum_deposit_eth
+
+    events = bidding_log.get_all_entries()
+    assert 3 == len(events)
+    event_args = events[2]['args']
+    assert event_args['staker'] == ursula3
     assert event_args['depositedETH'] == maximum_deposit_eth
     assert event_args['claimedTokens'] == token_economics.maximum_allowed_locked
 
@@ -154,14 +195,14 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     # Ursula does second bid
     tx = worklock.functions.bid().transact({'from': ursula1, 'value': minimum_deposit_eth, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.remainingTokens().call() == worklock_supply - \
-           2 * token_economics.minimum_allowed_locked - token_economics.maximum_allowed_locked
+    remaining_tokens -= token_economics.minimum_allowed_locked
+    assert worklock.functions.remainingTokens().call() == remaining_tokens
     assert worklock.functions.workInfo(ursula1).call()[0] == 2 * minimum_deposit_eth
-    assert testerchain.w3.eth.getBalance(worklock.address) == maximum_deposit_eth + 2 * minimum_deposit_eth
+    assert testerchain.w3.eth.getBalance(worklock.address) == 2 * maximum_deposit_eth + 2 * minimum_deposit_eth
 
     events = bidding_log.get_all_entries()
-    assert 3 == len(events)
-    event_args = events[2]['args']
+    assert 4 == len(events)
+    event_args = events[3]['args']
     assert event_args['staker'] == ursula1
     assert event_args['depositedETH'] == minimum_deposit_eth
     assert event_args['claimedTokens'] == token_economics.minimum_allowed_locked
@@ -172,18 +213,21 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
             {'from': ursula1, 'value': maximum_deposit_eth - 2 * minimum_deposit_eth, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
-    # Can't claim or refund while bidding phase
+    # Can't claim, refund or burn while bidding phase
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.claim().transact({'from': ursula1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.burnRemaining().transact({'from': ursula1, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
 
     # Wait for the end of bidding
     testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
 
-    # Can't bid after the enf of bidding
+    # Can't bid after the end of bidding
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.bid().transact({'from': ursula1, 'value': minimum_deposit_eth, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
@@ -240,7 +284,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert measure_work
     assert periods == 2 * token_economics.minimum_locked_periods
     assert token.functions.balanceOf(worklock.address).call() == \
-           worklock_supply - 2 * token_economics.minimum_allowed_locked - token_economics.maximum_allowed_locked
+           remaining_tokens + token_economics.maximum_allowed_locked
     assert token.functions.balanceOf(escrow.address).call() == \
            2 * token_economics.minimum_allowed_locked + token_economics.maximum_allowed_locked
 
@@ -261,7 +305,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert worklock.functions.workInfo(ursula1).call()[0] == minimum_deposit_eth
     assert worklock.functions.getRemainingWork(ursula1).call() == minimum_deposit_eth * refund_rate - refund_rate // 2
     assert testerchain.w3.eth.getBalance(ursula1) == ursula1_balance + minimum_deposit_eth
-    assert testerchain.w3.eth.getBalance(worklock.address) == maximum_deposit_eth + minimum_deposit_eth
+    assert testerchain.w3.eth.getBalance(worklock.address) == 2 * maximum_deposit_eth + minimum_deposit_eth
     _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula1).call()
     assert measure_work
 
@@ -283,7 +327,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert worklock.functions.workInfo(ursula1).call()[0] == 0
     assert worklock.functions.getRemainingWork(ursula1).call() == 0
     assert testerchain.w3.eth.getBalance(ursula1) == ursula1_balance + minimum_deposit_eth
-    assert testerchain.w3.eth.getBalance(worklock.address) == maximum_deposit_eth
+    assert testerchain.w3.eth.getBalance(worklock.address) == 2 * maximum_deposit_eth
     _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula1).call()
     assert not measure_work
 
@@ -300,6 +344,25 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
+
+    # Now burn remaining tokens
+    assert worklock.functions.remainingTokens().call() == remaining_tokens
+    tx = worklock.functions.burnRemaining().transact({'from': ursula1, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.remainingTokens().call() == 0
+    assert token.functions.balanceOf(worklock.address).call() == token_economics.maximum_allowed_locked
+    assert token.functions.balanceOf(escrow.address).call() == worklock_supply - token_economics.maximum_allowed_locked
+
+    # Can't burn twice
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.burnRemaining().transact({'from': ursula1, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+
+    events = burning_log.get_all_entries()
+    assert 1 == len(events)
+    event_args = events[0]['args']
+    assert event_args['sender'] == ursula1
+    assert event_args['value'] == remaining_tokens
 
 
 @pytest.mark.slow

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -103,7 +103,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow, 
     end_bid_date = start_bid_date + (60 * 60)
     boosting_refund = 50
     slowing_refund = 100
-    locked_duration = 60 * 60
+    locking_duration = 60 * 60
     worklock, _ = deploy_contract(
         contract_name='WorkLock',
         _token=token.address,
@@ -112,13 +112,13 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow, 
         _startBidDate=start_bid_date,
         _endBidDate=end_bid_date,
         _boostingRefund=boosting_refund,
-        _lockedDuration=locked_duration
+        _lockingDuration=locking_duration
     )
     assert worklock.functions.startBidDate().call() == start_bid_date
     assert worklock.functions.endBidDate().call() == end_bid_date
     assert worklock.functions.boostingRefund().call() == boosting_refund
     assert worklock.functions.SLOWING_REFUND().call() == slowing_refund
-    assert worklock.functions.lockedDuration().call() == locked_duration
+    assert worklock.functions.lockingDuration().call() == locking_duration
 
     deposit_log = worklock.events.Deposited.createFilter(fromBlock='latest')
     bidding_log = worklock.events.Bid.createFilter(fromBlock='latest')
@@ -316,6 +316,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow, 
     assert preallocation_escrow_1.functions.router().call() == router.address
     assert preallocation_escrow_1.functions.lockedValue().call() == staker1_tokens
     assert preallocation_escrow_1.functions.getLockedTokens().call() == staker1_tokens
+    assert preallocation_escrow_1.functions.endLockTimestamp().call() == \
+           testerchain.w3.eth.getBlock(block_identifier='latest').timestamp + locking_duration
     staker1_remaining_work = int(-(-8 * worklock_supply * slowing_refund // (boosting_refund * 10)))  # div ceil
     assert worklock.functions.ethToWork(2 * deposit_eth_1).call() == staker1_remaining_work
     assert worklock.functions.workToETH(staker1_remaining_work).call() == 2 * deposit_eth_1

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -14,17 +14,66 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-
+import os
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from eth_utils import to_wei
+from eth_utils import to_wei, keccak, to_normalized_address, to_canonical_address, to_checksum_address
+from web3.contract import Contract
 
 
 @pytest.fixture()
 def token(testerchain, token_economics, deploy_contract):
     contract, _ = deploy_contract('NuCypherToken', _totalSupply=token_economics.erc20_total_supply)
     return contract
+
+
+@pytest.fixture()
+def router(testerchain, deploy_contract):
+    staking_interface, _ = deploy_contract('StakingInterfaceMock')
+    secret = os.urandom(32)
+    secret_hash = keccak(secret)
+    contract, _ = deploy_contract('StakingInterfaceRouter', staking_interface.address, secret_hash)
+    return contract
+
+
+def next_address(testerchain, worklock):
+    nonce = testerchain.w3.eth.getTransactionCount(worklock.address)
+    if nonce == 0:
+        data = bytes.fromhex('d6') + \
+               bytes.fromhex('94') + \
+               to_canonical_address(worklock.address) + \
+               bytes.fromhex('80')
+    elif nonce <= 127:
+        data = bytes.fromhex('d6') + \
+               bytes.fromhex('94') + \
+               to_canonical_address(worklock.address) + \
+               nonce.to_bytes(1, byteorder='big')
+    elif nonce <= 255:
+        data = bytes.fromhex('d7') + \
+               bytes.fromhex('94') + \
+               to_canonical_address(worklock.address) + \
+               bytes.fromhex('81') + \
+               nonce.to_bytes(1, byteorder='big')
+    elif nonce <= 65535:
+        data = bytes.fromhex('d8') + \
+               bytes.fromhex('94') + \
+               to_canonical_address(worklock.address) + \
+               bytes.fromhex('82') + \
+               nonce.to_bytes(2, byteorder='big')
+    elif nonce <= 16777215:
+        data = bytes.fromhex('d9') + \
+               bytes.fromhex('94') + \
+               to_canonical_address(worklock.address) + \
+               bytes.fromhex('83') + \
+               nonce.to_bytes(3, byteorder='big')
+    else:
+        data = bytes.fromhex('da') + \
+               bytes.fromhex('94') + \
+               to_canonical_address(worklock.address) + \
+               bytes.fromhex('84') + \
+               nonce.to_bytes(4, byteorder='big')
+    return to_checksum_address(keccak(data)[12:32])
 
 
 @pytest.fixture()
@@ -40,8 +89,13 @@ def escrow(testerchain, token_economics, deploy_contract, token):
 
 
 @pytest.mark.slow
-def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
-    creator, ursula1, ursula2, ursula3, *everyone_else = testerchain.w3.eth.accounts
+def test_worklock(testerchain, token_economics, deploy_contract, token, escrow, router):
+    creator, staker1, staker2, staker3, *everyone_else = testerchain.w3.eth.accounts
+
+    # Deploy fake preallocation escrow
+    preallocation_escrow_fake, _ = deploy_contract('PreallocationEscrow', router.address, token.address)
+    tx = preallocation_escrow_fake.functions.transferOwnership(staker1).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
 
     # Deploy WorkLock
     now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
@@ -49,18 +103,22 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     end_bid_date = start_bid_date + (60 * 60)
     boosting_refund = 50
     slowing_refund = 100
+    locked_duration = 60 * 60
     worklock, _ = deploy_contract(
         contract_name='WorkLock',
         _token=token.address,
         _escrow=escrow.address,
+        _router=router.address,
         _startBidDate=start_bid_date,
         _endBidDate=end_bid_date,
-        _boostingRefund=boosting_refund
+        _boostingRefund=boosting_refund,
+        _lockedDuration=locked_duration
     )
     assert worklock.functions.startBidDate().call() == start_bid_date
     assert worklock.functions.endBidDate().call() == end_bid_date
     assert worklock.functions.boostingRefund().call() == boosting_refund
     assert worklock.functions.SLOWING_REFUND().call() == slowing_refund
+    assert worklock.functions.lockedDuration().call() == locked_duration
 
     deposit_log = worklock.events.Deposited.createFilter(fromBlock='latest')
     bidding_log = worklock.events.Bid.createFilter(fromBlock='latest')
@@ -94,138 +152,138 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     # Give Ursulas some ETH
     deposit_eth_1 = to_wei(4, 'ether')
     deposit_eth_2 = deposit_eth_1 // 4
-    ursula1_balance = 10 * deposit_eth_1
+    staker1_balance = 10 * deposit_eth_1
     tx = testerchain.w3.eth.sendTransaction(
-        {'from': testerchain.etherbase_account, 'to': ursula1, 'value': ursula1_balance})
+        {'from': testerchain.etherbase_account, 'to': staker1, 'value': staker1_balance})
     testerchain.wait_for_receipt(tx)
-    ursula2_balance = ursula1_balance
+    ursula2_balance = staker1_balance
     tx = testerchain.w3.eth.sendTransaction(
-        {'from': testerchain.etherbase_account, 'to': ursula2, 'value': ursula2_balance})
+        {'from': testerchain.etherbase_account, 'to': staker2, 'value': ursula2_balance})
     testerchain.wait_for_receipt(tx)
-    ursula3_balance = ursula1_balance
+    staker3_balance = staker1_balance
     tx = testerchain.w3.eth.sendTransaction(
-        {'from': testerchain.etherbase_account, 'to': ursula3, 'value': ursula3_balance})
+        {'from': testerchain.etherbase_account, 'to': staker3, 'value': staker3_balance})
     testerchain.wait_for_receipt(tx)
 
     # Can't do anything before start date
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.bid().transact({'from': ursula1, 'value': deposit_eth_1, 'gas_price': 0})
+        tx = worklock.functions.bid().transact({'from': staker1, 'value': deposit_eth_1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.claim().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.refund(preallocation_escrow_fake.address).transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.burnUnclaimed().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.burnUnclaimed().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.cancelBid().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.cancelBid().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Wait for the start of bidding
     testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
 
     # Ursula does first bid
-    assert worklock.functions.workInfo(ursula1).call()[0] == 0
+    assert worklock.functions.workInfo(staker1).call()[0] == 0
     assert testerchain.w3.eth.getBalance(worklock.address) == 0
-    tx = worklock.functions.bid().transact({'from': ursula1, 'value': deposit_eth_1, 'gas_price': 0})
+    tx = worklock.functions.bid().transact({'from': staker1, 'value': deposit_eth_1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula1).call()[0] == deposit_eth_1
+    assert worklock.functions.workInfo(staker1).call()[0] == deposit_eth_1
     assert testerchain.w3.eth.getBalance(worklock.address) == deposit_eth_1
     assert worklock.functions.ethToTokens(deposit_eth_1).call() == worklock_supply
 
     events = bidding_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert event_args['staker'] == ursula1
+    assert event_args['sender'] == staker1
     assert event_args['depositedETH'] == deposit_eth_1
 
     # Second Ursula does first bid
-    assert worklock.functions.workInfo(ursula2).call()[0] == 0
-    tx = worklock.functions.bid().transact({'from': ursula2, 'value': deposit_eth_2, 'gas_price': 0})
+    assert worklock.functions.workInfo(staker2).call()[0] == 0
+    tx = worklock.functions.bid().transact({'from': staker2, 'value': deposit_eth_2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula2).call()[0] == deposit_eth_2
+    assert worklock.functions.workInfo(staker2).call()[0] == deposit_eth_2
     assert testerchain.w3.eth.getBalance(worklock.address) == deposit_eth_1 + deposit_eth_2
     assert worklock.functions.ethToTokens(deposit_eth_2).call() == worklock_supply // 5
 
     events = bidding_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
-    assert event_args['staker'] == ursula2
+    assert event_args['sender'] == staker2
     assert event_args['depositedETH'] == deposit_eth_2
 
     # Third Ursula does first bid
-    assert worklock.functions.workInfo(ursula3).call()[0] == 0
-    tx = worklock.functions.bid().transact({'from': ursula3, 'value': deposit_eth_2, 'gas_price': 0})
+    assert worklock.functions.workInfo(staker3).call()[0] == 0
+    tx = worklock.functions.bid().transact({'from': staker3, 'value': deposit_eth_2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula3).call()[0] == deposit_eth_2
+    assert worklock.functions.workInfo(staker3).call()[0] == deposit_eth_2
     assert testerchain.w3.eth.getBalance(worklock.address) == deposit_eth_1 + 2 * deposit_eth_2
     assert worklock.functions.ethToTokens(deposit_eth_2).call() == worklock_supply // 6
 
     events = bidding_log.get_all_entries()
     assert 3 == len(events)
     event_args = events[2]['args']
-    assert event_args['staker'] == ursula3
+    assert event_args['sender'] == staker3
     assert event_args['depositedETH'] == deposit_eth_2
 
     # Ursula does second bid
-    tx = worklock.functions.bid().transact({'from': ursula1, 'value': deposit_eth_1, 'gas_price': 0})
+    tx = worklock.functions.bid().transact({'from': staker1, 'value': deposit_eth_1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula1).call()[0] == 2 * deposit_eth_1
+    assert worklock.functions.workInfo(staker1).call()[0] == 2 * deposit_eth_1
     assert testerchain.w3.eth.getBalance(worklock.address) == 2 * deposit_eth_1 + 2 * deposit_eth_2
     assert worklock.functions.ethToTokens(deposit_eth_2).call() == worklock_supply // 10
 
     events = bidding_log.get_all_entries()
     assert 4 == len(events)
     event_args = events[3]['args']
-    assert event_args['staker'] == ursula1
+    assert event_args['sender'] == staker1
     assert event_args['depositedETH'] == deposit_eth_1
 
     # Can't claim, refund or burn while bidding phase
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.claim().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.refund(preallocation_escrow_fake.address).transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.burnUnclaimed().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.burnUnclaimed().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # But can cancel bid
-    ursula3_balance = testerchain.w3.eth.getBalance(ursula3)
-    tx = worklock.functions.cancelBid().transact({'from': ursula3, 'gas_price': 0})
+    staker3_balance = testerchain.w3.eth.getBalance(staker3)
+    tx = worklock.functions.cancelBid().transact({'from': staker3, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula3).call()[0] == 0
+    assert worklock.functions.workInfo(staker3).call()[0] == 0
     assert testerchain.w3.eth.getBalance(worklock.address) == 2 * deposit_eth_1 + deposit_eth_2
     assert worklock.functions.ethToTokens(deposit_eth_2).call() == worklock_supply // 9
-    assert testerchain.w3.eth.getBalance(ursula3) == ursula3_balance + deposit_eth_2
+    assert testerchain.w3.eth.getBalance(staker3) == staker3_balance + deposit_eth_2
 
     events = canceling_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert event_args['staker'] == ursula3
+    assert event_args['sender'] == staker3
     assert event_args['value'] == deposit_eth_2
 
     # Can't cancel twice in a row
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.cancelBid().transact({'from': ursula3, 'gas_price': 0})
+        tx = worklock.functions.cancelBid().transact({'from': staker3, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Third Ursula does second bid
-    assert worklock.functions.workInfo(ursula3).call()[0] == 0
-    tx = worklock.functions.bid().transact({'from': ursula3, 'value': deposit_eth_2, 'gas_price': 0})
+    assert worklock.functions.workInfo(staker3).call()[0] == 0
+    tx = worklock.functions.bid().transact({'from': staker3, 'value': deposit_eth_2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula3).call()[0] == deposit_eth_2
+    assert worklock.functions.workInfo(staker3).call()[0] == deposit_eth_2
     assert testerchain.w3.eth.getBalance(worklock.address) == 2 * deposit_eth_1 + 2 * deposit_eth_2
     assert worklock.functions.ethToTokens(deposit_eth_2).call() == worklock_supply // 10
 
     events = bidding_log.get_all_entries()
     assert 5 == len(events)
     event_args = events[4]['args']
-    assert event_args['staker'] == ursula3
+    assert event_args['sender'] == staker3
     assert event_args['depositedETH'] == deposit_eth_2
 
     # Wait for the end of bidding
@@ -233,194 +291,243 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
 
     # Can't bid after the end of bidding
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.bid().transact({'from': ursula1, 'value': deposit_eth_1, 'gas_price': 0})
+        tx = worklock.functions.bid().transact({'from': staker1, 'value': deposit_eth_1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     # Can't refund without claim
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.refund(preallocation_escrow_fake.address).transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Ursula claims tokens
-    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula1).call()
+    preallocation_escrow_1_address = next_address(testerchain, worklock)
+    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(preallocation_escrow_1_address).call()
     assert not measure_work
-    tx = worklock.functions.claim().transact({'from': ursula1, 'gas_price': 0})
+    tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    ursula1_tokens = 8 * worklock_supply // 10
-    assert token.functions.balanceOf(ursula1).call() == ursula1_tokens
-    ursula1_remaining_work = int(-(-8 * worklock_supply * slowing_refund // (boosting_refund * 10)))  # div ceil
-    assert worklock.functions.ethToWork(2 * deposit_eth_1).call() == ursula1_remaining_work
-    assert worklock.functions.workToETH(ursula1_remaining_work).call() == 2 * deposit_eth_1
-    assert worklock.functions.getRemainingWork(ursula1).call() == ursula1_remaining_work
-    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - ursula1_tokens
-    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula1).call()
+    staker1_tokens = 8 * worklock_supply // 10
+    preallocation_escrow_1 = testerchain.client.get_contract(
+        abi=preallocation_escrow_fake.abi,
+        address=worklock.functions.workInfo(staker1).call()[2],
+        ContractFactoryClass=Contract)
+    assert preallocation_escrow_1.address == preallocation_escrow_1_address
+    assert token.functions.balanceOf(staker1).call() == 0
+    assert token.functions.balanceOf(preallocation_escrow_1.address).call() == staker1_tokens
+    assert preallocation_escrow_1.functions.owner().call() == staker1
+    assert preallocation_escrow_1.functions.router().call() == router.address
+    assert preallocation_escrow_1.functions.lockedValue().call() == staker1_tokens
+    assert preallocation_escrow_1.functions.getLockedTokens().call() == staker1_tokens
+    staker1_remaining_work = int(-(-8 * worklock_supply * slowing_refund // (boosting_refund * 10)))  # div ceil
+    assert worklock.functions.ethToWork(2 * deposit_eth_1).call() == staker1_remaining_work
+    assert worklock.functions.workToETH(staker1_remaining_work).call() == 2 * deposit_eth_1
+    assert worklock.functions.getRemainingWork(preallocation_escrow_1_address).call() == staker1_remaining_work
+    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - staker1_tokens
+    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(preallocation_escrow_1_address).call()
     assert measure_work
 
     events = claim_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert event_args['staker'] == ursula1
-    assert event_args['claimedTokens'] == ursula1_tokens
+    assert event_args['sender'] == staker1
+    assert event_args['claimedTokens'] == staker1_tokens
+    assert event_args['preallocationEscrow'] == preallocation_escrow_1_address
 
     # Can't claim more than once
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.claim().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     # Can't refund without work
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.refund(preallocation_escrow_1.address).transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     # Can't cancel after claim
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.cancelBid().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.cancelBid().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # One of Ursulas cancel bid
-    ursula3_balance = testerchain.w3.eth.getBalance(ursula3)
-    ursula3_tokens = worklock_supply // 10
-    assert worklock.functions.ethToTokens(deposit_eth_2).call() == ursula3_tokens
-    tx = worklock.functions.cancelBid().transact({'from': ursula3, 'gas_price': 0})
+    staker3_balance = testerchain.w3.eth.getBalance(staker3)
+    staker3_tokens = worklock_supply // 10
+    assert worklock.functions.ethToTokens(deposit_eth_2).call() == staker3_tokens
+    tx = worklock.functions.cancelBid().transact({'from': staker3, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.ethToTokens(deposit_eth_2).call() == ursula3_tokens
-    assert worklock.functions.workInfo(ursula3).call()[0] == 0
+    assert worklock.functions.ethToTokens(deposit_eth_2).call() == staker3_tokens
+    assert worklock.functions.workInfo(staker3).call()[0] == 0
     assert testerchain.w3.eth.getBalance(worklock.address) == 2 * deposit_eth_1 + deposit_eth_2
-    assert testerchain.w3.eth.getBalance(ursula3) == ursula3_balance + deposit_eth_2
-    assert worklock.functions.unclaimedTokens().call() == ursula3_tokens
-    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - ursula1_tokens
+    assert testerchain.w3.eth.getBalance(staker3) == staker3_balance + deposit_eth_2
+    assert worklock.functions.unclaimedTokens().call() == staker3_tokens
+    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - staker1_tokens
 
     # Second Ursula claims tokens
-    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula2).call()
+    preallocation_escrow_2_address = next_address(testerchain, worklock)
+    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(preallocation_escrow_2_address).call()
     assert not measure_work
-    ursula2_tokens = ursula3_tokens
-    # ursula2_tokens * slowing_refund / boosting_refund
-    ursula2_remaining_work = int(-(-worklock_supply * slowing_refund // (boosting_refund * 10)))  # div ceil
-    assert worklock.functions.ethToWork(deposit_eth_2).call() == ursula2_remaining_work
-    assert worklock.functions.workToETH(ursula2_remaining_work).call() == deposit_eth_2
-    tx = escrow.functions.setCompletedWork(ursula2, ursula2_remaining_work // 2).transact()
+    staker2_tokens = staker3_tokens
+    # staker2_tokens * slowing_refund / boosting_refund
+    staker2_remaining_work = int(-(-worklock_supply * slowing_refund // (boosting_refund * 10)))  # div ceil
+    assert worklock.functions.ethToWork(deposit_eth_2).call() == staker2_remaining_work
+    assert worklock.functions.workToETH(staker2_remaining_work).call() == deposit_eth_2
+    tx = escrow.functions.setCompletedWork(preallocation_escrow_2_address, staker2_remaining_work // 2).transact()
     testerchain.wait_for_receipt(tx)
-    tx = worklock.functions.claim().transact({'from': ursula2, 'gas_price': 0})
+    tx = worklock.functions.claim().transact({'from': staker2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.getRemainingWork(ursula2).call() == ursula2_remaining_work
-    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - ursula1_tokens - ursula2_tokens
-    assert token.functions.balanceOf(ursula2).call() == ursula2_tokens
-    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula2).call()
+    assert worklock.functions.getRemainingWork(preallocation_escrow_2_address).call() == staker2_remaining_work
+    assert token.functions.balanceOf(worklock.address).call() == worklock_supply - staker1_tokens - staker2_tokens
+    assert token.functions.balanceOf(staker2).call() == 0
+    preallocation_escrow_2 = testerchain.client.get_contract(
+        abi=preallocation_escrow_fake.abi,
+        address=worklock.functions.workInfo(staker2).call()[2],
+        ContractFactoryClass=Contract)
+    assert preallocation_escrow_2.address == preallocation_escrow_2_address
+    assert token.functions.balanceOf(preallocation_escrow_2.address).call() == staker2_tokens
+    assert preallocation_escrow_2.functions.owner().call() == staker2
+    assert preallocation_escrow_2.functions.getLockedTokens().call() == staker2_tokens
+    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(preallocation_escrow_2.address).call()
     assert measure_work
 
     events = claim_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
-    assert event_args['staker'] == ursula2
-    assert event_args['claimedTokens'] == ursula2_tokens
+    assert event_args['sender'] == staker2
+    assert event_args['claimedTokens'] == staker2_tokens
+    assert event_args['preallocationEscrow'] == preallocation_escrow_2_address
 
     # "Do" some work and partial refund
-    ursula1_balance = testerchain.w3.eth.getBalance(ursula1)
-    completed_work = ursula1_remaining_work // 2 + 1
-    remaining_work = ursula1_remaining_work - completed_work
-    tx = escrow.functions.setCompletedWork(ursula1, completed_work).transact()
+    staker1_balance = testerchain.w3.eth.getBalance(staker1)
+    completed_work = staker1_remaining_work // 2 + 1
+    remaining_work = staker1_remaining_work - completed_work
+    tx = escrow.functions.setCompletedWork(preallocation_escrow_1_address, completed_work).transact()
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.getRemainingWork(ursula1).call() == remaining_work
-    tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+    assert worklock.functions.getRemainingWork(preallocation_escrow_1_address).call() == remaining_work
+
+    # Can't refund using wrong escrow address
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.refund(preallocation_escrow_fake.address).transact({'from': staker1, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+    # Only owner of escrow can call refund
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.refund(preallocation_escrow_1_address).transact({'from': staker2, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+
+    tx = worklock.functions.refund(preallocation_escrow_1_address).transact({'from': staker1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula1).call()[0] == deposit_eth_1
-    assert worklock.functions.getRemainingWork(ursula1).call() == remaining_work
-    assert testerchain.w3.eth.getBalance(ursula1) == ursula1_balance + deposit_eth_1
+    assert worklock.functions.workInfo(staker1).call()[0] == deposit_eth_1
+    assert worklock.functions.getRemainingWork(preallocation_escrow_1_address).call() == remaining_work
+    assert testerchain.w3.eth.getBalance(staker1) == staker1_balance + deposit_eth_1
     assert testerchain.w3.eth.getBalance(worklock.address) == deposit_eth_1 + deposit_eth_2
-    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula1).call()
+    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(preallocation_escrow_1_address).call()
     assert measure_work
 
     events = refund_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert event_args['staker'] == ursula1
+    assert event_args['sender'] == staker1
+    assert event_args['preallocationEscrow'] == preallocation_escrow_1_address
     assert event_args['refundETH'] == deposit_eth_1
-    assert event_args['completedWork'] == ursula1_remaining_work // 2
+    assert event_args['completedWork'] == staker1_remaining_work // 2
+
+    # Transfer ownership of preallocation escrow to the new staker
+    tx = preallocation_escrow_1.functions.transferOwnership(staker2).transact({'from': staker1, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
 
     # "Do" more work and full refund
-    ursula1_balance = testerchain.w3.eth.getBalance(ursula1)
-    completed_work = ursula1_remaining_work
-    tx = escrow.functions.setCompletedWork(ursula1, completed_work).transact()
+    staker1_balance = testerchain.w3.eth.getBalance(staker1)
+    staker2_balance = testerchain.w3.eth.getBalance(staker2)
+    completed_work = staker1_remaining_work
+    tx = escrow.functions.setCompletedWork(preallocation_escrow_1_address, completed_work).transact()
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.getRemainingWork(ursula1).call() == 0
-    tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+    assert worklock.functions.getRemainingWork(preallocation_escrow_1_address).call() == 0
+
+    # Only ??? owner of escrow can call refund
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.refund(preallocation_escrow_1_address).transact({'from': staker1, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+
+    tx = worklock.functions.refund(preallocation_escrow_1_address).transact({'from': staker2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(ursula1).call()[0] == 0
-    assert worklock.functions.getRemainingWork(ursula1).call() == 0
-    assert testerchain.w3.eth.getBalance(ursula1) == ursula1_balance + deposit_eth_1
+    assert worklock.functions.workInfo(staker1).call()[0] == 0
+    assert worklock.functions.workInfo(staker2).call()[0] == deposit_eth_2
+    assert worklock.functions.getRemainingWork(preallocation_escrow_1_address).call() == 0
+    assert testerchain.w3.eth.getBalance(staker2) == staker2_balance + deposit_eth_1
+    assert testerchain.w3.eth.getBalance(staker1) == staker1_balance
     assert testerchain.w3.eth.getBalance(worklock.address) == deposit_eth_2
-    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(ursula1).call()
+    _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(preallocation_escrow_1_address).call()
     assert not measure_work
 
     events = refund_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
-    assert event_args['staker'] == ursula1
+    assert event_args['sender'] == staker2
+    assert event_args['preallocationEscrow'] == preallocation_escrow_1_address
     assert event_args['refundETH'] == deposit_eth_1
-    assert event_args['completedWork'] == ursula1_remaining_work // 2
+    assert event_args['completedWork'] == staker1_remaining_work // 2
 
     # Can't refund more tokens
-    tx = escrow.functions.setCompletedWork(ursula1, 2 * completed_work).transact()
+    tx = escrow.functions.setCompletedWork(staker1, 2 * completed_work).transact()
     testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.refund().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.refund(preallocation_escrow_1_address).transact({'from': staker2, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Now burn remaining tokens
-    assert worklock.functions.unclaimedTokens().call() == ursula3_tokens
-    tx = worklock.functions.burnUnclaimed().transact({'from': ursula1, 'gas_price': 0})
+    assert worklock.functions.unclaimedTokens().call() == staker3_tokens
+    tx = worklock.functions.burnUnclaimed().transact({'from': staker1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.unclaimedTokens().call() == 0
     assert token.functions.balanceOf(worklock.address).call() == 0
-    assert token.functions.balanceOf(escrow.address).call() == ursula3_tokens
+    assert token.functions.balanceOf(escrow.address).call() == staker3_tokens
 
     # Can't burn twice
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.burnUnclaimed().transact({'from': ursula1, 'gas_price': 0})
+        tx = worklock.functions.burnUnclaimed().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     events = burning_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert event_args['sender'] == ursula1
-    assert event_args['value'] == ursula3_tokens
+    assert event_args['sender'] == staker1
+    assert event_args['value'] == staker3_tokens
 
 
 @pytest.mark.slow
-def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow):
+def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow, router):
     # Deploy WorkLock
     now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     start_bid_date = now
     end_bid_date = start_bid_date + (60 * 60)
-    deposit_rate = 1
-    refund_rate = 1
+    boosting_refund = 100
+    locked_duration = 60 * 60
     worklock, _ = deploy_contract(
         contract_name='WorkLock',
         _token=token.address,
         _escrow=escrow.address,
+        _router=router.address,
         _startBidDate=start_bid_date,
         _endBidDate=end_bid_date,
-        _depositRate=deposit_rate,
-        _refundRate=refund_rate,
-        _lockedPeriods=2 * token_economics.minimum_locked_periods
+        _boostingRefund=boosting_refund,
+        _lockedDuration=locked_duration
     )
     refund_log = worklock.events.Refund.createFilter(fromBlock='latest')
-    worklock_supply = 2 * token_economics.maximum_allowed_locked - 1
-    tx = token.functions.transfer(worklock.address, worklock_supply).transact()
+    worklock_supply = 3 * token_economics.maximum_allowed_locked
+    tx = token.functions.approve(worklock.address, worklock_supply).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = worklock.functions.tokenDeposit(worklock_supply).transact()
     testerchain.wait_for_receipt(tx)
 
     reentrancy_contract, _ = deploy_contract('ReentrancyTest')
     contract_address = reentrancy_contract.address
-    minimum_deposit_eth = token_economics.minimum_allowed_locked // deposit_rate
+    deposit_eth = to_wei(3, 'ether')
     tx = testerchain.client.send_transaction(
-        {'from': testerchain.etherbase_account, 'to': contract_address, 'value': minimum_deposit_eth})
+        {'from': testerchain.etherbase_account, 'to': contract_address, 'value': deposit_eth})
     testerchain.wait_for_receipt(tx)
 
     # Bid
     transaction = worklock.functions.bid().buildTransaction({'gas': 0})
-    tx = reentrancy_contract.functions.setData(1, transaction['to'], minimum_deposit_eth, transaction['data']).transact()
+    tx = reentrancy_contract.functions.setData(1, transaction['to'], deposit_eth, transaction['data']).transact()
     testerchain.wait_for_receipt(tx)
     tx = testerchain.client.send_transaction({'to': contract_address})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(contract_address).call()[0] == minimum_deposit_eth
-    assert testerchain.w3.eth.getBalance(worklock.address) == minimum_deposit_eth
+    assert worklock.functions.workInfo(contract_address).call()[0] == deposit_eth
+    assert testerchain.w3.eth.getBalance(worklock.address) == deposit_eth
 
     # Claim
     testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
@@ -429,20 +536,21 @@ def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow
     testerchain.wait_for_receipt(tx)
     tx = testerchain.client.send_transaction({'to': contract_address})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.getRemainingWork(contract_address).call() == minimum_deposit_eth * refund_rate
+    preallocation_escrow = worklock.functions.workInfo(contract_address).call()[2]
+    assert worklock.functions.getRemainingWork(preallocation_escrow).call() == worklock_supply
 
     # Prepare for refund and check reentrancy protection
     balance = testerchain.w3.eth.getBalance(contract_address)
-    completed_work = refund_rate * minimum_deposit_eth // 3
-    tx = escrow.functions.setCompletedWork(contract_address, completed_work).transact()
+    completed_work = worklock_supply // 3
+    tx = escrow.functions.setCompletedWork(preallocation_escrow, completed_work).transact()
     testerchain.wait_for_receipt(tx)
-    transaction = worklock.functions.refund().buildTransaction({'gas': 0})
+    transaction = worklock.functions.refund(preallocation_escrow).buildTransaction({'gas': 0})
     tx = reentrancy_contract.functions.setData(2, transaction['to'], 0, transaction['data']).transact()
     testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = testerchain.client.send_transaction({'to': contract_address})
         testerchain.wait_for_receipt(tx)
     assert testerchain.w3.eth.getBalance(contract_address) == balance
-    assert worklock.functions.workInfo(contract_address).call()[0] == minimum_deposit_eth
-    assert worklock.functions.getRemainingWork(contract_address).call() == 2 * minimum_deposit_eth * refund_rate // 3
+    assert worklock.functions.workInfo(contract_address).call()[0] == deposit_eth
+    assert worklock.functions.getRemainingWork(preallocation_escrow).call() == 2 * worklock_supply // 3
     assert len(refund_log.get_all_entries()) == 0

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -93,7 +93,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow, 
     creator, staker1, staker2, staker3, *everyone_else = testerchain.w3.eth.accounts
 
     # Deploy fake preallocation escrow
-    preallocation_escrow_fake, _ = deploy_contract('PreallocationEscrow', router.address, token.address)
+    preallocation_escrow_fake, _ = deploy_contract('PreallocationEscrow', router.address, token.address, escrow.address)
     tx = preallocation_escrow_fake.functions.transferOwnership(staker1).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -55,7 +55,8 @@ def test_nucypher_deploy_contracts(click_runner,
     command = ['contracts',
                '--registry-outfile', registry_filepath,
                '--provider', TEST_PROVIDER_URI,
-               '--poa']
+               '--poa',
+               '--se-test-mode']
 
     user_input = '0\n' + 'Y\n' + (f'{INSECURE_SECRETS[1]}\n' * 8) + 'DEPLOY'
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
@@ -101,6 +102,7 @@ def test_nucypher_deploy_contracts(click_runner,
     assert token_agent.get_balance() == 0
     staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)
     assert staking_agent.get_current_period()
+    assert staking_agent.contract.functions.isTestContract().call()
 
     # and at least the others can be instantiated
     assert PolicyManagerAgent(registry=registry)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -457,7 +457,7 @@ def _make_agency(testerchain, test_registry):
     token_deployer = NucypherTokenDeployer(deployer_address=origin, registry=test_registry)
     token_deployer.deploy()
 
-    staking_escrow_deployer = StakingEscrowDeployer(deployer_address=origin, registry=test_registry)
+    staking_escrow_deployer = StakingEscrowDeployer(deployer_address=origin, registry=test_registry, test_mode=True)
     staking_escrow_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
 
     policy_manager_deployer = PolicyManagerDeployer(deployer_address=origin, registry=test_registry)


### PR DESCRIPTION
Included #1321 
Opens #1540, #1529, #1508

* Burn tokens in `StakingEscrow` (for future reward)
* Ability to burn remaining tokens in `WorkLock`
* Explicit initialization for `StakingEscrow` and `WorkLock`
* New function - `cancelBid`
* Tokens locked in `PreallocationEscrow` in `claim`
* Ability to change `WorkLock` address in `StakingEcrow` if test flag was set <-- (what do you think, is it ok?)
