### PR TITLE
Fix "invalid escape sequence" warnings for regexes in test_status

### DIFF
--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -50,12 +50,12 @@ def test_nucypher_status_network(click_runner, testerchain, test_registry, agenc
 
     agents = (token_agent, staking_agent, policy_agent, adjudicator_agent)
     for agent in agents:
-        contract_regex = f"^{agent.contract_name} \.+ {agent.contract_address}"
+        contract_regex = fr"^{agent.contract_name} \.+ {agent.contract_address}"
         assert re.search(contract_regex, result.output, re.MULTILINE)
 
-    assert re.search(f"^Provider URI \.+ {TEST_PROVIDER_URI}", result.output, re.MULTILINE)
+    assert re.search(fr"^Provider URI \.+ {TEST_PROVIDER_URI}", result.output, re.MULTILINE)
     #assert re.search(f"^Registry \.+ {registry_filepath}", result.output, re.MULTILINE)
-    assert re.search(f"^Current Period \.+ {staking_agent.get_current_period()}", result.output, re.MULTILINE)
+    assert re.search(fr"^Current Period \.+ {staking_agent.get_current_period()}", result.output, re.MULTILINE)
 
 
 def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agency, stakers):
@@ -72,9 +72,9 @@ def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agenc
     staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
 
     # TODO: Use regex matching instead of this
-    assert re.search(f"^Current period: {staking_agent.get_current_period()}", result.output, re.MULTILINE)
+    assert re.search(fr"^Current period: {staking_agent.get_current_period()}", result.output, re.MULTILINE)
     for staker in stakers:
-        assert re.search(f"^{staker.checksum_address}", result.output, re.MULTILINE)
+        assert re.search(fr"^{staker.checksum_address}", result.output, re.MULTILINE)
 
     # Get info of only one staker
     some_dude = random.choice(stakers)
@@ -90,8 +90,8 @@ def test_nucypher_status_stakers(click_runner, testerchain, test_registry, agenc
     owned_tokens = NU.from_nunits(staking_agent.owned_tokens(staking_address))
     locked_tokens = NU.from_nunits(staking_agent.get_locked_tokens(staking_address))
 
-    assert re.search(f"^Current period: {staking_agent.get_current_period()}", result.output, re.MULTILINE)
-    assert re.search(f"Worker:\s+{some_dude.worker_address}", result.output, re.MULTILINE)
-    assert re.search(f"Stake:\s+{round(owned_tokens, 2)}  \(Locked: {round(locked_tokens, 2)}\)", result.output, re.MULTILINE)
+    assert re.search(fr"^Current period: {staking_agent.get_current_period()}", result.output, re.MULTILINE)
+    assert re.search(fr"Worker:\s+{some_dude.worker_address}", result.output, re.MULTILINE)
+    assert re.search(fr"Stake:\s+{round(owned_tokens, 2)}  \(Locked: {round(locked_tokens, 2)}\)", result.output, re.MULTILINE)
 
 


### PR DESCRIPTION
Just a small fix for annoying warnings. Turn regex f-strings into raw f-strings.