### PR TITLE
Improve CLI commands to better detect invalid option/commands and provide context-specific help

### DIFF
--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -270,10 +270,13 @@ def public_keys(click_config,
 
 
 @alice.command('derive-policy-pubkey')
-@_api_options
 @click.option('--label', help="The label for a policy", type=click.STRING, required=True)
+@_api_options
 @nucypher_click_config
 def derive_policy_pubkey(click_config,
+
+                         # Other (required)
+                         label,
 
                          # API Options
                          geth,
@@ -288,9 +291,7 @@ def derive_policy_pubkey(click_config,
                          hw_wallet,
                          teacher_uri,
                          min_stake,
-
-                         # Other
-                         label):
+                         ):
     """
     Get a policy public key from a policy label.
     """
@@ -308,7 +309,6 @@ def derive_policy_pubkey(click_config,
 
 
 @alice.command()
-@_api_options
 @click.option('--bob-encrypting-key', help="Bob's encrypting key as a hexadecimal string", type=click.STRING,
               required=True)
 @click.option('--bob-verifying-key', help="Bob's verifying key as a hexadecimal string", type=click.STRING,
@@ -318,8 +318,14 @@ def derive_policy_pubkey(click_config,
 @click.option('--n', help="N-Total KFrags", type=click.INT)
 @click.option('--expiration', help="Expiration Datetime of a policy", type=click.STRING)  # TODO: click.DateTime()
 @click.option('--value', help="Total policy value (in Wei)", type=types.WEI)
+@_api_options
 @nucypher_click_config
 def grant(click_config,
+          # Other (required)
+          bob_encrypting_key, bob_verifying_key, label,
+
+          # Other
+          m, n, expiration, value,
 
           # API Options
           geth,
@@ -334,9 +340,7 @@ def grant(click_config,
           hw_wallet,
           teacher_uri,
           min_stake,
-
-          # Other
-          bob_encrypting_key, bob_verifying_key, label, m, n, expiration, value):
+          ):
     """
     Create and enact an access policy for some Bob.
     """
@@ -365,12 +369,15 @@ def grant(click_config,
 
 
 @alice.command()
-@_api_options
 @click.option('--bob-verifying-key', help="Bob's verifying key as a hexadecimal string", type=click.STRING,
               required=True)
 @click.option('--label', help="The label for a policy", type=click.STRING, required=True)
+@_api_options
 @nucypher_click_config
 def revoke(click_config,
+
+           # Other (required)
+           bob_verifying_key, label,
 
            # API Options
            geth,
@@ -385,9 +392,7 @@ def revoke(click_config,
            hw_wallet,
            teacher_uri,
            min_stake,
-
-           # Other
-           bob_verifying_key, label):
+           ):
     """
     Revoke a policy.
     """
@@ -406,12 +411,15 @@ def revoke(click_config,
 
 
 @alice.command()
-@_api_options
 @click.option('--label', help="The label for a policy", type=click.STRING, required=True)
 @click.option('--message-kit', help="The message kit unicode string encoded in base64", type=click.STRING,
               required=True)
+@_api_options
 @nucypher_click_config
 def decrypt(click_config,
+
+            # Other (required)
+            label, message_kit,
 
             # API Options
             geth,
@@ -426,9 +434,7 @@ def decrypt(click_config,
             hw_wallet,
             teacher_uri,
             min_stake,
-
-            # Other
-            label, message_kit):
+            ):
     """
     Decrypt data encrypted under an Alice's policy public key.
     """

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -46,7 +46,7 @@ def _api_options(func):
 @click.group()
 def alice():
     """
-    Alice the Policy Authority" management commands.
+    "Alice the Policy Authority" management commands.
     """
     pass
 
@@ -208,7 +208,7 @@ def run(click_config,
                                                    geth, network, pay_with, provider_uri, registry_filepath)
     #############
 
-    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_uri, min_stake)
 
     try:
         # RPC
@@ -263,7 +263,7 @@ def public_keys(click_config,
                                                    geth, network, pay_with, provider_uri, registry_filepath)
     #############
 
-    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_uri, min_stake)
 
     response = ALICE.controller.public_keys()
     return response
@@ -301,7 +301,7 @@ def derive_policy_pubkey(click_config,
                                                    geth, network, pay_with, provider_uri, registry_filepath)
     #############
 
-    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_uri, min_stake)
 
     # Request
     return ALICE.controller.derive_policy_encrypting_key(label=label)
@@ -347,7 +347,7 @@ def grant(click_config,
                                                    geth, network, pay_with, provider_uri, registry_filepath)
     #############
 
-    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_uri, min_stake)
 
     # Request
     grant_request = {
@@ -398,7 +398,7 @@ def revoke(click_config,
                                                    geth, network, pay_with, provider_uri, registry_filepath)
     #############
 
-    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_uri, min_stake)
 
     # Request
     revoke_request = {'label': label, 'bob_verifying_key': bob_verifying_key}
@@ -439,7 +439,7 @@ def decrypt(click_config,
                                                    geth, network, pay_with, provider_uri, registry_filepath)
     #############
 
-    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_uri, min_stake)
 
     # Request
     request_data = {'label': label, 'message_kit': message_kit}
@@ -502,7 +502,7 @@ def _get_or_create_alice_config(click_config, dev, network, eth_node, provider_u
     return alice_config
 
 
-def _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri):
+def _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_uri, min_stake):
     #
     # Produce Alice
     #
@@ -518,8 +518,9 @@ def _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake
                                            teacher_uri=teacher_uri,
                                            min_stake=min_stake,
                                            client_password=client_password)
+
+        return ALICE
     except NucypherKeyring.AuthenticationFailed as e:
         emitter.echo(str(e), color='red', bold=True)
         click.get_current_context().exit(1)
         # TODO: Exit codes (not only for this, but for other exceptions)
-    return ALICE

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -147,13 +147,7 @@ def view(click_config, config_file):
 def destroy(click_config,
 
             # Admin Options
-            geth,
-            provider_uri,
-            federated_only,
-            dev,
-            pay_with,
-            network,
-            registry_filepath,
+            geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
 
             # Other
             config_file, discovery_port, force):
@@ -182,18 +176,8 @@ def destroy(click_config,
 def run(click_config,
 
         # API Options
-        geth,
-        provider_uri,
-        federated_only,
-        dev,
-        pay_with,
-        network,
-        registry_filepath,
-        config_file,
-        discovery_port,
-        hw_wallet,
-        teacher_uri,
-        min_stake,
+        geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+        config_file, discovery_port, hw_wallet, teacher_uri, min_stake,
 
         # Other
         controller_port, dry_run):
@@ -240,19 +224,8 @@ def run(click_config,
 def public_keys(click_config,
 
                 # API Options
-                geth,
-                provider_uri,
-                federated_only,
-                dev,
-                pay_with,
-                network,
-                registry_filepath,
-                config_file,
-                discovery_port,
-                hw_wallet,
-                teacher_uri,
-                min_stake,
-                ):
+                geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+                config_file, discovery_port, hw_wallet, teacher_uri, min_stake):
     """
     Obtain Alice's public verification and encryption keys.
     """
@@ -279,19 +252,9 @@ def derive_policy_pubkey(click_config,
                          label,
 
                          # API Options
-                         geth,
-                         provider_uri,
-                         federated_only,
-                         dev,
-                         pay_with,
-                         network,
-                         registry_filepath,
-                         config_file,
-                         discovery_port,
-                         hw_wallet,
-                         teacher_uri,
-                         min_stake,
-                         ):
+                         # API Options
+                         geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+                         config_file, discovery_port, hw_wallet, teacher_uri, min_stake):
     """
     Get a policy public key from a policy label.
     """
@@ -328,19 +291,8 @@ def grant(click_config,
           m, n, expiration, value,
 
           # API Options
-          geth,
-          provider_uri,
-          federated_only,
-          dev,
-          pay_with,
-          network,
-          registry_filepath,
-          config_file,
-          discovery_port,
-          hw_wallet,
-          teacher_uri,
-          min_stake,
-          ):
+          geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+          config_file, discovery_port, hw_wallet, teacher_uri, min_stake):
     """
     Create and enact an access policy for some Bob.
     """
@@ -380,19 +332,8 @@ def revoke(click_config,
            bob_verifying_key, label,
 
            # API Options
-           geth,
-           provider_uri,
-           federated_only,
-           dev,
-           pay_with,
-           network,
-           registry_filepath,
-           config_file,
-           discovery_port,
-           hw_wallet,
-           teacher_uri,
-           min_stake,
-           ):
+           geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+           config_file, discovery_port, hw_wallet, teacher_uri, min_stake):
     """
     Revoke a policy.
     """
@@ -422,19 +363,8 @@ def decrypt(click_config,
             label, message_kit,
 
             # API Options
-            geth,
-            provider_uri,
-            federated_only,
-            dev,
-            pay_with,
-            network,
-            registry_filepath,
-            config_file,
-            discovery_port,
-            hw_wallet,
-            teacher_uri,
-            min_stake,
-            ):
+            geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+            config_file, discovery_port, hw_wallet, teacher_uri, min_stake):
     """
     Decrypt data encrypted under an Alice's policy public key.
     """

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -442,7 +442,6 @@ def _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_u
     #
     # Produce Alice
     #
-    # TODO: OH MY.
     client_password = None
     if not alice_config.federated_only:
         if (not hw_wallet or not dev) and not click_config.json_ipc:
@@ -459,4 +458,3 @@ def _create_alice(alice_config, click_config, dev, emitter, hw_wallet, teacher_u
     except NucypherKeyring.AuthenticationFailed as e:
         emitter.echo(str(e), color='red', bold=True)
         click.get_current_context().exit(1)
-        # TODO: Exit codes (not only for this, but for other exceptions)

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -12,9 +12,8 @@ from nucypher.config.characters import AliceConfiguration
 from nucypher.config.keyring import NucypherKeyring
 
 
-# Args (geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath, config_file, discovery_port,
-#       hw_wallet, teacher_uri, min_stake)
-def _api_options(func):
+# Args (geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath)
+def _admin_options(func):
     @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
     @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
     @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
@@ -22,6 +21,16 @@ def _api_options(func):
     @click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
     @click.option('--network', help="Network Domain Name", type=click.STRING)
     @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+# Args (geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath, config_file, discovery_port,
+#       hw_wallet, teacher_uri, min_stake)
+def _api_options(func):
+    @_admin_options
     @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
     @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
     @click.option('--hw-wallet/--no-hw-wallet', default=False)
@@ -43,22 +52,27 @@ def alice():
 
 
 @alice.command()
-@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@_admin_options
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
-@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
 @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
 @click.option('--m', help="M-Threshold KFrags", type=click.INT)
 @click.option('--n', help="N-Total KFrags", type=click.INT)
 @click.option('--rate', help="Policy rate per period in wei", type=click.FLOAT)
 @click.option('--duration-periods', help="Policy duration in periods", type=click.FLOAT)
 @nucypher_click_config
-def init(click_config, geth, provider_uri, config_root, federated_only, dev, pay_with,
-         network, registry_filepath, poa, m, n, rate, duration_periods):
+def init(click_config,
+
+         # Admin Options
+         geth,
+         provider_uri,
+         federated_only,
+         dev,
+         pay_with,
+         network,
+         registry_filepath,
+
+         # Other
+         config_root, poa, m, n, rate, duration_periods):
     """
     Create a brand new persistent Alice.
     """
@@ -125,18 +139,23 @@ def view(click_config, config_file):
 
 
 @alice.command()
-@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
-@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@_admin_options
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @nucypher_click_config
-def destroy(click_config, geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+def destroy(click_config,
+
+            # Admin Options
+            geth,
+            provider_uri,
+            federated_only,
+            dev,
+            pay_with,
+            network,
+            registry_filepath,
+
+            # Other
             config_file, discovery_port, force):
     """
     Delete existing Alice's configuration.
@@ -504,5 +523,3 @@ def _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake
         click.get_current_context().exit(1)
         # TODO: Exit codes (not only for this, but for other exceptions)
     return ALICE
-
-

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -1,7 +1,8 @@
+import functools
+
 import click
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 
-from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.characters.banners import ALICE_BANNER
 from nucypher.cli import actions, painting, types
 from nucypher.cli.actions import get_nucypher_password, select_client_account, get_client_password
@@ -11,109 +12,62 @@ from nucypher.config.characters import AliceConfiguration
 from nucypher.config.keyring import NucypherKeyring
 
 
-@click.command()
-@click.argument('action')
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
-@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
-@click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
-@click.option('--controller-port', help="The host port to run Alice HTTP services on", type=NETWORK_PORT, default=AliceConfiguration.DEFAULT_CONTROLLER_PORT)
-@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--sync/--no-sync', default=True)
-@click.option('--hw-wallet/--no-hw-wallet', default=False)
+# Args (geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath, config_file, discovery_port,
+#       hw_wallet, teacher_uri, min_stake)
+def _api_options(func):
+    @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+    @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
+    @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+    @click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+    @click.option('--network', help="Network Domain Name", type=click.STRING)
+    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+    @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+    @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
+    @click.option('--hw-wallet/--no-hw-wallet', default=False)
+    @click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+    @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT,
+                  default=0)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@click.group()
+def alice():
+    """
+    Alice the Policy Authority" management commands.
+    """
+    pass
+
+
+@alice.command()
 @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
-@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
 @click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--bob-encrypting-key', help="Bob's encrypting key as a hexadecimal string", type=click.STRING)
-@click.option('--bob-verifying-key', help="Bob's verifying key as a hexadecimal string", type=click.STRING)
-@click.option('--label', help="The label for a policy", type=click.STRING)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
 @click.option('--m', help="M-Threshold KFrags", type=click.INT)
 @click.option('--n', help="N-Total KFrags", type=click.INT)
-@click.option('--value', help="Total policy value (in Wei)", type=types.WEI)
 @click.option('--rate', help="Policy rate per period in wei", type=click.FLOAT)
 @click.option('--duration-periods', help="Policy duration in periods", type=click.FLOAT)
-@click.option('--expiration', help="Expiration Datetime of a policy", type=click.STRING)  # TODO: click.DateTime()
-@click.option('--message-kit', help="The message kit unicode string encoded in base64", type=click.STRING)
 @nucypher_click_config
-def alice(click_config,
-          action,
-
-          # Mode
-          dev,
-          force,
-          dry_run,
-
-          # Network
-          teacher_uri,
-          min_stake,
-          federated_only,
-          network,
-          discovery_port,
-          controller_port,
-
-          # Filesystem
-          config_root,
-          config_file,
-
-          # Blockchain
-          pay_with,
-          provider_uri,
-          geth,
-          sync,
-          poa,
-          registry_filepath,
-          hw_wallet,
-
-          # Alice
-          bob_encrypting_key,
-          bob_verifying_key,
-          label,
-          m,
-          n,
-          value,
-          rate,
-          duration_periods,
-          expiration,
-          message_kit,
-
-          ):
+def init(click_config, geth, provider_uri, config_root, federated_only, dev, pay_with,
+         network, registry_filepath, poa, m, n, rate, duration_periods):
     """
-    "Alice the Policy Authority" management commands.
-
-    \b
-    Actions
-    -------------------------------------------------
-    \b
-    init                  Create a brand new persistent Alice
-    view                  View existing Alice's configuration.
-    run                   Start Alice's controller.
-    destroy               Delete existing Alice's configuration.
-    public-keys           Obtain Alice's public verification and encryption keys.
-    derive-policy-pubkey  Get a policy public key from a policy label.
-    grant                 Create and enact an access policy for some Bob.
-    revoke                Revoke a policy.
-    decrypt               Decrypt data encrypted under an Alice's policy public key.
-
+    Create a brand new persistent Alice.
     """
 
-    #
-    # Validate
-    #
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
 
     if federated_only and geth:
         raise click.BadOptionUsage(option_name="--geth", message="Federated only cannot be used with the --geth flag")
-
-    # Banner
-    emitter = click_config.emitter
-    emitter.clear()
-    emitter.banner(ALICE_BANNER)
 
     #
     # Managed Ethereum Client
@@ -124,58 +78,390 @@ def alice(click_config,
         ETH_NODE = actions.get_provider_process()
         provider_uri = ETH_NODE.provider_uri(scheme='file')
 
+    #############
+
+    if dev:
+        raise click.BadArgumentUsage("Cannot create a persistent development character")
+
+    if not provider_uri and not federated_only:
+        raise click.BadOptionUsage(option_name='--provider',
+                                   message="--provider is required to create a new decentralized alice.")
+
+    if not config_root:  # Flag
+        config_root = click_config.config_file  # Envvar
+
+    if not pay_with and not federated_only:
+        pay_with = select_client_account(emitter=emitter, provider_uri=provider_uri)
+
+    new_alice_config = AliceConfiguration.generate(password=get_nucypher_password(confirm=True),
+                                                   config_root=config_root,
+                                                   checksum_address=pay_with,
+                                                   domains={network} if network else None,
+                                                   federated_only=federated_only,
+                                                   registry_filepath=registry_filepath,
+                                                   provider_process=ETH_NODE,
+                                                   poa=poa,
+                                                   provider_uri=provider_uri,
+                                                   m=m,
+                                                   n=n,
+                                                   duration_periods=duration_periods,
+                                                   rate=rate)
+
+    painting.paint_new_installation_help(emitter, new_configuration=new_alice_config)
+
+
+@alice.command()
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@nucypher_click_config
+def view(click_config, config_file):
+    """
+    View existing Alice's configuration.
+    """
+    emitter = _setup_emitter(click_config)
+
+    configuration_file_location = config_file or AliceConfiguration.default_filepath()
+    response = AliceConfiguration._read_configuration_file(filepath=configuration_file_location)
+    return emitter.ipc(response=response, request_id=0, duration=0)  # FIXME: what are request_id and duration here?
+
+
+@alice.command()
+@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@nucypher_click_config
+def destroy(click_config, geth, provider_uri, federated_only, dev, pay_with, network, registry_filepath,
+            config_file, discovery_port, force):
+    """
+    Delete existing Alice's configuration.
+    """
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    alice_config, provider_uri = _get_alice_config(click_config, config_file, dev, discovery_port, federated_only,
+                                                   geth, network, pay_with, provider_uri, registry_filepath)
+    #############
+
+    if dev:
+        message = "'nucypher alice destroy' cannot be used in --dev mode"
+        raise click.BadOptionUsage(option_name='--dev', message=message)
+    return actions.destroy_configuration(emitter, character_config=alice_config, force=force)
+
+
+@alice.command()
+@_api_options
+@click.option('--controller-port', help="The host port to run Alice HTTP services on", type=NETWORK_PORT,
+              default=AliceConfiguration.DEFAULT_CONTROLLER_PORT)
+@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+@nucypher_click_config
+def run(click_config,
+
+        # API Options
+        geth,
+        provider_uri,
+        federated_only,
+        dev,
+        pay_with,
+        network,
+        registry_filepath,
+        config_file,
+        discovery_port,
+        hw_wallet,
+        teacher_uri,
+        min_stake,
+
+        # Other
+        controller_port, dry_run):
+    """
+    Start Alice's controller.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    alice_config, provider_uri = _get_alice_config(click_config, config_file, dev, discovery_port, federated_only,
+                                                   geth, network, pay_with, provider_uri, registry_filepath)
+    #############
+
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+
+    try:
+        # RPC
+        if click_config.json_ipc:
+            rpc_controller = ALICE.make_rpc_controller()
+            _transport = rpc_controller.make_control_transport()
+            rpc_controller.start()
+            return
+
+        # HTTP
+        else:
+            emitter.message(f"Alice Verifying Key {bytes(ALICE.stamp).hex()}", color="green", bold=True)
+            controller = ALICE.make_web_controller(crash_on_error=click_config.debug)
+            ALICE.log.info('Starting HTTP Character Web Controller')
+            emitter.message(f'Running HTTP Alice Controller at http://localhost:{controller_port}')
+            return controller.start(http_port=controller_port, dry_run=dry_run)
+
+    # Handle Crash
+    except Exception as e:
+        alice_config.log.critical(str(e))
+        emitter.message(f"{e.__class__.__name__} {e}", color='red', bold=True)
+        if click_config.debug:
+            raise  # Crash :-(
+
+
+@alice.command("public-keys")
+@_api_options
+@nucypher_click_config
+def public_keys(click_config,
+
+                # API Options
+                geth,
+                provider_uri,
+                federated_only,
+                dev,
+                pay_with,
+                network,
+                registry_filepath,
+                config_file,
+                discovery_port,
+                hw_wallet,
+                teacher_uri,
+                min_stake,
+                ):
+    """
+    Obtain Alice's public verification and encryption keys.
+    """
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    alice_config, provider_uri = _get_alice_config(click_config, config_file, dev, discovery_port, federated_only,
+                                                   geth, network, pay_with, provider_uri, registry_filepath)
+    #############
+
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+
+    response = ALICE.controller.public_keys()
+    return response
+
+
+@alice.command('derive-policy-pubkey')
+@_api_options
+@click.option('--label', help="The label for a policy", type=click.STRING, required=True)
+@nucypher_click_config
+def derive_policy_pubkey(click_config,
+
+                         # API Options
+                         geth,
+                         provider_uri,
+                         federated_only,
+                         dev,
+                         pay_with,
+                         network,
+                         registry_filepath,
+                         config_file,
+                         discovery_port,
+                         hw_wallet,
+                         teacher_uri,
+                         min_stake,
+
+                         # Other
+                         label):
+    """
+    Get a policy public key from a policy label.
+    """
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    alice_config, provider_uri = _get_alice_config(click_config, config_file, dev, discovery_port, federated_only,
+                                                   geth, network, pay_with, provider_uri, registry_filepath)
+    #############
+
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+
+    # Request
+    return ALICE.controller.derive_policy_encrypting_key(label=label)
+
+
+@alice.command()
+@_api_options
+@click.option('--bob-encrypting-key', help="Bob's encrypting key as a hexadecimal string", type=click.STRING,
+              required=True)
+@click.option('--bob-verifying-key', help="Bob's verifying key as a hexadecimal string", type=click.STRING,
+              required=True)
+@click.option('--label', help="The label for a policy", type=click.STRING, required=True)
+@click.option('--m', help="M-Threshold KFrags", type=click.INT)
+@click.option('--n', help="N-Total KFrags", type=click.INT)
+@click.option('--expiration', help="Expiration Datetime of a policy", type=click.STRING)  # TODO: click.DateTime()
+@click.option('--value', help="Total policy value (in Wei)", type=types.WEI)
+@nucypher_click_config
+def grant(click_config,
+
+          # API Options
+          geth,
+          provider_uri,
+          federated_only,
+          dev,
+          pay_with,
+          network,
+          registry_filepath,
+          config_file,
+          discovery_port,
+          hw_wallet,
+          teacher_uri,
+          min_stake,
+
+          # Other
+          bob_encrypting_key, bob_verifying_key, label, m, n, expiration, value):
+    """
+    Create and enact an access policy for some Bob.
+    """
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    alice_config, provider_uri = _get_alice_config(click_config, config_file, dev, discovery_port, federated_only,
+                                                   geth, network, pay_with, provider_uri, registry_filepath)
+    #############
+
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+
+    # Request
+    grant_request = {
+        'bob_encrypting_key': bob_encrypting_key,
+        'bob_verifying_key': bob_verifying_key,
+        'label': label,
+        'm': m,
+        'n': n,
+        'expiration': expiration,
+    }
+
+    if not ALICE.federated_only:
+        grant_request.update({'value': value})
+    return ALICE.controller.grant(request=grant_request)
+
+
+@alice.command()
+@_api_options
+@click.option('--bob-verifying-key', help="Bob's verifying key as a hexadecimal string", type=click.STRING,
+              required=True)
+@click.option('--label', help="The label for a policy", type=click.STRING, required=True)
+@nucypher_click_config
+def revoke(click_config,
+
+           # API Options
+           geth,
+           provider_uri,
+           federated_only,
+           dev,
+           pay_with,
+           network,
+           registry_filepath,
+           config_file,
+           discovery_port,
+           hw_wallet,
+           teacher_uri,
+           min_stake,
+
+           # Other
+           bob_verifying_key, label):
+    """
+    Revoke a policy.
+    """
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    alice_config, provider_uri = _get_alice_config(click_config, config_file, dev, discovery_port, federated_only,
+                                                   geth, network, pay_with, provider_uri, registry_filepath)
+    #############
+
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+
+    # Request
+    revoke_request = {'label': label, 'bob_verifying_key': bob_verifying_key}
+    return ALICE.controller.revoke(request=revoke_request)
+
+
+@alice.command()
+@_api_options
+@click.option('--label', help="The label for a policy", type=click.STRING, required=True)
+@click.option('--message-kit', help="The message kit unicode string encoded in base64", type=click.STRING,
+              required=True)
+@nucypher_click_config
+def decrypt(click_config,
+
+            # API Options
+            geth,
+            provider_uri,
+            federated_only,
+            dev,
+            pay_with,
+            network,
+            registry_filepath,
+            config_file,
+            discovery_port,
+            hw_wallet,
+            teacher_uri,
+            min_stake,
+
+            # Other
+            label, message_kit):
+    """
+    Decrypt data encrypted under an Alice's policy public key.
+    """
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    alice_config, provider_uri = _get_alice_config(click_config, config_file, dev, discovery_port, federated_only,
+                                                   geth, network, pay_with, provider_uri, registry_filepath)
+    #############
+
+    ALICE = _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri)
+
+    # Request
+    request_data = {'label': label, 'message_kit': message_kit}
+    response = ALICE.controller.decrypt(request=request_data)
+    return response
+
+
+def _setup_emitter(click_config):
+    # Banner
+    emitter = click_config.emitter
+    emitter.clear()
+    emitter.banner(ALICE_BANNER)
+
+    return emitter
+
+
+def _get_alice_config(click_config, config_file, dev, discovery_port, federated_only, geth, network, pay_with,
+                      provider_uri, registry_filepath):
+    if federated_only and geth:
+        raise click.BadOptionUsage(option_name="--geth", message="Federated only cannot be used with the --geth flag")
     #
-    # Eager Actions (No Authentication Required)
+    # Managed Ethereum Client
     #
+    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
+    if geth:
+        ETH_NODE = actions.get_provider_process()
+        provider_uri = ETH_NODE.provider_uri(scheme='file')
 
-    if action == 'init':
-        """Create a brand-new persistent Alice"""
+    # Get config
+    alice_config = _get_or_create_alice_config(click_config, dev, network, ETH_NODE, provider_uri,
+                                               config_file, discovery_port, pay_with, registry_filepath)
+    return alice_config, provider_uri
 
-        if dev:
-            raise click.BadArgumentUsage("Cannot create a persistent development character")
 
-        if not provider_uri and not federated_only:
-            raise click.BadOptionUsage(option_name='--provider',
-                                       message="--provider is required to create a new decentralized alice.")
-
-        if not config_root:                         # Flag
-            config_root = click_config.config_file  # Envvar
-
-        if not pay_with and not federated_only:
-            pay_with = select_client_account(emitter=emitter, provider_uri=provider_uri)
-
-        new_alice_config = AliceConfiguration.generate(password=get_nucypher_password(confirm=True),
-                                                       config_root=config_root,
-                                                       checksum_address=pay_with,
-                                                       domains={network} if network else None,
-                                                       federated_only=federated_only,
-                                                       registry_filepath=registry_filepath,
-                                                       provider_process=ETH_NODE,
-                                                       poa=poa,
-                                                       provider_uri=provider_uri,
-                                                       m=m,
-                                                       n=n,
-                                                       duration_periods=duration_periods,
-                                                       rate=rate)
-
-        painting.paint_new_installation_help(emitter, new_configuration=new_alice_config)
-        return  # Exit
-
-    elif action == "view":
-        """Paint an existing configuration to the console"""
-        configuration_file_location = config_file or AliceConfiguration.default_filepath()
-        response = AliceConfiguration._read_configuration_file(filepath=configuration_file_location)
-        return emitter.ipc(response=response, request_id=0, duration=0)  # FIXME: what are request_id and duration here?
-
-    #
-    # Get Alice Configuration
-    #
-
+def _get_or_create_alice_config(click_config, dev, network, eth_node, provider_uri, config_file,
+                                discovery_port, pay_with, registry_filepath):
     if dev:
         alice_config = AliceConfiguration(dev_mode=True,
                                           network_middleware=click_config.middleware,
                                           domains={network},
-                                          provider_process=ETH_NODE,
+                                          provider_process=eth_node,
                                           provider_uri=provider_uri,
                                           federated_only=True)
 
@@ -188,30 +474,24 @@ def alice(click_config,
                 network_middleware=click_config.middleware,
                 rest_port=discovery_port,
                 checksum_address=pay_with,
-                provider_process=ETH_NODE,
+                provider_process=eth_node,
                 provider_uri=provider_uri,
                 registry_filepath=registry_filepath)
         except FileNotFoundError:
             return actions.handle_missing_configuration_file(character_config_class=AliceConfiguration,
                                                              config_file=config_file)
+    return alice_config
 
-    if action == "destroy":
-        """Delete all configuration files from the disk"""
-        if dev:
-            message = "'nucypher alice destroy' cannot be used in --dev mode"
-            raise click.BadOptionUsage(option_name='--dev', message=message)
-        return actions.destroy_configuration(emitter, character_config=alice_config, force=force)
 
+def _create_alice(alice_config, click_config, dev, emitter, hw_wallet, min_stake, teacher_uri):
     #
     # Produce Alice
     #
-
     # TODO: OH MY.
     client_password = None
     if not alice_config.federated_only:
         if (not hw_wallet or not dev) and not click_config.json_ipc:
             client_password = get_client_password(checksum_address=alice_config.checksum_address)
-
     try:
         ALICE = actions.make_cli_character(character_config=alice_config,
                                            click_config=click_config,
@@ -223,100 +503,6 @@ def alice(click_config,
         emitter.echo(str(e), color='red', bold=True)
         click.get_current_context().exit(1)
         # TODO: Exit codes (not only for this, but for other exceptions)
+    return ALICE
 
-    #
-    # Admin Actions
-    #
 
-    if action == "run":
-        """Start Alice Controller"""
-
-        try:
-
-            # RPC
-            if click_config.json_ipc:
-                rpc_controller = ALICE.make_rpc_controller()
-                _transport = rpc_controller.make_control_transport()
-                rpc_controller.start()
-                return
-
-            # HTTP
-            else:
-                emitter.message(f"Alice Verifying Key {bytes(ALICE.stamp).hex()}", color="green", bold=True)
-                controller = ALICE.make_web_controller(crash_on_error=click_config.debug)
-                ALICE.log.info('Starting HTTP Character Web Controller')
-                emitter.message(f'Running HTTP Alice Controller at http://localhost:{controller_port}')
-                return controller.start(http_port=controller_port, dry_run=dry_run)
-
-        # Handle Crash
-        except Exception as e:
-            alice_config.log.critical(str(e))
-            emitter.message(f"{e.__class__.__name__} {e}", color='red', bold=True)
-            if click_config.debug:
-                raise  # Crash :-(
-            return
-
-    #
-    # Alice API
-    #
-
-    elif action == "public-keys":
-        response = ALICE.controller.public_keys()
-        return response
-
-    elif action == "derive-policy-pubkey":
-
-        # Validate
-        if not label:
-            raise click.BadOptionUsage(option_name='label',
-                                       message="--label is required for deriving a policy encrypting key.")
-
-        # Request
-        return ALICE.controller.derive_policy_encrypting_key(label=label)
-
-    elif action == "grant":
-
-        # Validate
-        if not all((bob_verifying_key, bob_encrypting_key, label)):
-            raise click.BadArgumentUsage(message="--bob-verifying-key, --bob-encrypting-key, and --label are "
-                                                 "required options to grant (optionally --m, --n, and --expiration).")
-
-        # Request
-        grant_request = {
-            'bob_encrypting_key': bob_encrypting_key,
-            'bob_verifying_key': bob_verifying_key,
-            'label': label,
-            'm': m,
-            'n': n,
-            'expiration': expiration,
-        }
-
-        if not ALICE.federated_only:
-            grant_request.update({'value': value})
-        return ALICE.controller.grant(request=grant_request)
-
-    elif action == "revoke":
-
-        # Validate
-        if not label and bob_verifying_key:
-            raise click.BadArgumentUsage(message=f"--label and --bob-verifying-key are required options for revoke.")
-
-        # Request
-        revoke_request = {'label': label, 'bob_verifying_key': bob_verifying_key}
-        return ALICE.controller.revoke(request=revoke_request)
-
-    elif action == "decrypt":
-
-        # Validate
-        if not all((label, message_kit)):
-            input_specification, output_specification = ALICE.controller.get_specifications(interface_name=action)
-            required_fields = ', '.join(input_specification)
-            raise click.BadArgumentUsage(f'{required_fields} are required flags to decrypt')
-
-        # Request
-        request_data = {'label': label, 'message_kit': message_kit}
-        response = ALICE.controller.decrypt(request=request_data)
-        return response
-
-    else:
-        raise click.BadArgumentUsage(f"No such argument {action}")

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -181,6 +181,7 @@ def view(click_config,
 @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @nucypher_click_config
 def destroy(click_config,
 
@@ -194,6 +195,7 @@ def destroy(click_config,
             dev,
             config_file,
             discovery_port,
+            force
             ):
     """
     Delete existing Bob's configuration.
@@ -201,8 +203,8 @@ def destroy(click_config,
     ### Setup ###
     emitter = _setup_emitter(click_config)
 
-    bob_config = _get_bob_config(click_config, provider_uri, network, registry_filepath, checksum_address,
-                                 dev, config_file, discovery_port)
+    bob_config = _get_bob_config(click_config, dev, provider_uri, network, registry_filepath, checksum_address,
+                                 config_file, discovery_port)
     #############
 
     # Validate
@@ -211,7 +213,7 @@ def destroy(click_config,
         raise click.BadOptionUsage(option_name='--dev', message=message)
 
     # Request
-    return actions.destroy_configuration(emitter, character_config=bob_config)
+    return actions.destroy_configuration(emitter, character_config=bob_config, force=force)
 
 
 @bob.command(name='public-keys')

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -1,6 +1,7 @@
+import functools
+
 import click
 
-from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.characters.banners import BOB_BANNER
 from nucypher.cli import actions, painting
 from nucypher.cli.actions import get_nucypher_password, select_client_account
@@ -11,106 +12,309 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.powers import DecryptingPower
 
 
-@click.command()
-@click.argument('action')
-@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
-@click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
-@click.option('--controller-port', help="The host port to run Bob HTTP services on", type=NETWORK_PORT, default=BobConfiguration.DEFAULT_CONTROLLER_PORT)
-@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
-@click.option('--label', help="The label for a policy", type=click.STRING)
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
-@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string", type=click.STRING)
-@click.option('--alice-verifying-key', help="Alice's verifying key as a hexadecimal string", type=click.STRING)
-@click.option('--message-kit', help="The message kit unicode string encoded in base64", type=click.STRING)
-@click.option('--sync/--no-sync', default=True)
-@nucypher_click_config
-def bob(click_config,
-        action,
-        teacher_uri,
-        min_stake,
-        controller_port,
-        discovery_port,
-        federated_only,
-        network,
-        config_root,
-        config_file,
-        checksum_address,
-        provider_uri,
-        registry_filepath,
-        dev,
-        force,
-        poa,
-        dry_run,
-        label,
-        policy_encrypting_key,
-        alice_verifying_key,
-        message_kit,
-        sync):
+# Args (provider_uri, network, registry_filepath, checksum_address)
+def _admin_options(func):
+    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+    @click.option('--network', help="Network Domain Name", type=click.STRING)
+    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+    @click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+# Args (provider_uri, network, registry_filepath, checksum_address, dev, config_file, discovery_port,
+#       teacher_uri, min_stake)
+def _api_options(func):
+    @_admin_options
+    @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+    @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+    @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
+    @click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+    @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT,
+                  default=0)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@click.group()
+def bob():
     """
     "Bob" management commands.
+    """
+    pass
 
-    \b
-    Actions
-    -------------------------------------------------
-    \b
-    init         Create a brand new persistent Bob
-    view         View existing Bob's configuration.
-    run          Start Bob's controller.
-    destroy      Delete existing Bob's configuration.
-    public-keys  Obtain Bob's public verification and encryption keys.
-    retrieve     Obtain plaintext from encrypted data, if access was granted.
+
+@bob.command()
+@_admin_options
+@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
+@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@nucypher_click_config
+def init(click_config,
+
+         # Admin Options
+         provider_uri,
+         network,
+         registry_filepath,
+         checksum_address,
+
+         # Other
+         federated_only, config_root):
 
     """
+    Create a brand new persistent Bob.
+    """
+    emitter = _setup_emitter(click_config)
 
-    #
+    if not config_root:  # Flag
+        config_root = click_config.config_file  # Envvar
+    if not checksum_address and not federated_only:
+        checksum_address = select_client_account(emitter=emitter, provider_uri=provider_uri)
+
+    new_bob_config = BobConfiguration.generate(password=get_nucypher_password(confirm=True),
+                                               config_root=config_root or DEFAULT_CONFIG_ROOT,
+                                               checksum_address=checksum_address,
+                                               domains={network} if network else None,
+                                               federated_only=federated_only,
+                                               registry_filepath=registry_filepath,
+                                               provider_uri=provider_uri)
+    return painting.paint_new_installation_help(emitter, new_configuration=new_bob_config)
+
+
+@bob.command()
+@_api_options
+@click.option('--controller-port', help="The host port to run Bob HTTP services on", type=NETWORK_PORT,
+              default=BobConfiguration.DEFAULT_CONTROLLER_PORT)
+@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+@nucypher_click_config
+def run(click_config,
+
+        # API Options
+        provider_uri,
+        network,
+        registry_filepath,
+        checksum_address,
+        dev,
+        config_file,
+        discovery_port,
+        teacher_uri,
+        min_stake,
+
+        # Other
+        controller_port, dry_run):
+    """
+    Start Bob's controller.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    bob_config = _get_bob_config(click_config, dev, provider_uri, network, registry_filepath, checksum_address,
+                                 config_file, discovery_port)
+    #############
+
+    BOB = actions.make_cli_character(character_config=bob_config,
+                                     click_config=click_config,
+                                     dev=dev,
+                                     teacher_uri=teacher_uri,
+                                     min_stake=min_stake)
+
+    # RPC
+    if click_config.json_ipc:
+        rpc_controller = BOB.make_rpc_controller()
+        _transport = rpc_controller.make_control_transport()
+        rpc_controller.start()
+        return
+
+    # Echo Public Keys
+    emitter.message(f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
+    bob_encrypting_key = bytes(BOB.public_keys(DecryptingPower)).hex()
+    emitter.message(f"Bob Encrypting Key {bob_encrypting_key}", color="blue", bold=True)
+    # Start Controller
+    controller = BOB.make_web_controller(crash_on_error=click_config.debug)
+    BOB.log.info('Starting HTTP Character Web Controller')
+    return controller.start(http_port=controller_port, dry_run=dry_run)
+
+
+@bob.command()
+@_api_options
+@nucypher_click_config
+def view(click_config,
+
+         # API Options
+         provider_uri,
+         network,
+         registry_filepath,
+         checksum_address,
+         dev,
+         config_file,
+         discovery_port,
+         teacher_uri,
+         min_stake,
+         ):
+    """
+    View existing Bob's configuration.
+    """
+    ### Setup ###
+    _setup_emitter(click_config)
+
+    bob_config = _get_bob_config(click_config, dev, provider_uri, network, registry_filepath, checksum_address,
+                                 config_file, discovery_port)
+    #############
+
+    BOB = actions.make_cli_character(character_config=bob_config,
+                                     click_config=click_config,
+                                     dev=dev,
+                                     teacher_uri=teacher_uri,
+                                     min_stake=min_stake)
+
+    response = BobConfiguration._read_configuration_file(filepath=config_file or bob_config.config_file_location)
+    return BOB.controller.emitter.ipc(response, request_id=0,
+                                      duration=0)  # FIXME: #1216 - what are request_id and duration here?
+
+
+@bob.command()
+@_admin_options
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
+@nucypher_click_config
+def destroy(click_config,
+
+            # Admin Options
+            provider_uri,
+            network,
+            registry_filepath,
+            checksum_address,
+
+            # Other
+            dev,
+            config_file,
+            discovery_port,
+            ):
+    """
+    Delete existing Bob's configuration.
+    """
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    bob_config = _get_bob_config(click_config, provider_uri, network, registry_filepath, checksum_address,
+                                 dev, config_file, discovery_port)
+    #############
+
     # Validate
-    #
+    if dev:
+        message = "'nucypher bob destroy' cannot be used in --dev mode"
+        raise click.BadOptionUsage(option_name='--dev', message=message)
 
-    # Banner
-    emitter = click_config.emitter
-    emitter.clear()
-    emitter.banner(BOB_BANNER)
+    # Request
+    return actions.destroy_configuration(emitter, character_config=bob_config)
 
-    #
-    # Eager Actions
-    #
 
-    if action == 'init':
-        """Create a brand-new persistent Bob"""
+@bob.command('public-keys')
+@_api_options
+@nucypher_click_config
+def public_keys(click_config,
 
-        if dev:
-            raise click.BadArgumentUsage("Cannot create a persistent development character")
+                # API Options
+                provider_uri,
+                network,
+                registry_filepath,
+                checksum_address,
+                dev,
+                config_file,
+                discovery_port,
+                teacher_uri,
+                min_stake,
+                ):
+    """
+    Obtain Bob's public verification and encryption keys.
+    """
 
-        if not config_root:  # Flag
-            config_root = click_config.config_file  # Envvar
+    ### Setup ###
+    _setup_emitter(click_config)
 
-        if not checksum_address and not federated_only:
-            checksum_address = select_client_account(emitter=emitter, provider_uri=provider_uri)
+    bob_config = _get_bob_config(click_config, dev, provider_uri, network, registry_filepath, checksum_address,
+                                 config_file, discovery_port)
+    #############
 
-        new_bob_config = BobConfiguration.generate(password=get_nucypher_password(confirm=True),
-                                                   config_root=config_root or DEFAULT_CONFIG_ROOT,
-                                                   checksum_address=checksum_address,
-                                                   domains={network} if network else None,
-                                                   federated_only=federated_only,
-                                                   registry_filepath=registry_filepath,
-                                                   provider_uri=provider_uri)
+    BOB = actions.make_cli_character(character_config=bob_config,
+                                     click_config=click_config,
+                                     dev=dev,
+                                     teacher_uri=teacher_uri,
+                                     min_stake=min_stake)
 
-        return painting.paint_new_installation_help(emitter, new_configuration=new_bob_config)
+    response = BOB.controller.public_keys()
+    return response
 
-    #
-    # Make Bob
-    #
 
+@bob.command()
+@_api_options
+@click.option('--label', help="The label for a policy", type=click.STRING)
+@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string",
+              type=click.STRING)
+@click.option('--alice-verifying-key', help="Alice's verifying key as a hexadecimal string", type=click.STRING)
+@click.option('--message-kit', help="The message kit unicode string encoded in base64", type=click.STRING)
+@nucypher_click_config
+def retrieve(click_config,
+
+             # API Options
+             provider_uri,
+             network,
+             registry_filepath,
+             checksum_address,
+             dev,
+             config_file,
+             discovery_port,
+             teacher_uri,
+             min_stake,
+
+             # Other
+             label,
+             policy_encrypting_key,
+             alice_verifying_key,
+             message_kit
+             ):
+    """
+    Obtain plaintext from encrypted data, if access was granted.
+    """
+
+    ### Setup ###
+    _setup_emitter(click_config)
+
+    bob_config = _get_bob_config(click_config, dev, provider_uri, network, registry_filepath, checksum_address,
+                                 config_file, discovery_port)
+    #############
+
+    BOB = actions.make_cli_character(character_config=bob_config,
+                                     click_config=click_config,
+                                     dev=dev,
+                                     teacher_uri=teacher_uri,
+                                     min_stake=min_stake)
+
+    # Validate
+    if not all((label, policy_encrypting_key, alice_verifying_key, message_kit)):
+        input_specification, output_specification = BOB.control.get_specifications(interface_name='retrieve')
+        required_fields = ', '.join(input_specification)
+        raise click.BadArgumentUsage(f'{required_fields} are required flags to retrieve')
+
+    # Request
+    bob_request_data = {
+        'label': label,
+        'policy_encrypting_key': policy_encrypting_key,
+        'alice_verifying_key': alice_verifying_key,
+        'message_kit': message_kit,
+    }
+
+    response = BOB.controller.retrieve(request=bob_request_data)
+    return response
+
+
+def _get_bob_config(click_config, dev, provider_uri, network, registry_filepath, checksum_address, config_file,
+                    discovery_port):
     if dev:
         bob_config = BobConfiguration(dev_mode=True,
                                       domains={network},
@@ -133,77 +337,13 @@ def bob(click_config,
             return actions.handle_missing_configuration_file(character_config_class=BobConfiguration,
                                                              config_file=config_file)
 
-    BOB = actions.make_cli_character(character_config=bob_config,
-                                     click_config=click_config,
-                                     dev=dev,
-                                     teacher_uri=teacher_uri,
-                                     min_stake=min_stake)
+    return bob_config
 
-    #
-    # Admin Action
-    #
 
-    if action == "run":
+def _setup_emitter(click_config):
+    # Banner
+    emitter = click_config.emitter
+    emitter.clear()
+    emitter.banner(BOB_BANNER)
 
-        # RPC
-        if click_config.json_ipc:
-            rpc_controller = BOB.make_rpc_controller()
-            _transport = rpc_controller.make_control_transport()
-            rpc_controller.start()
-            return
-
-        # Echo Public Keys
-        emitter.message(f"Bob Verifying Key {bytes(BOB.stamp).hex()}", color='green', bold=True)
-        bob_encrypting_key = bytes(BOB.public_keys(DecryptingPower)).hex()
-        emitter.message(f"Bob Encrypting Key {bob_encrypting_key}", color="blue", bold=True)
-
-        # Start Controller
-        controller = BOB.make_web_controller(crash_on_error=click_config.debug)
-        BOB.log.info('Starting HTTP Character Web Controller')
-        return controller.start(http_port=controller_port , dry_run=dry_run)
-
-    elif action == "view":
-        """Paint an existing configuration to the console"""
-        response = BobConfiguration._read_configuration_file(filepath=config_file or bob_config.config_file_location)
-        return BOB.controller.emitter.ipc(response, request_id=0, duration=0)  # FIXME: #1216 - what are request_id and duration here?
-
-    elif action == "destroy":
-        """Delete Bob's character configuration files from the disk"""
-
-        # Validate
-        if dev:
-            message = "'nucypher bob destroy' cannot be used in --dev mode"
-            raise click.BadOptionUsage(option_name='--dev', message=message)
-
-        # Request
-        return actions.destroy_configuration(emitter, character_config=bob_config)
-
-    #
-    # Bob API Actions
-    #
-
-    elif action == "public-keys":
-        response = BOB.controller.public_keys()
-        return response
-
-    elif action == "retrieve":
-
-        # Validate
-        if not all((label, policy_encrypting_key, alice_verifying_key, message_kit)):
-            input_specification, output_specification = BOB.control.get_specifications(interface_name='retrieve')
-            required_fields = ', '.join(input_specification)
-            raise click.BadArgumentUsage(f'{required_fields} are required flags to retrieve')
-
-        # Request
-        bob_request_data = {
-            'label': label,
-            'policy_encrypting_key': policy_encrypting_key,
-            'alice_verifying_key': alice_verifying_key,
-            'message_kit': message_kit,
-        }
-
-        response = BOB.controller.retrieve(request=bob_request_data)
-        return response
-
-    else:
-        raise click.BadArgumentUsage(f"No such argument {action}")
+    return emitter

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -56,10 +56,7 @@ def bob():
 def init(click_config,
 
          # Admin Options
-         provider_uri,
-         network,
-         registry_filepath,
-         checksum_address,
+         provider_uri, network, registry_filepath, checksum_address,
 
          # Other
          federated_only, config_root):
@@ -93,15 +90,8 @@ def init(click_config,
 def run(click_config,
 
         # API Options
-        provider_uri,
-        network,
-        registry_filepath,
-        checksum_address,
-        dev,
-        config_file,
-        discovery_port,
-        teacher_uri,
-        min_stake,
+        provider_uri, network, registry_filepath, checksum_address, dev, config_file, discovery_port,
+        teacher_uri, min_stake,
 
         # Other
         controller_port, dry_run):
@@ -145,16 +135,8 @@ def run(click_config,
 def view(click_config,
 
          # API Options
-         provider_uri,
-         network,
-         registry_filepath,
-         checksum_address,
-         dev,
-         config_file,
-         discovery_port,
-         teacher_uri,
-         min_stake,
-         ):
+         provider_uri, network, registry_filepath, checksum_address, dev, config_file, discovery_port,
+         teacher_uri, min_stake):
     """
     View existing Bob's configuration.
     """
@@ -186,16 +168,10 @@ def view(click_config,
 def destroy(click_config,
 
             # Admin Options
-            provider_uri,
-            network,
-            registry_filepath,
-            checksum_address,
+            provider_uri, network, registry_filepath, checksum_address,
 
             # Other
-            dev,
-            config_file,
-            discovery_port,
-            force
+            dev, config_file, discovery_port, force
             ):
     """
     Delete existing Bob's configuration.
@@ -222,16 +198,8 @@ def destroy(click_config,
 def public_keys(click_config,
 
                 # API Options
-                provider_uri,
-                network,
-                registry_filepath,
-                checksum_address,
-                dev,
-                config_file,
-                discovery_port,
-                teacher_uri,
-                min_stake,
-                ):
+                provider_uri, network, registry_filepath, checksum_address, dev, config_file, discovery_port,
+                teacher_uri, min_stake):
     """
     Obtain Bob's public verification and encryption keys.
     """
@@ -264,22 +232,11 @@ def public_keys(click_config,
 def retrieve(click_config,
 
              # API Options
-             provider_uri,
-             network,
-             registry_filepath,
-             checksum_address,
-             dev,
-             config_file,
-             discovery_port,
-             teacher_uri,
-             min_stake,
+             provider_uri, network, registry_filepath, checksum_address, dev, config_file, discovery_port,
+             teacher_uri, min_stake,
 
              # Other
-             label,
-             policy_encrypting_key,
-             alice_verifying_key,
-             message_kit
-             ):
+             label, policy_encrypting_key, alice_verifying_key, message_kit):
     """
     Obtain plaintext from encrypted data, if access was granted.
     """

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -214,7 +214,7 @@ def destroy(click_config,
     return actions.destroy_configuration(emitter, character_config=bob_config)
 
 
-@bob.command('public-keys')
+@bob.command(name='public-keys')
 @_api_options
 @nucypher_click_config
 def public_keys(click_config,

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -43,7 +43,7 @@ def _api_options(func):
 @click.group()
 def bob():
     """
-    "Bob" management commands.
+    "Bob the Data Recipient" management commands.
     """
     pass
 

--- a/nucypher/cli/characters/enrico.py
+++ b/nucypher/cli/characters/enrico.py
@@ -31,7 +31,11 @@ def enrico():
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT)
 @nucypher_click_config
 def run(click_config,
-        policy_encrypting_key,  # common
+
+        # Common
+        policy_encrypting_key,
+
+        # Other
         dry_run, http_port):
     """
     Start Enrico's controller.
@@ -51,12 +55,17 @@ def run(click_config,
 
 
 @enrico.command()
-@_common_options
 @click.option('--message', help="A unicode message to encrypt for a policy", type=click.STRING, required=True)
+@_common_options
 @nucypher_click_config
 def encrypt(click_config,
-            policy_encrypting_key,  # common
-            message):
+
+            # Other (required)
+            message,
+
+            # Common
+            policy_encrypting_key,
+            ):
     """
     Encrypt a message under a given policy public key.
     """

--- a/nucypher/cli/characters/enrico.py
+++ b/nucypher/cli/characters/enrico.py
@@ -1,3 +1,5 @@
+import functools
+
 import click
 from umbral.keys import UmbralPublicKey
 
@@ -7,19 +9,30 @@ from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT
 
 
+# Args (policy_encrypting_key)
+def _common_options(func):
+    @click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string", type=click.STRING, required=True)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
 @click.group()
 def enrico():
     """
     Enrico the Encryptor" management commands.
     """
+    pass
 
 
 @enrico.command()
-@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string", type=click.STRING, required=True)
+@_common_options
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT)
 @nucypher_click_config
-def run(click_config, policy_encrypting_key, dry_run, http_port):
+def run(click_config,
+        policy_encrypting_key,  # common
+        dry_run, http_port):
     """
     Start Enrico's controller.
     """
@@ -38,10 +51,12 @@ def run(click_config, policy_encrypting_key, dry_run, http_port):
 
 
 @enrico.command()
-@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string", type=click.STRING, required=True)
+@_common_options
 @click.option('--message', help="A unicode message to encrypt for a policy", type=click.STRING, required=True)
 @nucypher_click_config
-def encrypt(click_config, policy_encrypting_key, message):
+def encrypt(click_config,
+            policy_encrypting_key,  # common
+            message):
     """
     Encrypt a message under a given policy public key.
     """

--- a/nucypher/cli/characters/enrico.py
+++ b/nucypher/cli/characters/enrico.py
@@ -7,73 +7,59 @@ from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT
 
 
-@click.command()
-@click.argument('action')
+@click.group()
+def enrico():
+    """
+    Enrico the Encryptor" management commands.
+    """
+
+
+@enrico.command()
+@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string", type=click.STRING, required=True)
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
 @click.option('--http-port', help="The host port to run Moe HTTP services on", type=NETWORK_PORT)
-@click.option('--message', help="A unicode message to encrypt for a policy", type=click.STRING)
-@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexidecimal string", type=click.STRING)
 @nucypher_click_config
-def enrico(click_config, action, policy_encrypting_key, dry_run, http_port, message):
+def run(click_config, policy_encrypting_key, dry_run, http_port):
     """
-    "Enrico the Encryptor" management commands.
-
-    \b
-    Actions
-    -------------------------------------------------
-    \b
-    run       Start Enrico's controller.
-    encrypt   Encrypt a message under a given policy public key
-
+    Start Enrico's controller.
     """
+    ENRICO = _create_enrico(click_config, policy_encrypting_key)
 
-    #
-    # Validate
-    #
+    # RPC
+    if click_config.json_ipc:
+        rpc_controller = ENRICO.make_rpc_controller()
+        _transport = rpc_controller.make_control_transport()
+        rpc_controller.start()
+        return
 
-    if not policy_encrypting_key:
-        raise click.BadArgumentUsage('--policy-encrypting-key is required to start Enrico.')
+    ENRICO.log.info('Starting HTTP Character Web Controller')
+    controller = ENRICO.make_web_controller()
+    return controller.start(http_port=http_port, dry_run=dry_run)
 
-    # Banner
+
+@enrico.command()
+@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string", type=click.STRING, required=True)
+@click.option('--message', help="A unicode message to encrypt for a policy", type=click.STRING, required=True)
+@nucypher_click_config
+def encrypt(click_config, policy_encrypting_key, message):
+    """
+    Encrypt a message under a given policy public key.
+    """
+    ENRICO = _create_enrico(click_config, policy_encrypting_key)
+
+    # Request
+    encryption_request = {'message': message}
+    response = ENRICO.controller.encrypt_message(request=encryption_request)
+    return response
+
+
+def _create_enrico(click_config, policy_encrypting_key):
     emitter = click_config.emitter
     emitter.clear()
     emitter.banner(ENRICO_BANNER.format(policy_encrypting_key))
-
-    #
-    # Make Enrico
-    #
 
     policy_encrypting_key = UmbralPublicKey.from_bytes(bytes.fromhex(policy_encrypting_key))
     ENRICO = Enrico(policy_encrypting_key=policy_encrypting_key)
     ENRICO.controller.emitter = emitter  # TODO: set it on object creation? Or not set at all?
 
-    #
-    # Actions
-    #
-
-    if action == 'run':
-
-        # RPC
-        if click_config.json_ipc:
-            rpc_controller = ENRICO.make_rpc_controller()
-            _transport = rpc_controller.make_control_transport()
-            rpc_controller.start()
-            return
-
-        ENRICO.log.info('Starting HTTP Character Web Controller')
-        controller = ENRICO.make_web_controller()
-        return controller.start(http_port=http_port, dry_run=dry_run)
-
-    elif action == 'encrypt':
-
-        # Validate
-        if not message:
-            raise click.BadArgumentUsage('--message is a required flag to encrypt.')
-
-        # Request
-        encryption_request = {'message': message}
-        response = ENRICO.controller.encrypt_message(request=encryption_request)
-        return response
-
-    else:
-        raise click.BadArgumentUsage
+    return ENRICO

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -12,122 +12,259 @@ from nucypher.config.characters import FelixConfiguration
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 
 
-@click.command()
-@click.argument('action')
-@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-@click.option('--enode', help="An ethereum bootnode enode address to start learning from", type=click.STRING)
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
-@click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
-@click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
-@click.option('--discovery-port', help="The host port to run Felix Node Discovery services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_LEARNER_PORT)
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True, default=False)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
-@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@nucypher_click_config
-def felix(click_config,
-          action,
-          teacher_uri,
-          enode,
-          min_stake,
-          network,
-          host,
-          dry_run,
-          port,
-          discovery_port,
-          provider_uri,
-          geth,
-          config_root,
-          checksum_address,
-          poa,
-          config_file,
-          db_filepath,
-          registry_filepath,
-          dev,
-          force):
+@click.group()
+def felix():
     """
     "Felix the Faucet" management commands.
     """
 
-    emitter = click_config.emitter
 
-    # Intro
-    emitter.clear()
-    emitter.banner(FELIX_BANNER.format(checksum_address or ''))
+@felix.command()
+@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
+@click.option('--discovery-port', help="The host port to run Felix Node Discovery services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_LEARNER_PORT)
+@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+@nucypher_click_config
+def init(click_config,
+         geth,
+         dev,
+         config_root,
+         host,
+         discovery_port,
+         db_filepath,
+         network,
+         checksum_address,
+         registry_filepath,
+         provider_uri,
+         poa):
+    """
+    Create a brand-new Felix.
+    """
+    emitter = setup_emitter(click_config, checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
-        ETH_NODE = actions.get_provider_process(dev=dev)
+        ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    if action == "init":
-        """Create a brand-new Felix"""
-
-        if not config_root:                         # Flag
-            config_root = DEFAULT_CONFIG_ROOT       # Envvar or init-only default
-
-        try:
-            new_felix_config = FelixConfiguration.generate(password=get_nucypher_password(confirm=True),
-                                                           config_root=config_root,
-                                                           rest_host=host,
-                                                           rest_port=discovery_port,
-                                                           db_filepath=db_filepath,
-                                                           domains={network} if network else None,
-                                                           checksum_address=checksum_address,
-                                                           registry_filepath=registry_filepath,
-                                                           provider_uri=provider_uri,
-                                                           provider_process=ETH_NODE,
-                                                           poa=poa)
-        except Exception as e:
-            if click_config.debug:
-                raise
-            else:
-                emitter.echo(str(e), color='red', bold=True)
-                raise click.Abort
-
-        # Paint Help
-        painting.paint_new_installation_help(emitter, new_configuration=new_felix_config)
-
-        return  # <-- do not remove (conditional flow control)
-
-    # Domains -> bytes | or default
-    domains = [network] if network else None
-
-    # Load Felix from Configuration File with overrides
-    try:
-        felix_config = FelixConfiguration.from_configuration_file(filepath=config_file,
-                                                                  domains=domains,
-                                                                  registry_filepath=registry_filepath,
-                                                                  provider_process=ETH_NODE,
-                                                                  provider_uri=provider_uri,
-                                                                  rest_host=host,
-                                                                  rest_port=port,
-                                                                  db_filepath=db_filepath,
-                                                                  poa=poa)
-
-    except FileNotFoundError:
-        emitter.echo(f"No Felix configuration file found at {config_file}. "
-                     f"Check the filepath or run 'nucypher felix init' to create a new system configuration.")
-        raise click.Abort
-
-    if action == "destroy":
-        """Delete all configuration files from the disk"""
-        if dev:
-            message = "'nucypher felix destroy' cannot be used in --dev mode"
-            raise click.BadOptionUsage(option_name='--dev', message=message)
-        actions.destroy_configuration(emitter, character_config=felix_config, force=force)
-        return
+    if not config_root:  # Flag
+        config_root = DEFAULT_CONFIG_ROOT  # Envvar or init-only default
 
     try:
+        new_felix_config = FelixConfiguration.generate(password=get_nucypher_password(confirm=True),
+                                                       config_root=config_root,
+                                                       rest_host=host,
+                                                       rest_port=discovery_port,
+                                                       db_filepath=db_filepath,
+                                                       domains={network} if network else None,
+                                                       checksum_address=checksum_address,
+                                                       registry_filepath=registry_filepath,
+                                                       provider_uri=provider_uri,
+                                                       provider_process=ETH_NODE,
+                                                       poa=poa)
+    except Exception as e:
+        if click_config.debug:
+            raise
+        else:
+            emitter.echo(str(e), color='red', bold=True)
+            raise click.Abort
 
+    # Paint Help
+    painting.paint_new_installation_help(emitter, new_configuration=new_felix_config)
+
+
+@felix.command()
+@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
+@click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
+@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
+@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@nucypher_click_config
+def destroy(click_config, checksum_address, geth, dev, network, config_file, registry_filepath, provider_uri, host, port, db_filepath, poa, force):
+    """
+    Destroy Felix Configuration.
+    """
+    emitter = setup_emitter(click_config, checksum_address)
+
+    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
+    if geth:
+        ETH_NODE = actions.get_provider_process(dev)
+        provider_uri = ETH_NODE.provider_uri
+
+    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port, db_filepath, poa)
+    actions.destroy_configuration(emitter, character_config=felix_config, force=force)
+
+
+@felix.command()
+@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
+@click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
+@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
+@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
+@nucypher_click_config
+def createdb(click_config, checksum_address, geth, dev, network, config_file, registry_filepath, provider_uri, host, port, db_filepath, poa, force, teacher_uri, min_stake):
+    """
+    Create Felix DB.
+    """
+    emitter = setup_emitter(click_config, checksum_address)
+
+    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
+    if geth:
+        ETH_NODE = actions.get_provider_process(dev)
+        provider_uri = ETH_NODE.provider_uri
+
+    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                              db_filepath, poa)
+    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+
+    if os.path.isfile(FELIX.db_filepath):
+        if not force:
+            click.confirm("Overwrite existing database?", abort=True)
+        os.remove(FELIX.db_filepath)
+        emitter.echo(f"Destroyed existing database {FELIX.db_filepath}")
+
+    FELIX.create_tables()
+    emitter.echo(f"\nCreated new database at {FELIX.db_filepath}", color='green')
+
+@felix.command()
+@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
+@click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
+@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
+@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
+@nucypher_click_config
+def view(click_config, checksum_address, geth, dev, network, config_file, registry_filepath, provider_uri, host, port, db_filepath, poa, teacher_uri, min_stake):
+    """
+    View Felix token balance.
+    """
+    emitter = setup_emitter(click_config, checksum_address)
+
+    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
+    if geth:
+        ETH_NODE = actions.get_provider_process(dev)
+        provider_uri = ETH_NODE.provider_uri
+
+    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                              db_filepath, poa)
+    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+
+    token_balance = FELIX.token_balance
+    eth_balance = FELIX.eth_balance
+    emitter.echo(f"""
+        Address .... {FELIX.checksum_address}
+        NU ......... {str(token_balance)}
+        ETH ........ {str(eth_balance)}
+    """)
+
+
+@felix.command()
+@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
+@click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
+@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
+@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
+@nucypher_click_config
+def accounts(click_config, checksum_address, geth, dev, network, config_file, registry_filepath, provider_uri, host, port, db_filepath, poa, teacher_uri, min_stake):
+    """
+    View Felix known accounts.
+    """
+    emitter = setup_emitter(click_config, checksum_address)
+
+    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
+    if geth:
+        ETH_NODE = actions.get_provider_process(dev)
+        provider_uri = ETH_NODE.provider_uri
+
+    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                              db_filepath, poa)
+    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+
+    accounts = FELIX.blockchain.client.accounts
+    for account in accounts:
+        emitter.echo(account)
+
+
+@felix.command()
+@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True, default=False)
+@click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--network', help="Network Domain Name", type=click.STRING)
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+@click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
+@click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
+@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
+@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
+@nucypher_click_config
+def run(click_config, dry_run, checksum_address, geth, dev, network, config_file, registry_filepath, provider_uri, host, port, db_filepath, poa, teacher_uri, min_stake):
+    """
+    Run Felix service.
+    """
+    emitter = setup_emitter(click_config, checksum_address)
+
+    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
+    if geth:
+        ETH_NODE = actions.get_provider_process(dev)
+        provider_uri = ETH_NODE.provider_uri
+
+    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                              db_filepath, poa)
+    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+
+    emitter.echo("Waiting for blockchain sync...", color='yellow')
+    emitter.message(f"Running Felix on {host}:{port}")
+    FELIX.start(host=host,
+                port=port,
+                web_services=not dry_run,
+                distribution=True,
+                crash_on_error=click_config.debug)
+
+
+def create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network):
+    try:
         # Authenticate
         unlock_nucypher_keyring(emitter,
                                 character_configuration=felix_config,
@@ -145,6 +282,7 @@ def felix(click_config,
         FELIX = felix_config.produce(domains=network, known_nodes=teacher_nodes)
         FELIX.make_web_app()  # attach web application, but dont start service
 
+        return FELIX
     except Exception as e:
         if click_config.debug:
             raise
@@ -152,39 +290,35 @@ def felix(click_config,
             emitter.echo(str(e), color='red', bold=True)
             raise click.Abort
 
-    if action == "createdb":  # Initialize Database
-        if os.path.isfile(FELIX.db_filepath):
-            if not force:
-                click.confirm("Overwrite existing database?", abort=True)
-            os.remove(FELIX.db_filepath)
-            emitter.echo(f"Destroyed existing database {FELIX.db_filepath}")
 
-        FELIX.create_tables()
-        emitter.echo(f"\nCreated new database at {FELIX.db_filepath}", color='green')
+def get_config(emitter, network, config_file, registry_filepath, eth_node, provider_uri, host, port, db_filepath, poa):
+    # Domains -> bytes | or default
+    domains = [network] if network else None
 
-    elif action == 'view':
-        token_balance = FELIX.token_balance
-        eth_balance = FELIX.eth_balance
-        emitter.echo(f"""
-Address .... {FELIX.checksum_address}
-NU ......... {str(token_balance)}
-ETH ........ {str(eth_balance)}
-        """)
+    # Load Felix from Configuration File with overrides
+    try:
+        felix_config = FelixConfiguration.from_configuration_file(filepath=config_file,
+                                                                  domains=domains,
+                                                                  registry_filepath=registry_filepath,
+                                                                  provider_process=eth_node,
+                                                                  provider_uri=provider_uri,
+                                                                  rest_host=host,
+                                                                  rest_port=port,
+                                                                  db_filepath=db_filepath,
+                                                                  poa=poa)
 
-    elif action == "accounts":
-        accounts = FELIX.blockchain.client.accounts
-        for account in accounts:
-            emitter.echo(account)
+        return felix_config
+    except FileNotFoundError:
+        emitter.echo(f"No Felix configuration file found at {config_file}. "
+                     f"Check the filepath or run 'nucypher felix init' to create a new system configuration.")
+        raise click.Abort
 
-    elif action == 'run':     # Start web services
 
-        emitter.echo("Waiting for blockchain sync...", color='yellow')
-        emitter.message(f"Running Felix on {host}:{port}")
-        FELIX.start(host=host,
-                    port=port,
-                    web_services=not dry_run,
-                    distribution=True,
-                    crash_on_error=click_config.debug)
+def setup_emitter(click_config, checksum_address):
+    emitter = click_config.emitter
 
-    else:
-        raise click.BadArgumentUsage("No such argument {}".format(action))
+    # Intro
+    emitter.clear()
+    emitter.banner(FELIX_BANNER.format(checksum_address or ''))
+
+    return emitter

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -14,7 +14,7 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 
 
 # Args (checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa)
-def _common_options(func):
+def _admin_options(func):
     @click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
     @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
     @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
@@ -31,7 +31,8 @@ def _common_options(func):
 
 
 # Args (config_file, port, teacher_uri)
-def _admin_options(func):
+def _api_options(func):
+    @_admin_options
     @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
     @click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT,
                   default=FelixConfiguration.DEFAULT_REST_PORT)
@@ -53,13 +54,13 @@ def felix():
 
 
 @felix.command()
-@_common_options
+@_admin_options
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
 @click.option('--discovery-port', help="The host port to run Felix Node Discovery services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_LEARNER_PORT)
 @nucypher_click_config
 def init(click_config,
 
-         # Common Options
+         # Admin Options
          checksum_address,
          geth,
          dev,
@@ -110,14 +111,14 @@ def init(click_config,
 
 
 @felix.command()
-@_common_options
+@_admin_options
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @nucypher_click_config
 def destroy(click_config,
 
-            # Common Options
+            # Admin Options
             checksum_address,
             geth,
             dev,
@@ -145,13 +146,12 @@ def destroy(click_config,
 
 
 @felix.command()
-@_common_options
-@_admin_options
+@_api_options
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @nucypher_click_config
 def createdb(click_config,
 
-             # Common Options
+             # API Options
              checksum_address,
              geth,
              dev,
@@ -161,8 +161,6 @@ def createdb(click_config,
              host,
              db_filepath,
              poa,
-
-             # Admin Options
              config_file,
              port,
              teacher_uri,
@@ -195,12 +193,11 @@ def createdb(click_config,
 
 
 @felix.command()
-@_common_options
-@_admin_options
+@_api_options
 @nucypher_click_config
 def view(click_config,
 
-         # Common Options
+         # API Options
          checksum_address,
          geth,
          dev,
@@ -210,8 +207,6 @@ def view(click_config,
          host,
          db_filepath,
          poa,
-
-         # Admin Options
          config_file,
          port,
          teacher_uri,
@@ -240,12 +235,11 @@ def view(click_config,
 
 
 @felix.command()
-@_common_options
-@_admin_options
+@_api_options
 @nucypher_click_config
 def accounts(click_config,
 
-             # Common Options
+             # API Options
              checksum_address,
              geth,
              dev,
@@ -255,8 +249,6 @@ def accounts(click_config,
              host,
              db_filepath,
              poa,
-
-             # Admin Options
              config_file,
              port,
              teacher_uri,
@@ -281,13 +273,12 @@ def accounts(click_config,
 
 
 @felix.command()
-@_common_options
-@_admin_options
+@_api_options
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True, default=False)
 @nucypher_click_config
 def run(click_config,
 
-        # Common Options
+        # API Options
         checksum_address,
         geth,
         dev,
@@ -297,8 +288,6 @@ def run(click_config,
         host,
         db_filepath,
         poa,
-
-        # Admin Options
         config_file,
         port,
         teacher_uri,

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -61,19 +61,10 @@ def felix():
 def init(click_config,
 
          # Admin Options
-         checksum_address,
-         geth,
-         dev,
-         network,
-         registry_filepath,
-         provider_uri,
-         host,
-         db_filepath,
-         poa,
+         checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
 
          # Other
-         config_root,
-         discovery_port):
+         config_root, discovery_port):
     """
     Create a brand-new Felix.
     """
@@ -119,15 +110,7 @@ def init(click_config,
 def destroy(click_config,
 
             # Admin Options
-            checksum_address,
-            geth,
-            dev,
-            network,
-            registry_filepath,
-            provider_uri,
-            host,
-            db_filepath,
-            poa,
+            checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
 
             # Other
             config_file, port, force):
@@ -152,19 +135,8 @@ def destroy(click_config,
 def createdb(click_config,
 
              # API Options
-             checksum_address,
-             geth,
-             dev,
-             network,
-             registry_filepath,
-             provider_uri,
-             host,
-             db_filepath,
-             poa,
-             config_file,
-             port,
-             teacher_uri,
-             min_stake,
+             checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
+             config_file, port, teacher_uri, min_stake,
 
              # Other
              force):
@@ -198,19 +170,8 @@ def createdb(click_config,
 def view(click_config,
 
          # API Options
-         checksum_address,
-         geth,
-         dev,
-         network,
-         registry_filepath,
-         provider_uri,
-         host,
-         db_filepath,
-         poa,
-         config_file,
-         port,
-         teacher_uri,
-         min_stake):
+         checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
+         config_file, port, teacher_uri, min_stake):
     """
     View Felix token balance.
     """
@@ -240,19 +201,8 @@ def view(click_config,
 def accounts(click_config,
 
              # API Options
-             checksum_address,
-             geth,
-             dev,
-             network,
-             registry_filepath,
-             provider_uri,
-             host,
-             db_filepath,
-             poa,
-             config_file,
-             port,
-             teacher_uri,
-             min_stake):
+             checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
+             config_file, port, teacher_uri, min_stake):
     """
     View Felix known accounts.
     """
@@ -279,19 +229,8 @@ def accounts(click_config,
 def run(click_config,
 
         # API Options
-        checksum_address,
-        geth,
-        dev,
-        network,
-        registry_filepath,
-        provider_uri,
-        host,
-        db_filepath,
-        poa,
-        config_file,
-        port,
-        teacher_uri,
-        min_stake,
+        checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
+        config_file, port, teacher_uri, min_stake,
 
         # Other
         dry_run):

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -36,6 +36,8 @@ def _admin_options(func):
     @click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT,
                   default=FelixConfiguration.DEFAULT_REST_PORT)
     @click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+    @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT,
+                  default=0)
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -146,7 +148,6 @@ def destroy(click_config,
 @_common_options
 @_admin_options
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def createdb(click_config,
 
@@ -165,9 +166,10 @@ def createdb(click_config,
              config_file,
              port,
              teacher_uri,
+             min_stake,
 
              # Other
-             force, min_stake):
+             force):
     """
     Create Felix DB.
     """
@@ -195,7 +197,6 @@ def createdb(click_config,
 @felix.command()
 @_common_options
 @_admin_options
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def view(click_config,
 
@@ -214,8 +215,6 @@ def view(click_config,
          config_file,
          port,
          teacher_uri,
-
-         # Other
          min_stake):
     """
     View Felix token balance.
@@ -243,7 +242,6 @@ def view(click_config,
 @felix.command()
 @_common_options
 @_admin_options
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def accounts(click_config,
 
@@ -262,8 +260,6 @@ def accounts(click_config,
              config_file,
              port,
              teacher_uri,
-
-             # Other
              min_stake):
     """
     View Felix known accounts.
@@ -288,7 +284,6 @@ def accounts(click_config,
 @_common_options
 @_admin_options
 @click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True, default=False)
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def run(click_config,
 
@@ -307,9 +302,10 @@ def run(click_config,
         config_file,
         port,
         teacher_uri,
+        min_stake,
 
         # Other
-        dry_run, min_stake):
+        dry_run):
     """
     Run Felix service.
     """

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -56,7 +56,19 @@ def felix():
 @click.option('--discovery-port', help="The host port to run Felix Node Discovery services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_LEARNER_PORT)
 @nucypher_click_config
 def init(click_config,
-         checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa,  # common
+
+         # Common Options
+         checksum_address,
+         geth,
+         dev,
+         network,
+         registry_filepath,
+         provider_uri,
+         host,
+         db_filepath,
+         poa,
+
+         # Other
          config_root,
          discovery_port):
     """
@@ -102,7 +114,19 @@ def init(click_config,
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
 @nucypher_click_config
 def destroy(click_config,
-            checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa,  # common
+
+            # Common Options
+            checksum_address,
+            geth,
+            dev,
+            network,
+            registry_filepath,
+            provider_uri,
+            host,
+            db_filepath,
+            poa,
+
+            # Other
             config_file, port, force):
     """
     Destroy Felix Configuration.
@@ -125,8 +149,24 @@ def destroy(click_config,
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def createdb(click_config,
-             checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa,  # common
-             config_file, port, teacher_uri,  # admin
+
+             # Common Options
+             checksum_address,
+             geth,
+             dev,
+             network,
+             registry_filepath,
+             provider_uri,
+             host,
+             db_filepath,
+             poa,
+
+             # Admin Options
+             config_file,
+             port,
+             teacher_uri,
+
+             # Other
              force, min_stake):
     """
     Create Felix DB.
@@ -158,8 +198,24 @@ def createdb(click_config,
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def view(click_config,
-         checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa,  # common
-         config_file, port, teacher_uri,  # admin
+
+         # Common Options
+         checksum_address,
+         geth,
+         dev,
+         network,
+         registry_filepath,
+         provider_uri,
+         host,
+         db_filepath,
+         poa,
+
+         # Admin Options
+         config_file,
+         port,
+         teacher_uri,
+
+         # Other
          min_stake):
     """
     View Felix token balance.
@@ -190,8 +246,24 @@ def view(click_config,
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def accounts(click_config,
-             checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa,  # common
-             config_file, port, teacher_uri,  # admin
+
+             # Common Options
+             checksum_address,
+             geth,
+             dev,
+             network,
+             registry_filepath,
+             provider_uri,
+             host,
+             db_filepath,
+             poa,
+
+             # Admin Options
+             config_file,
+             port,
+             teacher_uri,
+
+             # Other
              min_stake):
     """
     View Felix known accounts.
@@ -219,8 +291,24 @@ def accounts(click_config,
 @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
 @nucypher_click_config
 def run(click_config,
-        checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa,  # common
-        config_file, port, teacher_uri,  # admin
+
+        # Common Options
+        checksum_address,
+        geth,
+        dev,
+        network,
+        registry_filepath,
+        provider_uri,
+        host,
+        db_filepath,
+        poa,
+
+        # Admin Options
+        config_file,
+        port,
+        teacher_uri,
+
+        # Other
         dry_run, min_stake):
     """
     Run Felix service.

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -47,7 +47,7 @@ def init(click_config,
     """
     Create a brand-new Felix.
     """
-    emitter = setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(click_config, checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
@@ -98,14 +98,14 @@ def destroy(click_config, checksum_address, geth, dev, network, config_file, reg
     """
     Destroy Felix Configuration.
     """
-    emitter = setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(click_config, checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port, db_filepath, poa)
+    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port, db_filepath, poa)
     actions.destroy_configuration(emitter, character_config=felix_config, force=force)
 
 
@@ -129,16 +129,16 @@ def createdb(click_config, checksum_address, geth, dev, network, config_file, re
     """
     Create Felix DB.
     """
-    emitter = setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(click_config, checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                              db_filepath, poa)
-    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                               db_filepath, poa)
+    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
 
     if os.path.isfile(FELIX.db_filepath):
         if not force:
@@ -168,16 +168,16 @@ def view(click_config, checksum_address, geth, dev, network, config_file, regist
     """
     View Felix token balance.
     """
-    emitter = setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(click_config, checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                              db_filepath, poa)
-    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                               db_filepath, poa)
+    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
 
     token_balance = FELIX.token_balance
     eth_balance = FELIX.eth_balance
@@ -207,16 +207,16 @@ def accounts(click_config, checksum_address, geth, dev, network, config_file, re
     """
     View Felix known accounts.
     """
-    emitter = setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(click_config, checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                              db_filepath, poa)
-    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                               db_filepath, poa)
+    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
 
     accounts = FELIX.blockchain.client.accounts
     for account in accounts:
@@ -243,16 +243,16 @@ def run(click_config, dry_run, checksum_address, geth, dev, network, config_file
     """
     Run Felix service.
     """
-    emitter = setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(click_config, checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                              db_filepath, poa)
-    FELIX = create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
+                               db_filepath, poa)
+    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
 
     emitter.echo("Waiting for blockchain sync...", color='yellow')
     emitter.message(f"Running Felix on {host}:{port}")
@@ -263,7 +263,7 @@ def run(click_config, dry_run, checksum_address, geth, dev, network, config_file
                 crash_on_error=click_config.debug)
 
 
-def create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network):
+def _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network):
     try:
         # Authenticate
         unlock_nucypher_keyring(emitter,
@@ -291,7 +291,7 @@ def create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, ne
             raise click.Abort
 
 
-def get_config(emitter, network, config_file, registry_filepath, eth_node, provider_uri, host, port, db_filepath, poa):
+def _get_config(emitter, network, config_file, registry_filepath, eth_node, provider_uri, host, port, db_filepath, poa):
     # Domains -> bytes | or default
     domains = [network] if network else None
 
@@ -314,7 +314,7 @@ def get_config(emitter, network, config_file, registry_filepath, eth_node, provi
         raise click.Abort
 
 
-def setup_emitter(click_config, checksum_address):
+def _setup_emitter(click_config, checksum_address):
     emitter = click_config.emitter
 
     # Intro

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -108,9 +108,8 @@ def init_stakeholder(click_config,
                      # Other
                      config_root, force,
 
-                     # Admin Option
-                     poa,
-                     registry_filepath):
+                     # Admin Options
+                     poa, registry_filepath):
     """
     Create a new stakeholder configuration.
     """
@@ -132,11 +131,7 @@ def init_stakeholder(click_config,
 def list(click_config,
 
          # API Options
-         poa,
-         registry_filepath,
-         config_file,
-         provider_uri,
-         staking_address):
+         poa, registry_filepath, config_file, provider_uri, staking_address):
     """
     List active stakes for current stakeholder.
     """
@@ -161,11 +156,7 @@ def list(click_config,
 def accounts(click_config,
 
              # API Options
-             poa,
-             registry_filepath,
-             config_file,
-             provider_uri,
-             staking_address):
+             poa, registry_filepath, config_file, provider_uri, staking_address):
     """
     Show ETH and NU balances for stakeholder's accounts.
     """
@@ -186,13 +177,7 @@ def accounts(click_config,
 def set_worker(click_config,
 
                # Worker Options
-               poa,
-               registry_filepath,
-               config_file,
-               provider_uri,
-               staking_address,
-               hw_wallet,
-               worker_address):
+               poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet, worker_address):
     """
     Bond a worker to a staker.
     """
@@ -243,13 +228,7 @@ def set_worker(click_config,
 def detach_worker(click_config,
 
                   # Worker Options
-                  poa,
-                  registry_filepath,
-                  config_file,
-                  provider_uri,
-                  staking_address,
-                  hw_wallet,
-                  worker_address):
+                  poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet, worker_address):
     """
     Detach worker currently bonded to a staker.
     """
@@ -302,17 +281,10 @@ def detach_worker(click_config,
 def create(click_config,
 
            # Stake Options
-           poa,
-           registry_filepath,
-           config_file,
-           provider_uri,
-           staking_address,
-           hw_wallet,
+           poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet,
 
            # Other
-           force,
-           value,
-           lock_periods):
+           force, value, lock_periods):
     """
     Initialize a new stake.
     """
@@ -397,17 +369,10 @@ def create(click_config,
 def restake(click_config,
 
             # Stake Options
-            poa,
-            registry_filepath,
-            config_file,
-            provider_uri,
-            staking_address,
-            hw_wallet,
+            poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet,
 
             # Other
-            enable,
-            lock_until,
-            force):
+            enable, lock_until, force):
     """
     Manage re-staking with --enable or --disable.
     """
@@ -457,18 +422,10 @@ def restake(click_config,
 def divide(click_config,
 
            # Stake Options
-           poa,
-           registry_filepath,
-           config_file,
-           provider_uri,
-           staking_address,
-           hw_wallet,
+           poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet,
 
            # Other
-           force,
-           value,
-           lock_periods,
-           index):
+           force, value, lock_periods, index):
     """
     Create a new stake from part of an existing one.
     """
@@ -541,18 +498,11 @@ def divide(click_config,
 @nucypher_click_config
 def collect_reward(click_config,
 
-                   # API Options
-                   poa,
-                   registry_filepath,
-                   config_file,
-                   provider_uri,
-                   staking_address,
-                   hw_wallet,
+                   # Stake Options
+                   poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet,
 
                    # Other
-                   staking_reward,
-                   policy_reward,
-                   withdraw_address):
+                   staking_reward, policy_reward, withdraw_address):
     """
     Withdraw staking reward.
     """

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 """
+import functools
 
 import click
 from web3 import Web3
@@ -41,376 +42,575 @@ from nucypher.cli.types import (
 from nucypher.config.characters import StakeHolderConfiguration
 
 
-@click.command()
-@click.argument('action')
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--hw-wallet/--no-hw-wallet', default=False)  # TODO: Make True or deprecate.
-@click.option('--sync/--no-sync', default=True)
-@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
-@click.option('--poa', help="Inject POA middleware", is_flag=True)
-@click.option('--offline', help="Operate in offline mode", is_flag=True)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI i.e. 'file:///path/to/geth.ipc'", type=click.STRING)
-@click.option('--staking-address', help="Address to stake NU ERC20 tokens", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--worker-address', help="Address to assign as an Ursula-Worker", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--staking-reward/--no-staking-reward', is_flag=True, default=False)
-@click.option('--policy-reward/--no-policy-reward', is_flag=True, default=False)
-@click.option('--withdraw-address', help="Send reward collection to an alternate address", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--value', help="Token value of stake", type=click.INT)
-@click.option('--lock-periods', help="Duration of stake in periods.", type=click.INT)
-@click.option('--index', help="A specific stake index to resume", type=click.INT)
-@click.option('--enable/--disable', help="Used to enable and disable re-staking", is_flag=True, default=True)
-@click.option('--lock-until', help="Period to release re-staking lock", type=click.IntRange(min=0))
-@nucypher_click_config
-def stake(click_config,
-          action,
+# Args (poa, registry_filepath)
+def _admin_options(func):
+    @click.option('--poa', help="Inject POA middleware", is_flag=True)
+    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
 
-          config_root,
-          config_file,
 
-          # Mode
-          force,
-          offline,
-          hw_wallet,
+# Args (poa, registry_filepath, config_file, provider_uri, staking_address)
+def _api_options(func):
+    @_admin_options
+    @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI i.e. 'file:///path/to/geth.ipc'",
+                  type=click.STRING)
+    @click.option('--staking-address', help="Address to stake NU ERC20 tokens", type=EIP55_CHECKSUM_ADDRESS)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
 
-          # Blockchain
-          poa,
-          registry_filepath,
-          provider_uri,
-          sync,
+# Args (poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet)
+def _stake_options(func):
+    @_api_options
+    @click.option('--hw-wallet/--no-hw-wallet', default=False)  # TODO: Make True or deprecate.
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
 
-          # Stake
-          staking_address,
-          worker_address,
-          withdraw_address,
-          value,
-          lock_periods,
-          index,
-          policy_reward,
-          staking_reward,
-          enable,
-          lock_until,
+    return wrapper
 
-          ) -> None:
+# Args (poa, registry_filepath, config_file, provider_uri, staking_address, hw_wallet, worker_address)
+def _worker_options(func):
+    @_stake_options
+    @click.option('--worker-address', help="Address to assign as an Ursula-Worker", type=EIP55_CHECKSUM_ADDRESS)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@click.group()
+def stake():
     """
     Manage stakes and other staker-related operations.
+    """
+    pass
 
-    \b
-    Actions
-    -------------------------------------------------
-    init-stakeholder  Create a new stakeholder configuration
-    list              List active stakes for current stakeholder
-    accounts          Show ETH and NU balances for stakeholder's accounts
-    sync              Synchronize stake data with on-chain information
-    set-worker        Bond a worker to a staker
-    detach-worker     Detach worker currently bonded to a staker
-    init              Create a new stake
-    restake           Manage re-staking with --enable or --disable
-    divide            Create a new stake from part of an existing one
-    collect-reward    Withdraw staking reward
 
+@stake.command(name='init-stakeholder')
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI i.e. 'file:///path/to/geth.ipc'",
+              type=click.STRING, required=True)
+@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@_admin_options
+@nucypher_click_config
+def init_stakeholder(click_config,
+
+                     # Other (required)
+                     provider_uri,
+
+                     # Other
+                     config_root, force,
+
+                     # Admin Option
+                     poa,
+                     registry_filepath):
+    """
+    Create a new stakeholder configuration.
     """
 
-    # Banner
-    emitter = click_config.emitter
-    emitter.clear()
-    emitter.banner(StakeHolder.banner)
+    emitter = _setup_emitter(click_config)
+    new_stakeholder = StakeHolderConfiguration.generate(config_root=config_root,
+                                                        provider_uri=provider_uri,
+                                                        poa=poa,
+                                                        sync=False,
+                                                        registry_filepath=registry_filepath)
 
-    if action == 'init-stakeholder':
+    filepath = new_stakeholder.to_configuration_file(override=force)
+    emitter.echo(f"Wrote new stakeholder configuration to {filepath}", color='green')
 
-        if not provider_uri:
-            raise click.BadOptionUsage(option_name='--provider',
-                                       message="--provider is required to create a new stakeholder.")
 
-        new_stakeholder = StakeHolderConfiguration.generate(config_root=config_root,
-                                                            provider_uri=provider_uri,
-                                                            poa=poa,
-                                                            sync=False,
-                                                            registry_filepath=registry_filepath)
+@stake.command()
+@_api_options
+@nucypher_click_config
+def list(click_config,
 
-        filepath = new_stakeholder.to_configuration_file(override=force)
-        emitter.echo(f"Wrote new stakeholder configuration to {filepath}", color='green')
-        return  # Exit
+         # API Options
+         poa,
+         registry_filepath,
+         config_file,
+         provider_uri,
+         staking_address):
+    """
+    List active stakes for current stakeholder.
+    """
 
-    try:
-        stakeholder_config = StakeHolderConfiguration.from_configuration_file(filepath=config_file,
-                                                                              provider_uri=provider_uri,
-                                                                              poa=poa,
-                                                                              sync=False,
-                                                                              registry_filepath=registry_filepath)
-    except FileNotFoundError:
-        return actions.handle_missing_configuration_file(character_config_class=StakeHolderConfiguration,
-                                                         config_file=config_file)
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
 
-    #
-    # Make Stakeholder
-    #
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
 
-    STAKEHOLDER = stakeholder_config.produce(initial_address=staking_address)
-    blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)  # Eager connection
+    stakes = STAKEHOLDER.all_stakes
+    if not stakes:
+        emitter.echo(f"There are no active stakes")
+    else:
+        painting.paint_stakes(emitter=emitter, stakes=stakes)
+    return  # Exit
+
+
+@stake.command()
+@_api_options
+@nucypher_click_config
+def accounts(click_config,
+
+             # API Options
+             poa,
+             registry_filepath,
+             config_file,
+             provider_uri,
+             staking_address):
+    """
+    Show ETH and NU balances for stakeholder's accounts.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
+
+    for address, balances in STAKEHOLDER.wallet.balances.items():
+        emitter.echo(f"{address} | {Web3.fromWei(balances['ETH'], 'ether')} ETH | {NU.from_nunits(balances['NU'])}")
+
+
+@stake.command('set-worker')
+@_worker_options
+@nucypher_click_config
+def set_worker(click_config,
+
+               # Worker Options
+               poa,
+               registry_filepath,
+               config_file,
+               provider_uri,
+               staking_address,
+               hw_wallet,
+               worker_address):
+    """
+    Bond a worker to a staker.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
+
+    economics = STAKEHOLDER.economics
+
+    if not staking_address:
+        staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).staker_address
+
+    if not worker_address:
+        worker_address = click.prompt("Enter worker address", type=EIP55_CHECKSUM_ADDRESS)
+
+    # TODO: Check preconditions (e.g., minWorkerPeriods, already in use, etc)
+
+    password = None
+    if not hw_wallet and not blockchain.client.is_local:
+        password = get_client_password(checksum_address=staking_address)
+
+    STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+    receipt = STAKEHOLDER.set_worker(worker_address=worker_address)
+
+    # TODO: Double-check dates
+    current_period = STAKEHOLDER.staking_agent.get_current_period()
+    bonded_date = datetime_at_period(period=current_period, seconds_per_period=economics.seconds_per_period)
+    min_worker_periods = STAKEHOLDER.staking_agent.staking_parameters()[7]
+    release_period = current_period + min_worker_periods
+    release_date = datetime_at_period(period=release_period, seconds_per_period=economics.seconds_per_period)
+
+    emitter.echo(f"\nWorker {worker_address} successfully bonded to staker {staking_address}", color='green')
+    paint_receipt_summary(emitter=emitter,
+                          receipt=receipt,
+                          chain_name=blockchain.client.chain_name,
+                          transaction_type='set_worker')
+    emitter.echo(f"Bonded at period #{current_period} ({bonded_date})", color='green')
+    emitter.echo(f"This worker can be replaced or detached after period "
+                 f"#{release_period} ({release_date})", color='green')
+
+
+@stake.command('detach-worker')
+@_worker_options
+@nucypher_click_config
+def detach_worker(click_config,
+
+                  # Worker Options
+                  poa,
+                  registry_filepath,
+                  config_file,
+                  provider_uri,
+                  staking_address,
+                  hw_wallet,
+                  worker_address):
+    """
+    Detach worker currently bonded to a staker.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
+
+    economics = STAKEHOLDER.economics
+
+    if not staking_address:
+        staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).staker_address
+
+    if worker_address:
+        raise click.BadOptionUsage(message="detach-worker cannot be used together with --worker-address",
+                                   option_name='--worker-address')
+
+    # TODO: Check preconditions (e.g., minWorkerPeriods)
+
+    worker_address = STAKEHOLDER.staking_agent.get_worker_from_staker(staking_address)
+
+    password = None
+    if not hw_wallet and not blockchain.client.is_local:
+        password = get_client_password(checksum_address=staking_address)
+
+    # TODO: Create Stakeholder.detach_worker() and use it here
+    STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+    receipt = STAKEHOLDER.set_worker(worker_address=BlockchainInterface.NULL_ADDRESS)
+
+    # TODO: Double-check dates
+    current_period = STAKEHOLDER.staking_agent.get_current_period()
+    bonded_date = datetime_at_period(period=current_period, seconds_per_period=economics.seconds_per_period)
+
+    emitter.echo(f"Successfully detached worker {worker_address} from staker {staking_address}", color='green')
+    paint_receipt_summary(emitter=emitter,
+                          receipt=receipt,
+                          chain_name=blockchain.client.chain_name,
+                          transaction_type='detach_worker')
+    emitter.echo(f"Detached at period #{current_period} ({bonded_date})", color='green')
+
+
+@stake.command()
+@_stake_options
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@click.option('--value', help="Token value of stake", type=click.INT)
+@click.option('--lock-periods', help="Duration of stake in periods.", type=click.INT)
+@nucypher_click_config
+def create(click_config,
+
+           # Stake Options
+           poa,
+           registry_filepath,
+           config_file,
+           provider_uri,
+           staking_address,
+           hw_wallet,
+
+           # Other
+           force,
+           value,
+           lock_periods):
+    """
+    Initialize a new stake.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
+
     economics = STAKEHOLDER.economics
 
     # Dynamic click types (Economics)
     min_locked = economics.minimum_allowed_locked
     stake_value_range = click.FloatRange(min=NU.from_nunits(min_locked).to_tokens(), clamp=False)
     stake_duration_range = click.IntRange(min=economics.minimum_locked_periods, clamp=False)
+
+    #
+    # Get Staking Account
+    #
+
+    password = None
+    if not staking_address:
+        staking_address = select_client_account(prompt="Select staking account",
+                                                emitter=emitter,
+                                                provider_uri=STAKEHOLDER.wallet.blockchain.provider_uri)
+
+    if not hw_wallet and not blockchain.client.is_local:
+        password = click.prompt(f"Enter password to unlock {staking_address}",
+                                hide_input=True,
+                                confirmation_prompt=False)
+    #
+    # Stage Stake
+    #
+
+    if not value:
+        value = click.prompt(f"Enter stake value in NU",
+                             type=stake_value_range,
+                             default=NU.from_nunits(min_locked).to_tokens())
+    value = NU.from_tokens(value)
+
+    if not lock_periods:
+        prompt = f"Enter stake duration ({STAKEHOLDER.economics.minimum_locked_periods} periods minimum)"
+        lock_periods = click.prompt(prompt, type=stake_duration_range)
+
+    start_period = STAKEHOLDER.staking_agent.get_current_period()
+    end_period = start_period + lock_periods
+
+    #
+    # Review
+    #
+
+    if not force:
+        painting.paint_staged_stake(emitter=emitter,
+                                    stakeholder=STAKEHOLDER,
+                                    staking_address=staking_address,
+                                    stake_value=value,
+                                    lock_periods=lock_periods,
+                                    start_period=start_period,
+                                    end_period=end_period)
+
+        confirm_staged_stake(staker_address=staking_address, value=value, lock_periods=lock_periods)
+
+    # Last chance to bail
+    click.confirm("Publish staged stake to the blockchain?", abort=True)
+
+    # Execute
+    STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+    new_stake = STAKEHOLDER.initialize_stake(amount=value, lock_periods=lock_periods)
+
+    painting.paint_staking_confirmation(emitter=emitter,
+                                        ursula=STAKEHOLDER,
+                                        transactions=new_stake.transactions)
+
+
+@stake.command()
+@_stake_options
+@click.option('--enable/--disable', help="Used to enable and disable re-staking", is_flag=True, default=True)
+@click.option('--lock-until', help="Period to release re-staking lock", type=click.IntRange(min=0))
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@nucypher_click_config
+def restake(click_config,
+
+            # Stake Options
+            poa,
+            registry_filepath,
+            config_file,
+            provider_uri,
+            staking_address,
+            hw_wallet,
+
+            # Other
+            enable,
+            lock_until,
+            force):
+    """
+    Manage re-staking with --enable or --disable.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
+
+    # Authenticate
+    if not staking_address:
+        staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).staker_address
+    password = None
+    if not hw_wallet and not blockchain.client.is_local:
+        password = get_client_password(checksum_address=staking_address)
+    STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+
+    # Inner Exclusive Switch
+    if lock_until:
+        if not force:
+            confirm_enable_restaking_lock(emitter, staking_address=staking_address, release_period=lock_until)
+        receipt = STAKEHOLDER.enable_restaking_lock(release_period=lock_until)
+        emitter.echo(f'Successfully enabled re-staking lock for {staking_address} until {lock_until}',
+                     color='green', verbosity=1)
+    elif enable:
+        if not force:
+            confirm_enable_restaking(emitter, staking_address=staking_address)
+        receipt = STAKEHOLDER.enable_restaking()
+        emitter.echo(f'Successfully enabled re-staking for {staking_address}', color='green', verbosity=1)
+    else:
+        if not force:
+            click.confirm(f"Confirm disable re-staking for staker {staking_address}?", abort=True)
+        receipt = STAKEHOLDER.disable_restaking()
+        emitter.echo(f'Successfully disabled re-staking for {staking_address}', color='green', verbosity=1)
+
+    paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=blockchain.client.chain_name)
+
+
+@stake.command()
+@_stake_options
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@click.option('--value', help="Token value of stake", type=click.INT)
+@click.option('--lock-periods', help="Duration of stake in periods.", type=click.INT)
+@click.option('--index', help="A specific stake index to resume", type=click.INT)
+@nucypher_click_config
+def divide(click_config,
+
+           # Stake Options
+           poa,
+           registry_filepath,
+           config_file,
+           provider_uri,
+           staking_address,
+           hw_wallet,
+
+           # Other
+           force,
+           value,
+           lock_periods,
+           index):
+    """
+    Create a new stake from part of an existing one.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
+
+    economics = STAKEHOLDER.economics
+
+    # Dynamic click types (Economics)
+    min_locked = economics.minimum_allowed_locked
+    stake_value_range = click.FloatRange(min=NU.from_nunits(min_locked).to_tokens(), clamp=False)
     stake_extension_range = click.IntRange(min=1, max=economics.maximum_allowed_locked, clamp=False)
 
-    #
-    # Eager Actions
-    #
-
-    if action == 'list':
-        stakes = STAKEHOLDER.all_stakes
-        if not stakes:
-            emitter.echo(f"There are no active stakes")
-        else:
-            painting.paint_stakes(emitter=emitter, stakes=stakes)
-        return  # Exit
-
-    elif action == 'accounts':
-        for address, balances in STAKEHOLDER.wallet.balances.items():
-            emitter.echo(f"{address} | {Web3.fromWei(balances['ETH'], 'ether')} ETH | {NU.from_nunits(balances['NU'])}")
-        return  # Exit
-
-    elif action == 'set-worker':
-
-        if not staking_address:
-            staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).staker_address
-
-        if not worker_address:
-            worker_address = click.prompt("Enter worker address", type=EIP55_CHECKSUM_ADDRESS)
-
-        # TODO: Check preconditions (e.g., minWorkerPeriods, already in use, etc)
-
-        password = None
-        if not hw_wallet and not blockchain.client.is_local:
-            password = get_client_password(checksum_address=staking_address)
-
-        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
-        receipt = STAKEHOLDER.set_worker(worker_address=worker_address)
-
-        # TODO: Double-check dates
-        current_period = STAKEHOLDER.staking_agent.get_current_period()
-        bonded_date = datetime_at_period(period=current_period, seconds_per_period=economics.seconds_per_period)
-        min_worker_periods = STAKEHOLDER.staking_agent.staking_parameters()[7]
-        release_period = current_period + min_worker_periods
-        release_date = datetime_at_period(period=release_period, seconds_per_period=economics.seconds_per_period)
-
-        emitter.echo(f"\nWorker {worker_address} successfully bonded to staker {staking_address}", color='green')
-        paint_receipt_summary(emitter=emitter,
-                              receipt=receipt,
-                              chain_name=blockchain.client.chain_name,
-                              transaction_type='set_worker')
-        emitter.echo(f"Bonded at period #{current_period} ({bonded_date})", color='green')
-        emitter.echo(f"This worker can be replaced or detached after period "
-                     f"#{release_period} ({release_date})", color='green')
-        return  # Exit
-
-    elif action == 'detach-worker':
-
-        if not staking_address:
-            staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).staker_address
-
-        if worker_address:
-            raise click.BadOptionUsage(message="detach-worker cannot be used together with --worker-address",
-                                       option_name='--worker-address')
-
-        # TODO: Check preconditions (e.g., minWorkerPeriods)
-
-        worker_address = STAKEHOLDER.staking_agent.get_worker_from_staker(staking_address)
-
-        password = None
-        if not hw_wallet and not blockchain.client.is_local:
-            password = get_client_password(checksum_address=staking_address)
-
-        # TODO: Create Stakeholder.detach_worker() and use it here
-        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
-        receipt = STAKEHOLDER.set_worker(worker_address=BlockchainInterface.NULL_ADDRESS)
-
-        # TODO: Double-check dates
-        current_period = STAKEHOLDER.staking_agent.get_current_period()
-        bonded_date = datetime_at_period(period=current_period, seconds_per_period=economics.seconds_per_period)
-
-        emitter.echo(f"Successfully detached worker {worker_address} from staker {staking_address}", color='green')
-        paint_receipt_summary(emitter=emitter,
-                              receipt=receipt,
-                              chain_name=blockchain.client.chain_name,
-                              transaction_type='detach_worker')
-        emitter.echo(f"Detached at period #{current_period} ({bonded_date})", color='green')
-        return  # Exit
-
-    elif action == 'create':
-        """Initialize a new stake"""
-
-        #
-        # Get Staking Account
-        #
-
-        password = None
-        if not staking_address:
-            staking_address = select_client_account(prompt="Select staking account",
-                                                    emitter=emitter,
-                                                    provider_uri=STAKEHOLDER.wallet.blockchain.provider_uri)
-
-        if not hw_wallet and not blockchain.client.is_local:
-            password = click.prompt(f"Enter password to unlock {staking_address}",
-                                    hide_input=True,
-                                    confirmation_prompt=False)
-        #
-        # Stage Stake
-        #
-
-        if not value:
-            value = click.prompt(f"Enter stake value in NU",
-                                 type=stake_value_range,
-                                 default=NU.from_nunits(min_locked).to_tokens())
-        value = NU.from_tokens(value)
-
-        if not lock_periods:
-            prompt = f"Enter stake duration ({STAKEHOLDER.economics.minimum_locked_periods} periods minimum)"
-            lock_periods = click.prompt(prompt, type=stake_duration_range)
-
-        start_period = STAKEHOLDER.staking_agent.get_current_period()
-        end_period = start_period + lock_periods
-
-        #
-        # Review
-        #
-
-        if not force:
-            painting.paint_staged_stake(emitter=emitter,
-                                        stakeholder=STAKEHOLDER,
-                                        staking_address=staking_address,
-                                        stake_value=value,
-                                        lock_periods=lock_periods,
-                                        start_period=start_period,
-                                        end_period=end_period)
-
-            confirm_staged_stake(staker_address=staking_address, value=value, lock_periods=lock_periods)
-
-        # Last chance to bail
-        click.confirm("Publish staged stake to the blockchain?", abort=True)
-
-        # Execute
-        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
-        new_stake = STAKEHOLDER.initialize_stake(amount=value, lock_periods=lock_periods)
-
-        painting.paint_staking_confirmation(emitter=emitter,
-                                            ursula=STAKEHOLDER,
-                                            transactions=new_stake.transactions)
-        return  # Exit
-
-    elif action == "restake":
-
-        # Authenticate
-        if not staking_address:
-            staking_address = select_stake(stakeholder=STAKEHOLDER, emitter=emitter).staker_address
-        password = None
-        if not hw_wallet and not blockchain.client.is_local:
-            password = get_client_password(checksum_address=staking_address)
-        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
-
-        # Inner Exclusive Switch
-        if lock_until:
-            if not force:
-                confirm_enable_restaking_lock(emitter, staking_address=staking_address, release_period=lock_until)
-            receipt = STAKEHOLDER.enable_restaking_lock(release_period=lock_until)
-            emitter.echo(f'Successfully enabled re-staking lock for {staking_address} until {lock_until}',
-                         color='green', verbosity=1)
-        elif enable:
-            if not force:
-                confirm_enable_restaking(emitter, staking_address=staking_address)
-            receipt = STAKEHOLDER.enable_restaking()
-            emitter.echo(f'Successfully enabled re-staking for {staking_address}', color='green', verbosity=1)
-        else:
-            if not force:
-                click.confirm(f"Confirm disable re-staking for staker {staking_address}?", abort=True)
-            receipt = STAKEHOLDER.disable_restaking()
-            emitter.echo(f'Successfully disabled re-staking for {staking_address}', color='green', verbosity=1)
-
-        paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=blockchain.client.chain_name)
-        return  # Exit
-
-    elif action == 'divide':
-        """Divide an existing stake by specifying the new target value and end period"""
-
-        if staking_address and index is not None:  # 0 is valid.
-            current_stake = STAKEHOLDER.stakes[index]
-        else:
-            current_stake = select_stake(stakeholder=STAKEHOLDER, emitter=emitter)
-
-        #
-        # Stage Stake
-        #
-
-        # Value
-        if not value:
-            value = click.prompt(f"Enter target value (must be less than or equal to {str(current_stake.value)})",
-                                 type=stake_value_range)
-        value = NU(value, 'NU')
-
-        # Duration
-        if not lock_periods:
-            extension = click.prompt("Enter number of periods to extend", type=stake_extension_range)
-        else:
-            extension = lock_periods
-
-        if not force:
-            painting.paint_staged_stake_division(emitter=emitter,
-                                                 stakeholder=STAKEHOLDER,
-                                                 original_stake=current_stake,
-                                                 target_value=value,
-                                                 extension=extension)
-            click.confirm("Is this correct?", abort=True)
-
-        # Execute
-        password = None
-        if not hw_wallet and not blockchain.client.is_local:
-            password = get_client_password(checksum_address=current_stake.staker_address)
-
-        STAKEHOLDER.assimilate(checksum_address=current_stake.staker_address, password=password)
-        modified_stake, new_stake = STAKEHOLDER.divide_stake(stake_index=current_stake.index,
-                                                             target_value=value,
-                                                             additional_periods=extension)
-        emitter.echo('Successfully divided stake', color='green', verbosity=1)
-        paint_receipt_summary(emitter=emitter,
-                              receipt=new_stake.receipt,
-                              chain_name=blockchain.client.chain_name)
-
-        # Show the resulting stake list
-        painting.paint_stakes(emitter=emitter, stakes=STAKEHOLDER.stakes)
-        return  # Exit
-
-    elif action == 'collect-reward':
-        """Withdraw staking reward to the specified wallet address"""
-
-        password = None
-        if not hw_wallet and not blockchain.client.is_local:
-            password = get_client_password(checksum_address=staking_address)
-
-        if not staking_reward and not policy_reward:
-            raise click.BadArgumentUsage(f"Either --staking-reward or --policy-reward must be True to collect rewards.")
-
-        STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
-        if staking_reward:
-            # Note: Sending staking / inflation rewards to another account is not allowed.
-            staking_receipt = STAKEHOLDER.collect_staking_reward()
-            paint_receipt_summary(receipt=staking_receipt,
-                                  chain_name=STAKEHOLDER.wallet.blockchain.client.chain_name,
-                                  emitter=emitter)
-
-        if policy_reward:
-            policy_receipt = STAKEHOLDER.collect_policy_reward(collector_address=withdraw_address)
-            paint_receipt_summary(receipt=policy_receipt,
-                                  chain_name=STAKEHOLDER.wallet.blockchain.client.chain_name,
-                                  emitter=emitter)
-
-        return  # Exit
-
-    # Catch-All for unknown actions
+    if staking_address and index is not None:  # 0 is valid.
+        current_stake = STAKEHOLDER.stakes[index]
     else:
-        ctx = click.get_current_context()
-        raise click.UsageError(message=f"Unknown action '{action}'.", ctx=ctx)
+        current_stake = select_stake(stakeholder=STAKEHOLDER, emitter=emitter)
 
+    #
+    # Stage Stake
+    #
+
+    # Value
+    if not value:
+        value = click.prompt(f"Enter target value (must be less than or equal to {str(current_stake.value)})",
+                             type=stake_value_range)
+    value = NU(value, 'NU')
+
+    # Duration
+    if not lock_periods:
+        extension = click.prompt("Enter number of periods to extend", type=stake_extension_range)
+    else:
+        extension = lock_periods
+
+    if not force:
+        painting.paint_staged_stake_division(emitter=emitter,
+                                             stakeholder=STAKEHOLDER,
+                                             original_stake=current_stake,
+                                             target_value=value,
+                                             extension=extension)
+        click.confirm("Is this correct?", abort=True)
+
+    # Execute
+    password = None
+    if not hw_wallet and not blockchain.client.is_local:
+        password = get_client_password(checksum_address=current_stake.staker_address)
+
+    STAKEHOLDER.assimilate(checksum_address=current_stake.staker_address, password=password)
+    modified_stake, new_stake = STAKEHOLDER.divide_stake(stake_index=current_stake.index,
+                                                         target_value=value,
+                                                         additional_periods=extension)
+    emitter.echo('Successfully divided stake', color='green', verbosity=1)
+    paint_receipt_summary(emitter=emitter,
+                          receipt=new_stake.receipt,
+                          chain_name=blockchain.client.chain_name)
+
+    # Show the resulting stake list
+    painting.paint_stakes(emitter=emitter, stakes=STAKEHOLDER.stakes)
+
+
+@stake.command('collect-reward')
+@_stake_options
+@click.option('--staking-reward/--no-staking-reward', is_flag=True, default=False)
+@click.option('--policy-reward/--no-policy-reward', is_flag=True, default=False)
+@click.option('--withdraw-address', help="Send reward collection to an alternate address", type=EIP55_CHECKSUM_ADDRESS)
+@nucypher_click_config
+def collect_reward(click_config,
+
+                   # API Options
+                   poa,
+                   registry_filepath,
+                   config_file,
+                   provider_uri,
+                   staking_address,
+                   hw_wallet,
+
+                   # Other
+                   staking_reward,
+                   policy_reward,
+                   withdraw_address):
+    """
+    Withdraw staking reward.
+    """
+
+    ### Setup ###
+    emitter = _setup_emitter(click_config)
+
+    STAKEHOLDER, blockchain = _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address)
+    #############
+
+    password = None
+    if not hw_wallet and not blockchain.client.is_local:
+        password = get_client_password(checksum_address=staking_address)
+
+    if not staking_reward and not policy_reward:
+        raise click.BadArgumentUsage(f"Either --staking-reward or --policy-reward must be True to collect rewards.")
+
+    STAKEHOLDER.assimilate(checksum_address=staking_address, password=password)
+    if staking_reward:
+        # Note: Sending staking / inflation rewards to another account is not allowed.
+        staking_receipt = STAKEHOLDER.collect_staking_reward()
+        paint_receipt_summary(receipt=staking_receipt,
+                              chain_name=STAKEHOLDER.wallet.blockchain.client.chain_name,
+                              emitter=emitter)
+
+    if policy_reward:
+        policy_receipt = STAKEHOLDER.collect_policy_reward(collector_address=withdraw_address)
+        paint_receipt_summary(receipt=policy_receipt,
+                              chain_name=STAKEHOLDER.wallet.blockchain.client.chain_name,
+                              emitter=emitter)
+
+
+def _setup_emitter(click_config):
+    # Banner
+    emitter = click_config.emitter
+    emitter.clear()
+    emitter.banner(StakeHolder.banner)
+
+    return emitter
+
+
+def _get_stakeholder_config(config_file, provider_uri, poa, registry_filepath):
+    try:
+        stakeholder_config = StakeHolderConfiguration.from_configuration_file(filepath=config_file,
+                                                                              provider_uri=provider_uri,
+                                                                              poa=poa,
+                                                                              sync=False,
+                                                                              registry_filepath=registry_filepath)
+
+        return stakeholder_config
+    except FileNotFoundError:
+        return actions.handle_missing_configuration_file(character_config_class=StakeHolderConfiguration,
+                                                         config_file=config_file)
+
+
+def _create_stakeholder(config_file, provider_uri, poa, registry_filepath, staking_address):
+    stakeholder_config = _get_stakeholder_config(config_file, provider_uri, poa, registry_filepath)
+    stakeholder = stakeholder_config.produce(initial_address=staking_address)
+    blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)  # Eager connection
+
+    return stakeholder, blockchain

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -15,14 +15,12 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 """
-
+import functools
 
 import click
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 from twisted.internet import stdio
 
-from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainInterfaceFactory
-from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.utils import datetime_at_period
 from nucypher.characters.banners import URSULA_BANNER
 from nucypher.cli import actions, painting
@@ -45,78 +43,465 @@ from nucypher.utilities.sandbox.constants import (
 )
 
 
-@click.command()
-@click.argument('action')
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+# Args (geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
+#       rest_port, db_filepath, poa)
+def _admin_options(func):
+    @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+    @click.option('--network', help="Network Domain Name", type=click.STRING)
+    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+    @click.option('--staker-address', help="Run on behalf of a specified staking account", type=EIP55_CHECKSUM_ADDRESS)
+    @click.option('--worker-address', help="Run the worker-ursula with a specified address",
+                  type=EIP55_CHECKSUM_ADDRESS)
+    @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
+    @click.option('--rest-host', help="The host IP address to run Ursula network services on", type=click.STRING)
+    @click.option('--rest-port', help="The host port to run Ursula network services on", type=NETWORK_PORT)
+    @click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
+    @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+# Args (geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
+#       rest_port, db_filepath, poa, config_file, dev, lonely, teacher_uri, min_stake)
+def _api_options(func):
+    @_admin_options
+    @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+    @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+    @click.option('--lonely', help="Do not connect to seednodes", is_flag=True)
+    @click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
+    @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT,
+                  default=0)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@click.group()
+def ursula():
+    """
+    "Ursula the Untrusted" PRE Re-encryption node management commands.
+    """
+
+    pass
+
+
+@ursula.command()
+@_admin_options
 @click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
-@click.option('--lonely', help="Do not connect to seednodes", is_flag=True)
-@click.option('--network', help="Network Domain Name", type=click.STRING)
-@click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-@click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT, default=0)
-@click.option('--rest-host', help="The host IP address to run Ursula network services on", type=click.STRING)
-@click.option('--rest-port', help="The host port to run Ursula network services on", type=NETWORK_PORT)
-@click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
-@click.option('--staker-address', help="Run on behalf of a specified staking account", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--worker-address', help="Run the worker-ursula with a specified address", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
-@click.option('--interactive', '-I', help="Launch command interface after connecting to seednodes.", is_flag=True, default=False)
 @click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
-@click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
-@click.option('--sync/--no-sync', default=False)
 @nucypher_click_config
-def ursula(click_config,
-           action,
-           dev,
-           dry_run,
-           force,
-           lonely,
+def init(click_config,
+
+         # Admin Options
+         geth,
+         provider_uri,
+         network,
+         registry_filepath,
+         staker_address,
+         worker_address,
+         federated_only,
+         rest_host,
+         rest_port,
+         db_filepath,
+         poa,
+
+         # Other
+         force, config_root):
+    """
+    Create a new Ursula node configuration.
+    """
+
+    ### Setup ###
+    _validate_args(geth, federated_only, staker_address, registry_filepath)
+
+    emitter = _setup_emitter(click_config, worker_address)
+
+    _pre_launch_warnings(emitter, dev=None, force=force)
+
+    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
+    if geth:
+        ETH_NODE = actions.get_provider_process()
+        provider_uri = ETH_NODE.provider_uri(scheme='file')
+    #############
+
+    if (not staker_address or not worker_address) and not federated_only:
+        if not staker_address:
+            prompt = "Select staker account"
+            staker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=provider_uri)
+
+        if not worker_address:
+            prompt = "Select worker account"
+            worker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=provider_uri)
+    if not config_root:  # Flag
+        config_root = click_config.config_file  # Envvar
+    if not rest_host:
+        rest_host = actions.determine_external_ip_address(emitter, force=force)
+    ursula_config = UrsulaConfiguration.generate(password=get_nucypher_password(confirm=True),
+                                                 config_root=config_root,
+                                                 rest_host=rest_host,
+                                                 rest_port=rest_port,
+                                                 db_filepath=db_filepath,
+                                                 domains={network} if network else None,
+                                                 federated_only=federated_only,
+                                                 checksum_address=staker_address,
+                                                 worker_address=worker_address,
+                                                 registry_filepath=registry_filepath,
+                                                 provider_process=ETH_NODE,
+                                                 provider_uri=provider_uri,
+                                                 poa=poa)
+    painting.paint_new_installation_help(emitter, new_configuration=ursula_config)
+
+
+@ursula.command()
+@_admin_options
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@nucypher_click_config
+def destroy(click_config,
+
+            # Admin Options
+            geth,
+            provider_uri,
+            network,
+            registry_filepath,
+            staker_address,
+            worker_address,
+            federated_only,
+            rest_host,
+            rest_port,
+            db_filepath,
+            poa,
+
+            # Other
+            config_file, force, dev):
+    """
+    Delete Ursula node configuration.
+    """
+
+    ### Setup ###
+    _validate_args(geth, federated_only, staker_address, registry_filepath)
+
+    emitter = _setup_emitter(click_config, worker_address)
+
+    _pre_launch_warnings(emitter, dev=dev, force=force)
+
+    ursula_config, provider_uri = _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev,
+                                                     config_file, staker_address, worker_address, federated_only,
+                                                     rest_host, rest_port, db_filepath, poa)
+    #############
+
+    actions.destroy_configuration(emitter, character_config=ursula_config, force=force)
+
+
+@ursula.command()
+@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@nucypher_click_config
+def forget(click_config,
+
+           # Admin Options
+           geth,
+           provider_uri,
            network,
-           teacher_uri,
-           min_stake,
-           rest_host,
-           rest_port,
-           db_filepath,
+           registry_filepath,
            staker_address,
            worker_address,
            federated_only,
+           rest_host,
+           rest_port,
+           db_filepath,
            poa,
-           config_root,
-           config_file,
-           provider_uri,
-           geth,
-           registry_filepath,
-           interactive,
-           sync,
-           ) -> None:
+
+           # Other
+           config_file,  dev):
     """
-    "Ursula the Untrusted" PRE Re-encryption node management commands.
+    Forget all known nodes.
+    """
+    ### Setup ###
+    _validate_args(geth, federated_only, staker_address, registry_filepath)
 
-    \b
-    Actions
-    -------------------------------------------------
-    \b
-    init              Create a new Ursula node configuration.
-    view              View the Ursula node's configuration.
-    run               Run an "Ursula" node.
-    save-metadata     Manually write node metadata to disk without running
-    forget            Forget all known nodes.
-    destroy           Delete Ursula node configuration.
-    confirm-activity  Manually confirm-activity for the current period.
+    emitter = _setup_emitter(click_config, worker_address)
 
+    _pre_launch_warnings(emitter, dev=dev, force=None)
+
+    ursula_config, provider_uri = _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev,
+                                                     config_file, staker_address, worker_address, federated_only,
+                                                     rest_host, rest_port, db_filepath, poa)
+    #############
+
+    actions.forget(emitter, configuration=ursula_config)
+
+
+@ursula.command()
+@_api_options
+@click.option('--interactive', '-I', help="Launch command interface after connecting to seednodes.", is_flag=True,
+              default=False)
+@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+@nucypher_click_config
+def run(click_config,
+
+        # API Options
+        geth,
+        provider_uri,
+        network,
+        registry_filepath,
+        staker_address,
+        worker_address,
+        federated_only,
+        rest_host,
+        rest_port,
+        db_filepath,
+        poa,
+        config_file,
+        dev,
+        lonely,
+        teacher_uri,
+        min_stake,
+
+        # Other
+        interactive, dry_run):
+    """
+    Run an "Ursula" node.
     """
 
+    ### Setup ###
+    _validate_args(geth, federated_only, staker_address, registry_filepath)
+
+    emitter = _setup_emitter(click_config, worker_address)
+
+    _pre_launch_warnings(emitter, dev=dev, force=None)
+
+    ursula_config, provider_uri = _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev,
+                                                     config_file, staker_address, worker_address, federated_only,
+                                                     rest_host, rest_port, db_filepath, poa)
+    #############
+
+    URSULA = _create_ursula(ursula_config, click_config, dev, emitter, lonely, teacher_uri, min_stake)
+
+    # GO!
+    try:
+
+        # Ursula Deploy Warnings
+        emitter.message(
+            f"Starting Ursula on {URSULA.rest_interface}",
+            color='green',
+            bold=True)
+
+        emitter.message(
+            f"Connecting to {','.join(ursula_config.domains)}",
+            color='green',
+            bold=True)
+
+        emitter.message(
+            "Working ~ Keep Ursula Online!",
+            color='blue',
+            bold=True)
+
+        if interactive:
+            stdio.StandardIO(UrsulaCommandProtocol(ursula=URSULA, emitter=emitter))
+
+        if dry_run:
+            return  # <-- ABORT - (Last Chance)
+
+        # Run - Step 3
+        node_deployer = URSULA.get_deployer()
+        node_deployer.addServices()
+        node_deployer.catalogServers(node_deployer.hendrix)
+        node_deployer.run()  # <--- Blocking Call (Reactor)
+
+    # Handle Crash
+    except Exception as e:
+        ursula_config.log.critical(str(e))
+        emitter.message(
+            f"{e.__class__.__name__} {e}",
+            color='red',
+            bold=True)
+        raise  # Crash :-(
+
+    # Graceful Exit
+    finally:
+        emitter.message("Stopping Ursula", color='green')
+        ursula_config.cleanup()
+        emitter.message("Ursula Stopped", color='red')
+
+
+@ursula.command(name='save-metadata')
+@_api_options
+@nucypher_click_config
+def save_metadata(click_config,
+
+                  # API Options
+                  geth,
+                  provider_uri,
+                  network,
+                  registry_filepath,
+                  staker_address,
+                  worker_address,
+                  federated_only,
+                  rest_host,
+                  rest_port,
+                  db_filepath,
+                  poa,
+                  config_file,
+                  dev,
+                  lonely,
+                  teacher_uri,
+                  min_stake
+                  ):
+    """
+    Manually write node metadata to disk without running.
+    """
+    ### Setup ###
+    _validate_args(geth, federated_only, staker_address, registry_filepath)
+
+    emitter = _setup_emitter(click_config, worker_address)
+
+    _pre_launch_warnings(emitter, dev=dev, force=None)
+
+    ursula_config, provider_uri = _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev,
+                                                     config_file, staker_address, worker_address, federated_only,
+                                                     rest_host, rest_port, db_filepath, poa)
+    #############
+
+    URSULA = _create_ursula(ursula_config, click_config, dev, emitter, lonely, teacher_uri, min_stake)
+
+    metadata_path = ursula.write_node_metadata(node=URSULA)
+    emitter.message(f"Successfully saved node metadata to {metadata_path}.", color='green')
+
+
+@ursula.command()
+@_api_options
+@nucypher_click_config
+def view(click_config,
+
+         # API Options
+         geth,
+         provider_uri,
+         network,
+         registry_filepath,
+         staker_address,
+         worker_address,
+         federated_only,
+         rest_host,
+         rest_port,
+         db_filepath,
+         poa,
+         config_file,
+         dev,
+         lonely,
+         teacher_uri,
+         min_stake
+         ):
+    """
+    View the Ursula node's configuration.
+    """
+
+    ### Setup ###
+    _validate_args(geth, federated_only, staker_address, registry_filepath)
+
+    emitter = _setup_emitter(click_config, worker_address)
+
+    _pre_launch_warnings(emitter, dev=dev, force=None)
+
+    ursula_config, provider_uri = _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev,
+                                                     config_file, staker_address, worker_address, federated_only,
+                                                     rest_host, rest_port, db_filepath, poa)
+    #############
+
+    URSULA = _create_ursula(ursula_config, click_config, dev, emitter, lonely, teacher_uri, min_stake)
+
+    if not URSULA.federated_only:
+        blockchain = URSULA.staking_agent.blockchain
+
+        emitter.echo("BLOCKCHAIN ----------\n")
+        painting.paint_contract_status(emitter=emitter, registry=URSULA.registry)
+        current_block = blockchain.w3.eth.blockNumber
+        emitter.echo(f'Block # {current_block}')
+        # TODO: 1231
+        emitter.echo(f'NU Balance (staker): {URSULA.token_balance}')
+        emitter.echo(f'ETH Balance (worker): {blockchain.client.get_balance(URSULA.worker_address)}')
+        emitter.echo(f'Current Gas Price {blockchain.client.gas_price}')
+
+    emitter.echo("CONFIGURATION --------")
+    response = UrsulaConfiguration._read_configuration_file(filepath=config_file or ursula_config.config_file_location)
+    return emitter.ipc(response=response, request_id=0, duration=0)  # FIXME: what are request_id and duration here?
+
+
+@ursula.command(name='confirm-activity')
+@_api_options
+@nucypher_click_config
+def confirm_activity(click_config,
+
+                     # API Options
+                     geth,
+                     provider_uri,
+                     network,
+                     registry_filepath,
+                     staker_address,
+                     worker_address,
+                     federated_only,
+                     rest_host,
+                     rest_port,
+                     db_filepath,
+                     poa,
+                     config_file,
+                     dev,
+                     lonely,
+                     teacher_uri,
+                     min_stake
+                     ):
+    """
+    Manually confirm-activity for the current period.
+    """
+
+    ### Setup ###
+    _validate_args(geth, federated_only, staker_address, registry_filepath)
+
+    emitter = _setup_emitter(click_config, worker_address)
+
+    _pre_launch_warnings(emitter, dev=dev, force=None)
+
+    ursula_config, provider_uri = _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev,
+                                                     config_file, staker_address, worker_address, federated_only,
+                                                     rest_host, rest_port, db_filepath, poa)
+    #############
+
+    URSULA = _create_ursula(ursula_config, click_config, dev, emitter, lonely, teacher_uri, min_stake)
+
+    receipt = URSULA.confirm_activity()
+
+    confirmed_period = URSULA.staking_agent.get_current_period() + 1
+    date = datetime_at_period(period=confirmed_period,
+                              seconds_per_period=URSULA.economics.seconds_per_period)
+
+    # TODO: Double-check dates here
+    emitter.echo(f'\nActivity confirmed for period #{confirmed_period} '
+                 f'(starting at {date})', bold=True, color='blue')
+    painting.paint_receipt_summary(emitter=emitter,
+                                   receipt=receipt,
+                                   chain_name=URSULA.staking_agent.blockchain.client.chain_name)
+
+    # TODO: Check ActivityConfirmation event (see #1193)
+
+
+def _setup_emitter(click_config, worker_address):
+    # Banner
     emitter = click_config.emitter
+    emitter.clear()
+    emitter.banner(URSULA_BANNER.format(worker_address or ''))
 
+    return emitter
+
+
+def _validate_args(geth, federated_only, staker_address, registry_filepath):
     #
     # Validate
     #
-
     if federated_only:
         # TODO: consider rephrasing in a more universal voice.
         if geth:
@@ -131,73 +516,21 @@ def ursula(click_config,
             raise click.BadOptionUsage(option_name="--registry-filepath",
                                        message=f"--registry-filepath cannot be used in federated mode.")
 
-    # Banner
-    emitter.banner(URSULA_BANNER.format(worker_address or ''))
 
-    #
-    # Pre-Launch Warnings
-    #
-
+def _pre_launch_warnings(emitter, dev, force):
     if dev:
         emitter.echo("WARNING: Running in Development mode", color='yellow', verbosity=1)
     if force:
         emitter.echo("WARNING: Force is enabled", color='yellow', verbosity=1)
 
-    #
-    # Internal Ethereum Client
-    #
+
+def _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev, config_file,
+                       staker_address, worker_address, federated_only, rest_host, rest_port, db_filepath, poa):
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
     if geth:
         ETH_NODE = actions.get_provider_process()
         provider_uri = ETH_NODE.provider_uri(scheme='file')
-
-    #
-    # Eager Actions
-    #
-
-    if action == "init":
-        """Create a brand-new persistent Ursula"""
-
-        if dev:
-            raise click.BadArgumentUsage("Cannot create a persistent development character")
-
-        if (not staker_address or not worker_address) and not federated_only:
-
-            if not staker_address:
-                prompt = "Select staker account"
-                staker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=provider_uri)
-
-            if not worker_address:
-                prompt = "Select worker account"
-                worker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=provider_uri)
-
-        if not config_root:                         # Flag
-            config_root = click_config.config_file  # Envvar
-
-        if not rest_host:
-            rest_host = actions.determine_external_ip_address(emitter, force=force)
-
-        ursula_config = UrsulaConfiguration.generate(password=get_nucypher_password(confirm=True),
-                                                     config_root=config_root,
-                                                     rest_host=rest_host,
-                                                     rest_port=rest_port,
-                                                     db_filepath=db_filepath,
-                                                     domains={network} if network else None,
-                                                     federated_only=federated_only,
-                                                     checksum_address=staker_address,
-                                                     worker_address=worker_address,
-                                                     registry_filepath=registry_filepath,
-                                                     provider_process=ETH_NODE,
-                                                     provider_uri=provider_uri,
-                                                     poa=poa)
-
-        painting.paint_new_installation_help(emitter, new_configuration=ursula_config)
-        return
-
-    #
-    # Make Ursula
-    #
 
     if dev:
         ursula_config = UrsulaConfiguration(dev_mode=True,
@@ -232,23 +565,10 @@ def ursula(click_config,
             # TODO: Exit codes (not only for this, but for other exceptions)
             return click.get_current_context().exit(1)
 
-    #
-    # Configured Pre-Authentication Actions
-    #
+    return ursula_config, provider_uri
 
-    # Handle destruction and forget *before* network bootstrap and character initialization below
-    if action == "destroy":
-        """Delete all configuration files from the disk"""
-        if dev:
-            message = "'nucypher ursula destroy' cannot be used in --dev mode - There is nothing to destroy."
-            raise click.BadOptionUsage(option_name='--dev', message=message)
-        actions.destroy_configuration(emitter, character_config=ursula_config, force=force)
-        return
 
-    elif action == "forget":
-        actions.forget(emitter, configuration=ursula_config)
-        return
-
+def _create_ursula(ursula_config, click_config, dev, emitter, lonely, teacher_uri, min_stake):
     #
     # Make Ursula
     #
@@ -267,110 +587,9 @@ def ursula(click_config,
                                             dev=dev,
                                             lonely=lonely,
                                             client_password=client_password)
+
+        return URSULA
     except NucypherKeyring.AuthenticationFailed as e:
         emitter.echo(str(e), color='red', bold=True)
         # TODO: Exit codes (not only for this, but for other exceptions)
         return click.get_current_context().exit(1)
-
-    #
-    # Authenticated Action Switch
-    #
-
-    if action == 'run':
-        """Seed, Produce, Run!"""
-
-        # GO!
-        try:
-
-            # Ursula Deploy Warnings
-            emitter.message(
-                f"Starting Ursula on {URSULA.rest_interface}",
-                color='green',
-                bold=True)
-
-            emitter.message(
-                f"Connecting to {','.join(ursula_config.domains)}",
-                color='green',
-                bold=True)
-
-            emitter.message(
-                "Working ~ Keep Ursula Online!",
-                color='blue',
-                bold=True)
-
-            if interactive:
-                stdio.StandardIO(UrsulaCommandProtocol(ursula=URSULA, emitter=emitter))
-
-            if dry_run:
-                return  # <-- ABORT - (Last Chance)
-
-            # Run - Step 3
-            node_deployer = URSULA.get_deployer()
-            node_deployer.addServices()
-            node_deployer.catalogServers(node_deployer.hendrix)
-            node_deployer.run()   # <--- Blocking Call (Reactor)
-
-        # Handle Crash
-        except Exception as e:
-            ursula_config.log.critical(str(e))
-            emitter.message(
-                f"{e.__class__.__name__} {e}",
-                color='red',
-                bold=True)
-            raise  # Crash :-(
-
-        # Graceful Exit
-        finally:
-            emitter.message("Stopping Ursula", color='green')
-            ursula_config.cleanup()
-            emitter.message("Ursula Stopped", color='red')
-        return
-
-    elif action == "save-metadata":
-        """Manually save a node self-metadata file"""
-        metadata_path = ursula.write_node_metadata(node=URSULA)
-        emitter.message(f"Successfully saved node metadata to {metadata_path}.", color='green')
-        return
-
-    elif action == "view":
-        """Paint an existing configuration to the console"""
-
-        if not URSULA.federated_only:
-            blockchain = URSULA.staking_agent.blockchain
-
-            emitter.echo("BLOCKCHAIN ----------\n")
-            painting.paint_contract_status(emitter=emitter, registry=URSULA.registry)
-            current_block = blockchain.w3.eth.blockNumber
-            emitter.echo(f'Block # {current_block}')
-            # TODO: 1231
-            emitter.echo(f'NU Balance (staker): {URSULA.token_balance}')
-            emitter.echo(f'ETH Balance (worker): {blockchain.client.get_balance(URSULA.worker_address)}')
-            emitter.echo(f'Current Gas Price {blockchain.client.gas_price}')
-
-        emitter.echo("CONFIGURATION --------")
-        response = UrsulaConfiguration._read_configuration_file(filepath=config_file or ursula_config.config_file_location)
-        return emitter.ipc(response=response, request_id=0, duration=0)  # FIXME: what are request_id and duration here?
-
-    elif action == "forget":
-        actions.forget(emitter, configuration=ursula_config)
-        return
-
-    elif action == 'confirm-activity':
-        receipt = URSULA.confirm_activity()
-
-        confirmed_period = URSULA.staking_agent.get_current_period() + 1
-        date = datetime_at_period(period=confirmed_period,
-                                  seconds_per_period=URSULA.economics.seconds_per_period)
-
-        # TODO: Double-check dates here
-        emitter.echo(f'\nActivity confirmed for period #{confirmed_period} '
-                     f'(starting at {date})', bold=True, color='blue')
-        painting.paint_receipt_summary(emitter=emitter,
-                                       receipt=receipt,
-                                       chain_name=URSULA.staking_agent.blockchain.client.chain_name)
-
-        # TODO: Check ActivityConfirmation event (see #1193)
-        return
-
-    else:
-        raise click.BadArgumentUsage("No such argument {}".format(action))

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -97,17 +97,8 @@ def ursula():
 def init(click_config,
 
          # Admin Options
-         geth,
-         provider_uri,
-         network,
-         registry_filepath,
-         staker_address,
-         worker_address,
-         federated_only,
-         rest_host,
-         rest_port,
-         db_filepath,
-         poa,
+         geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
+         rest_port, db_filepath, poa,
 
          # Other
          force, config_root):
@@ -165,17 +156,8 @@ def init(click_config,
 def destroy(click_config,
 
             # Admin Options
-            geth,
-            provider_uri,
-            network,
-            registry_filepath,
-            staker_address,
-            worker_address,
-            federated_only,
-            rest_host,
-            rest_port,
-            db_filepath,
-            poa,
+            geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
+            rest_port, db_filepath, poa,
 
             # Other
             config_file, force, dev):
@@ -206,17 +188,8 @@ def destroy(click_config,
 def forget(click_config,
 
            # Admin Options
-           geth,
-           provider_uri,
-           network,
-           registry_filepath,
-           staker_address,
-           worker_address,
-           federated_only,
-           rest_host,
-           rest_port,
-           db_filepath,
-           poa,
+           geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
+           rest_port, db_filepath, poa,
 
            # Other
            config_file,  dev):
@@ -247,22 +220,8 @@ def forget(click_config,
 def run(click_config,
 
         # API Options
-        geth,
-        provider_uri,
-        network,
-        registry_filepath,
-        staker_address,
-        worker_address,
-        federated_only,
-        rest_host,
-        rest_port,
-        db_filepath,
-        poa,
-        config_file,
-        dev,
-        lonely,
-        teacher_uri,
-        min_stake,
+        geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
+        rest_port, db_filepath, poa, config_file, dev, lonely, teacher_uri, min_stake,
 
         # Other
         interactive, dry_run):
@@ -337,23 +296,8 @@ def run(click_config,
 def save_metadata(click_config,
 
                   # API Options
-                  geth,
-                  provider_uri,
-                  network,
-                  registry_filepath,
-                  staker_address,
-                  worker_address,
-                  federated_only,
-                  rest_host,
-                  rest_port,
-                  db_filepath,
-                  poa,
-                  config_file,
-                  dev,
-                  lonely,
-                  teacher_uri,
-                  min_stake
-                  ):
+                  geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only,
+                  rest_host, rest_port, db_filepath, poa, config_file, dev, lonely, teacher_uri, min_stake):
     """
     Manually write node metadata to disk without running.
     """
@@ -381,23 +325,8 @@ def save_metadata(click_config,
 def view(click_config,
 
          # API Options
-         geth,
-         provider_uri,
-         network,
-         registry_filepath,
-         staker_address,
-         worker_address,
-         federated_only,
-         rest_host,
-         rest_port,
-         db_filepath,
-         poa,
-         config_file,
-         dev,
-         lonely,
-         teacher_uri,
-         min_stake
-         ):
+         geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
+         rest_port, db_filepath, poa, config_file, dev, lonely, teacher_uri, min_stake):
     """
     View the Ursula node's configuration.
     """
@@ -439,23 +368,8 @@ def view(click_config,
 def confirm_activity(click_config,
 
                      # API Options
-                     geth,
-                     provider_uri,
-                     network,
-                     registry_filepath,
-                     staker_address,
-                     worker_address,
-                     federated_only,
-                     rest_host,
-                     rest_port,
-                     db_filepath,
-                     poa,
-                     config_file,
-                     dev,
-                     lonely,
-                     teacher_uri,
-                     min_stake
-                     ):
+                     geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only,
+                     rest_host, rest_port, db_filepath, poa, config_file, dev, lonely, teacher_uri, min_stake):
     """
     Manually confirm-activity for the current period.
     """

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -199,6 +199,7 @@ def destroy(click_config,
 
 
 @ursula.command()
+@_admin_options
 @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
 @nucypher_click_config
@@ -370,7 +371,7 @@ def save_metadata(click_config,
 
     URSULA = _create_ursula(ursula_config, click_config, dev, emitter, lonely, teacher_uri, min_stake)
 
-    metadata_path = ursula.write_node_metadata(node=URSULA)
+    metadata_path = URSULA.write_node_metadata(node=URSULA)
     emitter.message(f"Successfully saved node metadata to {metadata_path}.", color='green')
 
 

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -201,6 +201,8 @@ def nucypher_click_config(func):
                 debug,
                 **kwargs):
 
+        # NOTE: `set_options` MUST maintain same order as click_options provided - there is a unit test that depends
+        #       on this order being maintained
         config.set_options(
             mock_networking,
             etherscan,

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -113,19 +113,9 @@ def inspect(provider_uri, config_root, registry_infile, deployer_address, poa):
 @click.option('--retarget', '-d', help="Retarget a contract's proxy.", is_flag=True)
 @click.option('--target-address', help="Recipient's checksum address for token or ownership transference.",
               type=EIP55_CHECKSUM_ADDRESS)
-def upgrade(
-            # Admin Actor Options
-            provider_uri,
-            contract_name,
-            config_root,
-            poa,
-            force,
-            etherscan,
-            hw_wallet,
-            deployer_address,
-            registry_infile,
-            registry_outfile,
-            dev,
+def upgrade(# Admin Actor Options
+            provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address,
+            registry_infile, registry_outfile, dev,
 
             # Other
             retarget, target_address):
@@ -184,20 +174,9 @@ def upgrade(
 
 @deploy.command()
 @_admin_actor_options
-def rollback(
-             # Admin Actor Options
-             provider_uri,
-             contract_name,
-             config_root,
-             poa,
-             force,
-             etherscan,
-             hw_wallet,
-             deployer_address,
-             registry_infile,
-             registry_outfile,
-             dev,
-             ):
+def rollback(# Admin Actor Options
+             provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address,
+             registry_infile, registry_outfile, dev):
     """
     Rollback a proxy contract's target.
     """
@@ -236,19 +215,9 @@ def rollback(
 @_admin_actor_options
 @click.option('--bare', help="Deploy a contract *only* without any additional operations.", is_flag=True)
 @click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
-def contracts(
-              # Admin Actor Options
-              provider_uri,
-              contract_name,
-              config_root,
-              poa,
-              force,
-              etherscan,
-              hw_wallet,
-              deployer_address,
-              registry_infile,
-              registry_outfile,
-              dev,
+def contracts(# Admin Actor Options
+              provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address,
+              registry_infile, registry_outfile, dev,
 
               # Other
               bare, gas):
@@ -355,19 +324,9 @@ def contracts(
 @click.option('--allocation-infile', help="Input path for token allocation JSON file", type=EXISTING_READABLE_FILE)
 @click.option('--allocation-outfile', help="Output path for token allocation JSON file",
               type=click.Path(exists=False, file_okay=True))
-def allocations(
-                # Admin Actor Options
-                provider_uri,
-                contract_name,
-                config_root,
-                poa,
-                force,
-                etherscan,
-                hw_wallet,
-                deployer_address,
-                registry_infile,
-                registry_outfile,
-                dev,
+def allocations(# Admin Actor Options
+                provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address,
+                registry_infile, registry_outfile, dev,
 
                 # Other
                 allocation_infile, allocation_outfile):
@@ -408,19 +367,9 @@ def allocations(
 @click.option('--target-address', help="Recipient's checksum address for token or ownership transference.",
               type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--value', help="Amount of tokens to transfer in the smallest denomination", type=click.INT)
-def transfer_tokens(
-                    # Admin Actor Options
-                    provider_uri,
-                    contract_name,
-                    config_root,
-                    poa,
-                    force,
-                    etherscan,
-                    hw_wallet,
-                    deployer_address,
-                    registry_infile,
-                    registry_outfile,
-                    dev,
+def transfer_tokens(# Admin Actor Options
+                    provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address,
+                    registry_infile, registry_outfile, dev,
 
                     # Other
                     target_address, value):
@@ -468,19 +417,9 @@ def transfer_tokens(
 @click.option('--target-address', help="Recipient's checksum address for token or ownership transference.",
               type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
-def transfer_ownership(
-                       # Admin Actor Options
-                       provider_uri,
-                       contract_name,
-                       config_root,
-                       poa,
-                       force,
-                       etherscan,
-                       hw_wallet,
-                       deployer_address,
-                       registry_infile,
-                       registry_outfile,
-                       dev,
+def transfer_ownership(# Admin Actor Options
+                       provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address,
+                       registry_infile, registry_outfile, dev,
 
                        # Other
                        target_address, gas):

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -37,7 +37,8 @@ from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, EXISTING_READABLE_FILE
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 
 
-# Args (provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev)
+# Args (provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address,
+#       registry_infile, registry_outfile, dev)
 def _admin_actor_options(func):
     @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING, required=True)
     @click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)
@@ -110,8 +111,23 @@ def inspect(provider_uri, config_root, registry_infile, deployer_address, poa):
 @deploy.command()
 @_admin_actor_options
 @click.option('--retarget', '-d', help="Retarget a contract's proxy.", is_flag=True)
-@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
-def upgrade(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.",
+              type=EIP55_CHECKSUM_ADDRESS)
+def upgrade(
+            # Admin Actor Options
+            provider_uri,
+            contract_name,
+            config_root,
+            poa,
+            force,
+            etherscan,
+            hw_wallet,
+            deployer_address,
+            registry_infile,
+            registry_outfile,
+            dev,
+
+            # Other
             retarget, target_address):
     """
     Upgrade NuCypher existing proxy contract deployments.
@@ -168,7 +184,19 @@ def upgrade(provider_uri, contract_name, config_root, poa, force, etherscan, hw_
 
 @deploy.command()
 @_admin_actor_options
-def rollback(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev  # admin_actor
+def rollback(
+             # Admin Actor Options
+             provider_uri,
+             contract_name,
+             config_root,
+             poa,
+             force,
+             etherscan,
+             hw_wallet,
+             deployer_address,
+             registry_infile,
+             registry_outfile,
+             dev,
              ):
     """
     Rollback a proxy contract's target.
@@ -208,7 +236,21 @@ def rollback(provider_uri, contract_name, config_root, poa, force, etherscan, hw
 @_admin_actor_options
 @click.option('--bare', help="Deploy a contract *only* without any additional operations.", is_flag=True)
 @click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
-def contracts(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+def contracts(
+              # Admin Actor Options
+              provider_uri,
+              contract_name,
+              config_root,
+              poa,
+              force,
+              etherscan,
+              hw_wallet,
+              deployer_address,
+              registry_infile,
+              registry_outfile,
+              dev,
+
+              # Other
               bare, gas):
     """
     Compile and deploy contracts.
@@ -311,8 +353,23 @@ def contracts(provider_uri, contract_name, config_root, poa, force, etherscan, h
 @deploy.command()
 @_admin_actor_options
 @click.option('--allocation-infile', help="Input path for token allocation JSON file", type=EXISTING_READABLE_FILE)
-@click.option('--allocation-outfile', help="Output path for token allocation JSON file", type=click.Path(exists=False, file_okay=True))
-def allocations(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+@click.option('--allocation-outfile', help="Output path for token allocation JSON file",
+              type=click.Path(exists=False, file_okay=True))
+def allocations(
+                # Admin Actor Options
+                provider_uri,
+                contract_name,
+                config_root,
+                poa,
+                force,
+                etherscan,
+                hw_wallet,
+                deployer_address,
+                registry_infile,
+                registry_outfile,
+                dev,
+
+                # Other
                 allocation_infile, allocation_outfile):
     """
     Deploy pre-allocation contracts.
@@ -348,9 +405,24 @@ def allocations(provider_uri, contract_name, config_root, poa, force, etherscan,
 
 @deploy.command(name='transfer-tokens')
 @_admin_actor_options
-@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.",
+              type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--value', help="Amount of tokens to transfer in the smallest denomination", type=click.INT)
-def transfer_tokens(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+def transfer_tokens(
+                    # Admin Actor Options
+                    provider_uri,
+                    contract_name,
+                    config_root,
+                    poa,
+                    force,
+                    etherscan,
+                    hw_wallet,
+                    deployer_address,
+                    registry_infile,
+                    registry_outfile,
+                    dev,
+
+                    # Other
                     target_address, value):
     """
     Transfer tokens from a contract to another address using the owner's address.
@@ -393,9 +465,24 @@ def transfer_tokens(provider_uri, contract_name, config_root, poa, force, ethers
 
 @deploy.command("transfer-ownership")
 @_admin_actor_options
-@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.",
+              type=EIP55_CHECKSUM_ADDRESS)
 @click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
-def transfer_ownership(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+def transfer_ownership(
+                       # Admin Actor Options
+                       provider_uri,
+                       contract_name,
+                       config_root,
+                       poa,
+                       force,
+                       etherscan,
+                       hw_wallet,
+                       deployer_address,
+                       registry_infile,
+                       registry_outfile,
+                       dev,
+
+                       # Other
                        target_address, gas):
     """
     Transfer ownership of contracts to another address.

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -509,7 +509,6 @@ def transfer_ownership(
                                                                                            dev,
                                                                                            force)
 
-
     if not target_address:
         target_address = click.prompt("Enter new owner's checksum address", type=EIP55_CHECKSUM_ADDRESS)
 

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -14,10 +14,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-
+import functools
 import os
-import shutil
 
 import click
 
@@ -39,78 +37,452 @@ from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, EXISTING_READABLE_FILE
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 
 
-@click.command()
-@click.argument('action')
-@click.option('--force', is_flag=True)
-@click.option('--poa', help="Inject POA middleware", is_flag=True)
-@click.option('--etherscan/--no-etherscan', help="Enable/disable viewing TX in Etherscan", default=False)
-@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-@click.option('--hw-wallet/--no-hw-wallet', default=False)  # TODO: Make True by default.
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)
-@click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
-@click.option('--deployer-address', help="Deployer's checksum address", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--retarget', '-d', help="Retarget a contract's proxy.", is_flag=True)
-@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
-@click.option('--registry-infile', help="Input path for contract registry file", type=EXISTING_READABLE_FILE)
-@click.option('--value', help="Amount of tokens to transfer in the smallest denomination", type=click.INT)
-@click.option('--dev', '-d', help="Forcibly use the development registry filepath.", is_flag=True)
-@click.option('--bare', help="Deploy a contract *only* without any additional operations.", is_flag=True)
-@click.option('--registry-outfile', help="Output path for contract registry file", type=click.Path(file_okay=True))
-@click.option('--allocation-infile', help="Input path for token allocation JSON file", type=EXISTING_READABLE_FILE)
-@click.option('--allocation-outfile', help="Output path for token allocation JSON file", type=click.Path(exists=False, file_okay=True))
-def deploy(action,
-           poa,
-           etherscan,
-           provider_uri,
-           gas,
-           deployer_address,
-           contract_name,
-           allocation_infile,
-           allocation_outfile,
-           registry_infile,
-           registry_outfile,
-           value,
-           target_address,
-           retarget,
-           bare,
-           config_root,
-           hw_wallet,
-           force,
-           dev):
+# Args (provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev)
+def _admin_actor_options(func):
+    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING, required=True)
+    @click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING)
+    @click.option('--config-root', help="Custom configuration directory", type=click.Path())
+    @click.option('--poa', help="Inject POA middleware", is_flag=True)
+    @click.option('--force', is_flag=True)
+    @click.option('--etherscan/--no-etherscan', help="Enable/disable viewing TX in Etherscan", default=False)
+    @click.option('--hw-wallet/--no-hw-wallet', default=False)  # TODO: Make True by default.
+    @click.option('--deployer-address', help="Deployer's checksum address", type=EIP55_CHECKSUM_ADDRESS)
+    @click.option('--registry-infile', help="Input path for contract registry file", type=EXISTING_READABLE_FILE)
+    @click.option('--registry-outfile', help="Output path for contract registry file", type=click.Path(file_okay=True))
+    @click.option('--dev', '-d', help="Forcibly use the development registry filepath.", is_flag=True)
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@click.group()
+def deploy():
     """
     Manage contract and registry deployment.
-
-    \b
-    Actions
-    -----------------------------------------------------------------------------
-    contracts              Compile and deploy contracts.
-    allocations            Deploy pre-allocation contracts.
-    upgrade                Upgrade NuCypher existing proxy contract deployments.
-    rollback               Rollback a proxy contract's target.
-    inspect                Echo owner information and bare contract metadata.
-    transfer-tokens        Transfer tokens from a contract to another address using the owner's address.
-    transfer-ownership     Transfer ownership of contracts to another address.
     """
+    pass
 
+
+@deploy.command(name='download-registry')
+@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@click.option('--registry-outfile', help="Output path for contract registry file", type=click.Path(file_okay=True))
+@click.option('--force', is_flag=True)
+def download_registry(config_root, registry_outfile, force):
+    """
+    Download the latest registry.
+    """
+    # Init
     emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+
+    if not force:
+        prompt = f"Fetch and download latest registry from {BaseContractRegistry.PUBLICATION_ENDPOINT}?"
+        click.confirm(prompt, abort=True)
+    registry = InMemoryContractRegistry.from_latest_publication()
+    output_filepath = registry.commit(filepath=registry_outfile, overwrite=force)
+    emitter.message(f"Successfully downloaded latest registry to {output_filepath}")
+
+
+@deploy.command()
+@click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING, required=True)
+@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@click.option('--registry-infile', help="Input path for contract registry file", type=EXISTING_READABLE_FILE)
+@click.option('--deployer-address', help="Deployer's checksum address", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--poa', help="Inject POA middleware", is_flag=True)
+def inspect(provider_uri, config_root, registry_infile, deployer_address, poa):
+    """
+    Echo owner information and bare contract metadata.
+    """
+    # Init
+    emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+    _initialize_blockchain(poa, provider_uri)
+
+    if registry_infile:
+        registry = LocalContractRegistry(filepath=registry_infile)
+    else:
+        registry = InMemoryContractRegistry.from_latest_publication()
+    administrator = ContractAdministrator(registry=registry, deployer_address=deployer_address)
+    paint_deployer_contract_inspection(emitter=emitter, administrator=administrator)
+
+
+@deploy.command()
+@_admin_actor_options
+@click.option('--retarget', '-d', help="Retarget a contract's proxy.", is_flag=True)
+@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
+def upgrade(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+            retarget, target_address):
+    """
+    Upgrade NuCypher existing proxy contract deployments.
+    """
+    # Init
+    emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+    deployer_interface = _initialize_blockchain(poa, provider_uri)
+
+    # Warnings
+    _pre_launch_warnings(emitter, etherscan, hw_wallet)
 
     #
-    # Validate
+    # Make Authenticated Deployment Actor
+    #
+    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
+                                                                                           provider_uri,
+                                                                                           deployer_address,
+                                                                                           deployer_interface,
+                                                                                           contract_name,
+                                                                                           registry_infile,
+                                                                                           registry_outfile,
+                                                                                           hw_wallet,
+                                                                                           dev,
+                                                                                           force)
+
+    if not contract_name:
+        raise click.BadArgumentUsage(message="--contract-name is required when using --upgrade")
+
+    existing_secret = click.prompt('Enter existing contract upgrade secret', hide_input=True)
+    new_secret = click.prompt('Enter new contract upgrade secret', hide_input=True, confirmation_prompt=True)
+
+    if retarget:
+        if not target_address:
+            raise click.BadArgumentUsage(message="--target-address is required when using --retarget")
+        if not force:
+            click.confirm(f"Confirm re-target {contract_name}'s proxy to {target_address}?", abort=True)
+        receipt = ADMINISTRATOR.retarget_proxy(contract_name=contract_name,
+                                               target_address=target_address,
+                                               existing_plaintext_secret=existing_secret,
+                                               new_plaintext_secret=new_secret)
+        emitter.message(f"Successfully re-targeted {contract_name} proxy to {target_address}", color='green')
+        paint_receipt_summary(emitter=emitter, receipt=receipt)
+    else:
+        if not force:
+            click.confirm(f"Confirm deploy new version of {contract_name} and retarget proxy?", abort=True)
+        receipts = ADMINISTRATOR.upgrade_contract(contract_name=contract_name,
+                                                  existing_plaintext_secret=existing_secret,
+                                                  new_plaintext_secret=new_secret)
+        emitter.message(f"Successfully deployed and upgraded {contract_name}", color='green')
+        for name, receipt in receipts.items():
+            paint_receipt_summary(emitter=emitter, receipt=receipt)
+
+
+@deploy.command()
+@_admin_actor_options
+def rollback(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev  # admin_actor
+             ):
+    """
+    Rollback a proxy contract's target.
+    """
+    # Init
+    emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+    deployer_interface = _initialize_blockchain(poa, provider_uri)
+
+    # Warnings
+    _pre_launch_warnings(emitter, etherscan, hw_wallet)
+
+    #
+    # Make Authenticated Deployment Actor
+    #
+    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
+                                                                                           provider_uri,
+                                                                                           deployer_address,
+                                                                                           deployer_interface,
+                                                                                           contract_name,
+                                                                                           registry_infile,
+                                                                                           registry_outfile,
+                                                                                           hw_wallet,
+                                                                                           dev,
+                                                                                           force)
+
+    if not contract_name:
+        raise click.BadArgumentUsage(message="--contract-name is required when using --rollback")
+    existing_secret = click.prompt('Enter existing contract upgrade secret', hide_input=True)
+    new_secret = click.prompt('Enter new contract upgrade secret', hide_input=True, confirmation_prompt=True)
+    ADMINISTRATOR.rollback_contract(contract_name=contract_name,
+                                    existing_plaintext_secret=existing_secret,
+                                    new_plaintext_secret=new_secret)
+
+
+@deploy.command()
+@_admin_actor_options
+@click.option('--bare', help="Deploy a contract *only* without any additional operations.", is_flag=True)
+@click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
+def contracts(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+              bare, gas):
+    """
+    Compile and deploy contracts.
+    """
+    # Init
+    emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+    deployer_interface = _initialize_blockchain(poa, provider_uri)
+
+    # Warnings
+    _pre_launch_warnings(emitter, etherscan, hw_wallet)
+
+    #
+    # Make Authenticated Deployment Actor
+    #
+    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
+                                                                                           provider_uri,
+                                                                                           deployer_address,
+                                                                                           deployer_interface,
+                                                                                           contract_name,
+                                                                                           registry_infile,
+                                                                                           registry_outfile,
+                                                                                           hw_wallet,
+                                                                                           dev,
+                                                                                           force)
+
+    #
+    # Deploy Single Contract (Amend Registry)
     #
 
-    # Ensure config root exists, because we need a default place to put output files.
-    config_root = config_root or DEFAULT_CONFIG_ROOT
-    if not os.path.exists(config_root):
-        os.makedirs(config_root)
+    if contract_name:
+        try:
+            contract_deployer = ADMINISTRATOR.deployers[contract_name]
+        except KeyError:
+            message = f"No such contract {contract_name}. Available contracts are {ADMINISTRATOR.deployers.keys()}"
+            emitter.echo(message, color='red', bold=True)
+            raise click.Abort()
+
+        # Deploy
+        emitter.echo(f"Deploying {contract_name}")
+        if contract_deployer._upgradeable and not bare:
+            # NOTE: Bare deployments do not engage the proxy contract
+            secret = ADMINISTRATOR.collect_deployment_secret(deployer=contract_deployer)
+            receipts, agent = ADMINISTRATOR.deploy_contract(contract_name=contract_name,
+                                                            plaintext_secret=secret,
+                                                            gas_limit=gas,
+                                                            bare=bare)
+        else:
+            # Non-Upgradeable or Bare
+            receipts, agent = ADMINISTRATOR.deploy_contract(contract_name=contract_name,
+                                                            gas_limit=gas,
+                                                            bare=bare)
+
+        # Report
+        paint_contract_deployment(contract_name=contract_name,
+                                  contract_address=agent.contract_address,
+                                  receipts=receipts,
+                                  emitter=emitter,
+                                  chain_name=deployer_interface.client.chain_name,
+                                  open_in_browser=etherscan)
+        return  # Exit
 
     #
-    # Pre-Launch Warnings
+    # Deploy Automated Series (Create Registry)
     #
 
+    # Confirm filesystem registry writes.
+    if os.path.isfile(local_registry.filepath):
+        emitter.echo(f"\nThere is an existing contract registry at {local_registry.filepath}.\n"
+                     f"Did you mean 'nucypher-deploy upgrade'?\n", color='yellow')
+        click.confirm("*DESTROY* existing local registry and continue?", abort=True)
+        os.remove(local_registry.filepath)
+
+    # Stage Deployment
+    secrets = ADMINISTRATOR.collect_deployment_secrets()
+    paint_staged_deployment(deployer_interface=deployer_interface, administrator=ADMINISTRATOR, emitter=emitter)
+
+    # Confirm Trigger Deployment
+    if not confirm_deployment(emitter=emitter, deployer_interface=deployer_interface):
+        raise click.Abort()
+
+    # Delay - Last chance to abort via KeyboardInterrupt
+    paint_deployment_delay(emitter=emitter)
+
+    # Execute Deployment
+    deployment_receipts = ADMINISTRATOR.deploy_network_contracts(secrets=secrets,
+                                                                 emitter=emitter,
+                                                                 interactive=not force,
+                                                                 etherscan=etherscan)
+
+    # Paint outfile paths
+    registry_outfile = local_registry.filepath
+    emitter.echo('Generated registry {}'.format(registry_outfile), bold=True, color='blue')
+
+    # Save transaction metadata
+    receipts_filepath = ADMINISTRATOR.save_deployment_receipts(receipts=deployment_receipts)
+    emitter.echo(f"Saved deployment receipts to {receipts_filepath}", color='blue', bold=True)
+
+
+@deploy.command()
+@_admin_actor_options
+@click.option('--allocation-infile', help="Input path for token allocation JSON file", type=EXISTING_READABLE_FILE)
+@click.option('--allocation-outfile', help="Output path for token allocation JSON file", type=click.Path(exists=False, file_okay=True))
+def allocations(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+                allocation_infile, allocation_outfile):
+    """
+    Deploy pre-allocation contracts.
+    """
+    # Init
+    emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+    deployer_interface = _initialize_blockchain(poa, provider_uri)
+
+    # Warnings
+    _pre_launch_warnings(emitter, etherscan, hw_wallet)
+
+    #
+    # Make Authenticated Deployment Actor
+    #
+    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
+                                                                                           provider_uri,
+                                                                                           deployer_address,
+                                                                                           deployer_interface,
+                                                                                           contract_name,
+                                                                                           registry_infile,
+                                                                                           registry_outfile,
+                                                                                           hw_wallet,
+                                                                                           dev,
+                                                                                           force)
+
+    if not allocation_infile:
+        allocation_infile = click.prompt("Enter allocation data filepath")
+    click.confirm("Continue deploying and allocating?", abort=True)
+    ADMINISTRATOR.deploy_beneficiaries_from_file(allocation_data_filepath=allocation_infile,
+                                                 allocation_outfile=allocation_outfile)
+
+
+@deploy.command(name='transfer-tokens')
+@_admin_actor_options
+@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--value', help="Amount of tokens to transfer in the smallest denomination", type=click.INT)
+def transfer_tokens(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+                    target_address, value):
+    """
+    Transfer tokens from a contract to another address using the owner's address.
+    """
+    # Init
+    emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+    deployer_interface = _initialize_blockchain(poa, provider_uri)
+
+    # Warnings
+    _pre_launch_warnings(emitter, etherscan, hw_wallet)
+
+    #
+    # Make Authenticated Deployment Actor
+    #
+    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
+                                                                                           provider_uri,
+                                                                                           deployer_address,
+                                                                                           deployer_interface,
+                                                                                           contract_name,
+                                                                                           registry_infile,
+                                                                                           registry_outfile,
+                                                                                           hw_wallet,
+                                                                                           dev,
+                                                                                           force)
+
+    token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=local_registry)
+    if not target_address:
+        target_address = click.prompt("Enter recipient's checksum address", type=EIP55_CHECKSUM_ADDRESS)
+    if not value:
+        stake_value_range = click.FloatRange(min=0, clamp=False)
+        value = NU.from_tokens(click.prompt(f"Enter value in NU", type=stake_value_range))
+
+    click.confirm(f"Transfer {value} from {deployer_address} to {target_address}?", abort=True)
+    receipt = token_agent.transfer(amount=value,
+                                   sender_address=deployer_address,
+                                   target_address=target_address)
+    emitter.echo(f"OK | Receipt: {receipt['transactionHash'].hex()}")
+
+
+@deploy.command("transfer-ownership")
+@_admin_actor_options
+@click.option('--target-address', help="Recipient's checksum address for token or ownership transference.", type=EIP55_CHECKSUM_ADDRESS)
+@click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
+def transfer_ownership(provider_uri, contract_name, config_root, poa, force, etherscan, hw_wallet, deployer_address, registry_infile, registry_outfile, dev,  # admin_actor
+                       target_address, gas):
+    """
+    Transfer ownership of contracts to another address.
+    """
+    # Init
+    emitter = StdoutEmitter()
+    _ensure_config_root(config_root)
+    deployer_interface = _initialize_blockchain(poa, provider_uri)
+
+    # Warnings
+    _pre_launch_warnings(emitter, etherscan, hw_wallet)
+
+    #
+    # Make Authenticated Deployment Actor
+    #
+    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
+                                                                                           provider_uri,
+                                                                                           deployer_address,
+                                                                                           deployer_interface,
+                                                                                           contract_name,
+                                                                                           registry_infile,
+                                                                                           registry_outfile,
+                                                                                           hw_wallet,
+                                                                                           dev,
+                                                                                           force)
+
+
+    if not target_address:
+        target_address = click.prompt("Enter new owner's checksum address", type=EIP55_CHECKSUM_ADDRESS)
+
+    if contract_name:
+        try:
+            contract_deployer_class = ADMINISTRATOR.deployers[contract_name]
+        except KeyError:
+            message = f"No such contract {contract_name}. Available contracts are {ADMINISTRATOR.deployers.keys()}"
+            emitter.echo(message, color='red', bold=True)
+            raise click.Abort()
+        else:
+            contract_deployer = contract_deployer_class(registry=ADMINISTRATOR.registry,
+                                                        deployer_address=ADMINISTRATOR.deployer_address)
+            receipt = contract_deployer.transfer_ownership(new_owner=target_address, transaction_gas_limit=gas)
+            emitter.ipc(receipt, request_id=0, duration=0)  # TODO: #1216
+    else:
+        receipts = ADMINISTRATOR.relinquish_ownership(new_owner=target_address, transaction_gas_limit=gas)
+        emitter.ipc(receipts, request_id=0, duration=0)  # TODO: #1216
+
+
+def _make_authenticated_deployment_actor(emitter, provider_uri, deployer_address, deployer_interface, contract_name,
+                                         registry_infile, registry_outfile, hw_wallet, dev, force):
+    #
+    # Establish Registry
+    #
+    local_registry = establish_deployer_registry(emitter=emitter,
+                                                 use_existing_registry=bool(contract_name),
+                                                 registry_infile=registry_infile,
+                                                 registry_outfile=registry_outfile,
+                                                 dev=dev)
+    #
+    # Make Authenticated Deployment Actor
+    #
+    # Verify Address & collect password
+    if not deployer_address:
+        prompt = "Select deployer account"
+        deployer_address = select_client_account(emitter=emitter,
+                                                 prompt=prompt,
+                                                 provider_uri=provider_uri,
+                                                 show_balances=False)
+    if not force:
+        click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
+    password = None
+    if not hw_wallet and not deployer_interface.client.is_local:
+        password = get_client_password(checksum_address=deployer_address)
+    # Produce Actor
+    ADMINISTRATOR = ContractAdministrator(registry=local_registry,
+                                          client_password=password,
+                                          deployer_address=deployer_address)
+    # Verify ETH Balance
+    emitter.echo(f"\n\nDeployer ETH balance: {ADMINISTRATOR.eth_balance}")
+    if ADMINISTRATOR.eth_balance == 0:
+        emitter.echo("Deployer address has no ETH.", color='red', bold=True)
+        raise click.Abort()
+    return ADMINISTRATOR, deployer_address, local_registry
+
+
+def _pre_launch_warnings(emitter, etherscan, hw_wallet):
     if not hw_wallet:
         emitter.echo("WARNING: --no-hw-wallet is enabled.", color='yellow')
-
     if etherscan:
         emitter.echo("WARNING: --etherscan is enabled. "
                      "A browser tab will be opened with deployed contracts and TXs as provided by Etherscan.",
@@ -120,239 +492,20 @@ def deploy(action,
                      "If you want to see deployed contracts and TXs in your browser, activate --etherscan.",
                      color='yellow')
 
-    if action == "download-registry":
-        if not force:
-            prompt = f"Fetch and download latest registry from {BaseContractRegistry.PUBLICATION_ENDPOINT}?"
-            click.confirm(prompt, abort=True)
-        registry = InMemoryContractRegistry.from_latest_publication()
-        output_filepath = registry.commit(filepath=registry_outfile, overwrite=force)
-        emitter.message(f"Successfully downloaded latest registry to {output_filepath}")
-        return  # Exit
 
-    #
-    # Connect to Blockchain
-    #
-
-    if not provider_uri:
-        raise click.BadOptionUsage(message=f"--provider is required to deploy.", option_name="--provider")
-
+def _initialize_blockchain(poa, provider_uri):
     if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
         # Note: For test compatibility.
         deployer_interface = BlockchainDeployerInterface(provider_uri=provider_uri, poa=poa)
-        BlockchainInterfaceFactory.register_interface(interface=deployer_interface, sync=False, show_sync_progress=False)
+        BlockchainInterfaceFactory.register_interface(interface=deployer_interface, sync=False,
+                                                      show_sync_progress=False)
     else:
         deployer_interface = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)
+    return deployer_interface
 
-    if action == "inspect":
-        if registry_infile:
-            registry = LocalContractRegistry(filepath=registry_infile)
-        else:
-            registry = InMemoryContractRegistry.from_latest_publication()
-        administrator = ContractAdministrator(registry=registry, deployer_address=deployer_address)
-        paint_deployer_contract_inspection(emitter=emitter, administrator=administrator)
-        return  # Exit
 
-    #
-    # Establish Registry
-    #
-    local_registry = establish_deployer_registry(emitter=emitter,
-                                                 use_existing_registry=bool(contract_name),
-                                                 registry_infile=registry_infile,
-                                                 registry_outfile=registry_outfile,
-                                                 dev=dev)
-
-    #
-    # Make Authenticated Deployment Actor
-    #
-
-    # Verify Address & collect password
-    if not deployer_address:
-        prompt = "Select deployer account"
-        deployer_address = select_client_account(emitter=emitter,
-                                                 prompt=prompt,
-                                                 provider_uri=provider_uri,
-                                                 show_balances=False)
-
-    if not force:
-        click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
-
-    password = None
-    if not hw_wallet and not deployer_interface.client.is_local:
-        password = get_client_password(checksum_address=deployer_address)
-
-    # Produce Actor
-    ADMINISTRATOR = ContractAdministrator(registry=local_registry,
-                                          client_password=password,
-                                          deployer_address=deployer_address)
-
-    # Verify ETH Balance
-    emitter.echo(f"\n\nDeployer ETH balance: {ADMINISTRATOR.eth_balance}")
-    if ADMINISTRATOR.eth_balance == 0:
-        emitter.echo("Deployer address has no ETH.", color='red', bold=True)
-        raise click.Abort()
-
-    #
-    # Action switch
-    #
-
-    if action == 'upgrade':
-        if not contract_name:
-            raise click.BadArgumentUsage(message="--contract-name is required when using --upgrade")
-        existing_secret = click.prompt('Enter existing contract upgrade secret', hide_input=True)
-        new_secret = click.prompt('Enter new contract upgrade secret', hide_input=True, confirmation_prompt=True)
-
-        if retarget:
-            if not target_address:
-                raise click.BadArgumentUsage(message="--target-address is required when using --retarget")
-            if not force:
-                click.confirm(f"Confirm re-target {contract_name}'s proxy to {target_address}?", abort=True)
-            receipt = ADMINISTRATOR.retarget_proxy(contract_name=contract_name,
-                                                   target_address=target_address,
-                                                   existing_plaintext_secret=existing_secret,
-                                                   new_plaintext_secret=new_secret)
-            emitter.message(f"Successfully re-targeted {contract_name} proxy to {target_address}", color='green')
-            paint_receipt_summary(emitter=emitter, receipt=receipt)
-            return  # Exit
-        else:
-            if not force:
-                click.confirm(f"Confirm deploy new version of {contract_name} and retarget proxy?", abort=True)
-            receipts = ADMINISTRATOR.upgrade_contract(contract_name=contract_name,
-                                                      existing_plaintext_secret=existing_secret,
-                                                      new_plaintext_secret=new_secret)
-            emitter.message(f"Successfully deployed and upgraded {contract_name}", color='green')
-            for name, receipt in receipts.items():
-                paint_receipt_summary(emitter=emitter, receipt=receipt)
-            return  # Exit
-
-    elif action == 'rollback':
-        if not contract_name:
-            raise click.BadArgumentUsage(message="--contract-name is required when using --rollback")
-        existing_secret = click.prompt('Enter existing contract upgrade secret', hide_input=True)
-        new_secret = click.prompt('Enter new contract upgrade secret', hide_input=True, confirmation_prompt=True)
-        ADMINISTRATOR.rollback_contract(contract_name=contract_name,
-                                        existing_plaintext_secret=existing_secret,
-                                        new_plaintext_secret=new_secret)
-        return  # Exit
-
-    elif action == "contracts":
-
-        #
-        # Deploy Single Contract (Amend Registry)
-        #
-
-        if contract_name:
-            try:
-                contract_deployer = ADMINISTRATOR.deployers[contract_name]
-            except KeyError:
-                message = f"No such contract {contract_name}. Available contracts are {ADMINISTRATOR.deployers.keys()}"
-                emitter.echo(message, color='red', bold=True)
-                raise click.Abort()
-
-            # Deploy
-            emitter.echo(f"Deploying {contract_name}")
-            if contract_deployer._upgradeable and not bare:
-                # NOTE: Bare deployments do not engage the proxy contract
-                secret = ADMINISTRATOR.collect_deployment_secret(deployer=contract_deployer)
-                receipts, agent = ADMINISTRATOR.deploy_contract(contract_name=contract_name,
-                                                                plaintext_secret=secret,
-                                                                gas_limit=gas,
-                                                                bare=bare)
-            else:
-                # Non-Upgradeable or Bare
-                receipts, agent = ADMINISTRATOR.deploy_contract(contract_name=contract_name,
-                                                                gas_limit=gas,
-                                                                bare=bare)
-
-            # Report
-            paint_contract_deployment(contract_name=contract_name,
-                                      contract_address=agent.contract_address,
-                                      receipts=receipts,
-                                      emitter=emitter,
-                                      chain_name=deployer_interface.client.chain_name,
-                                      open_in_browser=etherscan)
-            return  # Exit
-
-        #
-        # Deploy Automated Series (Create Registry)
-        #
-
-        # Confirm filesystem registry writes.
-        if os.path.isfile(local_registry.filepath):
-            emitter.echo(f"\nThere is an existing contract registry at {local_registry.filepath}.\n"
-                         f"Did you mean 'nucypher-deploy upgrade'?\n", color='yellow')
-            click.confirm("*DESTROY* existing local registry and continue?", abort=True)
-            os.remove(local_registry.filepath)
-
-        # Stage Deployment
-        secrets = ADMINISTRATOR.collect_deployment_secrets()
-        paint_staged_deployment(deployer_interface=deployer_interface, administrator=ADMINISTRATOR, emitter=emitter)
-
-        # Confirm Trigger Deployment
-        if not confirm_deployment(emitter=emitter, deployer_interface=deployer_interface):
-            raise click.Abort()
-
-        # Delay - Last chance to abort via KeyboardInterrupt
-        paint_deployment_delay(emitter=emitter)
-
-        # Execute Deployment
-        deployment_receipts = ADMINISTRATOR.deploy_network_contracts(secrets=secrets,
-                                                                     emitter=emitter,
-                                                                     interactive=not force,
-                                                                     etherscan=etherscan)
-
-        # Paint outfile paths
-        registry_outfile = local_registry.filepath
-        emitter.echo('Generated registry {}'.format(registry_outfile), bold=True, color='blue')
-
-        # Save transaction metadata
-        receipts_filepath = ADMINISTRATOR.save_deployment_receipts(receipts=deployment_receipts)
-        emitter.echo(f"Saved deployment receipts to {receipts_filepath}", color='blue', bold=True)
-        return  # Exit
-
-    elif action == "allocations":
-        if not allocation_infile:
-            allocation_infile = click.prompt("Enter allocation data filepath")
-        click.confirm("Continue deploying and allocating?", abort=True)
-        ADMINISTRATOR.deploy_beneficiaries_from_file(allocation_data_filepath=allocation_infile,
-                                                     allocation_outfile=allocation_outfile)
-        return  # Exit
-
-    elif action == "transfer-tokens":
-        token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=local_registry)
-        if not target_address:
-            target_address = click.prompt("Enter recipient's checksum address", type=EIP55_CHECKSUM_ADDRESS)
-        if not value:
-            stake_value_range = click.FloatRange(min=0, clamp=False)
-            value = NU.from_tokens(click.prompt(f"Enter value in NU", type=stake_value_range))
-
-        click.confirm(f"Transfer {value} from {deployer_address} to {target_address}?", abort=True)
-        receipt = token_agent.transfer(amount=value,
-                                       sender_address=deployer_address,
-                                       target_address=target_address)
-        emitter.echo(f"OK | Receipt: {receipt['transactionHash'].hex()}")
-        return  # Exit
-
-    elif action == "transfer-ownership":
-        if not target_address:
-            target_address = click.prompt("Enter new owner's checksum address", type=EIP55_CHECKSUM_ADDRESS)
-
-        if contract_name:
-            try:
-                contract_deployer_class = ADMINISTRATOR.deployers[contract_name]
-            except KeyError:
-                message = f"No such contract {contract_name}. Available contracts are {ADMINISTRATOR.deployers.keys()}"
-                emitter.echo(message, color='red', bold=True)
-                raise click.Abort()
-            else:
-                contract_deployer = contract_deployer_class(registry=ADMINISTRATOR.registry,
-                                                            deployer_address=ADMINISTRATOR.deployer_address)
-                receipt = contract_deployer.transfer_ownership(new_owner=target_address, transaction_gas_limit=gas)
-                emitter.ipc(receipt, request_id=0, duration=0)  # TODO: #1216
-                return  # Exit
-        else:
-            receipts = ADMINISTRATOR.relinquish_ownership(new_owner=target_address, transaction_gas_limit=gas)
-            emitter.ipc(receipts, request_id=0, duration=0)  # TODO: #1216
-            return  # Exit
-
-    else:
-        raise click.BadArgumentUsage(message=f"Unknown action '{action}'")
+def _ensure_config_root(config_root):
+    # Ensure config root exists, because we need a default place to put output files.
+    config_root = config_root or DEFAULT_CONFIG_ROOT
+    if not os.path.exists(config_root):
+        os.makedirs(config_root)

--- a/nucypher/cli/status.py
+++ b/nucypher/cli/status.py
@@ -55,11 +55,7 @@ def status():
 def network(click_config,
 
             # Common Options
-            provider_uri,
-            geth,
-            poa,
-            registry_filepath
-            ):
+            provider_uri, geth, poa, registry_filepath):
     """
     Overall information of the NuCypher Network.
     """
@@ -77,10 +73,7 @@ def network(click_config,
 def stakers(click_config,
 
             # Common Options
-            provider_uri,
-            geth,
-            poa,
-            registry_filepath,
+            provider_uri, geth, poa, registry_filepath,
 
             # Other
             staking_address):
@@ -102,10 +95,7 @@ def stakers(click_config,
 def locked_tokens(click_config,
 
                   # Common Options
-                  provider_uri,
-                  geth,
-                  poa,
-                  registry_filepath,
+                  provider_uri, geth, poa, registry_filepath,
 
                   # Other
                   periods):

--- a/nucypher/cli/status.py
+++ b/nucypher/cli/status.py
@@ -53,7 +53,12 @@ def status():
 @_common_options
 @nucypher_click_config
 def network(click_config,
-            provider_uri, geth, poa, registry_filepath  # common
+
+            # Common Options
+            provider_uri,
+            geth,
+            poa,
+            registry_filepath
             ):
     """
     Overall information of the NuCypher Network.
@@ -70,7 +75,14 @@ def network(click_config,
 @click.option('--staking-address', help="Address of a NuCypher staker", type=EIP55_CHECKSUM_ADDRESS)
 @nucypher_click_config
 def stakers(click_config,
-            provider_uri, geth, poa, registry_filepath,  # common
+
+            # Common Options
+            provider_uri,
+            geth,
+            poa,
+            registry_filepath,
+
+            # Other
             staking_address):
     """
     Show relevant information about stakers.
@@ -88,7 +100,14 @@ def stakers(click_config,
 @click.option('--periods', help="Number of periods", type=click.INT, default=90)
 @nucypher_click_config
 def locked_tokens(click_config,
-                  provider_uri, geth, poa, registry_filepath,  # common
+
+                  # Common Options
+                  provider_uri,
+                  geth,
+                  poa,
+                  registry_filepath,
+
+                  # Other
                   periods):
     """
     Display a graph of the number of locked tokens over time.

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -20,7 +20,6 @@ import contextlib
 import json
 import os
 import shutil
-import sys
 
 import pytest
 from click.testing import CliRunner
@@ -29,10 +28,11 @@ from nucypher.blockchain.eth.registry import AllocationRegistry, InMemoryContrac
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.utilities.sandbox.constants import (
     MOCK_CUSTOM_INSTALLATION_PATH,
+    MOCK_CUSTOM_INSTALLATION_PATH_2,
+    INSECURE_DEVELOPMENT_PASSWORD,
     MOCK_ALLOCATION_INFILE,
     MOCK_REGISTRY_FILEPATH,
     ONE_YEAR_IN_SECONDS)
-from nucypher.utilities.sandbox.constants import MOCK_CUSTOM_INSTALLATION_PATH_2, INSECURE_DEVELOPMENT_PASSWORD
 
 
 @pytest.fixture(scope='module')

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -1,10 +1,11 @@
 from nucypher.cli.main import nucypher_cli
 
 
+# TODO: test can probably be removed (--dev is not a valid option for `init`)
 def test_bob_cannot_init_with_dev_flag(click_runner):
     init_args = ('bob', 'init',
                  '--federated-only',
                  '--dev')
     result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
     assert result.exit_code == 2
-    assert 'Cannot create a persistent development character' in result.output, 'Missing or invalid error message was produced.'
+    assert 'no such option: --dev' in result.output, 'Missing or invalid error message was produced.'

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -1,4 +1,80 @@
+import os
+
 from nucypher.cli.main import nucypher_cli
+from nucypher.config.characters import BobConfiguration
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, \
+    MOCK_IP_ADDRESS, MOCK_CUSTOM_INSTALLATION_PATH, TEMPORARY_DOMAIN
+from nucypher.cli.actions import SUCCESSFUL_DESTRUCTION
+
+
+def test_bob_public_keys(click_runner):
+    derive_key_args = ('bob', 'public-keys',
+                       '--dev')
+
+    result = click_runner.invoke(nucypher_cli, derive_key_args, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "bob_encrypting_key" in result.output
+    assert "bob_verifying_key" in result.output
+
+
+def test_initialize_bob_with_custom_configuration_root(custom_filepath, click_runner):
+    # Use a custom local filepath for configuration
+    init_args = ('bob', 'init',
+                 '--network', TEMPORARY_DOMAIN,
+                 '--federated-only',
+                 '--config-root', custom_filepath)
+
+    user_input = '{password}\n{password}'.format(password=INSECURE_DEVELOPMENT_PASSWORD, ip=MOCK_IP_ADDRESS)
+    result = click_runner.invoke(nucypher_cli, init_args, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # CLI Output
+    assert MOCK_CUSTOM_INSTALLATION_PATH in result.output, "Configuration not in system temporary directory"
+    assert "nucypher bob run" in result.output, 'Help message is missing suggested command'
+    assert 'IPv4' not in result.output
+
+    # Files and Directories
+    assert os.path.isdir(custom_filepath), 'Configuration file does not exist'
+    assert os.path.isdir(os.path.join(custom_filepath, 'keyring')), 'Keyring does not exist'
+    assert os.path.isdir(os.path.join(custom_filepath, 'known_nodes')), 'known_nodes directory does not exist'
+
+    custom_config_filepath = os.path.join(custom_filepath, BobConfiguration.generate_filename())
+    assert os.path.isfile(custom_config_filepath), 'Configuration file does not exist'
+
+    # Auth
+    assert 'Enter NuCypher keyring password:' in result.output, 'WARNING: User was not prompted for password'
+    assert 'Repeat for confirmation:' in result.output, 'User was not prompted to confirm password'
+
+
+def test_bob_control_starts_with_preexisting_configuration(click_runner, custom_filepath):
+    custom_config_filepath = os.path.join(custom_filepath, BobConfiguration.generate_filename())
+
+    init_args = ('bob', 'run',
+                 '--dry-run',
+                 '--config-file', custom_config_filepath)
+
+    user_input = '{password}\n{password}\n'.format(password=INSECURE_DEVELOPMENT_PASSWORD)
+    result = click_runner.invoke(nucypher_cli, init_args, input=user_input)
+    assert result.exit_code == 0
+    assert "Bob Verifying Key" in result.output
+    assert "Bob Encrypting Key" in result.output
+
+
+def test_bob_view_with_preexisting_configuration(click_runner, custom_filepath):
+    custom_config_filepath = os.path.join(custom_filepath, BobConfiguration.generate_filename())
+
+    view_args = ('bob', 'view',
+                 '--config-file', custom_config_filepath)
+
+    user_input = '{password}\n{password}\n'.format(password=INSECURE_DEVELOPMENT_PASSWORD)
+    result = click_runner.invoke(nucypher_cli, view_args, input=user_input)
+
+    assert result.exit_code == 0
+    assert "checksum_address" in result.output
+    assert "domains" in result.output
+    assert TEMPORARY_DOMAIN in result.output
+    assert custom_filepath in result.output
 
 
 # TODO: test can probably be removed (--dev is not a valid option for `init`)
@@ -9,3 +85,16 @@ def test_bob_cannot_init_with_dev_flag(click_runner):
     result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
     assert result.exit_code == 2
     assert 'no such option: --dev' in result.output, 'Missing or invalid error message was produced.'
+
+
+# Should be the last test since it deletes the configuration file
+def test_bob_destroy(click_runner, custom_filepath):
+    custom_config_filepath = os.path.join(custom_filepath, BobConfiguration.generate_filename())
+    destroy_args = ('bob', 'destroy',
+                    '--config-file', custom_config_filepath,
+                    '--force')
+
+    result = click_runner.invoke(nucypher_cli, destroy_args, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert SUCCESSFUL_DESTRUCTION in result.output
+    assert not os.path.exists(custom_config_filepath), "Bob config file was deleted"

--- a/tests/cli/test_bob.py
+++ b/tests/cli/test_bob.py
@@ -77,16 +77,6 @@ def test_bob_view_with_preexisting_configuration(click_runner, custom_filepath):
     assert custom_filepath in result.output
 
 
-# TODO: test can probably be removed (--dev is not a valid option for `init`)
-def test_bob_cannot_init_with_dev_flag(click_runner):
-    init_args = ('bob', 'init',
-                 '--federated-only',
-                 '--dev')
-    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
-    assert result.exit_code == 2
-    assert 'no such option: --dev' in result.output, 'Missing or invalid error message was produced.'
-
-
 # Should be the last test since it deletes the configuration file
 def test_bob_destroy(click_runner, custom_filepath):
     custom_config_filepath = os.path.join(custom_filepath, BobConfiguration.generate_filename())

--- a/tests/cli/test_cli_lifecycle.py
+++ b/tests/cli/test_cli_lifecycle.py
@@ -356,8 +356,9 @@ def _cli_lifecycle(click_runner,
                          '--policy-encrypting-key', policy_encrypting_key,
                          '--alice-verifying-key', alice_signing_key)
 
-        if federated:
-            retrieve_args += ('--federated-only',)
+        # TODO: Remove - Federated not used for retrieve any more
+        # if federated:
+        #    retrieve_args += ('--federated-only',)
 
         retrieve_response = click_runner.invoke(nucypher_cli, retrieve_args, catch_exceptions=False, env=envvars)
         assert retrieve_response.exit_code == 0

--- a/tests/cli/test_enrico.py
+++ b/tests/cli/test_enrico.py
@@ -1,0 +1,26 @@
+from nucypher.cli.main import nucypher_cli
+from umbral.keys import UmbralPrivateKey
+
+
+def test_enrico_encrypt(click_runner):
+    policy_encrypting_key = UmbralPrivateKey.gen_key().get_pubkey().to_bytes().hex()
+    encrypt_args = ('enrico', 'encrypt',
+                    '--message', 'to be or not to be',
+                    '--policy-encrypting-key', policy_encrypting_key)
+    result = click_runner.invoke(nucypher_cli, encrypt_args, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert policy_encrypting_key in result.output
+    assert "message_kit" in result.output
+    assert "signature" in result.output
+
+
+def test_enrico_control_starts(click_runner):
+    policy_encrypting_key = UmbralPrivateKey.gen_key().get_pubkey().to_bytes().hex()
+    run_args = ('enrico', 'run',
+                '--policy-encrypting-key', policy_encrypting_key,
+                '--dry-run')
+
+    result = click_runner.invoke(nucypher_cli, run_args, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert policy_encrypting_key in result.output

--- a/tests/cli/test_felix.py
+++ b/tests/cli/test_felix.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 import pytest_twisted
+from nucypher.cli.actions import SUCCESSFUL_DESTRUCTION
 from twisted.internet import threads
 from twisted.internet.task import Clock
 
@@ -145,3 +146,31 @@ def test_run_felix(click_runner,
     next_airdrop = staged_airdrops[0]
     next_airdrop.addCallback(confirm_airdrop)
     yield next_airdrop
+
+    # Felix view
+    view_args = ('felix', 'view',
+                 '--config-file', configuration_file_location,
+                 '--provider', TEST_PROVIDER_URI)
+    result = click_runner.invoke(nucypher_cli, view_args, catch_exceptions=False, env=envvars)
+    assert result.exit_code == 0
+    assert "Address" in result.output
+    assert "NU" in result.output
+    assert "ETH" in result.output
+
+    # Felix accounts
+    accounts_args = ('felix', 'accounts',
+                     '--config-file', configuration_file_location,
+                     '--provider', TEST_PROVIDER_URI)
+    result = click_runner.invoke(nucypher_cli, accounts_args, catch_exceptions=False, env=envvars)
+    assert result.exit_code == 0
+    assert testerchain.client.accounts[-1] in result.output
+
+    # Felix destroy
+    destroy_args = ('felix', 'destroy',
+                    '--config-file', configuration_file_location,
+                    '--provider', TEST_PROVIDER_URI,
+                    '--force')
+    result = click_runner.invoke(nucypher_cli, destroy_args, catch_exceptions=False, env=envvars)
+    assert result.exit_code == 0
+    assert SUCCESSFUL_DESTRUCTION in result.output
+    assert not os.path.exists(configuration_file_location), "Felix configuration file was deleted"

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -49,4 +49,4 @@ def test_nucypher_deploy_help_message(click_runner):
     help_args = ('--help', )
     result = click_runner.invoke(deploy, help_args, catch_exceptions=False)
     assert result.exit_code == 0
-    assert 'deploy [OPTIONS] ACTION' in result.output, 'Missing or invalid help text was produced.'
+    assert 'deploy [OPTIONS] COMMAND [ARGS]' in result.output, 'Missing or invalid help text was produced.'

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -14,12 +14,18 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+import inspect
+
+import click
 import pytest
 
 import nucypher
+from nucypher.cli.config import NucypherClickConfig
 from nucypher.cli.deploy import deploy
 from nucypher.cli.main import nucypher_cli, ENTRY_POINTS
-import click
+
+NUCYPHER_CLICK_CONFIG_OPTIONS = set(inspect.signature(NucypherClickConfig.set_options).parameters.keys())
+NUCYPHER_CLICK_CONFIG_OPTIONS.remove('self')
 
 
 def test_echo_nucypher_version(click_runner):
@@ -66,3 +72,28 @@ def test_nucypher_deploy_help_message(click_runner):
     result = click_runner.invoke(deploy, help_args, catch_exceptions=False)
     assert result.exit_code == 0
     assert 'deploy [OPTIONS] COMMAND [ARGS]' in result.output, 'Missing or invalid help text was produced.'
+
+
+@pytest.mark.parametrize('entry_point_name, entry_point', ([command.name, command] for command in ENTRY_POINTS))
+def test_character_command_options_and_parameters_match(entry_point_name, entry_point):
+    if isinstance(entry_point, click.Group):
+        for sub_command in entry_point.commands.values():
+            _check_command_options_and_parameters(sub_command)
+    else:
+        # Plain old command - currently just `moe`
+        _check_command_options_and_parameters(entry_point)
+
+
+def _check_command_options_and_parameters(command):
+    command_signature = inspect.signature(command.callback)
+
+    command_callback_params = set(command_signature.parameters.keys())
+    assert 'click_config' in command_callback_params, f"{command.name} specifies 'click_config' as a method parameter"
+
+    # remove click_config and add actual options
+    command_callback_params.remove('click_config')
+    command_callback_params.update(NUCYPHER_CLICK_CONFIG_OPTIONS)
+
+    command_options = set(p.name for p in command.params)
+    assert command_options == command_callback_params, \
+        f"click options provided for '{command.name}' matches the corresponding method parameters"

--- a/tests/cli/test_mixed_configurations.py
+++ b/tests/cli/test_mixed_configurations.py
@@ -259,7 +259,7 @@ def test_corrupted_configuration(click_runner,
 
     # Attempt destruction with invalid configuration (missing registry)
     ursula_file_location = os.path.join(custom_filepath, default_filename)
-    destruction_args = ('ursula', '--debug', 'destroy', '--config-file', ursula_file_location)
+    destruction_args = ('ursula', 'destroy', '--debug', '--config-file', ursula_file_location)
     result = click_runner.invoke(nucypher_cli, destruction_args, input='Y\n', catch_exceptions=False, env=envvars)
     assert result.exit_code == 0
 

--- a/tests/cli/ursula/test_federated_ursula.py
+++ b/tests/cli/ursula/test_federated_ursula.py
@@ -137,7 +137,7 @@ def test_ursula_view_configuration(custom_filepath, click_runner, nominal_federa
     custom_config_filepath = os.path.join(custom_filepath, UrsulaConfiguration.generate_filename())
     assert os.path.isfile(custom_config_filepath), 'Configuration file does not exist'
 
-    view_args = ('ursula', 'view', '--config-file', os.path.join(custom_filepath, UrsulaConfiguration.generate_filename()))
+    view_args = ('ursula', 'view', '--config-file', custom_config_filepath)
 
     # View the configuration
     result = click_runner.invoke(nucypher_cli, view_args,
@@ -180,6 +180,19 @@ def test_run_federated_ursula_from_config_file(custom_filepath, click_runner):
     assert "'help' or '?'" in result.output
 
 
+def test_ursula_save_metadata(click_runner, custom_filepath):
+    # Run Ursula
+    save_metadata_args = ('ursula', 'save-metadata',
+                          '--dev',
+                          '--federated-only')
+
+    result = click_runner.invoke(nucypher_cli, save_metadata_args, catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "Successfully saved node metadata" in result.output, "Node metadata successfully saved"
+
+
+# Should be the last test since it deletes the configuration file
 def test_ursula_destroy_configuration(custom_filepath, click_runner):
 
     preexisting_live_configuration = os.path.isdir(DEFAULT_CONFIG_ROOT)
@@ -217,3 +230,4 @@ def test_ursula_destroy_configuration(custom_filepath, click_runner):
     if preexisting_live_configuration_file:
         file_still_exists = os.path.isfile(os.path.join(DEFAULT_CONFIG_ROOT, UrsulaConfiguration.generate_filename()))
         assert file_still_exists, 'WARNING: Test command deleted live non-test files'
+

--- a/tests/cli/ursula/test_run_ursula.py
+++ b/tests/cli/ursula/test_run_ursula.py
@@ -172,17 +172,6 @@ def test_persistent_node_storage_integration(click_runner,
     assert result.exit_code == 0
 
 
-# TODO: test can probably be removed (--dev is not a valid option for `init`)
-def test_ursula_cannot_init_with_dev_flag(click_runner):
-    init_args = ('ursula', 'init',
-                 '--network', TEMPORARY_DOMAIN,
-                 '--federated-only',
-                 '--dev')
-    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
-    assert result.exit_code == 2
-    assert 'no such option: --dev' in result.output, 'Missing or invalid error message was produced.'
-
-
 def test_ursula_rest_host_determination(click_runner):
 
     # Patch the get_external_ip call

--- a/tests/cli/ursula/test_run_ursula.py
+++ b/tests/cli/ursula/test_run_ursula.py
@@ -172,6 +172,7 @@ def test_persistent_node_storage_integration(click_runner,
     assert result.exit_code == 0
 
 
+# TODO: test can probably be removed (--dev is not a valid option for `init`)
 def test_ursula_cannot_init_with_dev_flag(click_runner):
     init_args = ('ursula', 'init',
                  '--network', TEMPORARY_DOMAIN,
@@ -179,7 +180,7 @@ def test_ursula_cannot_init_with_dev_flag(click_runner):
                  '--dev')
     result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
     assert result.exit_code == 2
-    assert 'Cannot create a persistent development character' in result.output, 'Missing or invalid error message was produced.'
+    assert 'no such option: --dev' in result.output, 'Missing or invalid error message was produced.'
 
 
 def test_ursula_rest_host_determination(click_runner):

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -67,7 +67,6 @@ def test_new_stakeholder(click_runner,
                  '--poa',
                  '--config-root', custom_filepath,
                  '--provider', TEST_PROVIDER_URI,
-                 '--no-sync',
                  '--registry-filepath', mock_registry_filepath)
 
     result = click_runner.invoke(nucypher_cli,
@@ -106,7 +105,6 @@ def test_stake_init(click_runner,
                   '--config-file', stakeholder_configuration_file_location,
                   '--staking-address', manual_staker,
                   '--value', stake_value.to_tokens(),
-                  '--no-sync',
                   '--lock-periods', token_economics.minimum_locked_periods,
                   '--force')
 
@@ -166,7 +164,6 @@ def test_staker_divide_stakes(click_runner,
                    '--force',
                    '--staking-address', manual_staker,
                    '--index', 0,
-                   '--no-sync',
                    '--value', NU(token_economics.minimum_allowed_locked, 'NuNit').to_tokens(),
                    '--lock-periods', 10)
 
@@ -196,9 +193,7 @@ def test_stake_set_worker(click_runner,
     init_args = ('stake', 'set-worker',
                  '--config-file', stakeholder_configuration_file_location,
                  '--staking-address', manual_staker,
-                 '--worker-address', manual_worker,
-                 '--no-sync',
-                 '--force')
+                 '--worker-address', manual_worker)
 
     user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}'
     result = click_runner.invoke(nucypher_cli,
@@ -482,9 +477,7 @@ def test_collect_rewards_integration(click_runner,
                        '--policy-reward',
                        '--no-staking-reward',
                        '--staking-address', staker_address,
-                       '--withdraw-address', burner_wallet.address,
-                       '--force')
-
+                       '--withdraw-address', burner_wallet.address)
     result = click_runner.invoke(nucypher_cli,
                                  collection_args,
                                  input=INSECURE_DEVELOPMENT_PASSWORD,
@@ -511,8 +504,7 @@ def test_collect_rewards_integration(click_runner,
                        '--no-policy-reward',
                        '--staking-reward',
                        '--staking-address', staker_address,
-                       '--withdraw-address', burner_wallet.address,
-                       '--force')
+                       '--withdraw-address', burner_wallet.address)
 
     result = click_runner.invoke(nucypher_cli,
                                  collection_args,


### PR DESCRIPTION
Fixes #1286 .

In our current CLI setup we lay out all of the options for all commands even though some options only apply to specific "commands", and not to others. Furthermore, we can't do something like:
```
nucypher <character> <command> --help
```
and get specific help for that specific command.

One way for us to get around this could be to restructure our CLI commands a bit to instead use `click.group` and `click.command`. It would allow us to ensure that required options for a specific command/action are provided by specifying `required=True` for options tied to those specific commands/actions, or that options that aren't applicable to specific commands, can't be specified (a recurring example in our code is the `dev` option)

This would improve UX by providing more context-specific help, and inherently fixes the problem of detecting unrecognized commands.

The drawback of the above strategy is that common code/objects needed across different commands need to be refactored into common methods, but this may not be such a bad thing.