### PR TITLE
CLI options cleanup

### DIFF
--- a/nucypher/characters/control/emitters.py
+++ b/nucypher/characters/control/emitters.py
@@ -1,3 +1,4 @@
+import io
 import json
 import sys
 from functools import partial
@@ -8,6 +9,10 @@ from flask import Response
 from twisted.logger import Logger
 
 import nucypher
+
+
+def null_stream():
+    return open(os.devnull, 'w')
 
 
 class StdoutEmitter:
@@ -63,6 +68,12 @@ class StdoutEmitter:
             e_str = str(e)
             click.echo(message=e_str)
             self.log.info(e_str)
+
+    def get_stream(self, verbosity: int = 0):
+        if verbosity <= self.verbosity:
+            return click.get_text_stream('stdout')
+        else:
+            return null_stream()
 
 
 class JSONRPCStdoutEmitter(StdoutEmitter):
@@ -179,6 +190,9 @@ class JSONRPCStdoutEmitter(StdoutEmitter):
         # self.log.info(f"Error {e.code} | {e.message}")  # TODO: Restore this log message
         return size
 
+    def get_stream(self, *args, **kwargs):
+        return null_stream()
+
 
 class WebEmitter:
 
@@ -227,3 +241,6 @@ class WebEmitter:
         # ---------- HTTP OUTPUT
         response = drone_character.sink(response=serialized_response, status=200, content_type="application/javascript")
         return response
+
+    def get_stream(self, *args, **kwargs):
+        return null_stream()

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -308,14 +308,12 @@ def get_provider_process(start_now: bool = False):
 
 
 def make_cli_character(character_config,
-                       general_config,
+                       emitter,
                        unlock_keyring: bool = True,
                        teacher_uri: str = None,
                        min_stake: int = 0,
                        load_preferred_teachers: bool = True,
                        **config_args):
-
-    emitter = general_config.emitter
 
     #
     # Pre-Init

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -64,7 +64,7 @@ Delete all {name} character files including:
     - Known Nodes             ({nodestore})
     - Node Configuration File ({config})
     - Database                ({database})
-    
+
 Are you sure?'''
 
 SUCCESSFUL_DESTRUCTION = "Successfully destroyed NuCypher configuration"
@@ -269,8 +269,8 @@ By agreeing to stake {str(value)} ({str(value.to_nunits())} NuNits):
 
 - Staked tokens will be locked for the stake duration.
 
-- You are obligated to maintain a networked and available Ursula-Worker node 
-  bonded to the staker address {staker_address} for the duration 
+- You are obligated to maintain a networked and available Ursula-Worker node
+  bonded to the staker address {staker_address} for the duration
   of the stake(s) ({lock_periods} periods).
 
 - Agree to allow NuCypher network users to carry out uninterrupted re-encryption
@@ -308,14 +308,14 @@ def get_provider_process(start_now: bool = False):
 
 
 def make_cli_character(character_config,
-                       click_config,
+                       general_config,
                        unlock_keyring: bool = True,
                        teacher_uri: str = None,
                        min_stake: int = 0,
                        load_preferred_teachers: bool = True,
                        **config_args):
 
-    emitter = click_config.emitter
+    emitter = general_config.emitter
 
     #
     # Pre-Init
@@ -485,7 +485,7 @@ def confirm_deployment(emitter, deployer_interface) -> bool:
 
 def confirm_enable_restaking_lock(emitter, staking_address: str, release_period: int) -> bool:
     restaking_lock_agreement = f"""
-By enabling the re-staking lock for {staking_address}, you are committing to automatically 
+By enabling the re-staking lock for {staking_address}, you are committing to automatically
 re-stake all rewards until a future period.  You will not be able to disable re-staking until {release_period}.
     """
     emitter.message(restaking_lock_agreement)

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -396,7 +396,7 @@ def select_client_account(emitter,
 
     # Lazy connect the blockchain interface
     if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
-        BlockchainInterfaceFactory.initialize_interface(provider_uri=provider_uri)
+        BlockchainInterfaceFactory.initialize_interface(provider_uri=provider_uri, emitter=emitter)
     blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)
 
     # Lazy connect to contracts

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -477,7 +477,7 @@ def _create_alice(alice_config, general_config, dev, emitter, hw_wallet, teacher
             client_password = get_client_password(checksum_address=alice_config.checksum_address)
     try:
         ALICE = actions.make_cli_character(character_config=alice_config,
-                                           general_config=general_config,
+                                           emitter=general_config.emitter,
                                            unlock_keyring=not dev,
                                            teacher_uri=teacher_uri,
                                            min_stake=min_stake,

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -41,24 +41,158 @@ from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 option_bob_verifying_key = click.option(
     '--bob-verifying-key', help="Bob's verifying key as a hexadecimal string", type=click.STRING,
     required=True)
+option_pay_with = click.option(
+    '--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 
 
-group_admin = group_options(
-    'admin',
-    geth=option_geth,
-    provider_uri=option_provider_uri(),
-    federated_only=option_federated_only,
+class AliceConfigOptions:
+
+    __option_name__ = 'config_options'
+
+    def __init__(
+            self, dev, network, provider_uri, geth, federated_only, discovery_port,
+            pay_with, registry_filepath):
+
+        if federated_only and geth:
+            raise click.BadOptionUsage(
+                option_name="--geth",
+                message="--federated-only cannot be used with the --geth flag")
+
+        # Managed Ethereum Client
+        eth_node = NO_BLOCKCHAIN_CONNECTION
+        if geth:
+            eth_node = actions.get_provider_process()
+            provider_uri = ETH_NODE.provider_uri(scheme='file')
+
+        self.dev = dev
+        self.domains = {network} if network else None
+        self.provider_uri = provider_uri
+        self.geth = geth
+        self.federated_only = federated_only
+        self.eth_node = eth_node
+        self.pay_with = pay_with
+        self.discovery_port = discovery_port
+        self.registry_filepath = registry_filepath
+
+    def create_config(self, middleware, config_file):
+
+        if self.dev:
+
+            # Can be None as well, meaning it is unset - no error in this case
+            if self.federated_only is False:
+                raise click.BadOptionUsage(
+                    option_name="--federated-only",
+                    message="--federated-only cannot be explicitly set to False when --dev is set")
+
+            return AliceConfiguration(
+                dev_mode=True,
+                network_middleware=middleware,
+                domains={TEMPORARY_DOMAIN},
+                provider_process=self.eth_node,
+                provider_uri=self.provider_uri,
+                federated_only=True)
+
+        else:
+            try:
+                return AliceConfiguration.from_configuration_file(
+                    dev_mode=False,
+                    network_middleware=middleware,
+                    domains=self.domains,
+                    provider_process=self.eth_node,
+                    provider_uri=self.provider_uri,
+                    filepath=config_file,
+                    rest_port=self.discovery_port,
+                    checksum_address=self.pay_with,
+                    registry_filepath=self.registry_filepath)
+            except FileNotFoundError:
+                return actions.handle_missing_configuration_file(
+                    character_config_class=AliceConfiguration,
+                    config_file=config_file)
+
+    def generate_config(self, emitter, config_root, poa, light, m, n, duration_periods, rate):
+
+        if self.dev:
+            raise click.BadArgumentUsage("Cannot create a persistent development character")
+
+        if not self.provider_uri and not self.federated_only:
+            raise click.BadOptionUsage(
+                option_name='--provider',
+                message="--provider is required to create a new decentralized alice.")
+
+        pay_with = self.pay_with
+        if not pay_with and not self.federated_only:
+            pay_with = select_client_account(
+                emitter=emitter,
+                provider_uri=self.provider_uri)
+
+        return AliceConfiguration.generate(
+            password=get_nucypher_password(confirm=True),
+            config_root=config_root,
+            checksum_address=pay_with,
+            domains=self.domains,
+            federated_only=self.federated_only,
+            provider_uri=self.provider_uri,
+            provider_process=self.eth_node,
+            registry_filepath=self.registry_filepath,
+            poa=poa,
+            light=light,
+            m=m,
+            n=n,
+            duration_periods=duration_periods,
+            rate=rate)
+
+
+group_config_options = group_options(
+    AliceConfigOptions,
     dev=option_dev,
-    pay_with=click.option('--pay-with', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS),
     network=option_network,
-    registry_filepath=option_registry_filepath)
-
-
-group_api = group_options(
-    'api',
-    admin=group_admin,
-    config_file=option_config_file,
+    provider_uri=option_provider_uri(),
+    geth=option_geth,
+    federated_only=option_federated_only,
     discovery_port=option_discovery_port(),
+    pay_with=option_pay_with,
+    registry_filepath=option_registry_filepath,
+    )
+
+
+class AliceCharacterOptions:
+
+    __option_name__ = 'character_options'
+
+    def __init__(self, config_options, hw_wallet, teacher_uri, min_stake):
+        self.config_options = config_options
+        self.hw_wallet = hw_wallet
+        self.teacher_uri = teacher_uri
+        self.min_stake = min_stake
+
+    def create_character(self, emitter, config_file, middleware, json_ipc, load_seednodes=True):
+
+        config = self.config_options.create_config(middleware, config_file)
+
+        client_password = None
+        if not config.federated_only:
+            if (not self.hw_wallet or not config.dev_mode) and not json_ipc:
+                client_password = get_client_password(checksum_address=config.checksum_address)
+
+        try:
+            ALICE = actions.make_cli_character(character_config=config,
+                                               emitter=emitter,
+                                               unlock_keyring=not config.dev_mode,
+                                               teacher_uri=self.teacher_uri,
+                                               min_stake=self.min_stake,
+                                               client_password=client_password,
+                                               load_preferred_teachers=load_seednodes,
+                                               start_learning_now=load_seednodes)
+
+            return ALICE
+        except NucypherKeyring.AuthenticationFailed as e:
+            emitter.echo(str(e), color='red', bold=True)
+            click.get_current_context().exit(1)
+
+
+group_character_options = group_options(
+    AliceCharacterOptions,
+    config_options=group_config_options,
     hw_wallet=option_hw_wallet,
     teacher_uri=option_teacher_uri,
     min_stake=option_min_stake,
@@ -74,7 +208,7 @@ def alice():
 
 
 @alice.command()
-@group_admin
+@group_config_options
 @option_config_root
 @option_poa
 @option_light
@@ -83,63 +217,18 @@ def alice():
 @click.option('--rate', help="Policy rate per period in wei", type=click.FLOAT)
 @click.option('--duration-periods', help="Policy duration in periods", type=click.FLOAT)
 @group_general_config
-def init(general_config,
-
-         # Admin Options
-         admin,
-
-         # Other
-         config_root, poa, light, m, n, rate, duration_periods):
+def init(general_config, config_options, config_root, poa, light, m, n, rate, duration_periods):
     """
     Create a brand new persistent Alice.
     """
 
-    ### Setup ###
     emitter = _setup_emitter(general_config)
 
-    if admin.federated_only and admin.geth:
-        raise click.BadOptionUsage(option_name="--geth", message="Federated only cannot be used with the --geth flag")
+    if not config_root:
+        config_root = general_config.config_file # FIXME: better called `config_root`?
 
-    #
-    # Managed Ethereum Client
-    #
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if admin.geth:
-        ETH_NODE = actions.get_provider_process()
-        provider_uri = ETH_NODE.provider_uri(scheme='file')
-
-    #############
-
-    if admin.dev:
-        raise click.BadArgumentUsage("Cannot create a persistent development character")
-
-    if not provider_uri and not admin.federated_only:
-        raise click.BadOptionUsage(option_name='--provider',
-                                   message="--provider is required to create a new decentralized alice.")
-
-    if not config_root:  # Flag
-        config_root = general_config.config_file  # Envvar
-
-    pay_with = admin.pay_with
-    if not pay_with and not admin.federated_only:
-        pay_with = select_client_account(emitter=emitter, provider_uri=provider_uri)
-
-    new_alice_config = AliceConfiguration.generate(password=get_nucypher_password(confirm=True),
-                                                   config_root=config_root,
-                                                   checksum_address=pay_with,
-                                                   domains={admin.network} if admin.network else None,
-                                                   federated_only=admin.federated_only,
-                                                   registry_filepath=admin.registry_filepath,
-                                                   provider_process=ETH_NODE,
-                                                   poa=poa,
-                                                   light=light,
-                                                   provider_uri=provider_uri,
-                                                   m=m,
-                                                   n=n,
-                                                   duration_periods=duration_periods,
-                                                   rate=rate)
+    new_alice_config = config_options.generate_config(
+        emitter, config_root, poa, light, m, n, duration_periods, rate)
 
     painting.paint_new_installation_help(emitter, new_configuration=new_alice_config)
 
@@ -159,62 +248,32 @@ def view(general_config, config_file):
 
 
 @alice.command()
-@group_admin
+@group_config_options
 @option_config_file
-@option_discovery_port()
 @option_force
 @group_general_config
-def destroy(general_config,
-
-            # Admin Options
-            admin,
-
-            # Other
-            config_file, discovery_port, force):
+def destroy(general_config, config_options, config_file, force):
     """
     Delete existing Alice's configuration.
     """
-    ### Setup ###
     emitter = _setup_emitter(general_config)
-
-    alice_config, provider_uri = _get_alice_config(
-        general_config, config_file, admin.dev, discovery_port, admin.federated_only,
-        admin.geth, admin.network, admin.pay_with, admin.provider_uri, admin.registry_filepath)
-    #############
-
-    if admin.dev:
-        message = "'nucypher alice destroy' cannot be used in --dev mode"
-        raise click.BadOptionUsage(option_name='--dev', message=message)
+    alice_config = config_options.create_config(general_config.middleware, config_file)
     return actions.destroy_configuration(emitter, character_config=alice_config, force=force)
 
 
 @alice.command()
-@group_api
+@group_character_options
+@option_config_file
 @option_controller_port(default=AliceConfiguration.DEFAULT_CONTROLLER_PORT)
 @option_dry_run
 @group_general_config
-def run(general_config,
-
-        # API Options
-        api,
-
-        # Other
-        controller_port, dry_run):
+def run(general_config, character_options, config_file, controller_port, dry_run):
     """
     Start Alice's controller.
     """
-
-    ### Setup ###
     emitter = _setup_emitter(general_config)
-
-    admin = api.admin
-
-    alice_config, provider_uri = _get_alice_config(
-        general_config, api.config_file, admin.dev, api.discovery_port, admin.federated_only,
-        admin.geth, admin.network, admin.pay_with, admin.provider_uri, admin.registry_filepath)
-    #############
-
-    ALICE = _create_alice(alice_config, general_config, admin.dev, emitter, api.hw_wallet, api.teacher_uri, api.min_stake)
+    ALICE = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.json_ipc)
 
     try:
         # RPC
@@ -234,59 +293,40 @@ def run(general_config,
 
     # Handle Crash
     except Exception as e:
-        alice_config.log.critical(str(e))
+        ALICE.log.critical(str(e))
         emitter.message(f"{e.__class__.__name__} {e}", color='red', bold=True)
         if general_config.debug:
             raise  # Crash :-(
 
 
 @alice.command("public-keys")
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
-def public_keys(general_config, api):
+def public_keys(general_config, character_options, config_file):
     """
     Obtain Alice's public verification and encryption keys.
     """
-
-    ### Setup ###
     emitter = _setup_emitter(general_config)
-
-    admin = api.admin
-
-    alice_config, _ = _get_alice_config(
-        general_config, api.config_file, admin.dev, api.discovery_port, admin.federated_only,
-        admin.geth, admin.network, admin.pay_with, admin.provider_uri, admin.registry_filepath)
-    #############
-
-    ALICE = _create_alice(alice_config, general_config, admin.dev,
-                          emitter, api.hw_wallet, api.teacher_uri, api.min_stake, load_seednodes=False)
-
+    ALICE = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.json_ipc, load_seednodes=False)
     response = ALICE.controller.public_keys()
     return response
 
 
 @alice.command('derive-policy-pubkey')
 @option_label(required=True)
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
-def derive_policy_pubkey(general_config, label, api):
+def derive_policy_pubkey(general_config, label, character_options, config_file):
     """
     Get a policy public key from a policy label.
     """
     ### Setup ###
     emitter = _setup_emitter(general_config)
-
-    admin = api.admin
-
-    alice_config, _ = _get_alice_config(
-        general_config, api.config_file, admin.dev, api.discovery_port, admin.federated_only,
-        admin.geth, admin.network, admin.pay_with, admin.provider_uri, admin.registry_filepath)
-    #############
-
-    ALICE = _create_alice(alice_config, general_config, admin.dev,
-                          emitter, api.hw_wallet, api.teacher_uri, api.min_stake, load_seednodes=False)
-
-    # Request
+    ALICE = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.json_ipc, load_seednodes=False)
     return ALICE.controller.derive_policy_encrypting_key(label=label)
 
 
@@ -299,7 +339,8 @@ def derive_policy_pubkey(general_config, label, api):
 @option_n
 @click.option('--expiration', help="Expiration Datetime of a policy", type=click.STRING)  # TODO: click.DateTime()
 @click.option('--value', help="Total policy value (in Wei)", type=types.WEI)
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
 def grant(general_config,
           # Other (required)
@@ -309,7 +350,7 @@ def grant(general_config,
           m, n, expiration, value,
 
           # API Options
-          api
+          character_options, config_file
           ):
     """
     Create and enact an access policy for some Bob.
@@ -317,15 +358,8 @@ def grant(general_config,
     ### Setup ###
     emitter = _setup_emitter(general_config)
 
-    admin = api.admin
-
-    alice_config, _ = _get_alice_config(
-        general_config, api.config_file, admin.dev, api.discovery_port, admin.federated_only,
-        admin.geth, admin.network, admin.pay_with, admin.provider_uri, admin.registry_filepath)
-
-    #############
-
-    ALICE = _create_alice(alice_config, general_config, admin.dev, emitter, api.hw_wallet, api.teacher_uri, api.min_stake)
+    ALICE = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.json_ipc)
 
     # Request
     grant_request = {
@@ -345,7 +379,8 @@ def grant(general_config,
 @alice.command()
 @option_bob_verifying_key
 @option_label(required=True)
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
 def revoke(general_config,
 
@@ -353,7 +388,7 @@ def revoke(general_config,
            bob_verifying_key, label,
 
            # API Options
-           api
+           character_options, config_file
            ):
     """
     Revoke a policy.
@@ -361,15 +396,8 @@ def revoke(general_config,
     ### Setup ###
     emitter = _setup_emitter(general_config)
 
-    admin = api.admin
-
-    alice_config, _ = _get_alice_config(
-        general_config, api.config_file, admin.dev, api.discovery_port, admin.federated_only,
-        admin.geth, admin.network, admin.pay_with, admin.provider_uri, admin.registry_filepath)
-
-    #############
-
-    ALICE = _create_alice(alice_config, general_config, admin.dev, emitter, api.hw_wallet, api.teacher_uri, api.min_stake)
+    ALICE = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.json_ipc)
 
     # Request
     revoke_request = {'label': label, 'bob_verifying_key': bob_verifying_key}
@@ -379,7 +407,8 @@ def revoke(general_config,
 @alice.command()
 @option_label(required=True)
 @option_message_kit(required=True)
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
 def decrypt(general_config,
 
@@ -387,7 +416,7 @@ def decrypt(general_config,
             label, message_kit,
 
             # API Options
-            api
+            character_options, config_file
             ):
     """
     Decrypt data encrypted under an Alice's policy public key.
@@ -395,16 +424,8 @@ def decrypt(general_config,
     ### Setup ###
     emitter = _setup_emitter(general_config)
 
-    admin = api.admin
-
-    alice_config, _ = _get_alice_config(
-        general_config, api.config_file, admin.dev, api.discovery_port, admin.federated_only,
-        admin.geth, admin.network, admin.pay_with, admin.provider_uri, admin.registry_filepath)
-
-    #############
-
-    ALICE = _create_alice(alice_config, general_config, admin.dev, emitter,
-                          api.hw_wallet, api.teacher_uri, api.min_stake, load_seednodes=False)
+    ALICE = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.json_ipc, load_seednodes=False)
 
     # Request
     request_data = {'label': label, 'message_kit': message_kit}
@@ -419,73 +440,3 @@ def _setup_emitter(general_config):
     emitter.banner(ALICE_BANNER)
 
     return emitter
-
-
-def _get_alice_config(general_config, config_file, dev, discovery_port, federated_only, geth, network, pay_with,
-                      provider_uri, registry_filepath):
-    if federated_only and geth:
-        raise click.BadOptionUsage(option_name="--geth", message="Federated only cannot be used with the --geth flag")
-    #
-    # Managed Ethereum Client
-    #
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
-        ETH_NODE = actions.get_provider_process()
-        provider_uri = ETH_NODE.provider_uri(scheme='file')
-
-    # Get config
-    alice_config = _get_or_create_alice_config(general_config, dev, network, ETH_NODE, provider_uri,
-                                               config_file, discovery_port, pay_with, registry_filepath)
-    return alice_config, provider_uri
-
-
-def _get_or_create_alice_config(general_config, dev, network, eth_node, provider_uri, config_file,
-                                discovery_port, pay_with, registry_filepath):
-    if dev:
-        alice_config = AliceConfiguration(dev_mode=True,
-                                          network_middleware=general_config.middleware,
-                                          domains={TEMPORARY_DOMAIN},
-                                          provider_process=eth_node,
-                                          provider_uri=provider_uri,
-                                          federated_only=True)
-
-    else:
-        try:
-            alice_config = AliceConfiguration.from_configuration_file(
-                dev_mode=False,
-                filepath=config_file,
-                domains={network} if network else None,
-                network_middleware=general_config.middleware,
-                rest_port=discovery_port,
-                checksum_address=pay_with,
-                provider_process=eth_node,
-                provider_uri=provider_uri,
-                registry_filepath=registry_filepath)
-        except FileNotFoundError:
-            return actions.handle_missing_configuration_file(character_config_class=AliceConfiguration,
-                                                             config_file=config_file)
-    return alice_config
-
-
-def _create_alice(alice_config, general_config, dev, emitter, hw_wallet, teacher_uri, min_stake, load_seednodes=True):
-    #
-    # Produce Alice
-    #
-    client_password = None
-    if not alice_config.federated_only:
-        if (not hw_wallet or not dev) and not general_config.json_ipc:
-            client_password = get_client_password(checksum_address=alice_config.checksum_address)
-    try:
-        ALICE = actions.make_cli_character(character_config=alice_config,
-                                           emitter=general_config.emitter,
-                                           unlock_keyring=not dev,
-                                           teacher_uri=teacher_uri,
-                                           min_stake=min_stake,
-                                           client_password=client_password,
-                                           load_preferred_teachers=load_seednodes,
-                                           start_learning_now=load_seednodes)
-
-        return ALICE
-    except NucypherKeyring.AuthenticationFailed as e:
-        emitter.echo(str(e), color='red', bold=True)
-        click.get_current_context().exit(1)

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -76,7 +76,7 @@ class AliceConfigOptions:
         self.registry_filepath = registry_filepath
         self.middleware = middleware
 
-    def create_config(self, config_file):
+    def create_config(self, emitter, config_file):
 
         if self.dev:
 
@@ -87,6 +87,7 @@ class AliceConfigOptions:
                     message="--federated-only cannot be explicitly set to False when --dev is set")
 
             return AliceConfiguration(
+                emitter=emitter,
                 dev_mode=True,
                 network_middleware=self.middleware,
                 domains={TEMPORARY_DOMAIN},
@@ -97,6 +98,7 @@ class AliceConfigOptions:
         else:
             try:
                 return AliceConfiguration.from_configuration_file(
+                    emitter=emitter,
                     dev_mode=False,
                     network_middleware=self.middleware,
                     domains=self.domains,
@@ -170,7 +172,7 @@ class AliceCharacterOptions:
 
     def create_character(self, emitter, config_file, json_ipc, load_seednodes=True):
 
-        config = self.config_options.create_config(config_file)
+        config = self.config_options.create_config(emitter, config_file)
 
         client_password = None
         if not config.federated_only:
@@ -260,7 +262,7 @@ def destroy(general_config, config_options, config_file, force):
     Delete existing Alice's configuration.
     """
     emitter = _setup_emitter(general_config)
-    alice_config = config_options.create_config(config_file)
+    alice_config = config_options.create_config(emitter, config_file)
     return actions.destroy_configuration(emitter, character_config=alice_config, force=force)
 
 

--- a/nucypher/cli/characters/alice.py
+++ b/nucypher/cli/characters/alice.py
@@ -230,7 +230,7 @@ def init(general_config, config_options, config_root, poa, light, m, n, rate, du
     emitter = _setup_emitter(general_config)
 
     if not config_root:
-        config_root = general_config.config_file # FIXME: better called `config_root`?
+        config_root = general_config.config_root
 
     new_alice_config = config_options.generate_config(
         emitter, config_root, poa, light, m, n, duration_periods, rate)

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -124,7 +124,7 @@ def run(general_config,
     #############
 
     BOB = actions.make_cli_character(character_config=bob_config,
-                                     general_config=general_config,
+                                     emitter=emitter,
                                      unlock_keyring=not api.dev,
                                      teacher_uri=api.teacher_uri,
                                      min_stake=api.min_stake)
@@ -224,7 +224,7 @@ def public_keys(general_config,
     """
 
     ### Setup ###
-    _setup_emitter(general_config)
+    emitter = _setup_emitter(general_config)
 
     admin = api.admin
 
@@ -235,7 +235,7 @@ def public_keys(general_config,
     #############
 
     BOB = actions.make_cli_character(character_config=bob_config,
-                                     general_config=general_config,
+                                     emitter=emitter,
                                      unlock_keyring=not api.dev,
                                      teacher_uri=api.teacher_uri,
                                      min_stake=api.min_stake,
@@ -265,7 +265,7 @@ def retrieve(general_config,
     """
 
     ### Setup ###
-    _setup_emitter(general_config)
+    emitter = _setup_emitter(general_config)
 
     admin = api.admin
 
@@ -276,7 +276,7 @@ def retrieve(general_config,
     #############
 
     BOB = actions.make_cli_character(character_config=bob_config,
-                                     general_config=general_config,
+                                     emitter=emitter,
                                      unlock_keyring=not api.dev,
                                      teacher_uri=api.teacher_uri,
                                      min_stake=api.min_stake)

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -6,6 +6,25 @@ import click
 from nucypher.characters.banners import BOB_BANNER
 from nucypher.cli import actions, painting
 from nucypher.cli.actions import get_nucypher_password, select_client_account
+from nucypher.cli.common_options import (
+    option_checksum_address,
+    option_config_file,
+    option_config_root,
+    option_controller_port,
+    option_dev,
+    option_discovery_port,
+    option_dry_run,
+    option_federated_only,
+    option_force,
+    option_label,
+    option_message_kit,
+    option_min_stake,
+    option_network,
+    option_policy_encrypting_key,
+    option_provider_uri,
+    option_registry_filepath,
+    option_teacher_uri,
+    )
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import BobConfiguration
@@ -18,10 +37,10 @@ from nucypher.utilities.sandbox.constants import TEMPORARY_DOMAIN
 
 
 def _admin_options(func):
-    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-    @click.option('--network', help="Network Domain Name", type=click.STRING)
-    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
-    @click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+    @option_provider_uri()
+    @option_network
+    @option_registry_filepath
+    @option_checksum_address
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -32,12 +51,11 @@ def _admin_options(func):
 #       teacher_uri, min_stake)
 def _api_options(func):
     @_admin_options
-    @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-    @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-    @click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
-    @click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-    @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT,
-                  default=0)
+    @option_dev
+    @option_config_file
+    @option_discovery_port()
+    @option_teacher_uri
+    @option_min_stake
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -54,8 +72,8 @@ def bob():
 
 @bob.command()
 @_admin_options
-@click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True)
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@option_federated_only
+@option_config_root
 @nucypher_click_config
 def init(click_config,
 
@@ -87,9 +105,8 @@ def init(click_config,
 
 @bob.command()
 @_api_options
-@click.option('--controller-port', help="The host port to run Bob HTTP services on", type=NETWORK_PORT,
-              default=BobConfiguration.DEFAULT_CONTROLLER_PORT)
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+@option_controller_port(default=BobConfiguration.DEFAULT_CONTROLLER_PORT)
+@option_dry_run
 @nucypher_click_config
 def run(click_config,
 
@@ -156,10 +173,10 @@ def view(click_config,
 
 @bob.command()
 @_admin_options
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--discovery-port', help="The host port to run node discovery services on", type=NETWORK_PORT)
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@option_dev
+@option_config_file
+@option_discovery_port()
+@option_force
 @nucypher_click_config
 def destroy(click_config,
 
@@ -221,11 +238,10 @@ def public_keys(click_config,
 
 @bob.command()
 @_api_options
-@click.option('--label', help="The label for a policy", type=click.STRING)
-@click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string",
-              type=click.STRING)
+@option_label()
+@option_policy_encrypting_key()
 @click.option('--alice-verifying-key', help="Alice's verifying key as a hexadecimal string", type=click.STRING)
-@click.option('--message-kit', help="The message kit unicode string encoded in base64", type=click.STRING)
+@option_message_kit()
 @nucypher_click_config
 def retrieve(click_config,
 

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -51,9 +51,10 @@ class BobConfigOptions:
         self.dev = dev
         self.middleware = middleware
 
-    def create_config(self, config_file):
+    def create_config(self, emitter, config_file):
         if self.dev:
             return BobConfiguration(
+                emitter=emitter,
                 dev_mode=True,
                 domains={TEMPORARY_DOMAIN},
                 provider_uri=self.provider_uri,
@@ -63,6 +64,7 @@ class BobConfigOptions:
         else:
             try:
                 return BobConfiguration.from_configuration_file(
+                    emitter=emitter,
                     filepath=config_file,
                     domains=self.domains,
                     checksum_address=self.checksum_address,
@@ -115,7 +117,7 @@ class BobCharacterOptions:
         self.min_stake = min_stake
 
     def create_character(self, emitter, config_file):
-        config = self.config_options.create_config(config_file)
+        config = self.config_options.create_config(emitter, config_file)
 
         return actions.make_cli_character(character_config=config,
                                           emitter=emitter,
@@ -222,7 +224,7 @@ def destroy(general_config, config_options, config_file, force):
         message = "'nucypher bob destroy' cannot be used in --dev mode"
         raise click.BadOptionUsage(option_name='--dev', message=message)
 
-    bob_config = config_options.create_config(config_file)
+    bob_config = config_options.create_config(emitter, config_file)
 
     # Request
     return actions.destroy_configuration(emitter, character_config=bob_config, force=force)

--- a/nucypher/cli/characters/bob.py
+++ b/nucypher/cli/characters/bob.py
@@ -153,8 +153,8 @@ def init(general_config, config_options, federated_only, config_root):
     """
     emitter = _setup_emitter(general_config)
 
-    if not config_root:  # Flag
-        config_root = general_config.config_file  # Envvar
+    if not config_root:
+        config_root = general_config.config_root
 
     new_bob_config = config_options.generate_config(emitter, config_root, federated_only)
 

--- a/nucypher/cli/characters/enrico.py
+++ b/nucypher/cli/characters/enrico.py
@@ -7,7 +7,7 @@ from nucypher.cli.common_options import (
     option_dry_run,
     option_policy_encrypting_key,
     )
-from nucypher.cli.config import nucypher_click_config
+from nucypher.cli.config import group_general_config
 from nucypher.cli.types import NETWORK_PORT
 
 
@@ -23,20 +23,20 @@ def enrico():
 @option_policy_encrypting_key(required=True)
 @option_dry_run
 @click.option('--http-port', help="The host port to run Enrico HTTP services on", type=NETWORK_PORT)
-@nucypher_click_config
-def run(click_config, policy_encrypting_key, dry_run, http_port):
+@group_general_config
+def run(general_config, policy_encrypting_key, dry_run, http_port):
     """
     Start Enrico's controller.
     """
 
     ### Setup ###
-    emitter = _setup_emitter(click_config, policy_encrypting_key)
+    emitter = _setup_emitter(general_config, policy_encrypting_key)
 
     ENRICO = _create_enrico(emitter, policy_encrypting_key)
     #############
 
     # RPC
-    if click_config.json_ipc:
+    if general_config.json_ipc:
         rpc_controller = ENRICO.make_rpc_controller()
         _transport = rpc_controller.make_control_transport()
         rpc_controller.start()
@@ -50,14 +50,14 @@ def run(click_config, policy_encrypting_key, dry_run, http_port):
 @enrico.command()
 @option_policy_encrypting_key(required=True)
 @click.option('--message', help="A unicode message to encrypt for a policy", type=click.STRING, required=True)
-@nucypher_click_config
-def encrypt(click_config, policy_encrypting_key, message):
+@group_general_config
+def encrypt(general_config, policy_encrypting_key, message):
     """
     Encrypt a message under a given policy public key.
     """
 
     ### Setup ###
-    emitter = _setup_emitter(click_config, policy_encrypting_key)
+    emitter = _setup_emitter(general_config, policy_encrypting_key)
 
     ENRICO = _create_enrico(emitter, policy_encrypting_key)
     #############
@@ -68,8 +68,8 @@ def encrypt(click_config, policy_encrypting_key, message):
     return response
 
 
-def _setup_emitter(click_config, policy_encrypting_key):
-    emitter = click_config.emitter
+def _setup_emitter(general_config, policy_encrypting_key):
+    emitter = general_config.emitter
     emitter.clear()
     emitter.banner(ENRICO_BANNER.format(policy_encrypting_key))
 

--- a/nucypher/cli/characters/enrico.py
+++ b/nucypher/cli/characters/enrico.py
@@ -3,13 +3,12 @@ from umbral.keys import UmbralPublicKey
 
 from nucypher.characters.banners import ENRICO_BANNER
 from nucypher.characters.lawful import Enrico
+from nucypher.cli.common_options import (
+    option_dry_run,
+    option_policy_encrypting_key,
+    )
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT
-
-
-policy_encrypting_key_option =  \
-    click.option('--policy-encrypting-key', help="Encrypting Public Key for Policy as hexadecimal string",
-                 type=click.STRING, required=True)
 
 
 @click.group()
@@ -21,8 +20,8 @@ def enrico():
 
 
 @enrico.command()
-@policy_encrypting_key_option
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+@option_policy_encrypting_key(required=True)
+@option_dry_run
 @click.option('--http-port', help="The host port to run Enrico HTTP services on", type=NETWORK_PORT)
 @nucypher_click_config
 def run(click_config, policy_encrypting_key, dry_run, http_port):
@@ -49,7 +48,7 @@ def run(click_config, policy_encrypting_key, dry_run, http_port):
 
 
 @enrico.command()
-@policy_encrypting_key_option
+@option_policy_encrypting_key(required=True)
 @click.option('--message', help="A unicode message to encrypt for a policy", type=click.STRING, required=True)
 @nucypher_click_config
 def encrypt(click_config, policy_encrypting_key, message):

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -18,6 +18,7 @@ from nucypher.cli.common_options import (
     option_dry_run,
     option_force,
     option_geth,
+    option_middleware,
     option_min_stake,
     option_network,
     option_poa,
@@ -114,12 +115,13 @@ class FelixCharacterOptions:
 
     __option_name__ = 'character_options'
 
-    def __init__(self, config_options, teacher_uri, min_stake):
+    def __init__(self, config_options, teacher_uri, min_stake, middleware):
         self.config_options = config_options
         self.teacher_uris = [teacher_uri] if teacher_uri else None
         self.min_stake = min_stake
+        self.middleware = middleware
 
-    def create_character(self, emitter, config_file, middleware, debug):
+    def create_character(self, emitter, config_file, debug):
 
         felix_config = self.config_options.create_config(emitter, config_file)
 
@@ -135,7 +137,7 @@ class FelixCharacterOptions:
                                                    min_stake=self.min_stake,
                                                    federated_only=felix_config.federated_only,
                                                    network_domains=felix_config.domains,
-                                                   network_middleware=middleware)
+                                                   network_middleware=self.middleware)
 
             # Produce Felix
             FELIX = felix_config.produce(domains=self.config_options.domains, known_nodes=teacher_nodes)
@@ -155,6 +157,7 @@ group_character_options = group_options(
     config_options=group_config_options,
     teacher_uri=option_teacher_uri,
     min_stake=option_min_stake,
+    middleware=option_middleware,
     )
 
 
@@ -218,8 +221,7 @@ def createdb(general_config, character_options, config_file, force):
     """
     emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    FELIX = character_options.create_character(
-        emitter, config_file, general_config.middleware, general_config.debug)
+    FELIX = character_options.create_character(emitter, config_file, general_config.debug)
 
     if os.path.isfile(FELIX.db_filepath):
         if not force:
@@ -241,8 +243,7 @@ def view(general_config, character_options, config_file):
     """
     emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    FELIX = character_options.create_character(
-        emitter, config_file, general_config.middleware, general_config.debug)
+    FELIX = character_options.create_character(emitter, config_file, general_config.debug)
 
     token_balance = FELIX.token_balance
     eth_balance = FELIX.eth_balance
@@ -263,8 +264,7 @@ def accounts(general_config, character_options, config_file):
     """
     emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    FELIX = character_options.create_character(
-        emitter, config_file, general_config.middleware, general_config.debug)
+    FELIX = character_options.create_character(emitter, config_file, general_config.debug)
 
     accounts = FELIX.blockchain.client.accounts
     for account in accounts:
@@ -282,8 +282,7 @@ def run(general_config, character_options, config_file, dry_run):
     """
     emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    FELIX = character_options.create_character(
-        emitter, config_file, general_config.middleware, general_config.debug)
+    FELIX = character_options.create_character(emitter, config_file, general_config.debug)
 
     host = character_options.config_options.host
     port = character_options.config_options.port

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -7,23 +7,44 @@ from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 from nucypher.characters.banners import FELIX_BANNER
 from nucypher.cli import actions, painting
 from nucypher.cli.actions import get_nucypher_password, unlock_nucypher_keyring
+from nucypher.cli.common_options import (
+    option_checksum_address,
+    option_config_file,
+    option_config_root,
+    option_db_filepath,
+    option_dev,
+    option_discovery_port,
+    option_dry_run,
+    option_force,
+    option_geth,
+    option_min_stake,
+    option_network,
+    option_poa,
+    option_provider_uri,
+    option_registry_filepath,
+    option_teacher_uri,
+    )
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import FelixConfiguration
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 
 
+option_port = click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT,
+                  default=FelixConfiguration.DEFAULT_REST_PORT)
+
+
 # Args (checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa)
 def _admin_options(func):
-    @click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
-    @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-    @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-    @click.option('--network', help="Network Domain Name", type=click.STRING)
-    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
-    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
+    @option_checksum_address
+    @option_geth
+    @option_dev
+    @option_network
+    @option_registry_filepath
+    @option_provider_uri()
     @click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
-    @click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
-    @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+    @option_db_filepath
+    @option_poa
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -33,12 +54,10 @@ def _admin_options(func):
 # Args (config_file, port, teacher_uri)
 def _api_options(func):
     @_admin_options
-    @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-    @click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT,
-                  default=FelixConfiguration.DEFAULT_REST_PORT)
-    @click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-    @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT,
-                  default=0)
+    @option_config_file
+    @option_port
+    @option_teacher_uri
+    @option_min_stake
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -55,8 +74,8 @@ def felix():
 
 @felix.command()
 @_admin_options
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
-@click.option('--discovery-port', help="The host port to run Felix Node Discovery services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_LEARNER_PORT)
+@option_config_root
+@option_discovery_port(default=FelixConfiguration.DEFAULT_LEARNER_PORT)
 @nucypher_click_config
 def init(click_config,
 
@@ -103,9 +122,9 @@ def init(click_config,
 
 @felix.command()
 @_admin_options
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@option_config_file
+@option_port
+@option_force
 @nucypher_click_config
 def destroy(click_config,
 
@@ -130,7 +149,7 @@ def destroy(click_config,
 
 @felix.command()
 @_api_options
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@option_force
 @nucypher_click_config
 def createdb(click_config,
 
@@ -224,7 +243,7 @@ def accounts(click_config,
 
 @felix.command()
 @_api_options
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True, default=False)
+@option_dry_run
 @nucypher_click_config
 def run(click_config,
 

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -8,6 +8,7 @@ from nucypher.characters.banners import FELIX_BANNER
 from nucypher.cli import actions, painting
 from nucypher.cli.actions import get_nucypher_password, unlock_nucypher_keyring
 from nucypher.cli.common_options import (
+    group_options,
     option_checksum_address,
     option_config_file,
     option_config_root,
@@ -24,7 +25,7 @@ from nucypher.cli.common_options import (
     option_registry_filepath,
     option_teacher_uri,
     )
-from nucypher.cli.config import nucypher_click_config
+from nucypher.cli.config import group_general_config
 from nucypher.cli.types import NETWORK_PORT, EXISTING_READABLE_FILE, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.characters import FelixConfiguration
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
@@ -35,33 +36,29 @@ option_port = click.option('--port', help="The host port to run Felix HTTP servi
 
 
 # Args (checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa)
-def _admin_options(func):
-    @option_checksum_address
-    @option_geth
-    @option_dev
-    @option_network
-    @option_registry_filepath
-    @option_provider_uri()
-    @click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1')
-    @option_db_filepath
-    @option_poa
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-    return wrapper
+group_admin = group_options(
+    'admin',
+    checksum_address=option_checksum_address,
+    geth=option_geth,
+    dev=option_dev,
+    network=option_network,
+    registry_filepath=option_registry_filepath,
+    provider_uri=option_provider_uri(),
+    host=click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1'),
+    db_filepath=option_db_filepath,
+    poa=option_poa,
+    )
 
 
 # Args (config_file, port, teacher_uri)
-def _api_options(func):
-    @_admin_options
-    @option_config_file
-    @option_port
-    @option_teacher_uri
-    @option_min_stake
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        return func(*args, **kwargs)
-    return wrapper
+group_api = group_options(
+    'api',
+    admin=group_admin,
+    config_file=option_config_file,
+    port=option_port,
+    teacher_uri=option_teacher_uri,
+    min_stake=option_min_stake,
+    )
 
 
 @click.group()
@@ -73,25 +70,26 @@ def felix():
 
 
 @felix.command()
-@_admin_options
+@group_admin
 @option_config_root
 @option_discovery_port(default=FelixConfiguration.DEFAULT_LEARNER_PORT)
-@nucypher_click_config
-def init(click_config,
+@group_general_config
+def init(general_config,
 
          # Admin Options
-         checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
+         admin,
 
          # Other
          config_root, discovery_port):
     """
     Create a brand-new Felix.
     """
-    emitter = _setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(general_config, admin.checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
-        ETH_NODE = actions.get_provider_process(dev)
+    provider_uri = admin.provider_uri
+    if admin.geth:
+        ETH_NODE = actions.get_provider_process(admin.dev)
         provider_uri = ETH_NODE.provider_uri
 
     if not config_root:  # Flag
@@ -100,17 +98,17 @@ def init(click_config,
     try:
         new_felix_config = FelixConfiguration.generate(password=get_nucypher_password(confirm=True),
                                                        config_root=config_root,
-                                                       rest_host=host,
+                                                       rest_host=admin.host,
                                                        rest_port=discovery_port,
-                                                       db_filepath=db_filepath,
-                                                       domains={network} if network else None,
-                                                       checksum_address=checksum_address,
-                                                       registry_filepath=registry_filepath,
+                                                       db_filepath=admin.db_filepath,
+                                                       domains={admin.network} if admin.network else None,
+                                                       checksum_address=admin.checksum_address,
+                                                       registry_filepath=admin.registry_filepath,
                                                        provider_uri=provider_uri,
                                                        provider_process=ETH_NODE,
-                                                       poa=poa)
+                                                       poa=admin.poa)
     except Exception as e:
-        if click_config.debug:
+        if general_config.debug:
             raise
         else:
             emitter.echo(str(e), color='red', bold=True)
@@ -121,57 +119,63 @@ def init(click_config,
 
 
 @felix.command()
-@_admin_options
+@group_admin
 @option_config_file
 @option_port
 @option_force
-@nucypher_click_config
-def destroy(click_config,
+@group_general_config
+def destroy(general_config,
 
             # Admin Options
-            checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
+            admin,
 
             # Other
             config_file, port, force):
     """
     Destroy Felix Configuration.
     """
-    emitter = _setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(general_config, admin.checksum_address)
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
-        ETH_NODE = actions.get_provider_process(dev)
+    provider_uri = admin.provider_uri
+    if admin.geth:
+        ETH_NODE = actions.get_provider_process(admin.dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port, db_filepath, poa)
+    felix_config = _get_config(
+        emitter, admin.network, config_file, admin.registry_filepath, ETH_NODE, provider_uri,
+        admin.host, port, admin.db_filepath, admin.poa)
     actions.destroy_configuration(emitter, character_config=felix_config, force=force)
 
 
 @felix.command()
-@_api_options
+@group_api
 @option_force
-@nucypher_click_config
-def createdb(click_config,
+@group_general_config
+def createdb(general_config,
 
              # API Options
-             checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
-             config_file, port, teacher_uri, min_stake,
+             api,
 
              # Other
              force):
     """
     Create Felix DB.
     """
-    emitter = _setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+
+    admin = api.admin
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
-        ETH_NODE = actions.get_provider_process(dev)
+    provider_uri = admin.provider_uri
+    if api.admin.geth:
+        ETH_NODE = actions.get_provider_process(admin.dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                               db_filepath, poa)
-    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(
+        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
+        admin.host, api.port, admin.db_filepath, admin.poa)
+    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
 
     if os.path.isfile(FELIX.db_filepath):
         if not force:
@@ -184,26 +188,30 @@ def createdb(click_config,
 
 
 @felix.command()
-@_api_options
-@nucypher_click_config
-def view(click_config,
+@group_api
+@group_general_config
+def view(general_config,
 
          # API Options
-         checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
-         config_file, port, teacher_uri, min_stake):
+         api
+         ):
     """
     View Felix token balance.
     """
-    emitter = _setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+
+    admin = api.admin
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
+    provider_uri = admin.provider_uri
+    if api.admin.geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                               db_filepath, poa)
-    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(
+        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
+        admin.host, api.port, admin.db_filepath, admin.poa)
+    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
 
     token_balance = FELIX.token_balance
     eth_balance = FELIX.eth_balance
@@ -215,26 +223,30 @@ def view(click_config,
 
 
 @felix.command()
-@_api_options
-@nucypher_click_config
-def accounts(click_config,
+@group_api
+@group_general_config
+def accounts(general_config,
 
              # API Options
-             checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
-             config_file, port, teacher_uri, min_stake):
+             api
+             ):
     """
     View Felix known accounts.
     """
-    emitter = _setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+
+    admin = api.admin
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
+    provider_uri = admin.provider_uri
+    if api.admin.geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                               db_filepath, poa)
-    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(
+        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
+        admin.host, api.port, admin.db_filepath, admin.poa)
+    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
 
     accounts = FELIX.blockchain.client.accounts
     for account in accounts:
@@ -242,41 +254,44 @@ def accounts(click_config,
 
 
 @felix.command()
-@_api_options
+@group_api
 @option_dry_run
-@nucypher_click_config
-def run(click_config,
+@group_general_config
+def run(general_config,
 
         # API Options
-        checksum_address, geth, dev, network, registry_filepath, provider_uri, host, db_filepath, poa,
-        config_file, port, teacher_uri, min_stake,
+        api,
 
         # Other
         dry_run):
     """
     Run Felix service.
     """
-    emitter = _setup_emitter(click_config, checksum_address)
+    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+
+    admin = api.admin
 
     ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
+    provider_uri = admin.provider_uri
+    if api.admin.geth:
         ETH_NODE = actions.get_provider_process(dev)
         provider_uri = ETH_NODE.provider_uri
 
-    felix_config = _get_config(emitter, network, config_file, registry_filepath, ETH_NODE, provider_uri, host, port,
-                               db_filepath, poa)
-    FELIX = _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network)
+    felix_config = _get_config(
+        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
+        admin.host, api.port, admin.db_filepath, admin.poa)
+    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
 
     emitter.echo("Waiting for blockchain sync...", color='yellow')
-    emitter.message(f"Running Felix on {host}:{port}")
-    FELIX.start(host=host,
-                port=port,
+    emitter.message(f"Running Felix on {admin.host}:{api.port}")
+    FELIX.start(host=admin.host,
+                port=api.port,
                 web_services=not dry_run,
                 distribution=True,
-                crash_on_error=click_config.debug)
+                crash_on_error=general_config.debug)
 
 
-def _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, network):
+def _create_felix(emitter, general_config, felix_config, teacher_uri, min_stake, network):
     try:
         # Authenticate
         unlock_nucypher_keyring(emitter,
@@ -289,7 +304,7 @@ def _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, n
                                                min_stake=min_stake,
                                                federated_only=felix_config.federated_only,
                                                network_domains=felix_config.domains,
-                                               network_middleware=click_config.middleware)
+                                               network_middleware=general_config.middleware)
 
         # Produce Felix
         FELIX = felix_config.produce(domains=network, known_nodes=teacher_nodes)
@@ -297,7 +312,7 @@ def _create_felix(emitter, click_config, felix_config, teacher_uri, min_stake, n
 
         return FELIX
     except Exception as e:
-        if click_config.debug:
+        if general_config.debug:
             raise
         else:
             emitter.echo(str(e), color='red', bold=True)
@@ -327,8 +342,8 @@ def _get_config(emitter, network, config_file, registry_filepath, eth_node, prov
         raise click.Abort
 
 
-def _setup_emitter(click_config, checksum_address):
-    emitter = click_config.emitter
+def _setup_emitter(general_config, checksum_address):
+    emitter = general_config.emitter
 
     # Intro
     emitter.clear()

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -64,6 +64,7 @@ class FelixConfigOptions:
         # Load Felix from Configuration File with overrides
         try:
             return FelixConfiguration.from_configuration_file(
+                emitter=emitter,
                 filepath=config_file,
                 domains=self.domains,
                 registry_filepath=self.registry_filepath,

--- a/nucypher/cli/characters/felix.py
+++ b/nucypher/cli/characters/felix.py
@@ -35,27 +35,124 @@ option_port = click.option('--port', help="The host port to run Felix HTTP servi
                   default=FelixConfiguration.DEFAULT_REST_PORT)
 
 
-# Args (checksum_address, geth, dev, network, registry_filepath,  provider_uri, host, db_filepath, poa)
-group_admin = group_options(
-    'admin',
-    checksum_address=option_checksum_address,
+class FelixConfigOptions:
+
+    __option_name__ = 'config_options'
+
+    def __init__(
+            self, geth, dev, network, provider_uri, host,
+            db_filepath, checksum_address, registry_filepath, poa, port):
+
+        eth_node = NO_BLOCKCHAIN_CONNECTION
+        if geth:
+            eth_node = actions.get_provider_process(dev)
+            provider_uri = eth_node.provider_uri
+
+        self.eth_node = eth_node
+        self.provider_uri = provider_uri
+        self.domains = {network} if network else None
+        self.dev = dev
+        self.host = host
+        self.db_filepath = db_filepath
+        self.checksum_address = checksum_address
+        self.registry_filepath = registry_filepath
+        self.poa = poa
+        self.port = port
+
+    def create_config(self, emitter, config_file):
+        # Load Felix from Configuration File with overrides
+        try:
+            return FelixConfiguration.from_configuration_file(
+                filepath=config_file,
+                domains=self.domains,
+                registry_filepath=self.registry_filepath,
+                provider_process=self.eth_node,
+                provider_uri=self.provider_uri,
+                rest_host=self.host,
+                rest_port=self.port,
+                db_filepath=self.db_filepath,
+                poa=self.poa)
+
+            return felix_config
+        except FileNotFoundError:
+            emitter.echo(f"No Felix configuration file found at {config_file}. "
+                         f"Check the filepath or run 'nucypher felix init' to create a new system configuration.")
+            raise click.Abort
+
+    def generate_config(self, config_root, discovery_port):
+        # FIXME: why isn't port used here?
+        return FelixConfiguration.generate(
+            password=get_nucypher_password(confirm=True),
+            config_root=config_root,
+            rest_host=self.host,
+            rest_port=discovery_port,
+            db_filepath=self.db_filepath,
+            domains=self.domains,
+            checksum_address=self.checksum_address,
+            registry_filepath=self.registry_filepath,
+            provider_uri=self.provider_uri,
+            provider_process=self.eth_node,
+            poa=self.poa)
+
+
+group_config_options = group_options(
+    FelixConfigOptions,
     geth=option_geth,
     dev=option_dev,
     network=option_network,
-    registry_filepath=option_registry_filepath,
     provider_uri=option_provider_uri(),
     host=click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1'),
     db_filepath=option_db_filepath,
+    checksum_address=option_checksum_address,
+    registry_filepath=option_registry_filepath,
     poa=option_poa,
+    port=option_port,
     )
 
 
-# Args (config_file, port, teacher_uri)
-group_api = group_options(
-    'api',
-    admin=group_admin,
-    config_file=option_config_file,
-    port=option_port,
+class FelixCharacterOptions:
+
+    __option_name__ = 'character_options'
+
+    def __init__(self, config_options, teacher_uri, min_stake):
+        self.config_options = config_options
+        self.teacher_uris = [teacher_uri] if teacher_uri else None
+        self.min_stake = min_stake
+
+    def create_character(self, emitter, config_file, middleware, debug):
+
+        felix_config = self.config_options.create_config(emitter, config_file)
+
+        try:
+            # Authenticate
+            unlock_nucypher_keyring(emitter,
+                                    character_configuration=felix_config,
+                                    password=get_nucypher_password(confirm=False))
+
+            # Produce Teacher Ursulas
+            teacher_nodes = actions.load_seednodes(emitter,
+                                                   teacher_uris=self.teacher_uris,
+                                                   min_stake=self.min_stake,
+                                                   federated_only=felix_config.federated_only,
+                                                   network_domains=felix_config.domains,
+                                                   network_middleware=middleware)
+
+            # Produce Felix
+            FELIX = felix_config.produce(domains=self.config_options.domains, known_nodes=teacher_nodes)
+            FELIX.make_web_app()  # attach web application, but dont start service
+
+            return FELIX
+        except Exception as e:
+            if debug:
+                raise
+            else:
+                emitter.echo(str(e), color='red', bold=True)
+                raise click.Abort
+
+
+group_character_options = group_options(
+    FelixCharacterOptions,
+    config_options=group_config_options,
     teacher_uri=option_teacher_uri,
     min_stake=option_min_stake,
     )
@@ -70,43 +167,21 @@ def felix():
 
 
 @felix.command()
-@group_admin
+@group_general_config
 @option_config_root
 @option_discovery_port(default=FelixConfiguration.DEFAULT_LEARNER_PORT)
-@group_general_config
-def init(general_config,
-
-         # Admin Options
-         admin,
-
-         # Other
-         config_root, discovery_port):
+@group_config_options
+def init(general_config, config_options, config_root, discovery_port):
     """
     Create a brand-new Felix.
     """
-    emitter = _setup_emitter(general_config, admin.checksum_address)
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if admin.geth:
-        ETH_NODE = actions.get_provider_process(admin.dev)
-        provider_uri = ETH_NODE.provider_uri
+    emitter = _setup_emitter(general_config, config_options.checksum_address)
 
     if not config_root:  # Flag
         config_root = DEFAULT_CONFIG_ROOT  # Envvar or init-only default
 
     try:
-        new_felix_config = FelixConfiguration.generate(password=get_nucypher_password(confirm=True),
-                                                       config_root=config_root,
-                                                       rest_host=admin.host,
-                                                       rest_port=discovery_port,
-                                                       db_filepath=admin.db_filepath,
-                                                       domains={admin.network} if admin.network else None,
-                                                       checksum_address=admin.checksum_address,
-                                                       registry_filepath=admin.registry_filepath,
-                                                       provider_uri=provider_uri,
-                                                       provider_process=ETH_NODE,
-                                                       poa=admin.poa)
+        new_felix_config = config_options.generate_config(config_root, discovery_port)
     except Exception as e:
         if general_config.debug:
             raise
@@ -119,63 +194,32 @@ def init(general_config,
 
 
 @felix.command()
-@group_admin
+@group_config_options
 @option_config_file
-@option_port
 @option_force
 @group_general_config
-def destroy(general_config,
-
-            # Admin Options
-            admin,
-
-            # Other
-            config_file, port, force):
+def destroy(general_config, config_options, config_file, force):
     """
     Destroy Felix Configuration.
     """
-    emitter = _setup_emitter(general_config, admin.checksum_address)
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if admin.geth:
-        ETH_NODE = actions.get_provider_process(admin.dev)
-        provider_uri = ETH_NODE.provider_uri
-
-    felix_config = _get_config(
-        emitter, admin.network, config_file, admin.registry_filepath, ETH_NODE, provider_uri,
-        admin.host, port, admin.db_filepath, admin.poa)
+    emitter = _setup_emitter(general_config, config_options.checksum_address)
+    felix_config = config_options.create_config(emitter, config_file)
     actions.destroy_configuration(emitter, character_config=felix_config, force=force)
 
 
 @felix.command()
-@group_api
+@group_character_options
+@option_config_file
 @option_force
 @group_general_config
-def createdb(general_config,
-
-             # API Options
-             api,
-
-             # Other
-             force):
+def createdb(general_config, character_options, config_file, force):
     """
     Create Felix DB.
     """
-    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+    emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    admin = api.admin
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if api.admin.geth:
-        ETH_NODE = actions.get_provider_process(admin.dev)
-        provider_uri = ETH_NODE.provider_uri
-
-    felix_config = _get_config(
-        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
-        admin.host, api.port, admin.db_filepath, admin.poa)
-    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
+    FELIX = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.debug)
 
     if os.path.isfile(FELIX.db_filepath):
         if not force:
@@ -188,30 +232,17 @@ def createdb(general_config,
 
 
 @felix.command()
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
-def view(general_config,
-
-         # API Options
-         api
-         ):
+def view(general_config, character_options, config_file):
     """
     View Felix token balance.
     """
-    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+    emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    admin = api.admin
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if api.admin.geth:
-        ETH_NODE = actions.get_provider_process(dev)
-        provider_uri = ETH_NODE.provider_uri
-
-    felix_config = _get_config(
-        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
-        admin.host, api.port, admin.db_filepath, admin.poa)
-    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
+    FELIX = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.debug)
 
     token_balance = FELIX.token_balance
     eth_balance = FELIX.eth_balance
@@ -223,30 +254,17 @@ def view(general_config,
 
 
 @felix.command()
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
-def accounts(general_config,
-
-             # API Options
-             api
-             ):
+def accounts(general_config, character_options, config_file):
     """
     View Felix known accounts.
     """
-    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+    emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    admin = api.admin
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if api.admin.geth:
-        ETH_NODE = actions.get_provider_process(dev)
-        provider_uri = ETH_NODE.provider_uri
-
-    felix_config = _get_config(
-        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
-        admin.host, api.port, admin.db_filepath, admin.poa)
-    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
+    FELIX = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.debug)
 
     accounts = FELIX.blockchain.client.accounts
     for account in accounts:
@@ -254,92 +272,28 @@ def accounts(general_config,
 
 
 @felix.command()
-@group_api
+@group_character_options
+@option_config_file
 @option_dry_run
 @group_general_config
-def run(general_config,
-
-        # API Options
-        api,
-
-        # Other
-        dry_run):
+def run(general_config, character_options, config_file, dry_run):
     """
     Run Felix service.
     """
-    emitter = _setup_emitter(general_config, api.admin.checksum_address)
+    emitter = _setup_emitter(general_config, character_options.config_options.checksum_address)
 
-    admin = api.admin
+    FELIX = character_options.create_character(
+        emitter, config_file, general_config.middleware, general_config.debug)
 
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if api.admin.geth:
-        ETH_NODE = actions.get_provider_process(dev)
-        provider_uri = ETH_NODE.provider_uri
-
-    felix_config = _get_config(
-        emitter, admin.network, api.config_file, admin.registry_filepath, ETH_NODE, provider_uri,
-        admin.host, api.port, admin.db_filepath, admin.poa)
-    FELIX = _create_felix(emitter, general_config, felix_config, api.teacher_uri, api.min_stake, admin.network)
-
+    host = character_options.config_options.host
+    port = character_options.config_options.port
     emitter.echo("Waiting for blockchain sync...", color='yellow')
-    emitter.message(f"Running Felix on {admin.host}:{api.port}")
-    FELIX.start(host=admin.host,
-                port=api.port,
+    emitter.message(f"Running Felix on {host}:{port}")
+    FELIX.start(host=host,
+                port=port,
                 web_services=not dry_run,
                 distribution=True,
                 crash_on_error=general_config.debug)
-
-
-def _create_felix(emitter, general_config, felix_config, teacher_uri, min_stake, network):
-    try:
-        # Authenticate
-        unlock_nucypher_keyring(emitter,
-                                character_configuration=felix_config,
-                                password=get_nucypher_password(confirm=False))
-
-        # Produce Teacher Ursulas
-        teacher_nodes = actions.load_seednodes(emitter,
-                                               teacher_uris=[teacher_uri] if teacher_uri else None,
-                                               min_stake=min_stake,
-                                               federated_only=felix_config.federated_only,
-                                               network_domains=felix_config.domains,
-                                               network_middleware=general_config.middleware)
-
-        # Produce Felix
-        FELIX = felix_config.produce(domains=network, known_nodes=teacher_nodes)
-        FELIX.make_web_app()  # attach web application, but dont start service
-
-        return FELIX
-    except Exception as e:
-        if general_config.debug:
-            raise
-        else:
-            emitter.echo(str(e), color='red', bold=True)
-            raise click.Abort
-
-
-def _get_config(emitter, network, config_file, registry_filepath, eth_node, provider_uri, host, port, db_filepath, poa):
-    # Domains -> bytes | or default
-    domains = [network] if network else None
-
-    # Load Felix from Configuration File with overrides
-    try:
-        felix_config = FelixConfiguration.from_configuration_file(filepath=config_file,
-                                                                  domains=domains,
-                                                                  registry_filepath=registry_filepath,
-                                                                  provider_process=eth_node,
-                                                                  provider_uri=provider_uri,
-                                                                  rest_host=host,
-                                                                  rest_port=port,
-                                                                  db_filepath=db_filepath,
-                                                                  poa=poa)
-
-        return felix_config
-    except FileNotFoundError:
-        emitter.echo(f"No Felix configuration file found at {config_file}. "
-                     f"Check the filepath or run 'nucypher felix init' to create a new system configuration.")
-        raise click.Abort
 
 
 def _setup_emitter(general_config, checksum_address):

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -643,7 +643,7 @@ def collect_reward(general_config, transacting_staker_options, config_file,
                               emitter=emitter)
 
 
-@stake.command('preallocation')
+@stake.command()
 @click.argument('action', type=click.Choice(['status', 'withdraw']))
 @group_transacting_staker_options
 @option_config_file

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -70,9 +70,10 @@ class StakeHolderConfigOptions:
         self.light = light
         self.registry_filepath = registry_filepath
 
-    def create_config(self, config_file):
+    def create_config(self, emitter, config_file):
         try:
             return StakeHolderConfiguration.from_configuration_file(
+                emitter=emitter,
                 filepath=config_file,
                 provider_uri=self.provider_uri,
                 poa=self.poa,
@@ -118,8 +119,8 @@ class StakerOptions:
         self.config_options = config_options
         self.staking_address = staking_address
 
-    def create_character(self, config_file, individual_allocation=None, initial_address=None):
-        stakeholder_config = self.config_options.create_config(config_file)
+    def create_character(self, emitter, config_file, individual_allocation=None, initial_address=None):
+        stakeholder_config = self.config_options.create_config(emitter, config_file)
 
         if initial_address is None:
             initial_address = self.staking_address
@@ -149,7 +150,7 @@ class TransactingStakerOptions:
         self.beneficiary_address = beneficiary_address
         self.allocation_filepath = allocation_filepath
 
-    def create_character(self, config_file):
+    def create_character(self, emitter, config_file):
 
         opts = self.staker_options
 
@@ -180,6 +181,7 @@ class TransactingStakerOptions:
             initial_address = None
 
         return opts.create_character(
+            emitter,
             config_file,
             individual_allocation=individual_allocation,
             initial_address=initial_address)
@@ -236,7 +238,7 @@ def list(general_config, staker_options, config_file, all):
     List active stakes for current stakeholder.
     """
     emitter = _setup_emitter(general_config)
-    STAKEHOLDER = staker_options.create_character(config_file)
+    STAKEHOLDER = staker_options.create_character(emitter, config_file)
     painting.paint_stakes(emitter=emitter, stakes=STAKEHOLDER.all_stakes, paint_inactive=all)
 
 
@@ -249,7 +251,7 @@ def accounts(general_config, staker_options, config_file):
     Show ETH and NU balances for stakeholder's accounts.
     """
     emitter = _setup_emitter(general_config)
-    STAKEHOLDER = staker_options.create_character(config_file)
+    STAKEHOLDER = staker_options.create_character(emitter, config_file)
     painting.paint_accounts(emitter=emitter, balances=STAKEHOLDER.wallet.balances)
 
 
@@ -264,8 +266,10 @@ def set_worker(general_config, transacting_staker_options, config_file, force, w
     Bond a worker to a staker.
     """
     emitter = _setup_emitter(general_config)
-    STAKEHOLDER = transacting_staker_options.create_character(config_file)
+
+    STAKEHOLDER = transacting_staker_options.create_character(emitter, config_file)
     blockchain = transacting_staker_options.get_blockchain()
+
     economics = STAKEHOLDER.economics
 
     client_account, staking_address = handle_client_account_for_staking(
@@ -322,8 +326,10 @@ def detach_worker(general_config, transacting_staker_options, config_file, force
     Detach worker currently bonded to a staker.
     """
     emitter = _setup_emitter(general_config)
-    STAKEHOLDER = transacting_staker_options.create_character(config_file)
+
+    STAKEHOLDER = transacting_staker_options.create_character(emitter, config_file)
     blockchain = transacting_staker_options.get_blockchain()
+
     economics = STAKEHOLDER.economics
 
     client_account, staking_address = handle_client_account_for_staking(
@@ -366,8 +372,10 @@ def create(general_config, transacting_staker_options, config_file, force, value
     Initialize a new stake.
     """
     emitter = _setup_emitter(general_config)
-    STAKEHOLDER = transacting_staker_options.create_character(config_file)
+
+    STAKEHOLDER = transacting_staker_options.create_character(emitter, config_file)
     blockchain = transacting_staker_options.get_blockchain()
+
     economics = STAKEHOLDER.economics
 
     client_account, staking_address = handle_client_account_for_staking(
@@ -454,7 +462,8 @@ def restake(general_config, transacting_staker_options, config_file, enable, loc
     Manage re-staking with --enable or --disable.
     """
     emitter = _setup_emitter(general_config)
-    STAKEHOLDER = transacting_staker_options.create_character(config_file)
+
+    STAKEHOLDER = transacting_staker_options.create_character(emitter, config_file)
     blockchain = transacting_staker_options.get_blockchain()
 
     client_account, staking_address = handle_client_account_for_staking(
@@ -504,8 +513,9 @@ def divide(general_config, transacting_staker_options, config_file, force, value
     """
     emitter = _setup_emitter(general_config)
 
-    STAKEHOLDER = transacting_staker_options.create_character(config_file)
+    STAKEHOLDER = transacting_staker_options.create_character(emitter, config_file)
     blockchain = transacting_staker_options.get_blockchain()
+
     economics = STAKEHOLDER.economics
 
     client_account, staking_address = handle_client_account_for_staking(
@@ -599,7 +609,7 @@ def collect_reward(general_config, transacting_staker_options, config_file,
     ### Setup ###
     emitter = _setup_emitter(general_config)
 
-    STAKEHOLDER = transacting_staker_options.create_character(config_file)
+    STAKEHOLDER = transacting_staker_options.create_character(emitter, config_file)
     blockchain = transacting_staker_options.get_blockchain()
 
     if not staking_reward and not policy_reward:
@@ -647,7 +657,7 @@ def preallocation(general_config, transacting_staker_options, config_file, actio
     ### Setup ###
     emitter = _setup_emitter(general_config)
 
-    STAKEHOLDER = transacting_staker_options.create_character(config_file)
+    STAKEHOLDER = transacting_staker_options.create_character(emitter, config_file)
     blockchain = transacting_staker_options.get_blockchain()
 
     # Unauthenticated actions: status

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -518,7 +518,7 @@ def _create_ursula(ursula_config, general_config, dev, emitter, lonely, teacher_
 
     try:
         URSULA = actions.make_cli_character(character_config=ursula_config,
-                                            general_config=general_config,
+                                            emitter=general_config.emitter,
                                             min_stake=min_stake,
                                             teacher_uri=teacher_uri,
                                             unlock_keyring=not dev,

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -63,12 +63,123 @@ from nucypher.utilities.sandbox.constants import (
 )
 
 
-group_admin = group_options(
-    'admin',
+class UrsulaConfigOptions:
+
+    __option_name__ = 'config_options'
+
+    def __init__(self, geth, provider_uri, staker_address, worker_address, federated_only, rest_host,
+            rest_port, db_filepath, network, registry_filepath, dev, poa, light):
+
+        if federated_only:
+            # TODO: consider rephrasing in a more universal voice.
+            if geth:
+                raise click.BadOptionUsage(option_name="--geth",
+                                           message="--geth cannot be used in federated mode.")
+
+            if staker_address:
+                raise click.BadOptionUsage(option_name='--staker-address',
+                                           message="--staker-address cannot be used in federated mode.")
+
+            if registry_filepath:
+                raise click.BadOptionUsage(option_name="--registry-filepath",
+                                           message=f"--registry-filepath cannot be used in federated mode.")
+
+        eth_node = NO_BLOCKCHAIN_CONNECTION
+        provider_uri = provider_uri
+        if geth:
+            eth_node = actions.get_provider_process()
+            provider_uri = eth_node.provider_uri(scheme='file')
+
+        self.eth_node = eth_node
+        self.provider_uri = provider_uri
+        self.staker_address = staker_address
+        self.worker_address = worker_address
+        self.federated_only = federated_only
+        self.rest_host = rest_host
+        self.rest_port = rest_port # FIXME: not used in generate()
+        self.db_filepath = db_filepath
+        self.domains = {network} if network else None
+        self.registry_filepath = registry_filepath
+        self.dev = dev
+        self.poa = poa
+        self.light = light
+
+    def create_config(self, emitter, config_file):
+        if self.dev:
+            return UrsulaConfiguration(
+                dev_mode=True,
+                domains={TEMPORARY_DOMAIN},
+                poa=self.poa,
+                light=self.light,
+                registry_filepath=self.registry_filepath,
+                provider_process=self.eth_node,
+                provider_uri=self.provider_uri,
+                checksum_address=self.staker_address,
+                worker_address=self.worker_address,
+                federated_only=self.federated_only,
+                rest_host=self.rest_host,
+                rest_port=self.rest_port,
+                db_filepath=self.db_filepath)
+        else:
+            try:
+                return UrsulaConfiguration.from_configuration_file(
+                    filepath=config_file,
+                    domains=self.domains,
+                    registry_filepath=self.registry_filepath,
+                    provider_process=self.eth_node,
+                    provider_uri=self.provider_uri,
+                    rest_host=self.rest_host,
+                    rest_port=self.rest_port,
+                    db_filepath=self.db_filepath,
+                    poa=self.poa,
+                    light=self.light,
+                    federated_only=self.federated_only)
+            except FileNotFoundError:
+                return actions.handle_missing_configuration_file(character_config_class=UrsulaConfiguration,
+                                                                 config_file=config_file)
+            except NucypherKeyring.AuthenticationFailed as e:
+                emitter.echo(str(e), color='red', bold=True)
+                # TODO: Exit codes (not only for this, but for other exceptions)
+                return click.get_current_context().exit(1)
+
+    def generate_config(self, emitter, config_root, force):
+
+        assert not self.dev
+
+        staker_address = self.staker_address
+        worker_address = self.worker_address
+        if (not staker_address or not worker_address) and not self.federated_only:
+            if not staker_address:
+                staker_address = click.prompt("Enter staker address", type=EIP55_CHECKSUM_ADDRESS)
+
+            if not worker_address:
+                prompt = "Select worker account"
+                worker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=self.provider_uri)
+
+        rest_host = self.rest_host
+        if not rest_host:
+            rest_host = actions.determine_external_ip_address(emitter, force=force)
+
+        return UrsulaConfiguration.generate(password=get_nucypher_password(confirm=True),
+                                                     config_root=config_root,
+                                                     rest_host=rest_host,
+                                                     rest_port=self.rest_port,
+                                                     db_filepath=self.db_filepath,
+                                                     domains=self.domains,
+                                                     federated_only=self.federated_only,
+                                                     checksum_address=self.staker_address,
+                                                     worker_address=self.worker_address,
+                                                     registry_filepath=self.registry_filepath,
+                                                     provider_process=self.eth_node,
+                                                     provider_uri=self.provider_uri,
+                                                     poa=self.poa,
+                                                     light=self.light)
+
+
+group_config_options = group_options(
+    UrsulaConfigOptions,
     geth=option_geth,
     provider_uri=option_provider_uri(),
-    network=option_network,
-    registry_filepath=option_registry_filepath,
     staker_address=click.option('--staker-address', help="Run on behalf of a specified staking account", type=EIP55_CHECKSUM_ADDRESS),
     worker_address=click.option('--worker-address', help="Run the worker-ursula with a specified address",
                   type=EIP55_CHECKSUM_ADDRESS),
@@ -76,22 +187,61 @@ group_admin = group_options(
     rest_host=click.option('--rest-host', help="The host IP address to run Ursula network services on", type=click.STRING),
     rest_port=click.option('--rest-port', help="The host port to run Ursula network services on", type=NETWORK_PORT),
     db_filepath=option_db_filepath,
+    network=option_network,
+    registry_filepath=option_registry_filepath,
     poa=option_poa,
     light=option_light,
+    dev=option_dev,
     )
 
 
-# Args (geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
-#       rest_port, db_filepath, poa, config_file, dev, lonely, teacher_uri, min_stake)
-group_api = group_options(
-    'api',
-    admin=group_admin,
-    config_file=option_config_file,
-    dev=option_dev,
+class UrsulaCharacterOptions:
+
+    __option_name__ = 'character_options'
+
+    def __init__(self, config_options, lonely, teacher_uri, min_stake):
+        self.config_options = config_options
+        self.lonely = lonely
+        self.teacher_uri = teacher_uri
+        self.min_stake = min_stake
+
+    def create_character(self, emitter, config_file, json_ipc, load_seednodes=True):
+
+        ursula_config = self.config_options.create_config(emitter, config_file)
+
+        client_password = None
+        if not ursula_config.federated_only:
+            if not self.config_options.dev and not json_ipc:
+                client_password = get_client_password(checksum_address=ursula_config.worker_address,
+                                                      envvar="NUCYPHER_WORKER_ETH_PASSWORD")
+
+        try:
+            URSULA = actions.make_cli_character(character_config=ursula_config,
+                                                emitter=emitter,
+                                                min_stake=self.min_stake,
+                                                teacher_uri=self.teacher_uri,
+                                                unlock_keyring=not self.config_options.dev,
+                                                lonely=self.lonely,
+                                                client_password=client_password,
+                                                load_preferred_teachers=load_seednodes,
+                                                start_learning_now=load_seednodes)
+
+            return ursula_config, URSULA
+
+        except NucypherKeyring.AuthenticationFailed as e:
+            emitter.echo(str(e), color='red', bold=True)
+            # TODO: Exit codes (not only for this, but for other exceptions)
+            return click.get_current_context().exit(1)
+
+
+group_character_options = group_options(
+    UrsulaCharacterOptions,
+    config_options=group_config_options,
     lonely=click.option('--lonely', help="Do not connect to seednodes", is_flag=True),
     teacher_uri=option_teacher_uri,
     min_stake=option_min_stake,
     )
+
 
 @click.group()
 def ursula():
@@ -103,165 +253,65 @@ def ursula():
 
 
 @ursula.command()
-@group_admin
+@group_config_options
 @option_force
 @option_config_root
 @group_general_config
-def init(general_config,
-
-         # Admin Options
-         admin,
-
-         # Other
-         force, config_root):
+def init(general_config, config_options, force, config_root):
     """
     Create a new Ursula node configuration.
     """
-
-    ### Setup ###
-    _validate_args(admin.geth, admin.federated_only, admin.staker_address, admin.registry_filepath)
-
-    emitter = _setup_emitter(general_config, admin.worker_address)
-
+    emitter = _setup_emitter(general_config, config_options.worker_address)
     _pre_launch_warnings(emitter, dev=None, force=force)
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    provider_uri = admin.provider_uri
-    if admin.geth:
-        ETH_NODE = actions.get_provider_process()
-        provider_uri = ETH_NODE.provider_uri(scheme='file')
-    #############
-
-    staker_address = admin.staker_address
-    worker_address = admin.worker_address
-    if (not staker_address or not worker_address) and not admin.federated_only:
-        if not staker_address:
-            staker_address = click.prompt("Enter staker address", type=EIP55_CHECKSUM_ADDRESS)
-
-        if not worker_address:
-            prompt = "Select worker account"
-            worker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=provider_uri)
-    if not config_root:  # Flag
-        config_root = general_config.config_file  # Envvar
-
-    rest_host = admin.rest_host
-    if not rest_host:
-        rest_host = actions.determine_external_ip_address(emitter, force=force)
-    ursula_config = UrsulaConfiguration.generate(password=get_nucypher_password(confirm=True),
-                                                 config_root=config_root,
-                                                 rest_host=rest_host,
-                                                 rest_port=admin.rest_port,
-                                                 db_filepath=admin.db_filepath,
-                                                 domains={admin.network} if admin.network else None,
-                                                 federated_only=admin.federated_only,
-                                                 checksum_address=staker_address,
-                                                 worker_address=worker_address,
-                                                 registry_filepath=admin.registry_filepath,
-                                                 provider_process=ETH_NODE,
-                                                 provider_uri=provider_uri,
-                                                 poa=admin.poa,
-                                                 light=admin.light)
+    if not config_root:
+        config_root = general_config.config_file
+    ursula_config = config_options.generate_config(emitter, config_root, force)
     painting.paint_new_installation_help(emitter, new_configuration=ursula_config)
 
 
 @ursula.command()
-@group_admin
+@group_config_options
 @option_config_file
-@option_dev
 @option_force
 @group_general_config
-def destroy(general_config,
-
-            # Admin Options
-            admin,
-
-            # Other
-            config_file, force, dev):
+def destroy(general_config, config_options, config_file, force):
     """
     Delete Ursula node configuration.
     """
-
-    ### Setup ###
-    _validate_args(admin.geth, admin.federated_only, admin.staker_address, admin.registry_filepath)
-
-    emitter = _setup_emitter(general_config, admin.worker_address)
-
-    _pre_launch_warnings(emitter, dev=dev, force=force)
-
-    ursula_config, provider_uri = _get_ursula_config(
-        emitter, admin.geth, admin.provider_uri, admin.network, admin.registry_filepath, dev,
-        config_file, admin.staker_address, admin.worker_address, admin.federated_only,
-        admin.rest_host, admin.rest_port, admin.db_filepath, admin.poa, admin.light)
-    #############
-
+    emitter = _setup_emitter(general_config, config_options.worker_address)
+    _pre_launch_warnings(emitter, dev=config_options.dev, force=force)
+    ursula_config = config_options.create_config(emitter, config_file)
     actions.destroy_configuration(emitter, character_config=ursula_config, force=force)
 
 
 @ursula.command()
-@group_admin
+@group_config_options
 @option_config_file
-@option_dev
 @group_general_config
-def forget(general_config,
-
-           # Admin Options
-           admin,
-
-           # Other
-           config_file,  dev):
+def forget(general_config, config_options, config_file):
     """
     Forget all known nodes.
     """
-    ### Setup ###
-    _validate_args(admin.geth, admin.federated_only, admin.staker_address, admin.registry_filepath)
-
-    emitter = _setup_emitter(general_config, admin.worker_address)
-
+    emitter = _setup_emitter(general_config, config_options.worker_address)
     _pre_launch_warnings(emitter, dev=dev, force=None)
-
-    ursula_config, provider_uri = _get_ursula_config(
-        emitter, admin.geth, admin.provider_uri, admin.network, admin.registry_filepath, dev,
-        config_file, admin.staker_address, admin.worker_address, admin.federated_only,
-        admin.rest_host, admin.rest_port, admin.db_filepath, admin.poa, admin.light)
-
-    #############
-
+    ursula_config = config_options.create_config(emitter, config_file)
     actions.forget(emitter, configuration=ursula_config)
 
 
 @ursula.command()
-@group_api
+@group_character_options
+@option_config_file
 @click.option('--interactive', '-I', help="Launch command interface after connecting to seednodes.", is_flag=True,
               default=False)
 @option_dry_run
 @group_general_config
-def run(general_config,
-
-        # API Options
-        api,
-
-        # Other
-        interactive, dry_run):
+def run(general_config, character_options, config_file, interactive, dry_run):
     """
     Run an "Ursula" node.
     """
-
-    ### Setup ###
-    admin = api.admin
-    _validate_args(admin.geth, admin.federated_only, admin.staker_address, admin.registry_filepath)
-
-    emitter = _setup_emitter(general_config, admin.worker_address)
-
-    _pre_launch_warnings(emitter, dev=api.dev, force=None)
-
-    ursula_config, provider_uri = _get_ursula_config(
-        emitter, admin.geth, admin.provider_uri, admin.network, admin.registry_filepath, api.dev,
-        api.config_file, admin.staker_address, admin.worker_address, admin.federated_only,
-        admin.rest_host, admin.rest_port, admin.db_filepath, admin.poa, admin.light)
-
-    #############
-
-    URSULA = _create_ursula(ursula_config, general_config, api.dev, emitter, api.lonely, api.teacher_uri, api.min_stake)
+    emitter = _setup_emitter(general_config, character_options.config_options.worker_address)
+    _pre_launch_warnings(emitter, dev=character_options.config_options.dev, force=None)
+    ursula_config, URSULA = character_options.create_character(emitter, config_file, general_config.json_ipc)
 
     # GO!
     try:
@@ -311,100 +361,49 @@ def run(general_config,
 
 
 @ursula.command(name='save-metadata')
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
-def save_metadata(general_config,
-
-                  # API Options
-                  api
-                  ):
+def save_metadata(general_config, character_options, config_file):
     """
     Manually write node metadata to disk without running.
     """
-    ### Setup ###
-    admin = api.admin
-    _validate_args(admin.geth, admin.federated_only, admin.staker_address, admin.registry_filepath)
-
-    emitter = _setup_emitter(general_config, admin.worker_address)
-
-    _pre_launch_warnings(emitter, dev=api.dev, force=None)
-
-    ursula_config, provider_uri = _get_ursula_config(
-        emitter, admin.geth, admin.provider_uri, admin.network, admin.registry_filepath, api.dev,
-        api.config_file, admin.staker_address, admin.worker_address, admin.federated_only,
-        admin.rest_host, admin.rest_port, admin.db_filepath, admin.poa, admin.light)
-
-    #############
-
-    URSULA = _create_ursula(ursula_config, general_config, api.dev, emitter, api.lonely,
-                            api.teacher_uri, api.min_stake, load_seednodes=False)
-
+    emitter = _setup_emitter(general_config, character_options.config_options.worker_address)
+    _pre_launch_warnings(emitter, dev=character_options.config_options.dev, force=None)
+    _, URSULA = character_options.create_character(emitter, config_file, general_config.json_ipc, load_seednodes=False)
     metadata_path = URSULA.write_node_metadata(node=URSULA)
     emitter.message(f"Successfully saved node metadata to {metadata_path}.", color='green')
 
 
 @ursula.command()
-@group_api
+@group_config_options
+@option_config_file
 @group_general_config
-def view(general_config,
-
-         # API Options
-         api,
-         ):
+def view(general_config, config_options, config_file):
     """
     View the Ursula node's configuration.
     """
+    emitter = _setup_emitter(general_config, config_options.worker_address)
+    _pre_launch_warnings(emitter, dev=config_options.dev, force=None)
+    ursula_config = config_options.create_config(emitter, config_file)
 
-    ### Setup ###
-    admin = api.admin
-    _validate_args(admin.geth, admin.federated_only, admin.staker_address, admin.registry_filepath)
-
-    emitter = _setup_emitter(general_config, admin.worker_address)
-
-    _pre_launch_warnings(emitter, dev=api.dev, force=None)
-
-    ursula_config, provider_uri = _get_ursula_config(
-        emitter, admin.geth, admin.provider_uri, admin.network, admin.registry_filepath, api.dev,
-        api.config_file, admin.staker_address, admin.worker_address, admin.federated_only,
-        admin.rest_host, admin.rest_port, admin.db_filepath, admin.poa, admin.light)
-
-    #############
-
-    filepath = api.config_file or ursula_config.config_file_location
+    filepath = config_file or ursula_config.config_file_location
     emitter.echo(f"Ursula Configuration {filepath} \n {'='*55}")
     response = UrsulaConfiguration._read_configuration_file(filepath=filepath)
     return emitter.echo(json.dumps(response, indent=4))
 
 
 @ursula.command(name='confirm-activity')
-@group_api
+@group_character_options
+@option_config_file
 @group_general_config
-def confirm_activity(general_config,
-
-                     # API Options
-                     api
-                     ):
+def confirm_activity(general_config, character_options, config_file):
     """
     Manually confirm-activity for the current period.
     """
-
-    ### Setup ###
-    admin = api.admin
-    _validate_args(admin.geth, admin.federated_only, admin.staker_address, admin.registry_filepath)
-
-    emitter = _setup_emitter(general_config, admin.worker_address)
-
-    _pre_launch_warnings(emitter, dev=api.dev, force=None)
-
-    ursula_config, provider_uri = _get_ursula_config(
-        emitter, admin.geth, admin.provider_uri, admin.network, admin.registry_filepath, api.dev,
-        api.config_file, admin.staker_address, admin.worker_address, admin.federated_only,
-        admin.rest_host, admin.rest_port, admin.db_filepath, admin.poa, admin.light)
-
-    #############
-
-    URSULA = _create_ursula(ursula_config, general_config, api.dev, emitter,
-                            api.lonely, api.teacher_uri, api.min_stake, load_seednodes=False)
+    emitter = _setup_emitter(general_config, character_options.config_options.worker_address)
+    _pre_launch_warnings(emitter, dev=character_options.config_options.dev, force=None)
+    _, URSULA = character_options.create_character(emitter, config_file, general_config.json_ipc, load_seednodes=False)
 
     confirmed_period = URSULA.staking_agent.get_current_period() + 1
     click.echo(f"Confirming activity for period {confirmed_period}", color='blue')
@@ -433,102 +432,8 @@ def _setup_emitter(general_config, worker_address):
     return emitter
 
 
-def _validate_args(geth, federated_only, staker_address, registry_filepath):
-    #
-    # Validate
-    #
-    if federated_only:
-        # TODO: consider rephrasing in a more universal voice.
-        if geth:
-            raise click.BadOptionUsage(option_name="--geth",
-                                       message="--geth cannot be used in federated mode.")
-
-        if staker_address:
-            raise click.BadOptionUsage(option_name='--staker-address',
-                                       message="--staker-address cannot be used in federated mode.")
-
-        if registry_filepath:
-            raise click.BadOptionUsage(option_name="--registry-filepath",
-                                       message=f"--registry-filepath cannot be used in federated mode.")
-
-
 def _pre_launch_warnings(emitter, dev, force):
     if dev:
         emitter.echo("WARNING: Running in Development mode", color='yellow', verbosity=1)
     if force:
         emitter.echo("WARNING: Force is enabled", color='yellow', verbosity=1)
-
-
-def _get_ursula_config(emitter, geth, provider_uri, network, registry_filepath, dev, config_file,
-                       staker_address, worker_address, federated_only, rest_host, rest_port, db_filepath, poa, light):
-
-    ETH_NODE = NO_BLOCKCHAIN_CONNECTION
-    if geth:
-        ETH_NODE = actions.get_provider_process()
-        provider_uri = ETH_NODE.provider_uri(scheme='file')
-
-    if dev:
-        ursula_config = UrsulaConfiguration(dev_mode=True,
-                                            domains={TEMPORARY_DOMAIN},
-                                            poa=poa,
-                                            light=light,
-                                            registry_filepath=registry_filepath,
-                                            provider_process=ETH_NODE,
-                                            provider_uri=provider_uri,
-                                            checksum_address=staker_address,
-                                            worker_address=worker_address,
-                                            federated_only=federated_only,
-                                            rest_host=rest_host,
-                                            rest_port=rest_port,
-                                            db_filepath=db_filepath)
-    else:
-        try:
-            ursula_config = UrsulaConfiguration.from_configuration_file(filepath=config_file,
-                                                                        domains={network} if network else None,
-                                                                        registry_filepath=registry_filepath,
-                                                                        provider_process=ETH_NODE,
-                                                                        provider_uri=provider_uri,
-                                                                        rest_host=rest_host,
-                                                                        rest_port=rest_port,
-                                                                        db_filepath=db_filepath,
-                                                                        poa=poa,
-                                                                        light=light,
-                                                                        federated_only=federated_only)
-        except FileNotFoundError:
-            return actions.handle_missing_configuration_file(character_config_class=UrsulaConfiguration,
-                                                             config_file=config_file)
-        except NucypherKeyring.AuthenticationFailed as e:
-            emitter.echo(str(e), color='red', bold=True)
-            # TODO: Exit codes (not only for this, but for other exceptions)
-            return click.get_current_context().exit(1)
-
-    return ursula_config, provider_uri
-
-
-def _create_ursula(ursula_config, general_config, dev, emitter, lonely, teacher_uri, min_stake, load_seednodes=True):
-    #
-    # Make Ursula
-    #
-
-    client_password = None
-    if not ursula_config.federated_only:
-        if not dev and not general_config.json_ipc:
-            client_password = get_client_password(checksum_address=ursula_config.worker_address,
-                                                  envvar="NUCYPHER_WORKER_ETH_PASSWORD")
-
-    try:
-        URSULA = actions.make_cli_character(character_config=ursula_config,
-                                            emitter=general_config.emitter,
-                                            min_stake=min_stake,
-                                            teacher_uri=teacher_uri,
-                                            unlock_keyring=not dev,
-                                            lonely=lonely,
-                                            client_password=client_password,
-                                            load_preferred_teachers=load_seednodes,
-                                            start_learning_now=load_seednodes)
-
-        return URSULA
-    except NucypherKeyring.AuthenticationFailed as e:
-        emitter.echo(str(e), color='red', bold=True)
-        # TODO: Exit codes (not only for this, but for other exceptions)
-        return click.get_current_context().exit(1)

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -107,6 +107,7 @@ class UrsulaConfigOptions:
     def create_config(self, emitter, config_file):
         if self.dev:
             return UrsulaConfiguration(
+                emitter=emitter,
                 dev_mode=True,
                 domains={TEMPORARY_DOMAIN},
                 poa=self.poa,
@@ -123,6 +124,7 @@ class UrsulaConfigOptions:
         else:
             try:
                 return UrsulaConfiguration.from_configuration_file(
+                    emitter=emitter,
                     filepath=config_file,
                     domains=self.domains,
                     registry_filepath=self.registry_filepath,

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -31,6 +31,23 @@ from nucypher.cli.actions import (
     select_client_account,
     get_client_password
 )
+from nucypher.cli.common_options import (
+    option_config_file,
+    option_config_root,
+    option_db_filepath,
+    option_dev,
+    option_dry_run,
+    option_federated_only,
+    option_force,
+    option_geth,
+    option_light,
+    option_min_stake,
+    option_network,
+    option_poa,
+    option_provider_uri,
+    option_registry_filepath,
+    option_teacher_uri,
+    )
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.processes import UrsulaCommandProtocol
 from nucypher.cli.types import (
@@ -48,19 +65,19 @@ from nucypher.utilities.sandbox.constants import (
 # Args (geth, provider_uri, network, registry_filepath, staker_address, worker_address, federated_only, rest_host,
 #       rest_port, db_filepath, poa)
 def _admin_options(func):
-    @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING)
-    @click.option('--network', help="Network Domain Name", type=click.STRING)
-    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+    @option_geth
+    @option_provider_uri()
+    @option_network
+    @option_registry_filepath
     @click.option('--staker-address', help="Run on behalf of a specified staking account", type=EIP55_CHECKSUM_ADDRESS)
     @click.option('--worker-address', help="Run the worker-ursula with a specified address",
                   type=EIP55_CHECKSUM_ADDRESS)
-    @click.option('--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
+    @option_federated_only
     @click.option('--rest-host', help="The host IP address to run Ursula network services on", type=click.STRING)
     @click.option('--rest-port', help="The host port to run Ursula network services on", type=NETWORK_PORT)
-    @click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
-    @click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
-    @click.option('--light', help="Indicate that node is light", is_flag=True, default=False)
+    @option_db_filepath
+    @option_poa
+    @option_light
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -71,12 +88,11 @@ def _admin_options(func):
 #       rest_port, db_filepath, poa, config_file, dev, lonely, teacher_uri, min_stake)
 def _api_options(func):
     @_admin_options
-    @click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-    @click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+    @option_config_file
+    @option_dev
     @click.option('--lonely', help="Do not connect to seednodes", is_flag=True)
-    @click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
-    @click.option('--min-stake', help="The minimum stake the teacher must have to be a teacher", type=click.INT,
-                  default=0)
+    @option_teacher_uri
+    @option_min_stake
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -94,8 +110,8 @@ def ursula():
 
 @ursula.command()
 @_admin_options
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
-@click.option('--config-root', help="Custom configuration directory", type=click.Path())
+@option_force
+@option_config_root
 @nucypher_click_config
 def init(click_config,
 
@@ -152,9 +168,9 @@ def init(click_config,
 
 @ursula.command()
 @_admin_options
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
-@click.option('--force', help="Don't ask for confirmation", is_flag=True)
+@option_config_file
+@option_dev
+@option_force
 @nucypher_click_config
 def destroy(click_config,
 
@@ -185,8 +201,8 @@ def destroy(click_config,
 
 @ursula.command()
 @_admin_options
-@click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
-@click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+@option_config_file
+@option_dev
 @nucypher_click_config
 def forget(click_config,
 
@@ -218,7 +234,7 @@ def forget(click_config,
 @_api_options
 @click.option('--interactive', '-I', help="Launch command interface after connecting to seednodes.", is_flag=True,
               default=False)
-@click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+@option_dry_run
 @nucypher_click_config
 def run(click_config,
 

--- a/nucypher/cli/characters/ursula.py
+++ b/nucypher/cli/characters/ursula.py
@@ -266,7 +266,7 @@ def init(general_config, config_options, force, config_root):
     emitter = _setup_emitter(general_config, config_options.worker_address)
     _pre_launch_warnings(emitter, dev=None, force=force)
     if not config_root:
-        config_root = general_config.config_file
+        config_root = general_config.config_root
     ursula_config = config_options.generate_config(emitter, config_root, force)
     painting.paint_new_installation_help(emitter, new_configuration=ursula_config)
 

--- a/nucypher/cli/common_options.py
+++ b/nucypher/cli/common_options.py
@@ -1,0 +1,110 @@
+import click
+
+from nucypher.cli.types import (
+    EIP55_CHECKSUM_ADDRESS,
+    EXISTING_READABLE_FILE,
+    NETWORK_PORT,
+    )
+
+
+option_checksum_address = click.option(
+    '--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
+
+option_config_file = click.option(
+    '--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
+
+option_config_root = click.option(
+    '--config-root', help="Custom configuration directory", type=click.Path())
+
+def option_controller_port(default=None):
+    return click.option(
+        '--controller-port',
+        help="The host port to run Alice HTTP services on",
+        type=NETWORK_PORT,
+        default=default)
+
+option_dev = click.option('--dev', '-d', help="Enable development mode", is_flag=True)
+
+option_db_filepath = click.option(
+    '--db-filepath', help="The database filepath to connect to", type=click.STRING)
+
+def option_discovery_port(default=None):
+    return click.option(
+        '--discovery-port',
+        help="The host port to run node discovery services on",
+        type=NETWORK_PORT,
+        default=default)
+
+option_dry_run = click.option(
+    '--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
+
+option_etherscan = click.option(
+    '--etherscan/--no-etherscan', help="Enable/disable viewing TX in Etherscan")
+
+# Defaults to None since it can be overridden by the config file
+option_federated_only = click.option(
+    '--federated-only', '-F', help="Connect only to federated nodes", is_flag=True, default=None)
+
+option_force = click.option('--force', help="Don't ask for confirmation", is_flag=True)
+
+option_geth = click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
+
+# TODO: Make True by default or deprecate - see #1439
+option_hw_wallet = click.option('--hw-wallet/--no-hw-wallet')
+
+def option_label(required:bool = False):
+    return click.option(
+        '--label',
+        help="The label for a policy",
+        type=click.STRING,
+        required=required)
+
+option_light = click.option('--light', help="Indicate that node is light", is_flag=True)
+
+def option_message_kit(required:bool = False):
+    return click.option(
+        '--message-kit',
+        help="The message kit unicode string encoded in base64",
+        type=click.STRING,
+        required=required)
+
+option_m = click.option('--m', help="M-Threshold KFrags", type=click.INT)
+
+option_min_stake = click.option(
+    '--min-stake',
+    help="The minimum stake the teacher must have to be a teacher",
+    type=click.INT,
+    default=0)
+
+option_n = click.option('--n', help="N-Total KFrags", type=click.INT)
+
+option_network = click.option('--network', help="Network Domain Name", type=click.STRING)
+
+# Defaults to None since it can be overridden by the config file
+option_poa = click.option('--poa', help="Inject POA middleware", is_flag=True, default=None)
+
+def option_policy_encrypting_key(required:bool = False):
+    return click.option(
+        '--policy-encrypting-key',
+        help="Encrypting Public Key for Policy as hexadecimal string",
+        type=click.STRING,
+        required=required)
+
+def option_provider_uri(default=None, required:bool = False):
+    return click.option(
+        '--provider', 'provider_uri',
+        help="Blockchain provider's URI i.e. 'file:///path/to/geth.ipc'",
+        type=click.STRING,
+        required=required,
+        default=default)
+
+option_registry_filepath = click.option(
+    '--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+
+option_staking_address = click.option(
+    '--staking-address', help="Address of a NuCypher staker", type=EIP55_CHECKSUM_ADDRESS)
+
+option_teacher_uri = click.option(
+    '--teacher', 'teacher_uri',
+    help="An Ursula URI to start learning from (seednode)",
+    type=click.STRING)

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -45,9 +45,6 @@ class GroupGeneralConfig:
 
     verbosity = 0
 
-    # Output Sinks
-    __emitter = None
-
     # Environment Variables
     config_file = os.environ.get('NUCYPHER_CONFIG_FILE')
     sentry_endpoint = os.environ.get("NUCYPHER_SENTRY_DSN", NUCYPHER_SENTRY_ENDPOINT)
@@ -86,7 +83,7 @@ class GroupGeneralConfig:
         else:
             emitter = StdoutEmitter(verbosity=GroupGeneralConfig.verbosity)
 
-        self.attach_emitter(emitter)
+        self.emitter = emitter
 
         if verbose:
             self.emitter.message("Verbose mode is enabled", color='blue')
@@ -131,14 +128,6 @@ class GroupGeneralConfig:
 
         self.debug = debug
         self.json_ipc = json_ipc
-
-    @classmethod
-    def attach_emitter(cls, emitter) -> None:
-        cls.__emitter = emitter
-
-    @property
-    def emitter(cls):
-        return cls.__emitter
 
 
 group_general_config = group_options(

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -27,9 +27,7 @@ from twisted.logger import Logger
 from nucypher.characters.control.emitters import StdoutEmitter, JSONRPCStdoutEmitter
 from nucypher.cli.common_options import option_etherscan, group_options
 from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT
-from nucypher.network.middleware import RestMiddleware
 from nucypher.utilities.logging import GlobalLoggerSettings
-from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
 def get_env_bool(var_name: str, default: bool) -> bool:
@@ -57,8 +55,6 @@ class GroupGeneralConfig:
     log_to_file = get_env_bool("NUCYPHER_FILE_LOGS", True)
 
     def __init__(self,
-                    mock_networking,
-                    etherscan,
                     json_ipc,
                     verbose,
                     quiet,
@@ -133,19 +129,8 @@ class GroupGeneralConfig:
         if json_ipc:
             GlobalLoggerSettings.stop_console_logging()  # JSON-RPC Protection
 
-        # CLI Session Configuration
-        self.mock_networking = mock_networking
         self.debug = debug
         self.json_ipc = json_ipc
-        self.etherscan = etherscan
-
-        # Only used for testing outputs;
-        # Redirects outputs to in-memory python containers.
-        if mock_networking:
-            self.emitter.message("WARNING: Mock networking is enabled")
-            self.middleware = MockRestMiddleware()
-        else:
-            self.middleware = RestMiddleware()
 
     @classmethod
     def attach_emitter(cls, emitter) -> None:
@@ -158,8 +143,6 @@ class GroupGeneralConfig:
 
 group_general_config = group_options(
     GroupGeneralConfig,
-    mock_networking=click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True),
-    etherscan=option_etherscan,
     json_ipc=click.option('-J', '--json-ipc', help="Send all IPC output to stdout as JSON, and turn off the rest", is_flag=True),
     verbose=click.option('-v', '--verbose', help="Verbose console messages", is_flag=True),
     quiet=click.option('-Q', '--quiet', help="Disable console messages", is_flag=True),

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -46,7 +46,7 @@ class GroupGeneralConfig:
     verbosity = 0
 
     # Environment Variables
-    config_file = os.environ.get('NUCYPHER_CONFIG_FILE')
+    config_root = os.environ.get('NUCYPHER_CONFIG_ROOT')
     sentry_endpoint = os.environ.get("NUCYPHER_SENTRY_DSN", NUCYPHER_SENTRY_ENDPOINT)
     log_to_sentry = get_env_bool("NUCYPHER_SENTRY_LOGS", True)
     log_to_file = get_env_bool("NUCYPHER_FILE_LOGS", True)

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -25,6 +25,7 @@ import click
 from twisted.logger import Logger
 
 from nucypher.characters.control.emitters import StdoutEmitter, JSONRPCStdoutEmitter
+from nucypher.cli.common_options import option_etherscan
 from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT
 from nucypher.network.middleware import RestMiddleware
 from nucypher.utilities.logging import GlobalLoggerSettings
@@ -164,7 +165,7 @@ _nucypher_click_config = click.make_pass_decorator(NucypherClickConfig, ensure=T
 def nucypher_click_config(func):
     @_nucypher_click_config
     @click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True)
-    @click.option('--etherscan/--no-etherscan', help="Enable/disable viewing TX in Etherscan", default=False)
+    @option_etherscan
     @click.option('-J', '--json-ipc', help="Send all IPC output to stdout as JSON, and turn off the rest", is_flag=True)
     @click.option('-v', '--verbose', help="Verbose console messages", is_flag=True)
     @click.option('-Q', '--quiet', help="Disable console messages", is_flag=True)

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -25,7 +25,7 @@ import click
 from twisted.logger import Logger
 
 from nucypher.characters.control.emitters import StdoutEmitter, JSONRPCStdoutEmitter
-from nucypher.cli.common_options import option_etherscan
+from nucypher.cli.common_options import option_etherscan, group_options
 from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT
 from nucypher.network.middleware import RestMiddleware
 from nucypher.utilities.logging import GlobalLoggerSettings
@@ -41,7 +41,9 @@ def get_env_bool(var_name: str, default: bool) -> bool:
         return default
 
 
-class NucypherClickConfig:
+class GroupGeneralConfig:
+
+    __option_name__ = 'general_config'
 
     verbosity = 0
 
@@ -54,13 +56,7 @@ class NucypherClickConfig:
     log_to_sentry = get_env_bool("NUCYPHER_SENTRY_LOGS", True)
     log_to_file = get_env_bool("NUCYPHER_FILE_LOGS", True)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Logging
-        self.log = Logger(self.__class__.__name__)
-
-    def set_options(self,
+    def __init__(self,
                     mock_networking,
                     etherscan,
                     json_ipc,
@@ -73,6 +69,8 @@ class NucypherClickConfig:
                     log_level,
                     debug):
 
+        self.log = Logger(self.__class__.__name__)
+
         # Session Emitter for pre and post character control engagement.
         if verbose and quiet:
             raise click.BadOptionUsage(
@@ -81,16 +79,16 @@ class NucypherClickConfig:
                         "and cannot be used at the same time.")
 
         if verbose:
-            NucypherClickConfig.verbosity = 2
+            GroupGeneralConfig.verbosity = 2
         elif quiet:
-            NucypherClickConfig.verbosity = 0
+            GroupGeneralConfig.verbosity = 0
         else:
-            NucypherClickConfig.verbosity = 1
+            GroupGeneralConfig.verbosity = 1
 
         if json_ipc:
-            emitter = JSONRPCStdoutEmitter(verbosity=NucypherClickConfig.verbosity)
+            emitter = JSONRPCStdoutEmitter(verbosity=GroupGeneralConfig.verbosity)
         else:
-            emitter = StdoutEmitter(verbosity=NucypherClickConfig.verbosity)
+            emitter = StdoutEmitter(verbosity=GroupGeneralConfig.verbosity)
 
         self.attach_emitter(emitter)
 
@@ -158,68 +156,32 @@ class NucypherClickConfig:
         return cls.__emitter
 
 
-# Register the above click configuration classes as a decorators
-_nucypher_click_config = click.make_pass_decorator(NucypherClickConfig, ensure=True)
-
-
-def nucypher_click_config(func):
-    @_nucypher_click_config
-    @click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True)
-    @option_etherscan
-    @click.option('-J', '--json-ipc', help="Send all IPC output to stdout as JSON, and turn off the rest", is_flag=True)
-    @click.option('-v', '--verbose', help="Verbose console messages", is_flag=True)
-    @click.option('-Q', '--quiet', help="Disable console messages", is_flag=True)
-    @click.option('-L', '--no-logs', help="Disable all logging output", is_flag=True)
-    @click.option('--console-logs/--no-console-logs',
+group_general_config = group_options(
+    GroupGeneralConfig,
+    mock_networking=click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True),
+    etherscan=option_etherscan,
+    json_ipc=click.option('-J', '--json-ipc', help="Send all IPC output to stdout as JSON, and turn off the rest", is_flag=True),
+    verbose=click.option('-v', '--verbose', help="Verbose console messages", is_flag=True),
+    quiet=click.option('-Q', '--quiet', help="Disable console messages", is_flag=True),
+    no_logs=click.option('-L', '--no-logs', help="Disable all logging output", is_flag=True),
+    console_logs=click.option('--console-logs/--no-console-logs',
                   help="Enable/disable logging to console. "
                        "Defaults to `--no-console-logs`.",
-                  default=False)
-    @click.option('--file-logs/--no-file-logs',
+                  default=False),
+    file_logs=click.option('--file-logs/--no-file-logs',
                   help="Enable/disable logging to file. "
                        "Defaults to NUCYPHER_FILE_LOGS, or to `--file-logs` if it is not set.",
-                  default=None)
-    @click.option('--sentry-logs/--no-sentry-logs',
+                  default=None),
+    sentry_logs=click.option('--sentry-logs/--no-sentry-logs',
                   help="Enable/disable logging to Sentry. "
                   "Defaults to NUCYPHER_SENTRY_LOGS, or to `--sentry-logs` if it is not set.",
-                  default=None)
-    @click.option('--log-level', help="The log level for this process.  Is overridden by --debug.",
+                  default=None),
+    log_level=click.option('--log-level', help="The log level for this process.  Is overridden by --debug.",
                   type=click.Choice(['critical', 'error', 'warn', 'info', 'debug']),
-                  default='info')
-    @click.option('-D', '--debug',
+                  default='info'),
+    debug=click.option('-D', '--debug',
                   help="Enable debugging mode, crashing on more exceptions instead of trying to recover. "
                        "Also sets log level to \"debug\", turns on console and file logging "
                        "and turns off Sentry logging.",
-                  is_flag=True)
-    @functools.wraps(func)
-    def wrapper(config,
-                *args,
-                mock_networking,
-                etherscan,
-                json_ipc,
-                verbose,
-                quiet,
-                no_logs,
-                console_logs,
-                file_logs,
-                sentry_logs,
-                log_level,
-                debug,
-                **kwargs):
-
-        # NOTE: `set_options` MUST maintain same order as click_options provided - there is a unit test that depends
-        #       on this order being maintained
-        config.set_options(
-            mock_networking,
-            etherscan,
-            json_ipc,
-            verbose,
-            quiet,
-            no_logs,
-            console_logs,
-            file_logs,
-            sentry_logs,
-            log_level,
-            debug)
-
-        return func(config, *args, **kwargs)
-    return wrapper
+                  is_flag=True),
+    )

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -64,20 +64,120 @@ option_gas = click.option('--gas', help="Operate with a specified gas per-transa
 option_network__eth = click.option('--network', help="", type=click.Choice(CanonicalRegistrySource.networks), default='goerli')  # TODO: #1496
 
 
-group_admin_actor = group_options(
-    'admin_actor',
+def _pre_launch_warnings(emitter, etherscan, hw_wallet):
+    if not hw_wallet:
+        emitter.echo("WARNING: --no-hw-wallet is enabled.", color='yellow')
+    if etherscan:
+        emitter.echo("WARNING: --etherscan is enabled. "
+                     "A browser tab will be opened with deployed contracts and TXs as provided by Etherscan.",
+                     color='yellow')
+    else:
+        emitter.echo("WARNING: --etherscan is disabled. "
+                     "If you want to see deployed contracts and TXs in your browser, activate --etherscan.",
+                     color='yellow')
+
+
+def _initialize_blockchain(poa, provider_uri):
+    if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
+        # Note: For test compatibility.
+        deployer_interface = BlockchainDeployerInterface(provider_uri=provider_uri, poa=poa)
+        BlockchainInterfaceFactory.register_interface(interface=deployer_interface, sync=False,
+                                                      show_sync_progress=False)
+    else:
+        deployer_interface = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)
+
+    deployer_interface.connect()
+    return deployer_interface
+
+
+def _ensure_config_root(config_root):
+    # Ensure config root exists, because we need a default place to put output files.
+    config_root = config_root or DEFAULT_CONFIG_ROOT
+    if not os.path.exists(config_root):
+        os.makedirs(config_root)
+
+
+class ActorOptions:
+
+    __option_name__ = 'actor_options'
+
+    def __init__(self, provider_uri, deployer_address, contract_name,
+                registry_infile, registry_outfile, hw_wallet, dev, force, poa, config_root, etherscan,
+                se_test_mode):
+        self.provider_uri = provider_uri
+        self.deployer_address = deployer_address
+        self.contract_name = contract_name
+        self.registry_infile = registry_infile
+        self.registry_outfile = registry_outfile
+        self.hw_wallet = hw_wallet
+        self.dev = dev
+        self.force = force
+        self.config_root = config_root
+        self.etherscan = etherscan
+        self.poa = poa
+        self.se_test_mode = se_test_mode
+
+    def create_actor(self, emitter):
+
+        _ensure_config_root(self.config_root)
+        deployer_interface = _initialize_blockchain(self.poa, self.provider_uri)
+
+        # Warnings
+        _pre_launch_warnings(emitter, self.etherscan, self.hw_wallet)
+
+        #
+        # Establish Registry
+        #
+        local_registry = establish_deployer_registry(emitter=emitter,
+                                                     use_existing_registry=bool(self.contract_name),
+                                                     registry_infile=self.registry_infile,
+                                                     registry_outfile=self.registry_outfile,
+                                                     dev=self.dev)
+        #
+        # Make Authenticated Deployment Actor
+        #
+        # Verify Address & collect password
+        deployer_address = self.deployer_address
+        if not deployer_address:
+            prompt = "Select deployer account"
+            deployer_address = select_client_account(emitter=emitter,
+                                                     prompt=prompt,
+                                                     provider_uri=self.provider_uri,
+                                                     show_balances=False)
+
+        if not self.force:
+            click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
+
+        password = None
+        if not self.hw_wallet and not deployer_interface.client.is_local:
+            password = get_client_password(checksum_address=deployer_address)
+        # Produce Actor
+        ADMINISTRATOR = ContractAdministrator(registry=local_registry,
+                                              client_password=password,
+                                              deployer_address=deployer_address,
+                                              staking_escrow_test_mode=self.se_test_mode)
+        # Verify ETH Balance
+        emitter.echo(f"\n\nDeployer ETH balance: {ADMINISTRATOR.eth_balance}")
+        if ADMINISTRATOR.eth_balance == 0:
+            emitter.echo("Deployer address has no ETH.", color='red', bold=True)
+            raise click.Abort()
+        return ADMINISTRATOR, deployer_address, deployer_interface, local_registry
+
+
+group_actor_options = group_options(
+    ActorOptions,
     provider_uri=option_provider_uri(required=True),
     contract_name=click.option('--contract-name', help="Deploy a single contract by name", type=click.STRING),
-    config_root=option_config_root,
     poa=option_poa,
     force=option_force,
-    etherscan=option_etherscan,
     hw_wallet=option_hw_wallet,
     deployer_address=option_deployer_address,
     registry_infile=option_registry_infile,
     registry_outfile=option_registry_outfile,
     dev=click.option('--dev', '-d', help="Forcibly use the development registry filepath.", is_flag=True),
-    se_test_mode = click.option('--se-test-mode', help="Enable test mode for StakingEscrow in deployment.", is_flag=True),
+    se_test_mode=click.option('--se-test-mode', help="Enable test mode for StakingEscrow in deployment.", is_flag=True),
+    config_root=option_config_root,
+    etherscan=option_etherscan,
     )
 
 
@@ -146,43 +246,19 @@ def inspect(provider_uri, config_root, registry_infile, deployer_address, poa):
 
 
 @deploy.command()
-@group_admin_actor
+@group_actor_options
 @click.option('--retarget', '-d', help="Retarget a contract's proxy.", is_flag=True)
 @option_target_address
 @click.option('--ignore-deployed', help="Ignore already deployed contracts if exist.", is_flag=True)
-def upgrade(# Admin Actor Options
-            admin_actor,
-
-            # Other
-            retarget, target_address, ignore_deployed):
+def upgrade(actor_options, retarget, target_address, ignore_deployed):
     """
     Upgrade NuCypher existing proxy contract deployments.
     """
     # Init
     emitter = StdoutEmitter()
-    _ensure_config_root(admin_actor.config_root)
-    deployer_interface = _initialize_blockchain(admin_actor.poa, admin_actor.provider_uri)
+    ADMINISTRATOR, _, _, _ = actor_options.create_actor(emitter)
 
-    # Warnings
-    _pre_launch_warnings(emitter, admin_actor.etherscan, admin_actor.hw_wallet)
-
-    #
-    # Make Authenticated Deployment Actor
-    #
-    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
-                                                                                           admin_actor.provider_uri,
-                                                                                           admin_actor.deployer_address,
-                                                                                           deployer_interface,
-                                                                                           admin_actor.contract_name,
-                                                                                           admin_actor.registry_infile,
-                                                                                           admin_actor.registry_outfile,
-                                                                                           admin_actor.hw_wallet,
-                                                                                           admin_actor.dev,
-                                                                                           admin_actor.force,
-                                                                                           admin_actor.se_test_mode)
-
-    contract_name = admin_actor.contract_name
-
+    contract_name = actor_options.contract_name
     if not contract_name:
         raise click.BadArgumentUsage(message="--contract-name is required when using --upgrade")
 
@@ -192,7 +268,7 @@ def upgrade(# Admin Actor Options
     if retarget:
         if not target_address:
             raise click.BadArgumentUsage(message="--target-address is required when using --retarget")
-        if not admin_actor.force:
+        if not actor_options.force:
             click.confirm(f"Confirm re-target {contract_name}'s proxy to {target_address}?", abort=True)
         receipt = ADMINISTRATOR.retarget_proxy(contract_name=contract_name,
                                                target_address=target_address,
@@ -201,7 +277,7 @@ def upgrade(# Admin Actor Options
         emitter.message(f"Successfully re-targeted {contract_name} proxy to {target_address}", color='green')
         paint_receipt_summary(emitter=emitter, receipt=receipt)
     else:
-        if not admin_actor.force:
+        if not actor_options.force:
             click.confirm(f"Confirm deploy new version of {contract_name} and retarget proxy?", abort=True)
         receipts = ADMINISTRATOR.upgrade_contract(contract_name=contract_name,
                                                   existing_plaintext_secret=existing_secret,
@@ -213,86 +289,41 @@ def upgrade(# Admin Actor Options
 
 
 @deploy.command()
-@group_admin_actor
-def rollback(# Admin Actor Options
-             admin_actor,
-             ):
+@group_actor_options
+def rollback(actor_options):
     """
     Rollback a proxy contract's target.
     """
-    # Init
     emitter = StdoutEmitter()
-    _ensure_config_root(admin_actor.config_root)
-    deployer_interface = _initialize_blockchain(admin_actor.poa, admin_actor.provider_uri)
+    ADMINISTRATOR, _, _, _ = actor_options.create_actor(emitter)
 
-    # Warnings
-    _pre_launch_warnings(emitter, admin_actor.etherscan, admin_actor.hw_wallet)
-
-    #
-    # Make Authenticated Deployment Actor
-    #
-    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
-                                                                                           admin_actor.provider_uri,
-                                                                                           admin_actor.deployer_address,
-                                                                                           deployer_interface,
-                                                                                           admin_actor.contract_name,
-                                                                                           admin_actor.registry_infile,
-                                                                                           admin_actor.registry_outfile,
-                                                                                           admin_actor.hw_wallet,
-                                                                                           admin_actor.dev,
-                                                                                           admin_actor.force,
-                                                                                           admin_actor.se_test_mode)
-
-    if not admin_actor.contract_name:
+    if not actor_options.contract_name:
         raise click.BadArgumentUsage(message="--contract-name is required when using --rollback")
     existing_secret = click.prompt('Enter existing contract upgrade secret', hide_input=True)
     new_secret = click.prompt('Enter new contract upgrade secret', hide_input=True, confirmation_prompt=True)
-    ADMINISTRATOR.rollback_contract(contract_name=admin_actor.contract_name,
+    ADMINISTRATOR.rollback_contract(contract_name=actor_options.contract_name,
                                     existing_plaintext_secret=existing_secret,
                                     new_plaintext_secret=new_secret)
 
 
 @deploy.command()
-@group_admin_actor
+@group_actor_options
 @click.option('--bare', help="Deploy a contract *only* without any additional operations.", is_flag=True)
 @option_gas
 @click.option('--ignore-deployed', help="Ignore already deployed contracts if exist.", is_flag=True)
-def contracts(# Admin Actor Options
-              admin_actor,
-
-              # Other
-              bare, gas, ignore_deployed):
+def contracts(actor_options, bare, gas, ignore_deployed):
     """
     Compile and deploy contracts.
     """
     # Init
     emitter = StdoutEmitter()
-    _ensure_config_root(admin_actor.config_root)
-    deployer_interface = _initialize_blockchain(admin_actor.poa, admin_actor.provider_uri)
 
-    # Warnings
-    _pre_launch_warnings(emitter, admin_actor.etherscan, admin_actor.hw_wallet)
-
-
-    #
-    # Make Authenticated Deployment Actor
-    #
-    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
-                                                                                           admin_actor.provider_uri,
-                                                                                           admin_actor.deployer_address,
-                                                                                           deployer_interface,
-                                                                                           admin_actor.contract_name,
-                                                                                           admin_actor.registry_infile,
-                                                                                           admin_actor.registry_outfile,
-                                                                                           admin_actor.hw_wallet,
-                                                                                           admin_actor.dev,
-                                                                                           admin_actor.force,
-                                                                                           admin_actor.se_test_mode)
+    ADMINISTRATOR, _, deployer_interface, local_registry = actor_options.create_actor(emitter)
 
     #
     # Deploy Single Contract (Amend Registry)
     #
-    contract_name = admin_actor.contract_name
+    contract_name = actor_options.contract_name
     if contract_name:
         try:
             contract_deployer = ADMINISTRATOR.deployers[contract_name]
@@ -324,7 +355,7 @@ def contracts(# Admin Actor Options
                                   receipts=receipts,
                                   emitter=emitter,
                                   chain_name=deployer_interface.client.chain_name,
-                                  open_in_browser=admin_actor.etherscan)
+                                  open_in_browser=actor_options.etherscan)
         return  # Exit
 
     #
@@ -352,8 +383,8 @@ def contracts(# Admin Actor Options
     # Execute Deployment
     deployment_receipts = ADMINISTRATOR.deploy_network_contracts(secrets=secrets,
                                                                  emitter=emitter,
-                                                                 interactive=not admin_actor.force,
-                                                                 etherscan=admin_actor.etherscan,
+                                                                 interactive=not actor_options.force,
+                                                                 etherscan=actor_options.etherscan,
                                                                  ignore_deployed=ignore_deployed)
 
     # Paint outfile paths
@@ -366,51 +397,27 @@ def contracts(# Admin Actor Options
 
 
 @deploy.command()
-@group_admin_actor
+@group_actor_options
 @click.option('--allocation-infile', help="Input path for token allocation JSON file", type=EXISTING_READABLE_FILE)
 @click.option('--allocation-outfile', help="Output path for token allocation JSON file",
               type=click.Path(exists=False, file_okay=True))
 @click.option('--sidekick-account', help="A software-controlled account to assist the deployment",
               type=EIP55_CHECKSUM_ADDRESS)
-def allocations(# Admin Actor Options
-                admin_actor,
-
-                # Other
-                allocation_infile, allocation_outfile, sidekick_account):
+def allocations(actor_options, allocation_infile, allocation_outfile, sidekick_account):
     """
     Deploy pre-allocation contracts.
     """
-    # Init
-    emitter = StdoutEmitter()
-    _ensure_config_root(admin_actor.config_root)
-    deployer_interface = _initialize_blockchain(admin_actor.poa, admin_actor.provider_uri)
-
-    # Warnings
-    _pre_launch_warnings(emitter, admin_actor.etherscan, admin_actor.hw_wallet)
-
-    #
-    # Make Authenticated Deployment Actor
-    #
-    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
-                                                                                           admin_actor.provider_uri,
-                                                                                           admin_actor.deployer_address,
-                                                                                           deployer_interface,
-                                                                                           admin_actor.contract_name,
-                                                                                           admin_actor.registry_infile,
-                                                                                           admin_actor.registry_outfile,
-                                                                                           admin_actor.hw_wallet,
-                                                                                           admin_actor.dev,
-                                                                                           admin_actor.force,
-                                                                                           admin_actor.se_test_mode)
+    emitter = general_config.emitter
+    ADMINISTRATOR, _, deployer_interface, local_registry = actor_options.create_actor(emitter)
 
     if not sidekick_account and click.confirm('Do you want to use a sidekick account to assist during deployment?'):
         prompt = "Select sidekick account"
         sidekick_account = select_client_account(emitter=emitter,
                                                  prompt=prompt,
-                                                 provider_uri=provider_uri,
+                                                 provider_uri=actor_options.provider_uri,
                                                  registry=local_registry,
                                                  show_balances=True)
-        if not force:
+        if not actor_options.force:
             click.confirm(f"Selected {sidekick_account} - Continue?", abort=True)
 
     if sidekick_account:
@@ -424,43 +431,19 @@ def allocations(# Admin Actor Options
     ADMINISTRATOR.deploy_beneficiaries_from_file(allocation_data_filepath=allocation_infile,
                                                  allocation_outfile=allocation_outfile,
                                                  emitter=emitter,
-                                                 interactive=not admin_actor.force)
+                                                 interactive=not actor_options.force)
 
 
 @deploy.command(name='transfer-tokens')
-@group_admin_actor
+@group_actor_options
 @option_target_address
 @click.option('--value', help="Amount of tokens to transfer in the smallest denomination", type=click.INT)
-def transfer_tokens(# Admin Actor Options
-                    admin_actor,
-
-                    # Other
-                    target_address, value):
+def transfer_tokens(actor_options, target_address, value):
     """
     Transfer tokens from contract's owner address to another address
     """
-    # Init
     emitter = StdoutEmitter()
-    _ensure_config_root(admin_actor.config_root)
-    deployer_interface = _initialize_blockchain(admin_actor.poa, admin_actor.provider_uri)
-
-    # Warnings
-    _pre_launch_warnings(emitter, admin_actor.etherscan, admin_actor.hw_wallet)
-
-    #
-    # Make Authenticated Deployment Actor
-    #
-    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
-                                                                                           admin_actor.provider_uri,
-                                                                                           admin_actor.deployer_address,
-                                                                                           deployer_interface,
-                                                                                           admin_actor.contract_name,
-                                                                                           admin_actor.registry_infile,
-                                                                                           admin_actor.registry_outfile,
-                                                                                           admin_actor.hw_wallet,
-                                                                                           admin_actor.dev,
-                                                                                           admin_actor.force,
-                                                                                           admin_actor.se_test_mode)
+    ADMINISTRATOR, deployer_address, _, local_registry = actor_options.create_actor(emitter)
 
     token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=local_registry)
     if not target_address:
@@ -477,44 +460,20 @@ def transfer_tokens(# Admin Actor Options
 
 
 @deploy.command("transfer-ownership")
-@group_admin_actor
+@group_actor_options
 @option_target_address
 @option_gas
-def transfer_ownership(# Admin Actor Options
-                       admin_actor,
-
-                       # Other
-                       target_address, gas):
+def transfer_ownership(actor_options, target_address, gas):
     """
     Transfer ownership of contracts to another address.
     """
-    # Init
     emitter = StdoutEmitter()
-    _ensure_config_root(admin_actor.config_root)
-    deployer_interface = _initialize_blockchain(admin_actor.poa, admin_actor.provider_uri)
-
-    # Warnings
-    _pre_launch_warnings(emitter, admin_actor.etherscan, admin_actor.hw_wallet)
-
-    #
-    # Make Authenticated Deployment Actor
-    #
-    ADMINISTRATOR, deployer_address, local_registry = _make_authenticated_deployment_actor(emitter,
-                                                                                           admin_actor.provider_uri,
-                                                                                           admin_actor.deployer_address,
-                                                                                           deployer_interface,
-                                                                                           admin_actor.contract_name,
-                                                                                           admin_actor.registry_infile,
-                                                                                           admin_actor.registry_outfile,
-                                                                                           admin_actor.hw_wallet,
-                                                                                           admin_actor.dev,
-                                                                                           admin_actor.force,
-                                                                                           admin_actor.se_test_mode)
+    ADMINISTRATOR, _, _, _ = actor_options.create_actor(emitter)
 
     if not target_address:
         target_address = click.prompt("Enter new owner's checksum address", type=EIP55_CHECKSUM_ADDRESS)
 
-    contract_name = admin_actor.contract_name
+    contract_name = actor_options.contract_name
     if contract_name:
         try:
             contract_deployer_class = ADMINISTRATOR.deployers[contract_name]
@@ -530,74 +489,3 @@ def transfer_ownership(# Admin Actor Options
     else:
         receipts = ADMINISTRATOR.relinquish_ownership(new_owner=target_address, transaction_gas_limit=gas)
         emitter.ipc(receipts, request_id=0, duration=0)  # TODO: #1216
-
-
-def _make_authenticated_deployment_actor(emitter, provider_uri, deployer_address, deployer_interface, contract_name,
-                                         registry_infile, registry_outfile, hw_wallet, dev, force, se_test_mode):
-    #
-    # Establish Registry
-    #
-    local_registry = establish_deployer_registry(emitter=emitter,
-                                                 use_existing_registry=bool(contract_name),
-                                                 registry_infile=registry_infile,
-                                                 registry_outfile=registry_outfile,
-                                                 dev=dev)
-    #
-    # Make Authenticated Deployment Actor
-    #
-    # Verify Address & collect password
-    if not deployer_address:
-        prompt = "Select deployer account"
-        deployer_address = select_client_account(emitter=emitter,
-                                                 prompt=prompt,
-                                                 provider_uri=provider_uri,
-                                                 show_balances=False)
-    if not force:
-        click.confirm("Selected {} - Continue?".format(deployer_address), abort=True)
-    password = None
-    if not hw_wallet and not deployer_interface.client.is_local:
-        password = get_client_password(checksum_address=deployer_address)
-    # Produce Actor
-    ADMINISTRATOR = ContractAdministrator(registry=local_registry,
-                                          client_password=password,
-                                          deployer_address=deployer_address,
-                                          staking_escrow_test_mode=se_test_mode)
-    # Verify ETH Balance
-    emitter.echo(f"\n\nDeployer ETH balance: {ADMINISTRATOR.eth_balance}")
-    if ADMINISTRATOR.eth_balance == 0:
-        emitter.echo("Deployer address has no ETH.", color='red', bold=True)
-        raise click.Abort()
-    return ADMINISTRATOR, deployer_address, local_registry
-
-
-def _pre_launch_warnings(emitter, etherscan, hw_wallet):
-    if not hw_wallet:
-        emitter.echo("WARNING: --no-hw-wallet is enabled.", color='yellow')
-    if etherscan:
-        emitter.echo("WARNING: --etherscan is enabled. "
-                     "A browser tab will be opened with deployed contracts and TXs as provided by Etherscan.",
-                     color='yellow')
-    else:
-        emitter.echo("WARNING: --etherscan is disabled. "
-                     "If you want to see deployed contracts and TXs in your browser, activate --etherscan.",
-                     color='yellow')
-
-
-def _initialize_blockchain(poa, provider_uri):
-    if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
-        # Note: For test compatibility.
-        deployer_interface = BlockchainDeployerInterface(provider_uri=provider_uri, poa=poa)
-        BlockchainInterfaceFactory.register_interface(interface=deployer_interface, sync=False,
-                                                      show_sync_progress=False)
-    else:
-        deployer_interface = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)
-
-    deployer_interface.connect()
-    return deployer_interface
-
-
-def _ensure_config_root(config_root):
-    # Ensure config root exists, because we need a default place to put output files.
-    config_root = config_root or DEFAULT_CONFIG_ROOT
-    if not os.path.exists(config_root):
-        os.makedirs(config_root)

--- a/nucypher/cli/deploy.py
+++ b/nucypher/cli/deploy.py
@@ -77,12 +77,12 @@ def _pre_launch_warnings(emitter, etherscan, hw_wallet):
                      color='yellow')
 
 
-def _initialize_blockchain(poa, provider_uri):
+def _initialize_blockchain(poa, provider_uri, emitter):
     if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
         # Note: For test compatibility.
         deployer_interface = BlockchainDeployerInterface(provider_uri=provider_uri, poa=poa)
         BlockchainInterfaceFactory.register_interface(interface=deployer_interface, sync=False,
-                                                      show_sync_progress=False)
+                                                      emitter=emitter)
     else:
         deployer_interface = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)
 
@@ -120,7 +120,7 @@ class ActorOptions:
     def create_actor(self, emitter):
 
         _ensure_config_root(self.config_root)
-        deployer_interface = _initialize_blockchain(self.poa, self.provider_uri)
+        deployer_interface = _initialize_blockchain(self.poa, self.provider_uri, emitter)
 
         # Warnings
         _pre_launch_warnings(emitter, self.etherscan, self.hw_wallet)
@@ -235,7 +235,7 @@ def inspect(provider_uri, config_root, registry_infile, deployer_address, poa):
     # Init
     emitter = StdoutEmitter()
     _ensure_config_root(config_root)
-    _initialize_blockchain(poa, provider_uri)
+    _initialize_blockchain(poa, provider_uri, emitter)
 
     local_registry = establish_deployer_registry(emitter=emitter,
                                                  registry_infile=registry_infile,

--- a/nucypher/cli/status.py
+++ b/nucypher/cli/status.py
@@ -63,7 +63,7 @@ class RegistryOptions:
                                                                 poa=self.poa,
                                                                 light=self.light,
                                                                 sync=False,
-                                                                show_sync_progress=False)
+                                                                emitter=emitter)
 
             blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=self.provider_uri)
 

--- a/nucypher/cli/status.py
+++ b/nucypher/cli/status.py
@@ -25,6 +25,14 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import InMemoryContractRegistry, LocalContractRegistry
 from nucypher.characters.banners import NU_BANNER
 from nucypher.cli.actions import get_provider_process
+from nucypher.cli.common_options import (
+    option_geth,
+    option_light,
+    option_poa,
+    option_provider_uri,
+    option_registry_filepath,
+    option_staking_address,
+    )
 from nucypher.cli.config import nucypher_click_config
 from nucypher.cli.painting import paint_contract_status, paint_stakers, paint_locked_tokens_status
 from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, EXISTING_READABLE_FILE
@@ -32,11 +40,11 @@ from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, EXISTING_READABLE_FILE
 
 # Args (provider_uri, geth, poa, registry_filepath)
 def _common_options(func):
-    @click.option('--provider', 'provider_uri', help="Blockchain provider's URI", type=click.STRING, default="auto://")
-    @click.option('--geth', '-G', help="Run using the built-in geth node", is_flag=True)
-    @click.option('--poa', help="Inject POA middleware", is_flag=True, default=False)
-    @click.option('--light', help="Indicate that node is light", is_flag=True, default=False)
-    @click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+    @option_provider_uri(default="auto://")
+    @option_geth
+    @option_poa
+    @option_light
+    @option_registry_filepath
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -69,7 +77,7 @@ def network(click_config,
 
 @status.command()
 @_common_options
-@click.option('--staking-address', help="Address of a NuCypher staker", type=EIP55_CHECKSUM_ADDRESS)
+@option_staking_address
 @nucypher_click_config
 def stakers(click_config,
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -98,6 +98,8 @@ class CharacterConfiguration(BaseConfiguration):
                  # Registry
                  registry: BaseContractRegistry = None,
                  registry_filepath: str = None,
+
+                 emitter=None,
                  ):
 
         self.log = Logger(self.__class__.__name__)
@@ -183,14 +185,12 @@ class CharacterConfiguration(BaseConfiguration):
         else:
             is_initialized = BlockchainInterfaceFactory.is_interface_initialized(provider_uri=self.provider_uri)
             if not is_initialized and provider_uri:
-                from nucypher.cli.config import GroupGeneralConfig  # TODO: Need a better place for global verbosity, non-local to the CLI.
-
                 BlockchainInterfaceFactory.initialize_interface(provider_uri=self.provider_uri,
                                                                 poa=self.poa,
                                                                 light=self.is_light,
                                                                 provider_process=self.provider_process,
                                                                 sync=sync,
-                                                                show_sync_progress=GroupGeneralConfig.verbosity)
+                                                                emitter=emitter)
             else:
                 self.log.warn(f"Using existing blockchain interface connection ({self.provider_uri}).")
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -183,14 +183,14 @@ class CharacterConfiguration(BaseConfiguration):
         else:
             is_initialized = BlockchainInterfaceFactory.is_interface_initialized(provider_uri=self.provider_uri)
             if not is_initialized and provider_uri:
-                from nucypher.cli.config import NucypherClickConfig  # TODO: Need a better place for global verbosity, non-local to the CLI.
+                from nucypher.cli.config import GroupGeneralConfig  # TODO: Need a better place for global verbosity, non-local to the CLI.
 
                 BlockchainInterfaceFactory.initialize_interface(provider_uri=self.provider_uri,
                                                                 poa=self.poa,
                                                                 light=self.is_light,
                                                                 provider_process=self.provider_process,
                                                                 sync=sync,
-                                                                show_sync_progress=NucypherClickConfig.verbosity)
+                                                                show_sync_progress=GroupGeneralConfig.verbosity)
             else:
                 self.log.warn(f"Using existing blockchain interface connection ({self.provider_uri}).")
 

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -17,7 +17,6 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import pathlib
 from contextlib import contextmanager
-from functools import lru_cache
 
 from sentry_sdk import capture_exception, add_breadcrumb
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -165,7 +164,6 @@ def _ensure_dir_exists(path):
     pathlib.Path(path).mkdir(parents=True, exist_ok=True)
 
 
-@lru_cache()
 def get_json_file_observer(name="nucypher.json", path=USER_LOG_DIR):
     _ensure_dir_exists(path)
     logfile = LogFile(name=name, directory=path, rotateLength=MAXIMUM_LOG_SIZE, maxRotatedFiles=MAX_LOG_FILES)
@@ -173,7 +171,6 @@ def get_json_file_observer(name="nucypher.json", path=USER_LOG_DIR):
     return observer
 
 
-@lru_cache()
 def get_text_file_observer(name="nucypher.log", path=USER_LOG_DIR):
     _ensure_dir_exists(path)
     logfile = LogFile(name=name, directory=path, rotateLength=MAXIMUM_LOG_SIZE, maxRotatedFiles=MAX_LOG_FILES)

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -86,16 +86,6 @@ class GlobalLoggerSettings:
 
     @classmethod
     @contextmanager
-    def pause_console_logging_while(cls):
-        was_already_going = console_observer in globalLogPublisher._observers
-        if was_already_going:
-            globalLogPublisher.removeObserver(console_observer)
-        yield
-        if was_already_going:
-            globalLogPublisher.addObserver(console_observer)
-
-    @classmethod
-    @contextmanager
     def pause_all_logging_while(cls):
         former_observers = tuple(globalLogPublisher._observers)
         for observer in former_observers:

--- a/tests/cli/test_help.py
+++ b/tests/cli/test_help.py
@@ -20,12 +20,8 @@ import click
 import pytest
 
 import nucypher
-from nucypher.cli.config import NucypherClickConfig
 from nucypher.cli.deploy import deploy
 from nucypher.cli.main import nucypher_cli, ENTRY_POINTS
-
-NUCYPHER_CLICK_CONFIG_OPTIONS = set(inspect.signature(NucypherClickConfig.set_options).parameters.keys())
-NUCYPHER_CLICK_CONFIG_OPTIONS.remove('self')
 
 
 def test_echo_nucypher_version(click_runner):
@@ -72,28 +68,3 @@ def test_nucypher_deploy_help_message(click_runner):
     result = click_runner.invoke(deploy, help_args, catch_exceptions=False)
     assert result.exit_code == 0
     assert 'deploy [OPTIONS] COMMAND [ARGS]' in result.output, 'Missing or invalid help text was produced.'
-
-
-@pytest.mark.parametrize('entry_point_name, entry_point', ([command.name, command] for command in ENTRY_POINTS))
-def test_character_command_options_and_parameters_match(entry_point_name, entry_point):
-    if isinstance(entry_point, click.Group):
-        for sub_command in entry_point.commands.values():
-            _check_command_options_and_parameters(sub_command)
-    else:
-        # Plain old command - currently just `moe`
-        _check_command_options_and_parameters(entry_point)
-
-
-def _check_command_options_and_parameters(command):
-    command_signature = inspect.signature(command.callback)
-
-    command_callback_params = set(command_signature.parameters.keys())
-    assert 'click_config' in command_callback_params, f"{command.name} specifies 'click_config' as a method parameter"
-
-    # remove click_config and add actual options
-    command_callback_params.remove('click_config')
-    command_callback_params.update(NUCYPHER_CLICK_CONFIG_OPTIONS)
-
-    command_options = set(p.name for p in command.params)
-    assert command_options == command_callback_params, \
-        f"click options provided for '{command.name}' matches the corresponding method parameters"

--- a/tests/cli/test_rpc_ipc_transport.py
+++ b/tests/cli/test_rpc_ipc_transport.py
@@ -11,10 +11,6 @@ from nucypher.cli.processes import JSONRPCLineReceiver
 class TransportTrap:
     """Temporarily diverts system standard output"""
 
-    # Disable click sentry and file logging
-    GroupGeneralConfig.log_to_sentry = False
-    GroupGeneralConfig.log_to_file = True
-
     def __init__(self):
         self.___stdout = sys.stdout
         self.buffer = deque()

--- a/tests/cli/test_rpc_ipc_transport.py
+++ b/tests/cli/test_rpc_ipc_transport.py
@@ -4,7 +4,7 @@ from collections import deque
 
 import pytest
 
-from nucypher.cli.config import NucypherClickConfig
+from nucypher.cli.config import GroupGeneralConfig
 from nucypher.cli.processes import JSONRPCLineReceiver
 
 
@@ -12,8 +12,8 @@ class TransportTrap:
     """Temporarily diverts system standard output"""
 
     # Disable click sentry and file logging
-    NucypherClickConfig.log_to_sentry = False
-    NucypherClickConfig.log_to_file = True
+    GroupGeneralConfig.log_to_sentry = False
+    GroupGeneralConfig.log_to_file = True
 
     def __init__(self):
         self.___stdout = sys.stdout

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -535,7 +535,6 @@ def test_collect_rewards_integration(click_runner,
 
     # Collect Policy Reward
     collection_args = ('stake', 'collect-reward',
-                       '--mock-networking',
                        '--config-file', stakeholder_configuration_file_location,
                        '--policy-reward',
                        '--no-staking-reward',
@@ -561,7 +560,6 @@ def test_collect_rewards_integration(click_runner,
     balance_before_collecting = token_agent.get_balance(address=staker_address)
 
     collection_args = ('stake', 'collect-reward',
-                       '--mock-networking',
                        '--config-file', stakeholder_configuration_file_location,
                        '--no-policy-reward',
                        '--staking-reward',

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -449,7 +449,6 @@ def test_collect_rewards_integration(click_runner,
 
     # Collect Policy Reward
     collection_args = ('stake', 'collect-reward',
-                       '--mock-networking',
                        '--config-file', stakeholder_configuration_file_location,
                        '--policy-reward',
                        '--no-staking-reward',
@@ -481,7 +480,6 @@ def test_collect_rewards_integration(click_runner,
     balance_before_collecting = staker.token_agent.get_balance(address=staker_address)
 
     collection_args = ('stake', 'collect-reward',
-                       '--mock-networking',
                        '--config-file', stakeholder_configuration_file_location,
                        '--no-policy-reward',
                        '--staking-reward',

--- a/tests/cli/ursula/test_ursula_command.py
+++ b/tests/cli/ursula/test_ursula_command.py
@@ -8,10 +8,6 @@ from nucypher.characters.control.emitters import StdoutEmitter
 from nucypher.cli.config import GroupGeneralConfig
 from nucypher.cli.processes import UrsulaCommandProtocol
 
-# Override environment variables
-GroupGeneralConfig.log_to_sentry = False
-GroupGeneralConfig.log_to_file = False
-
 
 @contextmanager
 def capture_output():

--- a/tests/cli/ursula/test_ursula_command.py
+++ b/tests/cli/ursula/test_ursula_command.py
@@ -5,12 +5,12 @@ import pytest
 from io import StringIO
 
 from nucypher.characters.control.emitters import StdoutEmitter
-from nucypher.cli.config import NucypherClickConfig
+from nucypher.cli.config import GroupGeneralConfig
 from nucypher.cli.processes import UrsulaCommandProtocol
 
 # Override environment variables
-NucypherClickConfig.log_to_sentry = False
-NucypherClickConfig.log_to_file = False
+GroupGeneralConfig.log_to_sentry = False
+GroupGeneralConfig.log_to_file = False
 
 
 @contextmanager

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,15 +24,6 @@ from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
-#
-# Global Session Mock & Patch
-#
-
-
-# Disable click sentry and file logging
-GroupGeneralConfig.log_to_sentry = False
-GroupGeneralConfig.log_to_file = True
-
 # Crash on server error by default
 WebEmitter._crash_on_error_default = True
 
@@ -129,6 +120,7 @@ def pytest_collection_modifyitems(config, items):
 
     log_level_name = config.getoption("--log-level", "info", skip=True)
 
+    GlobalLoggerSettings.stop_sentry_logging()
     GlobalLoggerSettings.set_log_level(log_level_name)
     GlobalLoggerSettings.start_text_file_logging()
     GlobalLoggerSettings.start_json_file_logging()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import pytest
 
 from nucypher.characters.control.emitters import WebEmitter
-from nucypher.cli.config import NucypherClickConfig
+from nucypher.cli.config import GroupGeneralConfig
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
@@ -30,8 +30,8 @@ from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
 # Disable click sentry and file logging
-NucypherClickConfig.log_to_sentry = False
-NucypherClickConfig.log_to_file = True
+GroupGeneralConfig.log_to_sentry = False
+GroupGeneralConfig.log_to_file = True
 
 # Crash on server error by default
 WebEmitter._crash_on_error_default = True


### PR DESCRIPTION
A continuation of PR #1417, fixes #1431

- Moved repeating CLI options to a separate file
- Collected groups of options into objects to avoid long parameter lists
- Removed `etherscan` option from `config.py` - it is not used anywhere
- Moved `mock_networking` option from `config.py` to the characters that use it
- Got rid of `NucypherClickConfig` import in `CharacterConfiguration` constructor; fixes #1503 
- Removed assignments to `NucypherClickConfig` attributes which did nothing, and replaced these assignments with `GlobalLoggerSettings` method calls in `conftest.py`. **Note:** I'm assuming here that `NucypherClickConfig` was only used in CLI calls, which were all started with `click.invoke()` and therefore setting `NucypherClickConfig` attributes in the main process had no effect.
- Used `NucypherClickConfig` (now `GroupGeneralConfig`) in CLI `deploy` command, instead of creating an emitter manually; fixes #1556
- Removed caching from `get_json_file_observer()` and `get_text_file_observer()` in `logging.py`. These functions are called very rarely, and have side effects, so caching is not needed and can actually lead to failures there.
- **CHANGED:** `NUCYPHER_CONFIG_FILE` envvar renamed to `NUCYPHER_CONFIG_ROOT` (according to how it is used in the code)

Minor:
- Removed an unused method `GlobalLoggerSettings.pause_console_logging_while()`
- Removed an unneeded repetition of the command name in `stake.py::preallocation()`

Notes:
- Currently, some of the flag-type options (`federated_only` and `poa`) default to `None` because they can be loaded from the config file. I added the corresponding comments in this PR, but I would prefer a more explicit way to handle it. I already spent some time debugging test fails because I accidentally omitted `default=None` for `federated_only`.