### PR TITLE
Keyring update prevented character instantiation

### DIFF
--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -20,7 +20,7 @@ import json
 import os
 import stat
 from json import JSONDecodeError
-from os.path import dirname, abspath
+from os.path import abspath
 from typing import ClassVar, Tuple, Callable, Union, Dict, List
 
 from constant_sorrow.constants import FEDERATED_ADDRESS
@@ -49,8 +49,7 @@ from nucypher.crypto.powers import (
     SigningPower,
     DecryptingPower,
     KeyPairBasedPower,
-    DerivedKeyBasedPower,
-    TransactingPower
+    DerivedKeyBasedPower
 )
 from nucypher.network.server import TLSHostingPower
 
@@ -404,6 +403,10 @@ class NucypherKeyring:
     @property
     def certificate_filepath(self) -> str:
         return self.__tls_certificate
+
+    @property
+    def keyring_root(self) -> str:
+        return self.__keyring_root
 
     #
     # Utils

--- a/tests/config/test_keyring.py
+++ b/tests/config/test_keyring.py
@@ -58,4 +58,5 @@ def test_alice_uses_keyring(tmpdir):
         encrypting=True,
         rest=False,
         keyring_root=tmpdir)
+    keyring.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
     Alice(federated_only=True, start_learning_now=False, keyring=keyring)

--- a/tests/config/test_keyring.py
+++ b/tests/config/test_keyring.py
@@ -8,6 +8,8 @@ from nucypher.crypto.powers import DelegatingPower, DecryptingPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from constant_sorrow.constants import FEDERATED_ADDRESS
 
+from nucypher.characters.lawful import Alice
+
 
 def test_generate_alice_keyring(tmpdir):
 
@@ -47,3 +49,13 @@ def test_generate_alice_keyring(tmpdir):
     another_delegating_pubkey = another_delegating_power.get_pubkey_from_label(label)
 
     assert delegating_pubkey == another_delegating_pubkey
+
+
+def test_alice_uses_keyring(tmpdir):
+    keyring = NucypherKeyring.generate(
+        checksum_address=FEDERATED_ADDRESS,
+        password=INSECURE_DEVELOPMENT_PASSWORD,
+        encrypting=True,
+        rest=False,
+        keyring_root=tmpdir)
+    Alice(federated_only=True, start_learning_now=False, keyring=keyring)

--- a/tests/config/test_keyring.py
+++ b/tests/config/test_keyring.py
@@ -8,7 +8,7 @@ from nucypher.crypto.powers import DelegatingPower, DecryptingPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from constant_sorrow.constants import FEDERATED_ADDRESS
 
-from nucypher.characters.lawful import Alice
+from nucypher.characters.lawful import Alice, Bob, Ursula
 
 
 def test_generate_alice_keyring(tmpdir):
@@ -51,7 +51,7 @@ def test_generate_alice_keyring(tmpdir):
     assert delegating_pubkey == another_delegating_pubkey
 
 
-def test_alice_uses_keyring(tmpdir):
+def test_characters_use_keyring(tmpdir):
     keyring = NucypherKeyring.generate(
         checksum_address=FEDERATED_ADDRESS,
         password=INSECURE_DEVELOPMENT_PASSWORD,
@@ -60,3 +60,6 @@ def test_alice_uses_keyring(tmpdir):
         keyring_root=tmpdir)
     keyring.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
     Alice(federated_only=True, start_learning_now=False, keyring=keyring)
+    Bob(federated_only=True, start_learning_now=False, keyring=keyring)
+    Ursula(federated_only=True, start_learning_now=False, keyring=keyring,
+           rest_host='127.0.0.1', rest_port=12345)


### PR DESCRIPTION
After moving `keyring_root` to a hidden property, a `@property` decorated method was not created. Characters were never tested with a keyring, so the bug (https://github.com/nucypher/nucypher/issues/1412) was unnoticed.

This PR fixes the issue and tests if Alice can be created with a keyring