### PR TITLE
Cleanup of Moe Status Page regarding checksum, graphs, and states

### DIFF
--- a/nucypher/network/status_app/moe.py
+++ b/nucypher/network/status_app/moe.py
@@ -169,7 +169,7 @@ class MoeStatusApp(NetworkStatusPage):
                             layout=go.Layout(
                                 title=f'Staked NU over the previous {prior_periods} days.',
                                 xaxis={'title': 'Date', 'nticks': len(locked_tokens_dict) + 1},
-                                yaxis={'title': 'NU Tokens', 'zeroline': False},
+                                yaxis={'title': 'NU Tokens', 'zeroline': False, 'rangemode': 'tozero'},
                                 showlegend=False,
                                 paper_bgcolor='rgba(0,0,0,0)',
                                 plot_bgcolor='rgba(0,0,0,0)'
@@ -196,7 +196,7 @@ class MoeStatusApp(NetworkStatusPage):
                             layout=go.Layout(
                                 title=f'Num Stakers over the previous {prior_periods} days.',
                                 xaxis={'title': 'Date', 'nticks': len(num_stakers_dict) + 1, 'showgrid': False},
-                                yaxis={'title': 'Stakers', 'zeroline': False, 'showgrid': False},
+                                yaxis={'title': 'Stakers', 'zeroline': False, 'showgrid': False, 'rangemode': 'tozero'},
                                 showlegend=False,
                                 paper_bgcolor='rgba(0,0,0,0)',
                                 plot_bgcolor='rgba(0,0,0,0)'
@@ -224,7 +224,7 @@ class MoeStatusApp(NetworkStatusPage):
                             layout=go.Layout(
                                 title=f'Staked NU over the next {periods} days.',
                                 xaxis={'title': 'Days'},
-                                yaxis={'title': 'NU Tokens'},
+                                yaxis={'title': 'NU Tokens', 'rangemode': 'tozero'},
                                 showlegend=False,
                                 legend=go.layout.Legend(x=0, y=1.0),
                                 paper_bgcolor='rgba(0,0,0,0)',


### PR DESCRIPTION
Comments from @cygnusv in #963 :
- [x] The "Checksum" column is wrong. It's showing the worker address, instead of the checksum address.
- [x] In the "Num Stakers over the previous 30 days" chart, can you make the y-axis start from 0 (Discussion here: https://github.com/nucypher/nucypher/pull/963#issuecomment-544681150 and https://github.com/nucypher/nucypher/pull/963#issuecomment-544701507.)
- [x] The network status page shows the previous fleet states, but it doesn't show the current fleet state.