### PR TITLE
Unable to unlock account parity client due to typo

### DIFF
--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -358,7 +358,7 @@ class ParityClient(Web3Client):
         return to_checksum_address(new_account)  # cast and validate
 
     def unlock_account(self, address, password, duration: int = None) -> bool:
-        return self.w3.parity.unlockAccount.unlockAccount(address, password, duration)
+        return self.w3.parity.personal.unlockAccount(address, password, duration)
 
     def lock_account(self, address):
         return self.w3.parity.personal.lockAccount(address)


### PR DESCRIPTION
Haven't done any further digging into other issues that may exist on the "parity as an eth client" critical path, but thought I'd leave this PR here.