### PR TITLE
Touchups to the CLI allocation process: support for CSV, bugfixes, etc.

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -518,7 +518,7 @@ class ContractAdministrator(NucypherTokenActor):
             if emitter:
                 paint_deployed_allocations(emitter, allocated, failed)
 
-            csv_filename = f'allocations-{self.deployer_address[:6]}-{maya.now().epoch}.csv'
+            csv_filename = f'allocation-summary-{self.deployer_address[:6]}-{maya.now().epoch}.csv'
             csv_filepath = os.path.join(parent_path, csv_filename)
             write_deployed_allocations_to_csv(csv_filepath, allocated, failed)
             if emitter:
@@ -575,12 +575,12 @@ class ContractAdministrator(NucypherTokenActor):
         os.makedirs(DEFAULT_CONFIG_ROOT, exist_ok=True)
         with open(filepath, 'w') as file:
             data = dict()
-            for contract_name, receipts in receipts.items():
+            for contract_name, contract_receipts in receipts.items():
                 contract_records = dict()
-                for tx_name, receipt in receipts.items():
+                for tx_name, receipt in contract_receipts.items():
                     # Formatting
-                    receipt = {item: str(result) for item, result in receipt.items()}
-                    contract_records.update({tx_name: receipt for tx_name in receipts})
+                    pretty_receipt = {item: str(result) for item, result in receipt.items()}
+                    contract_records[tx_name] = pretty_receipt
                 data[contract_name] = contract_records
             data = json.dumps(data, indent=4)
             file.write(data)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -442,6 +442,12 @@ class ContractAdministrator(NucypherTokenActor):
         if emitter:
             emitter.echo(f"Saved allocation template file to {template_filepath}", color='blue', bold=True)
 
+        already_enrolled = [a['beneficiary_address'] for a in allocations
+                            if allocation_registry.is_beneficiary_enrolled(a['beneficiary_address'])]
+        if already_enrolled:
+            raise ValueError(f"The following beneficiaries are already enrolled in allocation registry "
+                             f"({allocation_registry.filepath}): {already_enrolled}")
+
         # Deploy each allocation contract
         with click.progressbar(length=total_deployment_transactions,
                                label="Allocation progress",

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -544,6 +544,10 @@ class ContractAdministrator(NucypherTokenActor):
                     allocation_data = json.loads(data)
                 except JSONDecodeError:
                     raise
+
+        for entry in allocation_data:
+            entry['beneficiary_address'] = to_checksum_address(entry['beneficiary_address'])
+
         return allocation_data
 
     def deploy_beneficiaries_from_file(self,

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -404,7 +404,7 @@ class AllocationRegistry(LocalContractRegistry):
         try:
             _ = self.search(beneficiary_address=beneficiary_address)
             return True
-        except self.UnknownBeneficiary:
+        except (self.UnknownBeneficiary, self.NoAllocationRegistry):
             return False
         # TODO: Tests!
 

--- a/tests/blockchain/eth/entities/deployers/test_deploy_preallocations.py
+++ b/tests/blockchain/eth/entities/deployers/test_deploy_preallocations.py
@@ -55,14 +55,12 @@ def test_deploy_and_allocate(agency, token_economics, test_registry):
     assert token_agent.get_balance(address=origin) > 1
 
     # Start allocating tokens
-    deposit_receipts, approve_hashes = list(), dict()
     for address, deployer in deployments.items():
         assert deployer.deployer_address == origin
 
-        deposit_receipt = deployer.initial_deposit(value=allocation, duration_seconds=token_economics.maximum_rewarded_periods)
-        deposit_receipts.append(deposit_receipt)
+        deployer.initial_deposit(value=allocation, duration_seconds=token_economics.maximum_rewarded_periods)
 
         beneficiary = random.choice(testerchain.unassigned_accounts)
         _assign_receipt = deployer.assign_beneficiary(beneficiary)
 
-    assert len(deposit_receipts) == number_of_deployments == len(deployments)
+    assert number_of_deployments == len(deployments)


### PR DESCRIPTION
Command to use the allocation CLI:
```nucypher-deploy allocations --provider <PROVIDER> --poa  --allocation-infile <ALLOCATION_FILE>```

Example of allocation file in CSV:
```
"beneficiary_address","name","amount","duration_seconds"
"0x1715a31490371EBC469D775d6b384C354Be803C7","Aunt Irma",15000000000000000000,259200
```
Note you need those exact column names.