### PR TITLE
Policy refactoring

### DIFF
--- a/docs/source/architecture/contracts.md
+++ b/docs/source/architecture/contracts.md
@@ -21,14 +21,14 @@ For a guide of how to deploy these contracts automatically, see the [Deployment 
 2. Deploy `StakingEscrow` with a dispatcher targeting it
 3. Deploy `PolicyManager` with its own dispatcher, also targeting it
 4. Deploy `Adjudicator` with a dispatcher
-5. Deploy `WorkLock` contract
-6. Transfer reward tokens to the `StakingEscrow` contract. These tokens are future mining rewards and initial allocations
-7. Run the `initialize()` method to initialize the `StakingEscrow` contract
-8. Set the address of the `PolicyManager` contract  in the `StakingEscrow` by using the `setPolicyManager(address)`
-9. Set the address of the `Adjudicator` contract  in the `StakingEscrow` by using the `setAdjudicator(address)`
-10. Set the address of the `WorkLock` contract  in the `StakingEscrow` by using the `setWorkLock(address)`
-11. Transfer tokens for distribution to the `WorkLock` contract
-12. Deploy `StakingInterface` with `StakingInterfaceRouter` targeting it
+5. Deploy `StakingInterface` with `StakingInterfaceRouter` targeting it
+6. Deploy `WorkLock` contract
+7. Set the address of the `PolicyManager` contract  in the `StakingEscrow` by using the `setPolicyManager(address)`
+8. Set the address of the `Adjudicator` contract  in the `StakingEscrow` by using the `setAdjudicator(address)`
+9. Set the address of the `WorkLock` contract  in the `StakingEscrow` by using the `setWorkLock(address)`
+10. Approve tokens transfer to the `StakingEscrow` contract. These tokens are future mining rewards
+11. Run the `initialize(uint256)` method to initialize the `StakingEscrow` contract
+12. Approve tokens transfer for distribution to the `WorkLock` contract and call `tokenDeposit(uint256)` method
 13. Pre-deposit tokens to the `PreallocationEscrow`:
 	* Create new instance of the `PreallocationEscrow` contract 
 	* Transfer ownership of the instance of the `PreallocationEscrow` contract to the user
@@ -41,22 +41,24 @@ For a guide of how to deploy these contracts automatically, see the [Deployment 
 
 Alice uses a network of Ursula stakers to deploy policies.
 In order to take advantage of the network, Alice chooses stakers and deploys policies with fees for those stakers.
-Alice can choose stakers by herself ("handpicked") or by using `StakingEscrow.sample(uint256[], uint16)` - This is  known as ("sampling").
-`sample` parameters are:
-* The array of absolute values
+Alice can choose stakers by herself ("handpicked") or select from the result of `StakingEscrow.getActiveStakers(uint16, uint256, uint256)` method - This is  known as ("sampling").
+`getActiveStakers` parameters are:
 * Minimum number of periods during which tokens are locked
+* Start index for looking in stakers array 
+* Max stakers for looking
 This method will return only active stakers.
 
-In order to place the fee for a policy, Alice calls the method `PolicyManager.createPolicy(bytes16, uint16, uint256, address[])`,
-specifying the staker's addresses, the policy ID (off-chain generation), the policy duration in periods, and the first period's reward.
-Payment should be added to the transaction in ETH and the amount is `firstReward * stakers.length + rewardRate * periods * stakers.length`.
-The reward rate must be greater than or equal to the minimum reward for each staker in the list. The first period's reward is not refundable, and can be zero.
+In order to place the fee for a policy, Alice calls the method `PolicyManager.createPolicy(bytes16, address, uint64, address[])`,
+specifying the staker's addresses, the policy ID (off-chain generation), the policy owner (could be zero address), and the end timestamp of the policy.
+Payment should be added to the transaction in ETH and the amount is `rewardRate * periods * stakers.length`, where `periods` is `endTimestampPeriod - currentPeriod + 1`.
+The reward rate must be greater than or equal to the minimum reward for each staker in the list.
 
 ### Alice Revokes a Blockchain Policy
 
 When Alice wants to revoke a policy, she calls the `PolicyManager.revokePolicy(bytes16)` or `PolicyManager.revokeArrangement(bytes16, address)`.
 Execution of these methods results in Alice recovering all fees for future periods, and also for periods when the stakers were inactive.
 Alice can refund ETH for any inactive periods without revoking the policy by using the method `PolicyManager.refund(bytes16)` or `PolicyManager.refund(bytes16, address)`.
+If Alice doesn't have ability to execute on-chain transaction or wants to share ability to revoke then she can sign revocation parameters. Anyone who have this signature will be able to revoke policy using `PolicyManager.revoke(bytes16, address, bytes)`
 
 
 ## Staker's Contract Interaction
@@ -118,7 +120,7 @@ The staker can set a minimum reward rate for a policy. For that, the staker shou
 ### NuCypher Partner Ursula Staking
 Some users will have locked but not staked tokens.
 In that case, an instance of the `PreallocationEscrow` contract will hold their tokens (method `PreallocationEscrow.initialDeposit(uint256, uint256)`).
-All tokens will be unlocked after a specified time and the user can retrieve them using the `PreallocationEscrow.withdraw(uint256)` method.
+All tokens will be unlocked after a specified time and the user can retrieve them using the `PreallocationEscrow.withdrawTokens(uint256)` method.
 When the user wants to become a staker - they use the `PreallocationEscrow` contract as a proxy for the `StakingEscrow` and `PolicyManager` contracts.
 
 

--- a/docs/source/architecture/contracts.md
+++ b/docs/source/architecture/contracts.md
@@ -20,13 +20,13 @@ For a guide of how to deploy these contracts automatically, see the [Deployment 
 1. Deploy `NuCypherToken` with all future supply tokens
 2. Deploy `StakingEscrow` with a dispatcher targeting it
 3. Deploy `PolicyManager` with its own dispatcher, also targeting it
-4. Deploy `Adjudicator` with a dispatcher
-5. Deploy `StakingInterface` with `StakingInterfaceRouter` targeting it
-6. Deploy `WorkLock` contract
-7. Set the address of the `PolicyManager` contract  in the `StakingEscrow` by using the `setPolicyManager(address)`
-8. Set the address of the `Adjudicator` contract  in the `StakingEscrow` by using the `setAdjudicator(address)`
+4. Set the address of the `PolicyManager` contract  in the `StakingEscrow` by using the `setPolicyManager(address)`
+5. Deploy `Adjudicator` with a dispatcher
+6. Set the address of the `Adjudicator` contract  in the `StakingEscrow` by using the `setAdjudicator(address)`
+7. Deploy `StakingInterface` with `StakingInterfaceRouter` targeting it
+8. Deploy `WorkLock` contract
 9. Set the address of the `WorkLock` contract  in the `StakingEscrow` by using the `setWorkLock(address)`
-10. Approve tokens transfer to the `StakingEscrow` contract. These tokens are future mining rewards
+10. Approve tokens transfer to the `StakingEscrow` contract. These tokens are future staking rewards
 11. Run the `initialize(uint256)` method to initialize the `StakingEscrow` contract
 12. Approve tokens transfer for distribution to the `WorkLock` contract and call `tokenDeposit(uint256)` method
 13. Pre-deposit tokens to the `PreallocationEscrow`:
@@ -44,12 +44,12 @@ In order to take advantage of the network, Alice chooses stakers and deploys pol
 Alice can choose stakers by herself ("handpicked") or select from the result of `StakingEscrow.getActiveStakers(uint16, uint256, uint256)` method - This is  known as ("sampling").
 `getActiveStakers` parameters are:
 * Minimum number of periods during which tokens are locked
-* Start index for looking in stakers array 
-* Max stakers for looking
+* Start index in stakers array 
+* Maximum number of stakers
 This method will return only active stakers.
 
 In order to place the fee for a policy, Alice calls the method `PolicyManager.createPolicy(bytes16, address, uint64, address[])`,
-specifying the staker's addresses, the policy ID (off-chain generation), the policy owner (could be zero address), and the end timestamp of the policy.
+specifying the policy ID (off-chain generation), the policy owner (could be zero address), the end timestamp of the policy and the stakers' addresses.
 Payment should be added to the transaction in ETH and the amount is `rewardRate * periods * stakers.length`, where `periods` is `endTimestampPeriod - currentPeriod + 1`.
 The reward rate must be greater than or equal to the minimum reward for each staker in the list.
 
@@ -58,7 +58,7 @@ The reward rate must be greater than or equal to the minimum reward for each sta
 When Alice wants to revoke a policy, she calls the `PolicyManager.revokePolicy(bytes16)` or `PolicyManager.revokeArrangement(bytes16, address)`.
 Execution of these methods results in Alice recovering all fees for future periods, and also for periods when the stakers were inactive.
 Alice can refund ETH for any inactive periods without revoking the policy by using the method `PolicyManager.refund(bytes16)` or `PolicyManager.refund(bytes16, address)`.
-If Alice doesn't have ability to execute on-chain transaction or wants to share ability to revoke then she can sign revocation parameters. Anyone who have this signature will be able to revoke policy using `PolicyManager.revoke(bytes16, address, bytes)`
+If Alice can't execute an on-chain transaction or wants to share the ability to revoke, then she can sign revocation parameters. Anyone who has this signature will be able to revoke policy using `PolicyManager.revoke(bytes16, address, bytes)`
 
 
 ## Staker's Contract Interaction

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -581,12 +581,11 @@ class PolicyManagerAgent(EthereumContractAgent):
                       policy_id: str,
                       author_address: str,
                       value: int,
-                      periods: int,
-                      first_period_reward: int,
+                      end_timestamp: int,
                       node_addresses: List[str]):
 
         payload = {'value': value}
-        contract_function = self.contract.functions.createPolicy(policy_id, periods, first_period_reward, node_addresses)
+        contract_function = self.contract.functions.createPolicy(policy_id, end_timestamp, node_addresses)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    payload=payload,
                                                    sender_address=author_address)

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -582,10 +582,15 @@ class PolicyManagerAgent(EthereumContractAgent):
                       author_address: str,
                       value: int,
                       end_timestamp: int,
-                      node_addresses: List[str]):
+                      node_addresses: List[str],
+                      owner_address: str = None):
 
+        owner_address = owner_address or author_address
         payload = {'value': value}
-        contract_function = self.contract.functions.createPolicy(policy_id, end_timestamp, node_addresses)
+        contract_function = self.contract.functions.createPolicy(policy_id,
+                                                                 owner_address,
+                                                                 end_timestamp,
+                                                                 node_addresses)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    payload=payload,
                                                    sender_address=author_address)

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -65,8 +65,8 @@ contract PolicyManager is Upgradeable {
         address creator;
 
         uint256 rewardRate;
-        uint256 startTimestamp;
-        uint256 endTimestamp;
+        uint64 startTimestamp;
+        uint64 endTimestamp;
         bool disabled;
 
         ArrangementInfo[] arrangements;
@@ -143,7 +143,7 @@ contract PolicyManager is Upgradeable {
     */
     function createPolicy(
         bytes16 _policyId,
-        uint256 _endTimestamp,
+        uint64 _endTimestamp,
         address[] memory _nodes
     )
         public payable
@@ -160,7 +160,7 @@ contract PolicyManager is Upgradeable {
 
         Policy storage policy = policies[_policyId];
         policy.creator = msg.sender;
-        policy.startTimestamp = block.timestamp;
+        policy.startTimestamp = uint64(block.timestamp);
         policy.endTimestamp = _endTimestamp;
         policy.rewardRate = msg.value.div(_nodes.length) / numberOfPeriods;
         require(policy.rewardRate > 0 && policy.rewardRate * numberOfPeriods * _nodes.length  == msg.value);

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -34,7 +34,7 @@ contract WorkLockInterface {
 /**
 * @notice Contract holds and locks stakers tokens.
 * Each staker that locks their tokens will receive some compensation
-* @dev |v2.1.1|
+* @dev |v2.1.2|
 */
 contract StakingEscrow is Issuer {
     using AdditionalMath for uint256;

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -11,6 +11,7 @@ contract PolicyManagerInterface {
     function register(address _node, uint16 _period) external;
     function updateReward(address _node, uint16 _period) external;
     function escrow() public view returns (address);
+    function setDefaultRewardDelta(address _node, uint16 _period) external;
 }
 
 
@@ -753,6 +754,7 @@ contract StakingEscrow is Issuer {
         if (lastActivePeriod < currentPeriod) {
             info.pastDowntime.push(Downtime(lastActivePeriod + 1, currentPeriod));
         }
+        policyManager.setDefaultRewardDelta(staker, nextPeriod);
         emit ActivityConfirmed(staker, nextPeriod, lockedTokens);
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -90,10 +90,16 @@ contract StakingEscrow is Issuer {
         uint16 workerStartPeriod;
         // last confirmed active period
         uint16 lastActivePeriod;
-        Downtime[] pastDowntime;
-        SubStakeInfo[] subStakes;
         bool measureWork;
         uint256 completedWork;
+
+        uint256 reservedSlot1;
+        uint256 reservedSlot2;
+        uint256 reservedSlot3;
+        uint256 reservedSlot4;
+
+        Downtime[] pastDowntime;
+        SubStakeInfo[] subStakes;
     }
 
     // Used as removed value for confirmedPeriod1(2)
@@ -1190,11 +1196,6 @@ contract StakingEscrow is Issuer {
         bytes32 memoryAddress = delegateGetData(_target, "stakerInfo(address)", 1, _staker, 0);
         assembly {
             result := memoryAddress
-            // copy data to the right position after the array pointer place
-            // measureWork
-            mstore(add(memoryAddress, 0x140), mload(add(memoryAddress, 0x100)))
-            // completedWork
-            mstore(add(memoryAddress, 0x160), mload(add(memoryAddress, 0x120)))
         }
     }
 

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -60,10 +60,12 @@ def datetime_at_period(period: int, seconds_per_period: int, start_of_period: bo
         return target_datetime
 
 
-def calculate_period_duration(future_time: maya.MayaDT, seconds_per_period: int) -> int:
+def calculate_period_duration(future_time: maya.MayaDT, seconds_per_period: int, now: maya.MayaDT = None) -> int:
     """Takes a future MayaDT instance and calculates the duration from now, returning in periods"""
+    if now is None:
+        now = maya.now()
     future_period = datetime_to_period(datetime=future_time, seconds_per_period=seconds_per_period)
-    current_period = datetime_to_period(datetime=maya.now(), seconds_per_period=seconds_per_period)
+    current_period = datetime_to_period(datetime=now, seconds_per_period=seconds_per_period)
     periods = future_period - current_period
     return periods
 

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -76,8 +76,7 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
                       m: int,
                       n: int,
                       expiration: maya.MayaDT,
-                      value: int = None,
-                      first_period_reward: int = None
+                      value: int = None
                       ) -> dict:
 
         from nucypher.characters.lawful import Bob
@@ -85,8 +84,13 @@ class AliceInterface(CharacterPublicInterface, AliceSpecification):
                                    verifying_key=bob_verifying_key)
 
         new_policy = self.character.create_policy(
-            bob=bob, label=label, m=m, n=n, expiration=expiration,
-            value=value, first_period_reward=first_period_reward)
+            bob=bob,
+            label=label,
+            m=m,
+            n=n,
+            expiration=expiration,
+            value=value
+        )
         response_data = {'label': new_policy.label, 'policy_encrypting_key': new_policy.public_key}
         return response_data
 

--- a/nucypher/characters/control/serializers.py
+++ b/nucypher/characters/control/serializers.py
@@ -87,7 +87,7 @@ class AliceControlJSONSerializer(CharacterControlJSONSerializer, MessageHandlerM
                             m=request['m'],
                             n=request['n'],
                             expiration=maya.MayaDT.from_iso8601(iso8601_string=request['expiration']))
-        for field in ('value', 'rate', 'first_period_reward'):
+        for field in ('value', 'rate'):
             if field in request:
                 parsed_input[field] = request[field]
         return parsed_input

--- a/nucypher/characters/control/specifications.py
+++ b/nucypher/characters/control/specifications.py
@@ -69,14 +69,14 @@ class CharacterSpecification(ABC):
 class AliceSpecification(CharacterSpecification):
 
     __create_policy = {'input': ('bob_encrypting_key', 'bob_verifying_key', 'm', 'n', 'label', 'expiration'),
-                       'optional': ('value', 'first_period_reward', 'rate'),
+                       'optional': ('value', 'rate'),
                        'output': ('label', 'policy_encrypting_key')}
 
     __derive_policy_encrypting_key = {'input': ('label', ),
                                       'output': ('policy_encrypting_key', 'label')}
 
     __grant = {'input': ('bob_encrypting_key', 'bob_verifying_key', 'm', 'n', 'label', 'expiration'),
-               'optional': ('value', 'first_period_reward', 'rate'),
+               'optional': ('value', 'rate'),
                'output': ('treasure_map', 'policy_encrypting_key', 'alice_verifying_key')}
 
     __revoke = {'input': ('label', 'bob_verifying_key', ),

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -105,7 +105,6 @@ class Alice(Character, BlockchainPolicyAuthor):
                  # Policy Value
                  rate: int = None,
                  duration_periods: int = None,
-                 first_period_reward: int = 0,
 
                  # Middleware
                  timeout: int = 10,  # seconds  # TODO: configure
@@ -144,7 +143,6 @@ class Alice(Character, BlockchainPolicyAuthor):
                                             registry=self.registry,
                                             rate=rate,
                                             duration_periods=duration_periods,
-                                            first_period_reward=first_period_reward,
                                             checksum_address=checksum_address)
 
         if is_me and controller:

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -151,7 +151,6 @@ class AliceConfiguration(CharacterConfiguration):
                  m: int = None,
                  n: int = None,
                  rate: int = None,
-                 first_period_reward: float = None,
                  duration_periods: int = None,
                  *args, **kwargs):
 
@@ -161,12 +160,10 @@ class AliceConfiguration(CharacterConfiguration):
         if not self.federated_only:
             self.rate = rate
             self.duration_periods = duration_periods
-            self.first_period_reward = first_period_reward or self.DEFAULT_FIRST_PERIOD_REWARD
 
     def static_payload(self) -> dict:
         payload = dict(m=self.m, n=self.n)
         if not self.federated_only:
-            payload['first_period_reward'] = self.first_period_reward
             if self.rate:
                 payload['rate'] = self.rate
             if self.duration_periods:

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -489,7 +489,9 @@ class BlockchainPolicy(Policy):
         rate_per_period = self.value // self.n // self.duration_periods  # wei
         recalculated_value = self.duration_periods * rate_per_period * self.n
         if recalculated_value != self.value:
-            raise ValueError(f"Invalid policy value calculation.")  # TODO: Make a better suggestion.
+            raise ValueError(f"Invalid policy value calculation - "
+                             f"{self.value} can't be divided into {self.n} staker payments per period "
+                             f"for {self.duration_periods} periods without a remainder")
 
     @staticmethod
     def generate_policy_parameters(n: int,
@@ -504,7 +506,7 @@ class BlockchainPolicy(Policy):
         # Check for policy params
         if not bool(value) ^ bool(rate):
             # TODO: Review this suggestion
-            raise BlockchainPolicy.InvalidPolicyValue(f"Only one parameter must be provided to calculate policy value and rate.")
+            raise BlockchainPolicy.InvalidPolicyValue(f"Either 'value' or 'rate'  must be provided for policy.")
 
         if not value:
             value = rate * duration_periods * n

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -467,10 +467,8 @@ class BlockchainPolicy(Policy):
                  rate: int,
                  duration_periods: int,
                  expiration: maya.MayaDT,
-                 first_period_reward: int,
                  *args, **kwargs):
 
-        self.first_period_reward = first_period_reward
         self.duration_periods = duration_periods
         self.expiration = expiration
         self.value = value
@@ -488,33 +486,28 @@ class BlockchainPolicy(Policy):
         self.validate_reward_value()
 
     def validate_reward_value(self) -> None:
-        rate_per_period = ((self.value // self.n) - self.first_period_reward) // self.duration_periods  # wei
-        if rate_per_period <= self.first_period_reward:
-            raise ValueError(
-                f"Policy rate ({rate_per_period} wei) is less then the initial reward ({self.first_period_reward})")
-
-        recalculated_value = ((self.duration_periods * rate_per_period) + self.first_period_reward) * self.n
+        rate_per_period = self.value // self.n // self.duration_periods  # wei
+        recalculated_value = self.duration_periods * rate_per_period * self.n
         if recalculated_value != self.value:
             raise ValueError(f"Invalid policy value calculation.")  # TODO: Make a better suggestion.
 
     @staticmethod
     def generate_policy_parameters(n: int,
                                    duration_periods: int,
-                                   first_period_reward: int = None,
                                    value: int = None,
                                    rate: int = None) -> dict:
 
         # Check for negative inputs
-        if sum(True for i in (n, duration_periods, first_period_reward, value, rate) if i is not None and i < 0) > 0:
+        if sum(True for i in (n, duration_periods, value, rate) if i is not None and i < 0) > 0:
             raise BlockchainPolicy.InvalidPolicyValue(f"Negative policy parameters are not allowed. Be positive.")
 
         # Check for policy params
-        if sum(True for i in (first_period_reward, value, rate) if i is not None) != 2:
+        if not bool(value) ^ bool(rate):
             # TODO: Review this suggestion
-            raise BlockchainPolicy.InvalidPolicyValue(f"Exactly two parameters must be provided to calculate policy value and rate.")
+            raise BlockchainPolicy.InvalidPolicyValue(f"Only one parameter must be provided to calculate policy value and rate.")
 
         if not value:
-            value = ((rate * duration_periods) + first_period_reward) * n
+            value = rate * duration_periods * n
 
         else:
             value_per_node = value // n
@@ -522,21 +515,13 @@ class BlockchainPolicy(Policy):
                 raise BlockchainPolicy.InvalidPolicyValue(f"Policy value of ({value} wei) cannot be"
                                                           f" divided by N ({n}) without a remainder.")
 
-            if not rate:
-                rate = (value_per_node - first_period_reward) // duration_periods
-                if rate * duration_periods + first_period_reward != value_per_node:
-                    raise BlockchainPolicy.InvalidPolicyValue(f"Policy value of ({value_per_node} wei) per node minus "
-                                                              f"first period reward ({first_period_reward} wei) "
-                                                              f"cannot be divided by duration ({duration_periods} periods)"
-                                                              f" without a remainder.")
-            else:
-                first_period_reward = value_per_node - (rate * duration_periods)
+            rate = value_per_node // duration_periods
+            if rate * duration_periods != value_per_node:
+                raise BlockchainPolicy.InvalidPolicyValue(f"Policy value of ({value_per_node} wei) per node "
+                                                          f"cannot be divided by duration ({duration_periods} periods)"
+                                                          f" without a remainder.")
 
-        if first_period_reward >= rate:
-            raise BlockchainPolicy.InvalidPolicyValue(f"Policy rate of ({rate} wei) per period must be greater than "
-                                                      f"the first period reward of ({first_period_reward} wei).")
-
-        params = dict(first_period_reward=first_period_reward, rate=rate, value=value)
+        params = dict(rate=rate, value=value)
         return params
 
     def __find_ursulas(self,
@@ -601,8 +586,7 @@ class BlockchainPolicy(Policy):
                        policy_id=self.hrac()[:16],          # bytes16 _policyID
                        author_address=self.author.checksum_address,
                        value=self.value,
-                       periods=self.duration_periods,           # uint16 _numberOfPeriods
-                       first_period_reward=self.first_period_reward,  # uint256 _firstPartialReward
+                       end_timestamp=self.expiration.epoch,           # uint16 _numberOfPeriods
                        node_addresses=prearranged_ursulas   # address[] memory _nodes
         )
 

--- a/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
@@ -140,4 +140,10 @@ contract StakingEscrowForPolicyMock {
         }
     }
 
+    function setDefaultRewardDelta(address _node, uint16 _startPeriod, uint16 _numberOfPeriods) public {
+        for (uint16 i = 0; i < _numberOfPeriods; i++) {
+            policyManager.setDefaultRewardDelta(_node, i + _startPeriod);
+        }
+    }
+
 }

--- a/tests/blockchain/eth/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingContractsTestSet.sol
@@ -73,7 +73,7 @@ contract StakingEscrowForStakingContractMock {
         periods += _periods;
     }
 
-    function getAllTokens(address _staker)
+    function getAllTokens(address)
         public view returns (uint256)
     {
         return value;

--- a/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
@@ -116,23 +116,18 @@ contract PolicyManagerForStakingEscrowMock {
         nodes[_node].push(_period);
     }
 
-    /**
-    * @notice Update node info
-    */
     function updateReward(address _node, uint16 _period) external {
         nodes[_node].push(_period);
     }
 
-    /**
-    * @notice Get length of array
-    */
+    function setDefaultRewardDelta(address _node, uint16 _period) external {
+        nodes[_node].push(_period);
+    }
+
     function getPeriodsLength(address _node) public view returns (uint256) {
         return nodes[_node].length;
     }
 
-    /**
-    * @notice Get period info
-    */
     function getPeriod(address _node, uint256 _index) public view returns (uint16) {
         return nodes[_node][_index];
     }

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
@@ -25,12 +25,11 @@ from web3.contract import Contract
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 
-CLIENT_FIELD = 0
+CREATOR_FIELD = 0
 RATE_FIELD = 1
-FIRST_REWARD_FIELD = 2
-START_PERIOD_FIELD = 3
-LAST_PERIOD_FIELD = 4
-DISABLED_FIELD = 5
+START_TIMESTAMP_FIELD = 2
+END_TIMESTAMP_FIELD = 3
+DISABLED_FIELD = 4
 
 REWARD_FIELD = 0
 REWARD_RATE_FIELD = 1
@@ -47,15 +46,16 @@ policy_id = os.urandom(POLICY_ID_LENGTH)
 policy_id_2 = os.urandom(POLICY_ID_LENGTH)
 policy_id_3 = os.urandom(POLICY_ID_LENGTH)
 rate = 20
+one_period = 60 * 60
 number_of_periods = 10
 value = rate * number_of_periods
 
 
 @pytest.mark.slow
 def test_create_revoke(testerchain, escrow, policy_manager):
-    creator, client, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
+    creator, policy_creator, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
 
-    client_balance = testerchain.client.get_balance(client)
+    client_balance = testerchain.client.get_balance(policy_creator)
     policy_created_log = policy_manager.events.PolicyCreated.createFilter(fromBlock='latest')
     arrangement_revoked_log = policy_manager.events.ArrangementRevoked.createFilter(fromBlock='latest')
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
@@ -67,36 +67,43 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert 0 < policy_manager.functions.nodes(node2).call()[LAST_MINED_PERIOD_FIELD]
     assert 0 < policy_manager.functions.nodes(node3).call()[LAST_MINED_PERIOD_FIELD]
     assert 0 == policy_manager.functions.nodes(bad_node).call()[LAST_MINED_PERIOD_FIELD]
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
 
     # Try to create policy for bad (unregistered) node
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, 1, 0, [bad_node])\
-            .transact({'from': client, 'value': value})
+        tx = policy_manager.functions.createPolicy(policy_id, end_timestamp, [bad_node])\
+            .transact({'from': policy_creator, 'value': value})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, 1, 0, [node1, bad_node])\
-            .transact({'from': client, 'value': value})
+        tx = policy_manager.functions.createPolicy(policy_id, end_timestamp, [node1, bad_node])\
+            .transact({'from': policy_creator, 'value': value})
         testerchain.wait_for_receipt(tx)
 
     # Try to create policy with no ETH
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, 1, 0, [node1]).transact({'from': client})
+        tx = policy_manager.functions.createPolicy(policy_id, end_timestamp, [node1]).transact({'from': policy_creator})
+        testerchain.wait_for_receipt(tx)
+
+    # Can't create policy using timestamp from the past
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = policy_manager.functions.createPolicy(policy_id, current_timestamp -1, [node1])\
+            .transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
 
     # Create policy
-    period = escrow.functions.getCurrentPeriod().call()
-    tx = policy_manager.functions.createPolicy(policy_id, number_of_periods, 0, [node1])\
-        .transact({'from': client, 'value': value, 'gas_price': 0})
+    tx = policy_manager.functions.createPolicy(policy_id, end_timestamp, [node1])\
+        .transact({'from': policy_creator, 'value': value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     # Check balances and policy info
     assert value == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - 200 == testerchain.client.get_balance(client)
+    assert client_balance - 200 == testerchain.client.get_balance(policy_creator)
     policy = policy_manager.functions.policies(policy_id).call()
-    assert client == policy[CLIENT_FIELD]
+    assert policy_creator == policy[CREATOR_FIELD]
     assert rate == policy[RATE_FIELD]
-    assert 0 == policy[FIRST_REWARD_FIELD]
-    assert period + 1 == policy[START_PERIOD_FIELD]
-    assert period + 10 == policy[LAST_PERIOD_FIELD]
+    assert current_timestamp == policy[START_TIMESTAMP_FIELD]
+    assert end_timestamp == policy[END_TIMESTAMP_FIELD]
     assert not policy[DISABLED_FIELD]
     assert 1 == policy_manager.functions.getArrangementsLength(policy_id).call()
     assert node1 == policy_manager.functions.getArrangementInfo(policy_id, 0).call()[0]
@@ -105,19 +112,19 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
 
     # Can't create policy with the same id
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, number_of_periods, 0, [node1])\
-            .transact({'from': client, 'value': value})
+        tx = policy_manager.functions.createPolicy(policy_id, end_timestamp, [node1])\
+            .transact({'from': policy_creator, 'value': value})
         testerchain.wait_for_receipt(tx)
 
     # Only policy owner can revoke policy
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': creator})
         testerchain.wait_for_receipt(tx)
-    tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert policy_manager.functions.policies(policy_id).call()[DISABLED_FIELD]
 
@@ -125,98 +132,98 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert value == event_args['value']
     events = arrangement_revoked_log.get_all_entries()
     assert 1 == len(events)
 
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
     assert value == event_args['value']
 
     # Can't revoke again because policy and all arrangements are disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': client})
+        tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id, node1).transact({'from': client})
+        tx = policy_manager.functions.revokeArrangement(policy_id, node1).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
 
     # Create new policy
-    period = escrow.functions.getCurrentPeriod().call()
-    tx = policy_manager.functions.createPolicy(policy_id_2, number_of_periods, 0, [node1, node2, node3])\
-        .transact({'from': client, 'value': 6 * value, 'gas_price': 0})
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
+    tx = policy_manager.functions.createPolicy(policy_id_2, end_timestamp, [node1, node2, node3])\
+        .transact({'from': policy_creator, 'value': 6 * value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     assert 6 * value == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - 6 * value == testerchain.client.get_balance(client)
+    assert client_balance - 6 * value == testerchain.client.get_balance(policy_creator)
     policy = policy_manager.functions.policies(policy_id_2).call()
-    assert client == policy[CLIENT_FIELD]
+    assert policy_creator == policy[CREATOR_FIELD]
     assert 2 * rate == policy[RATE_FIELD]
-    assert 0 == policy[FIRST_REWARD_FIELD]
-    assert period + 1 == policy[START_PERIOD_FIELD]
-    assert period + 10 == policy[LAST_PERIOD_FIELD]
+    assert current_timestamp == policy[START_TIMESTAMP_FIELD]
+    assert end_timestamp == policy[END_TIMESTAMP_FIELD]
     assert not policy[DISABLED_FIELD]
 
     events = policy_created_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
 
     # Can't revoke nonexistent arrangement
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.revokeArrangement(policy_id_2, testerchain.client.accounts[6])\
-            .transact({'from': client})
+            .transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     # Can't revoke null arrangement (also it's nonexistent)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': client})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
 
     # Revoke only one arrangement
-    tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 4 * value == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - 4 * value == testerchain.client.get_balance(client)
+    assert client_balance - 4 * value == testerchain.client.get_balance(policy_creator)
     assert not policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
 
     events = arrangement_revoked_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
     assert 2 * value == event_args['value']
 
     # Can't revoke again because arrangement is disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': client})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     # Can't revoke null arrangement (it's nonexistent)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': client})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
 
     # Revoke policy with remaining arrangements
-    tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 0 == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance == testerchain.client.get_balance(client)
+    assert client_balance == testerchain.client.get_balance(policy_creator)
     assert policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
 
     events = arrangement_revoked_log.get_all_entries()
     assert 4 == len(events)
     event_args = events[2]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node2 == event_args['node']
     assert 2 * value == event_args['value']
 
     event_args = events[3]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node3 == event_args['node']
     assert 2 * value == event_args['value']
     events = policy_revoked_log.get_all_entries()
@@ -224,27 +231,22 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     event_args = events[1]['args']
 
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert 4 * value == event_args['value']
 
     # Can't revoke policy again because policy and all arrangements are disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': client})
+        tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': client})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
 
     # Can't create policy with wrong ETH value - when reward is not calculated by formula:
-    # numberOfNodes * (firstPartialReward + rewardRate * numberOfPeriods)
+    # numberOfNodes * rewardRate * numberOfPeriods
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, 10, 0, [node1]).transact({'from': client, 'value': 11})
-        testerchain.wait_for_receipt(tx)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, 10, 1, [node1]).transact({'from': client, 'value': 22})
-        testerchain.wait_for_receipt(tx)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, 10, 1, [node1]).transact({'from': client, 'value': 11})
+        tx = policy_manager.functions.createPolicy(policy_id_3, end_timestamp, [node1])\
+            .transact({'from': policy_creator, 'value': 11})
         testerchain.wait_for_receipt(tx)
 
     # Set minimum reward rate for nodes
@@ -256,80 +258,16 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert 20 == policy_manager.functions.nodes(node2).call()[MIN_REWARD_RATE_FIELD]
 
     # Try to create policy with low rate
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + 10
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, 1, 0, [node1])\
-            .transact({'from': client, 'value': 5})
+        tx = policy_manager.functions.createPolicy(policy_id_3, end_timestamp, [node1])\
+            .transact({'from': policy_creator, 'value': 5})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, 1, 0, [node1, node2])\
-            .transact({'from': client, 'value': 30})
+        tx = policy_manager.functions.createPolicy(policy_id_3, end_timestamp, [node1, node2])\
+            .transact({'from': policy_creator, 'value': 30})
         testerchain.wait_for_receipt(tx)
-
-    # Create new policy with payment for the first period
-    period = escrow.functions.getCurrentPeriod().call()
-    tx = policy_manager.functions.createPolicy(policy_id_3, number_of_periods, int(0.5 * rate), [node1, node2, node3])\
-        .transact({'from': client,
-                   'value': int((0.5 * rate + rate * number_of_periods) * 3),
-                   'gas_price': 0})
-    testerchain.wait_for_receipt(tx)
-    assert 3 * value + 1.5 * rate == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - int(3 * value + 1.5 * rate) == testerchain.client.get_balance(client)
-    policy = policy_manager.functions.policies(policy_id_3).call()
-    assert client == policy[CLIENT_FIELD]
-    assert rate == policy[RATE_FIELD]
-    assert 0.5 * rate == policy[FIRST_REWARD_FIELD]
-    assert period + 1 == policy[START_PERIOD_FIELD]
-    assert period + 10 == policy[LAST_PERIOD_FIELD]
-    assert not policy[DISABLED_FIELD]
-
-    events = policy_created_log.get_all_entries()
-    assert 3 == len(events)
-    event_args = events[2]['args']
-    assert policy_id_3 == event_args['policyId']
-    assert client == event_args['client']
-
-    # Revoke only one arrangement
-    tx = policy_manager.functions.revokeArrangement(policy_id_3, node1).transact({'from': client, 'gas_price': 0})
-    testerchain.wait_for_receipt(tx)
-    assert 2 * value + rate == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - (2 * value + rate) == testerchain.client.get_balance(client)
-    assert not policy_manager.functions.policies(policy_id_3).call()[DISABLED_FIELD]
-
-    events = arrangement_revoked_log.get_all_entries()
-    assert 5 == len(events)
-    event_args = events[4]['args']
-    assert policy_id_3 == event_args['policyId']
-    assert client == event_args['client']
-    assert node1 == event_args['node']
-    assert value + 0.5 * rate == event_args['value']
-
-    # Revoke policy
-    tx = policy_manager.functions.revokePolicy(policy_id_3).transact({'from': client, 'gas_price': 0})
-    testerchain.wait_for_receipt(tx)
-    assert 0 == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance == testerchain.client.get_balance(client)
-    assert policy_manager.functions.policies(policy_id_3).call()[DISABLED_FIELD]
-
-    events = arrangement_revoked_log.get_all_entries()
-    assert 7 == len(events)
-    event_args = events[5]['args']
-    assert policy_id_3 == event_args['policyId']
-    assert client == event_args['client']
-    assert node2 == event_args['node']
-    assert value + 0.5 * rate == event_args['value']
-
-    event_args = events[6]['args']
-    assert policy_id_3 == event_args['policyId']
-    assert client == event_args['client']
-    assert node3 == event_args['node']
-    assert value + 0.5 * rate == event_args['value']
-
-    events = policy_revoked_log.get_all_entries()
-    assert 3 == len(events)
-    event_args = events[2]['args']
-    assert policy_id_3 == event_args['policyId']
-    assert client == event_args['client']
-    assert 2 * value + rate == event_args['value']
 
     events = arrangement_refund_log.get_all_entries()
     assert 0 == len(events)

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
@@ -152,6 +152,11 @@ def test_create_revoke(testerchain, escrow, policy_manager):
         testerchain.wait_for_receipt(tx)
 
     # Create new policy
+    period = escrow.functions.getCurrentPeriod().call()
+    tx = escrow.functions.setDefaultRewardDelta(node1, period, number_of_periods + 1).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setDefaultRewardDelta(node2, period, number_of_periods + 1).transact()
+    testerchain.wait_for_receipt(tx)
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id_2, end_timestamp, [node1, node2, node3])\
         .transact({'from': policy_creator, 'value': 6 * value, 'gas_price': 0})

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
@@ -25,7 +25,7 @@ from web3.contract import Contract
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 
-CREATOR_FIELD = 0
+SPONSOR_FIELD = 0
 OWNER_FIELD = 1
 RATE_FIELD = 2
 START_TIMESTAMP_FIELD = 3
@@ -47,14 +47,14 @@ POLICY_ID_LENGTH = 16
 
 @pytest.mark.slow
 def test_create_revoke(testerchain, escrow, policy_manager):
-    creator, policy_creator, bad_node, node1, node2, node3, policy_owner, *everyone_else = testerchain.client.accounts
+    creator, policy_sponsor, bad_node, node1, node2, node3, policy_owner, *everyone_else = testerchain.client.accounts
 
     rate = 20
     one_period = 60 * 60
     number_of_periods = 10
     value = rate * number_of_periods
 
-    policy_creator_balance = testerchain.client.get_balance(policy_creator)
+    policy_sponsor_balance = testerchain.client.get_balance(policy_sponsor)
     policy_owner_balance = testerchain.client.get_balance(policy_owner)
     policy_created_log = policy_manager.events.PolicyCreated.createFilter(fromBlock='latest')
     arrangement_revoked_log = policy_manager.events.ArrangementRevoked.createFilter(fromBlock='latest')
@@ -73,36 +73,36 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     # Try to create policy for bad (unregistered) node
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, policy_creator, end_timestamp, [bad_node])\
-            .transact({'from': policy_creator, 'value': value})
+        tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [bad_node])\
+            .transact({'from': policy_sponsor, 'value': value})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, policy_creator, end_timestamp, [node1, bad_node])\
-            .transact({'from': policy_creator, 'value': value})
+        tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [node1, bad_node])\
+            .transact({'from': policy_sponsor, 'value': value})
         testerchain.wait_for_receipt(tx)
 
     # Try to create policy with no ETH
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, policy_creator, end_timestamp, [node1])\
-            .transact({'from': policy_creator})
+        tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [node1])\
+            .transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
 
     # Can't create policy using timestamp from the past
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, policy_creator, current_timestamp -1, [node1])\
-            .transact({'from': policy_creator})
+        tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, current_timestamp -1, [node1])\
+            .transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
 
     # Create policy
-    tx = policy_manager.functions.createPolicy(policy_id, policy_creator, end_timestamp, [node1])\
-        .transact({'from': policy_creator, 'value': value, 'gas_price': 0})
+    tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [node1])\
+        .transact({'from': policy_sponsor, 'value': value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     # Check balances and policy info
     assert value == testerchain.client.get_balance(policy_manager.address)
-    assert policy_creator_balance - 200 == testerchain.client.get_balance(policy_creator)
+    assert policy_sponsor_balance - 200 == testerchain.client.get_balance(policy_sponsor)
     policy = policy_manager.functions.policies(policy_id).call()
-    assert policy_creator == policy[CREATOR_FIELD]
+    assert policy_sponsor == policy[SPONSOR_FIELD]
     assert BlockchainInterface.NULL_ADDRESS == policy[OWNER_FIELD]
     assert rate == policy[RATE_FIELD]
     assert current_timestamp == policy[START_TIMESTAMP_FIELD]
@@ -110,14 +110,14 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert not policy[DISABLED_FIELD]
     assert 1 == policy_manager.functions.getArrangementsLength(policy_id).call()
     assert node1 == policy_manager.functions.getArrangementInfo(policy_id, 0).call()[0]
-    assert policy_creator == policy_manager.functions.getPolicyOwner(policy_id).call()
+    assert policy_sponsor == policy_manager.functions.getPolicyOwner(policy_id).call()
 
     events = policy_created_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert policy_creator == event_args['creator']
-    assert policy_creator == event_args['owner']
+    assert policy_sponsor == event_args['sponsor']
+    assert policy_sponsor == event_args['owner']
     assert rate == event_args['rewardRate']
     assert current_timestamp == event_args['startTimestamp']
     assert end_timestamp == event_args['endTimestamp']
@@ -125,15 +125,15 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     # Can't create policy with the same id
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id, policy_creator, end_timestamp, [node1])\
-            .transact({'from': policy_creator, 'value': value})
+        tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [node1])\
+            .transact({'from': policy_sponsor, 'value': value})
         testerchain.wait_for_receipt(tx)
 
     # Only policy owner can revoke policy
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': creator})
         testerchain.wait_for_receipt(tx)
-    tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': policy_creator, 'gas_price': 0})
+    tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': policy_sponsor, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert policy_manager.functions.policies(policy_id).call()[DISABLED_FIELD]
 
@@ -141,23 +141,23 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert policy_creator == event_args['sender']
+    assert policy_sponsor == event_args['sender']
     assert value == event_args['value']
     events = arrangement_revoked_log.get_all_entries()
     assert 1 == len(events)
 
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert policy_creator == event_args['sender']
+    assert policy_sponsor == event_args['sender']
     assert node1 == event_args['node']
     assert value == event_args['value']
 
     # Can't revoke again because policy and all arrangements are disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokePolicy(policy_id).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id, node1).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokeArrangement(policy_id, node1).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
 
     # Create new policy
@@ -169,13 +169,13 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     policy_id_2 = os.urandom(POLICY_ID_LENGTH)
     tx = policy_manager.functions.createPolicy(policy_id_2, policy_owner, end_timestamp, [node1, node2, node3])\
-        .transact({'from': policy_creator, 'value': 6 * value, 'gas_price': 0})
+        .transact({'from': policy_sponsor, 'value': 6 * value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     assert 6 * value == testerchain.client.get_balance(policy_manager.address)
-    assert policy_creator_balance - 6 * value == testerchain.client.get_balance(policy_creator)
+    assert policy_sponsor_balance - 6 * value == testerchain.client.get_balance(policy_sponsor)
     policy = policy_manager.functions.policies(policy_id_2).call()
-    assert policy_creator == policy[CREATOR_FIELD]
+    assert policy_sponsor == policy[SPONSOR_FIELD]
     assert policy_owner == policy[OWNER_FIELD]
     assert 2 * rate == policy[RATE_FIELD]
     assert current_timestamp == policy[START_TIMESTAMP_FIELD]
@@ -187,7 +187,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert 2 == len(events)
     event_args = events[1]['args']
     assert policy_id_2 == event_args['policyId']
-    assert policy_creator == event_args['creator']
+    assert policy_sponsor == event_args['sponsor']
     assert policy_owner == event_args['owner']
     assert 2 * rate == event_args['rewardRate']
     assert current_timestamp == event_args['startTimestamp']
@@ -197,26 +197,26 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     # Can't revoke nonexistent arrangement
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.revokeArrangement(policy_id_2, testerchain.client.accounts[6])\
-            .transact({'from': policy_creator})
+            .transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
     # Can't revoke null arrangement (also it's nonexistent)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
 
-    # Policy creator can't revoke policy, only owner can
+    # Policy sponsor can't revoke policy, only owner can
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
 
     # Revoke only one arrangement
     tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_owner, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 4 * value == testerchain.client.get_balance(policy_manager.address)
-    assert policy_creator_balance - 4 * value == testerchain.client.get_balance(policy_creator)
+    assert policy_sponsor_balance - 4 * value == testerchain.client.get_balance(policy_sponsor)
     assert not policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
     assert policy_owner_balance == testerchain.client.get_balance(policy_owner)
 
@@ -230,18 +230,18 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     # Can't revoke again because arrangement is disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
     # Can't revoke null arrangement (it's nonexistent)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
 
     # Revoke policy with remaining arrangements
     tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': policy_owner, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 0 == testerchain.client.get_balance(policy_manager.address)
-    assert policy_creator_balance == testerchain.client.get_balance(policy_creator)
+    assert policy_sponsor_balance == testerchain.client.get_balance(policy_sponsor)
     assert policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
 
     events = arrangement_revoked_log.get_all_entries()
@@ -266,18 +266,18 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     # Can't revoke policy again because policy and all arrangements are disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokePolicy(policy_id_2).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_creator})
+        tx = policy_manager.functions.revokeArrangement(policy_id_2, node1).transact({'from': policy_sponsor})
         testerchain.wait_for_receipt(tx)
 
     # Can't create policy with wrong ETH value - when reward is not calculated by formula:
     # numberOfNodes * rewardRate * numberOfPeriods
     policy_id_3 = os.urandom(POLICY_ID_LENGTH)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, policy_creator, end_timestamp, [node1])\
-            .transact({'from': policy_creator, 'value': 11})
+        tx = policy_manager.functions.createPolicy(policy_id_3, policy_sponsor, end_timestamp, [node1])\
+            .transact({'from': policy_sponsor, 'value': 11})
         testerchain.wait_for_receipt(tx)
 
     # Set minimum reward rate for nodes
@@ -292,38 +292,38 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + 10
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, policy_creator, end_timestamp, [node1])\
-            .transact({'from': policy_creator, 'value': 5})
+        tx = policy_manager.functions.createPolicy(policy_id_3, policy_sponsor, end_timestamp, [node1])\
+            .transact({'from': policy_sponsor, 'value': 5})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.createPolicy(policy_id_3, policy_creator, end_timestamp, [node1, node2])\
-            .transact({'from': policy_creator, 'value': 30})
+        tx = policy_manager.functions.createPolicy(policy_id_3, policy_sponsor, end_timestamp, [node1, node2])\
+            .transact({'from': policy_sponsor, 'value': 30})
         testerchain.wait_for_receipt(tx)
 
     # Create new policy
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(
         policy_id_3, BlockchainInterface.NULL_ADDRESS, end_timestamp, [node1, node2]) \
-        .transact({'from': policy_creator, 'value': 2 * value, 'gas_price': 0})
+        .transact({'from': policy_sponsor, 'value': 2 * value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     assert 2 * value == testerchain.client.get_balance(policy_manager.address)
-    assert policy_creator_balance - 2 * value == testerchain.client.get_balance(policy_creator)
+    assert policy_sponsor_balance - 2 * value == testerchain.client.get_balance(policy_sponsor)
     policy = policy_manager.functions.policies(policy_id_3).call()
-    assert policy_creator == policy[CREATOR_FIELD]
+    assert policy_sponsor == policy[SPONSOR_FIELD]
     assert BlockchainInterface.NULL_ADDRESS == policy[OWNER_FIELD]
     assert rate == policy[RATE_FIELD]
     assert current_timestamp == policy[START_TIMESTAMP_FIELD]
     assert end_timestamp == policy[END_TIMESTAMP_FIELD]
     assert not policy[DISABLED_FIELD]
-    assert policy_creator == policy_manager.functions.getPolicyOwner(policy_id_3).call()
+    assert policy_sponsor == policy_manager.functions.getPolicyOwner(policy_id_3).call()
 
     events = policy_created_log.get_all_entries()
     assert 3 == len(events)
     event_args = events[2]['args']
     assert policy_id_3 == event_args['policyId']
-    assert policy_creator == event_args['creator']
-    assert policy_creator == event_args['owner']
+    assert policy_sponsor == event_args['sponsor']
+    assert policy_sponsor == event_args['owner']
     assert rate == event_args['rewardRate']
     assert current_timestamp == event_args['startTimestamp']
     assert end_timestamp == event_args['endTimestamp']
@@ -336,20 +336,20 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     # Only owner's signature can be used
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.revoke(policy_id_3, node1, wrong_signature)\
-            .transact({'from': policy_creator, 'gas_price': 0})
+            .transact({'from': policy_sponsor, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
-    signature = testerchain.client.sign_message(account=policy_creator, message=data)
+    signature = testerchain.client.sign_message(account=policy_sponsor, message=data)
     tx = policy_manager.functions.revoke(policy_id_3, node1, signature)\
-        .transact({'from': policy_creator, 'gas_price': 0})
+        .transact({'from': policy_sponsor, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert value == testerchain.client.get_balance(policy_manager.address)
-    assert policy_creator_balance - value == testerchain.client.get_balance(policy_creator)
+    assert policy_sponsor_balance - value == testerchain.client.get_balance(policy_sponsor)
     assert not policy_manager.functions.policies(policy_id_3).call()[DISABLED_FIELD]
     assert BlockchainInterface.NULL_ADDRESS == policy_manager.functions.getArrangementInfo(policy_id_3, 0).call()[0]
     assert node2 == policy_manager.functions.getArrangementInfo(policy_id_3, 1).call()[0]
 
     data = policy_id_3 + to_canonical_address(BlockchainInterface.NULL_ADDRESS)
-    signature = testerchain.client.sign_message(account=policy_creator, message=data)
+    signature = testerchain.client.sign_message(account=policy_sponsor, message=data)
     tx = policy_manager.functions.revoke(policy_id_3, BlockchainInterface.NULL_ADDRESS, signature)\
         .transact({'from': creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
@@ -359,11 +359,11 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     policy_id_4 = os.urandom(POLICY_ID_LENGTH)
     tx = policy_manager.functions.createPolicy(policy_id_4, policy_owner, end_timestamp, [node1, node2, node3]) \
-        .transact({'from': policy_creator, 'value': 3 * value, 'gas_price': 0})
+        .transact({'from': policy_sponsor, 'value': 3 * value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
 
     data = policy_id_4 + to_canonical_address(BlockchainInterface.NULL_ADDRESS)
-    wrong_signature = testerchain.client.sign_message(account=policy_creator, message=data)
+    wrong_signature = testerchain.client.sign_message(account=policy_sponsor, message=data)
     # Only owner's signature can be used
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.revoke(policy_id_4, BlockchainInterface.NULL_ADDRESS, wrong_signature)\

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
@@ -23,12 +23,11 @@ from eth_tester.exceptions import TransactionFailed
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 
-CLIENT_FIELD = 0
+CREATOR_FIELD = 0
 RATE_FIELD = 1
-FIRST_REWARD_FIELD = 2
-START_PERIOD_FIELD = 3
-LAST_PERIOD_FIELD = 4
-DISABLED_FIELD = 5
+START_TIMESTAMP_FIELD = 2
+END_TIMESTAMP_FIELD = 3
+DISABLED_FIELD = 4
 
 REWARD_FIELD = 0
 REWARD_RATE_FIELD = 1
@@ -40,25 +39,28 @@ policy_id = os.urandom(POLICY_ID_LENGTH)
 policy_id_2 = os.urandom(POLICY_ID_LENGTH)
 policy_id_3 = os.urandom(POLICY_ID_LENGTH)
 rate = 20
+one_period = 60 * 60
 number_of_periods = 10
 value = rate * number_of_periods
 
 
 @pytest.mark.slow
 def test_reward(testerchain, escrow, policy_manager):
-    creator, client, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
+    creator, policy_creator, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
     node_balance = testerchain.client.get_balance(node1)
     withdraw_log = policy_manager.events.Withdrawn.createFilter(fromBlock='latest')
 
     # Mint period without policies
     period = escrow.functions.getCurrentPeriod().call()
-    tx = escrow.functions.mint(period, 1).transact({'from': node1, 'gas_price': 0})
+    tx = escrow.functions.mint(period - 1, 1).transact({'from': node1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 0 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
 
     # Create policy
-    tx = policy_manager.functions.createPolicy(policy_id, number_of_periods, 0, [node1, node3])\
-        .transact({'from': client, 'value': 2 * value})
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
+    tx = policy_manager.functions.createPolicy(policy_id, end_timestamp, [node1, node3])\
+        .transact({'from': policy_creator, 'value': 2 * value})
     testerchain.wait_for_receipt(tx)
 
     # Nothing to withdraw
@@ -76,9 +78,9 @@ def test_reward(testerchain, escrow, policy_manager):
         testerchain.wait_for_receipt(tx)
 
     # Mint some periods for calling updateReward method
-    tx = escrow.functions.mint(period, 5).transact({'from': node1, 'gas_price': 0})
+    tx = escrow.functions.mint(period - 1, 5).transact({'from': node1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    period += 5
+    period += 4
     assert 80 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
 
     # Withdraw some ETH
@@ -118,8 +120,8 @@ def test_reward(testerchain, escrow, policy_manager):
     assert 120 == event_args['value']
 
     # Create policy
-    tx = policy_manager.functions.createPolicy(policy_id_2, number_of_periods, int(0.5 * rate), [node2, node3]) \
-        .transact({'from': client, 'value': int(2 * value + rate)})
+    tx = policy_manager.functions.createPolicy(policy_id_2, end_timestamp, [node2, node3]) \
+        .transact({'from': policy_creator, 'value': int(2 * value)})
     testerchain.wait_for_receipt(tx)
 
     # Mint some periods
@@ -127,40 +129,39 @@ def test_reward(testerchain, escrow, policy_manager):
     tx = escrow.functions.mint(period, 5).transact({'from': node2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     period += 5
-    assert 90 == policy_manager.functions.nodes(node2).call()[REWARD_FIELD]
+    assert 100 == policy_manager.functions.nodes(node2).call()[REWARD_FIELD]
 
     # Mint more periods
-    for x in range(6):
-        tx = escrow.functions.mint(period, 1).transact({'from': node2, 'gas_price': 0})
-        testerchain.wait_for_receipt(tx)
-        period += 1
-    assert 210 == policy_manager.functions.nodes(node2).call()[REWARD_FIELD]
+    tx = escrow.functions.mint(period, 6).transact({'from': node2, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    period += 6
+    assert 200 == policy_manager.functions.nodes(node2).call()[REWARD_FIELD]
 
     # Withdraw the second node reward to the first node
     node_balance = testerchain.client.get_balance(node1)
     node_2_balance = testerchain.client.get_balance(node2)
     tx = policy_manager.functions.withdraw(node1).transact({'from': node2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert node_balance + 210 == testerchain.client.get_balance(node1)
+    assert node_balance + 200 == testerchain.client.get_balance(node1)
     assert node_2_balance == testerchain.client.get_balance(node2)
-    assert value + 210 == testerchain.client.get_balance(policy_manager.address)
+    assert value + 200 == testerchain.client.get_balance(policy_manager.address)
 
     events = withdraw_log.get_all_entries()
     assert 3 == len(events)
     event_args = events[2]['args']
     assert node2 == event_args['node']
     assert node1 == event_args['recipient']
-    assert 210 == event_args['value']
+    assert 200 == event_args['value']
 
 
 @pytest.mark.slow
 def test_refund(testerchain, escrow, policy_manager):
     creator = testerchain.client.accounts[0]
-    client = testerchain.client.accounts[1]
+    policy_creator = testerchain.client.accounts[1]
     node1 = testerchain.client.accounts[3]
     node2 = testerchain.client.accounts[4]
     node3 = testerchain.client.accounts[5]
-    client_balance = testerchain.client.get_balance(client)
+    creator_balance = testerchain.client.get_balance(policy_creator)
     policy_created_log = policy_manager.events.PolicyCreated.createFilter(fromBlock='latest')
     arrangement_revoked_log = policy_manager.events.ArrangementRevoked.createFilter(fromBlock='latest')
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
@@ -168,55 +169,57 @@ def test_refund(testerchain, escrow, policy_manager):
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
 
     # Create policy
-    tx = policy_manager.functions.createPolicy(policy_id, number_of_periods, int(0.5 * rate), [node1]) \
-        .transact({'from': client, 'value': int(value + 0.5 * rate), 'gas_price': 0})
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
+    tx = policy_manager.functions.createPolicy(policy_id, end_timestamp, [node1]) \
+        .transact({'from': policy_creator, 'value': value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     period = escrow.functions.getCurrentPeriod().call()
     tx = escrow.functions.setLastActivePeriod(period - 1).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
-    testerchain.time_travel(hours=9)
+    testerchain.time_travel(hours=8)
     # Check that methods only calculate value
-    tx = policy_manager.functions.calculateRefundValue(policy_id).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.calculateRefundValue(policy_id).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    tx = policy_manager.functions.calculateRefundValue(policy_id, node1).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.calculateRefundValue(policy_id, node1).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 210 == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - 210 == testerchain.client.get_balance(client)
-    assert 190 == policy_manager.functions.calculateRefundValue(policy_id, node1).call({'from': client})
-    assert 190 == policy_manager.functions.calculateRefundValue(policy_id).call({'from': client})
+    assert 200 == testerchain.client.get_balance(policy_manager.address)
+    assert creator_balance - 200 == testerchain.client.get_balance(policy_creator)
+    assert 180 == policy_manager.functions.calculateRefundValue(policy_id, node1).call({'from': policy_creator})
+    assert 180 == policy_manager.functions.calculateRefundValue(policy_id).call({'from': policy_creator})
 
     # Call refund, the result must be almost all ETH without payment for one period
-    tx = policy_manager.functions.refund(policy_id).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.refund(policy_id).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 20 == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - 20 == testerchain.client.get_balance(client)
-    assert client == policy_manager.functions.policies(policy_id).call()[CLIENT_FIELD]
+    assert creator_balance - 20 == testerchain.client.get_balance(policy_creator)
+    assert policy_creator == policy_manager.functions.policies(policy_id).call()[CREATOR_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
-    assert 190 == event_args['value']
+    assert 180 == event_args['value']
 
     events = policy_refund_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert client == event_args['client']
-    assert 190 == event_args['value']
+    assert policy_creator == event_args['sender']
+    assert 180 == event_args['value']
 
     testerchain.time_travel(hours=1)
-    assert 20 == policy_manager.functions.calculateRefundValue(policy_id).call({'from': client})
-    assert 20 == policy_manager.functions.calculateRefundValue(policy_id, node1).call({'from': client})
+    assert 20 == policy_manager.functions.calculateRefundValue(policy_id).call({'from': policy_creator})
+    assert 20 == policy_manager.functions.calculateRefundValue(policy_id, node1).call({'from': policy_creator})
 
     # Call refund, last period must be refunded
-    tx = policy_manager.functions.refund(policy_id).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.refund(policy_id).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert 0 == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance == testerchain.client.get_balance(client)
+    assert creator_balance == testerchain.client.get_balance(policy_creator)
     assert policy_manager.functions.policies(policy_id).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -225,7 +228,7 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
     assert 20 == event_args['value']
 
@@ -235,68 +238,70 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 1 == len(events)
     event_args = events[0]['args']
     assert policy_id == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert 20 == event_args['value']
 
     # Can't refund again because policy and all arrangements are disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.refund(policy_id).transact({'from': client})
+        tx = policy_manager.functions.refund(policy_id).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.refund(policy_id, node1).transact({'from': client})
+        tx = policy_manager.functions.refund(policy_id, node1).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.refund(policy_id, BlockchainInterface.NULL_ADDRESS).transact({'from': client})
+        tx = policy_manager.functions.refund(policy_id, BlockchainInterface.NULL_ADDRESS).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        policy_manager.functions.calculateRefundValue(policy_id).call({'from': client})
+        policy_manager.functions.calculateRefundValue(policy_id).call({'from': policy_creator})
     with pytest.raises((TransactionFailed, ValueError)):
-        policy_manager.functions.calculateRefundValue(policy_id, node1).call({'from': client})
+        policy_manager.functions.calculateRefundValue(policy_id, node1).call({'from': policy_creator})
     with pytest.raises((TransactionFailed, ValueError)):
-        policy_manager.functions.calculateRefundValue(policy_id, BlockchainInterface.NULL_ADDRESS).call({'from': client})
+        policy_manager.functions.calculateRefundValue(policy_id, BlockchainInterface.NULL_ADDRESS).call({'from': policy_creator})
 
     # Create new policy
     testerchain.time_travel(hours=1)
     period = escrow.functions.getCurrentPeriod().call()
     tx = escrow.functions.setLastActivePeriod(period).transact()
     testerchain.wait_for_receipt(tx)
-    tx = policy_manager.functions.createPolicy(policy_id_2, number_of_periods, int(0.5 * rate), [node1, node2, node3]) \
-        .transact({'from': client, 'value': int(3 * value + 1.5 * rate), 'gas_price': 0})
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
+    tx = policy_manager.functions.createPolicy(policy_id_2, end_timestamp, [node1, node2, node3]) \
+        .transact({'from': policy_creator, 'value': 3 * value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
 
     # Nothing to refund because nodes are active in the current period
-    assert 0 == policy_manager.functions.calculateRefundValue(policy_id_2).call({'from': client})
-    assert 0 == policy_manager.functions.calculateRefundValue(policy_id_2, node1).call({'from': client})
-    tx = policy_manager.functions.refund(policy_id_2).transact({'from': client, 'gas_price': 0})
+    assert 0 == policy_manager.functions.calculateRefundValue(policy_id_2).call({'from': policy_creator})
+    assert 0 == policy_manager.functions.calculateRefundValue(policy_id_2, node1).call({'from': policy_creator})
+    tx = policy_manager.functions.refund(policy_id_2).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 3 * value + 1.5 * rate == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - int(3 * value + 1.5 * rate) == testerchain.client.get_balance(client)
+    assert 3 * value == testerchain.client.get_balance(policy_manager.address)
+    assert creator_balance - 3 * value == testerchain.client.get_balance(policy_creator)
 
     events = arrangement_refund_log.get_all_entries()
     assert 5 == len(events)
     event_args = events[1]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
     assert 0 == event_args['value']
 
     event_args = events[2]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node2 == event_args['node']
     assert 0 == event_args['value']
 
     event_args = events[3]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node3 == event_args['node']
     assert 0 == event_args['value']
 
     event_args = events[4]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
     assert 0 == event_args['value']
 
@@ -304,15 +309,15 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 2 == len(events)
     event_args = events[1]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert 0 == event_args['value']
 
     # Try to refund nonexistent policy
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.refund(policy_id_3).transact({'from': client})
+        tx = policy_manager.functions.refund(policy_id_3).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        policy_manager.functions.calculateRefundValue(policy_id_3).call({'from': client})
+        policy_manager.functions.calculateRefundValue(policy_id_3).call({'from': policy_creator})
     # Only policy owner can call refund
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.refund(policy_id_2).transact({'from': node1})
@@ -336,17 +341,17 @@ def test_refund(testerchain, escrow, policy_manager):
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.setLastActivePeriod(period + 8).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert 90 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
+    assert 100 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
 
     testerchain.time_travel(hours=10)
-    assert 360 == policy_manager.functions.calculateRefundValue(policy_id_2).call({'from': client})
-    assert 120 == policy_manager.functions.calculateRefundValue(policy_id_2, node1).call({'from': client})
+    assert 300 == policy_manager.functions.calculateRefundValue(policy_id_2).call({'from': policy_creator})
+    assert 100 == policy_manager.functions.calculateRefundValue(policy_id_2, node1).call({'from': policy_creator})
 
     # Refund for only inactive periods
-    tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 2 * value + 90 + rate == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - (2 * value + 90 + rate) == testerchain.client.get_balance(client)
+    assert 2 * value + 100 == testerchain.client.get_balance(policy_manager.address)
+    assert creator_balance - (2 * value + 100) == testerchain.client.get_balance(policy_creator)
     assert not policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -355,33 +360,35 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 2 == len(events)
     event_args = events[1]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
-    assert 120 == event_args['value']
+    assert 100 == event_args['value']
 
     events = policy_refund_log.get_all_entries()
     assert 2 == len(events)
 
     # Can't refund arrangement again because it's disabled
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': client})
+        tx = policy_manager.functions.refund(policy_id_2, node1).transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.refund(policy_id_2, BlockchainInterface.NULL_ADDRESS).transact({'from': client})
+        tx = policy_manager.functions.refund(policy_id_2, BlockchainInterface.NULL_ADDRESS)\
+            .transact({'from': policy_creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        policy_manager.functions.calculateRefundValue(policy_id_2, node1).call({'from': client})
+        policy_manager.functions.calculateRefundValue(policy_id_2, node1).call({'from': policy_creator})
     with pytest.raises((TransactionFailed, ValueError)):
-        policy_manager.functions.calculateRefundValue(policy_id_2, BlockchainInterface.NULL_ADDRESS).call({'from': client})
+        policy_manager.functions.calculateRefundValue(policy_id_2, BlockchainInterface.NULL_ADDRESS)\
+            .call({'from': policy_creator})
 
     # But can refund others arrangements
-    assert 240 == policy_manager.functions.calculateRefundValue(policy_id_2).call({'from': client})
-    assert 120 == policy_manager.functions.calculateRefundValue(policy_id_2, node2).call({'from': client})
-    assert 120 == policy_manager.functions.calculateRefundValue(policy_id_2, node3).call({'from': client})
-    tx = policy_manager.functions.refund(policy_id_2).transact({'from': client, 'gas_price': 0})
+    assert 200 == policy_manager.functions.calculateRefundValue(policy_id_2).call({'from': policy_creator})
+    assert 100 == policy_manager.functions.calculateRefundValue(policy_id_2, node2).call({'from': policy_creator})
+    assert 100 == policy_manager.functions.calculateRefundValue(policy_id_2, node3).call({'from': policy_creator})
+    tx = policy_manager.functions.refund(policy_id_2).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 3 * 90 == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - 3 * 90 == testerchain.client.get_balance(client)
+    assert 3 * 100 == testerchain.client.get_balance(policy_manager.address)
+    assert creator_balance - 3 * 100 == testerchain.client.get_balance(policy_creator)
     assert policy_manager.functions.policies(policy_id_2).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -390,15 +397,15 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 4 == len(events)
     event_args = events[2]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node2 == event_args['node']
-    assert 120 == event_args['value']
+    assert 100 == event_args['value']
 
     event_args = events[3]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node3 == event_args['node']
-    assert 120 == event_args['value']
+    assert 100 == event_args['value']
 
     events = policy_refund_log.get_all_entries()
     assert 2 == len(events)
@@ -406,36 +413,40 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 2 == len(events)
     event_args = events[1]['args']
     assert policy_id_2 == event_args['policyId']
-    assert client == event_args['client']
-    assert 2 * 120 == event_args['value']
+    assert policy_creator == event_args['sender']
+    assert 2 * 100 == event_args['value']
 
     # Create new policy
     period = escrow.functions.getCurrentPeriod().call()
-    tx = policy_manager.functions.createPolicy(policy_id_3, number_of_periods, int(0.5 * rate), [node1])\
-        .transact({'from': client, 'value': int(value + 0.5 * rate), 'gas_price': 0})
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
+    tx = policy_manager.functions.createPolicy(policy_id_3, end_timestamp, [node1])\
+        .transact({'from': policy_creator, 'value': value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
 
     # Mint some periods
     period += 1
     tx = escrow.functions.pushDowntimePeriod(period - 1, period).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    for x in range(3):
-        period += 1
-        tx = escrow.functions.mint(period, 1).transact({'from': node1})
-        testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.mint(period + 1, 3).transact({'from': node1})
+    testerchain.wait_for_receipt(tx)
+    period += 3
     tx = escrow.functions.setLastActivePeriod(period).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert 150 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
+    assert 160 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
 
     # Policy owner revokes policy
     testerchain.time_travel(hours=4)
-    assert 30 == policy_manager.functions.calculateRefundValue(policy_id_3).call({'from': client})
-    assert 30 == policy_manager.functions.calculateRefundValue(policy_id_3, node1).call({'from': client})
+    assert 40 == policy_manager.functions.calculateRefundValue(policy_id_3).call({'from': policy_creator})
+    assert 40 == policy_manager.functions.calculateRefundValue(policy_id_3, node1).call({'from': policy_creator})
 
-    tx = policy_manager.functions.revokePolicy(policy_id_3).transact({'from': client, 'gas_price': 0})
+    policy_manager_balance = testerchain.client.get_balance(policy_manager.address)
+    creator_balance = testerchain.client.get_balance(policy_creator)
+    tx = policy_manager.functions.revokePolicy(policy_id_3).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert 60 + 3 * 90 == testerchain.client.get_balance(policy_manager.address)
-    assert client_balance - (60 + 3 * 90) == testerchain.client.get_balance(client)
+    returned = 40 + 5 * rate
+    assert policy_manager_balance - returned == testerchain.client.get_balance(policy_manager.address)
+    assert creator_balance + returned == testerchain.client.get_balance(policy_creator)
     assert policy_manager.functions.policies(policy_id_3).call()[DISABLED_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
@@ -447,53 +458,52 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 5 == len(events)
     event_args = events[4]['args']
     assert policy_id_3 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
-    assert 150 == event_args['value']
+    assert returned == event_args['value']
 
     events = policy_revoked_log.get_all_entries()
     assert 3 == len(events)
     event_args = events[2]['args']
     assert policy_id_3 == event_args['policyId']
-    assert client == event_args['client']
-    assert 150 == event_args['value']
+    assert policy_creator == event_args['sender']
+    assert returned == event_args['value']
 
     # Minting is useless after policy is revoked
-    for x in range(20):
-        period += 1
-        tx = escrow.functions.mint(period, 1).transact({'from': node1})
-        testerchain.wait_for_receipt(tx)
-    assert 150 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
-
-
+    tx = escrow.functions.mint(period + 1, 20).transact({'from': node1})
+    testerchain.wait_for_receipt(tx)
+    period += 20
+    assert 160 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
 
     # Create policy again to test double call of `refund` with specific conditions
     policy_id_4 = os.urandom(POLICY_ID_LENGTH)
     number_of_periods_4 = 3
-    tx = policy_manager.functions.createPolicy(policy_id_4, number_of_periods_4, 0, [node1]) \
-        .transact({'from': client, 'value': number_of_periods_4 * rate, 'gas_price': 0})
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods_4 - 1) * one_period
+    tx = policy_manager.functions.createPolicy(policy_id_4, end_timestamp, [node1]) \
+        .transact({'from': policy_creator, 'value': number_of_periods_4 * rate, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
 
-    testerchain.time_travel(hours=number_of_periods_4 - 1)
+    testerchain.time_travel(hours=number_of_periods_4 - 2)
     period = escrow.functions.getCurrentPeriod().call()
-    client_balance = testerchain.client.get_balance(client)
+    creator_balance = testerchain.client.get_balance(policy_creator)
     tx = escrow.functions.pushDowntimePeriod(0, period).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.setLastActivePeriod(period + 1).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     refund_value = (number_of_periods_4 - 1) * rate
-    assert refund_value == policy_manager.functions.calculateRefundValue(policy_id_4).call({'from': client})
+    assert refund_value == policy_manager.functions.calculateRefundValue(policy_id_4).call({'from': policy_creator})
 
     # Call refund, the result must be almost all ETH without payment for one period
-    tx = policy_manager.functions.refund(policy_id_4).transact({'from': client, 'gas_price': 0})
+    tx = policy_manager.functions.refund(policy_id_4).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert client_balance + refund_value == testerchain.client.get_balance(client)
+    assert creator_balance + refund_value == testerchain.client.get_balance(policy_creator)
 
     events = arrangement_refund_log.get_all_entries()
     assert 6 == len(events)
     event_args = events[5]['args']
     assert policy_id_4 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
     assert refund_value == event_args['value']
 
@@ -501,21 +511,21 @@ def test_refund(testerchain, escrow, policy_manager):
     assert 3 == len(events)
     event_args = events[2]['args']
     assert policy_id_4 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert refund_value == event_args['value']
 
     # Call refund again, the client must not get anything from the second call
-    client_balance = testerchain.client.get_balance(client)
-    assert 0 == policy_manager.functions.calculateRefundValue(policy_id_4).call({'from': client})
-    tx = policy_manager.functions.refund(policy_id_4).transact({'from': client, 'gas_price': 0})
+    creator_balance = testerchain.client.get_balance(policy_creator)
+    assert 0 == policy_manager.functions.calculateRefundValue(policy_id_4).call({'from': policy_creator})
+    tx = policy_manager.functions.refund(policy_id_4).transact({'from': policy_creator, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert client_balance == testerchain.client.get_balance(client)
+    assert creator_balance == testerchain.client.get_balance(policy_creator)
 
     events = arrangement_refund_log.get_all_entries()
     assert 7 == len(events)
     event_args = events[6]['args']
     assert policy_id_4 == event_args['policyId']
-    assert client == event_args['client']
+    assert policy_creator == event_args['sender']
     assert node1 == event_args['node']
     assert 0 == event_args['value']
 

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
@@ -23,7 +23,7 @@ from eth_tester.exceptions import TransactionFailed
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 
-CREATOR_FIELD = 0
+SPONSOR_FIELD = 0
 OWNER_FIELD = 1
 RATE_FIELD = 2
 START_TIMESTAMP_FIELD = 3
@@ -47,7 +47,7 @@ value = rate * number_of_periods
 
 @pytest.mark.slow
 def test_reward(testerchain, escrow, policy_manager):
-    creator, policy_creator, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
+    creator, policy_sponsor, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
     node_balance = testerchain.client.get_balance(node1)
     withdraw_log = policy_manager.events.Withdrawn.createFilter(fromBlock='latest')
 
@@ -62,8 +62,8 @@ def test_reward(testerchain, escrow, policy_manager):
     testerchain.wait_for_receipt(tx)
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
-    tx = policy_manager.functions.createPolicy(policy_id, policy_creator, end_timestamp, [node1, node3])\
-        .transact({'from': policy_creator, 'value': 2 * value})
+    tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [node1, node3])\
+        .transact({'from': policy_sponsor, 'value': 2 * value})
     testerchain.wait_for_receipt(tx)
 
     # Nothing to withdraw
@@ -131,8 +131,8 @@ def test_reward(testerchain, escrow, policy_manager):
     period = escrow.functions.getCurrentPeriod().call()
     tx = escrow.functions.setDefaultRewardDelta(node1, period, 1).transact()
     testerchain.wait_for_receipt(tx)
-    tx = policy_manager.functions.createPolicy(policy_id_2, policy_creator, end_timestamp, [node2, node3]) \
-        .transact({'from': policy_creator, 'value': int(2 * value)})
+    tx = policy_manager.functions.createPolicy(policy_id_2, policy_sponsor, end_timestamp, [node2, node3]) \
+        .transact({'from': policy_sponsor, 'value': int(2 * value)})
     testerchain.wait_for_receipt(tx)
 
     # Mint some periods
@@ -201,7 +201,7 @@ def test_refund(testerchain, escrow, policy_manager):
     testerchain.wait_for_receipt(tx)
     assert 20 == testerchain.client.get_balance(policy_manager.address)
     assert creator_balance - 20 == testerchain.client.get_balance(policy_creator)
-    assert policy_creator == policy_manager.functions.policies(policy_id).call()[CREATOR_FIELD]
+    assert policy_creator == policy_manager.functions.policies(policy_id).call()[SPONSOR_FIELD]
 
     events = arrangement_refund_log.get_all_entries()
     assert 1 == len(events)

--- a/tests/blockchain/eth/entities/agents/test_preallocation_escrow_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_preallocation_escrow_agent.py
@@ -185,11 +185,12 @@ def test_collect_policy_reward(testerchain, agent, agency, token_economics, mock
     testerchain.time_travel(periods=1)
 
     mock_transacting_power_activation(account=author, password=INSECURE_DEVELOPMENT_PASSWORD)
-    _receipt = policy_agent.create_policy(policy_id=os.urandom(16),
+    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    policy_id = os.urandom(16)
+    _receipt = policy_agent.create_policy(policy_id=policy_id,
                                           author_address=author,
                                           value=to_wei(1, 'ether'),
-                                          periods=2,
-                                          first_period_reward=0,
+                                          end_timestamp=now + token_economics.hours_per_period * 60 * 60,
                                           node_addresses=[agent.contract_address])
 
     mock_transacting_power_activation(account=worker, password=INSECURE_DEVELOPMENT_PASSWORD)

--- a/tests/blockchain/eth/entities/agents/test_sampling_distribution.py
+++ b/tests/blockchain/eth/entities/agents/test_sampling_distribution.py
@@ -67,7 +67,8 @@ def test_sampling_distribution(testerchain, token, deploy_contract):
         _minLockedPeriods=2,
         _minAllowableLockedTokens=100,
         _maxAllowableLockedTokens=max_allowed_locked_tokens,
-        _minWorkerPeriods=1
+        _minWorkerPeriods=1,
+        _isTestContract=False
     )
     staking_agent = StakingEscrowAgent(registry=None, contract=staking_escrow_contract)
 
@@ -83,10 +84,10 @@ def test_sampling_distribution(testerchain, token, deploy_contract):
     creator = testerchain.etherbase_account
 
     # Give Escrow tokens for reward and initialize contract
-    tx = token.functions.transfer(staking_escrow_contract.address, 10 ** 9).transact({'from': creator})
+    tx = token.functions.approve(staking_escrow_contract.address, 10 ** 9).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
-    tx = staking_escrow_contract.functions.initialize().transact({'from': creator})
+    tx = staking_escrow_contract.functions.initialize(10 ** 9).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     stakers = testerchain.stakers_accounts

--- a/tests/characters/control/blockchain/conftest.py
+++ b/tests/characters/control/blockchain/conftest.py
@@ -79,8 +79,7 @@ def create_policy_control_request(blockchain_bob):
         'm': 2,
         'n': 3,
         'expiration': (maya.now() + datetime.timedelta(days=3)).iso8601(),
-        'value': 3 * 3 * 10 ** 16,
-        'first_period_reward': 4242
+        'value': 3 * 3 * 10 ** 16
     }
     return method_name, params
 
@@ -96,8 +95,7 @@ def grant_control_request(blockchain_bob):
         'm': 2,
         'n': 3,
         'expiration': (maya.now() + datetime.timedelta(days=3)).iso8601(),
-        'value': 3 * 3 * 10 ** 16,
-        'first_period_reward': 4242
+        'value': 3 * 3 * 10 ** 16
     }
     return method_name, params
 

--- a/tests/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/cli/ursula/test_stake_via_allocation_contract.py
@@ -464,7 +464,9 @@ def test_collect_rewards_integration(click_runner,
     blockchain_alice.selection_buffer = 1
 
     M, N = 1, 1
-    expiration = maya.now() + datetime.timedelta(days=3)
+    days = 3
+    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    expiration = maya.MayaDT(now).add(days=days-1)
     blockchain_policy = blockchain_alice.grant(bob=blockchain_bob,
                                                label=random_policy_label,
                                                m=M, n=N,

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -375,7 +375,9 @@ def test_collect_rewards_integration(click_runner,
     blockchain_alice.selection_buffer = 1
 
     M, N = 1, 1
-    expiration = maya.now() + datetime.timedelta(days=3)
+    days = 3
+    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    expiration = maya.MayaDT(now).add(days=days-1)
     blockchain_policy = blockchain_alice.grant(bob=blockchain_bob,
                                                label=random_policy_label,
                                                m=M, n=N,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -260,7 +260,7 @@ def idle_blockchain_policy(testerchain, blockchain_alice, blockchain_bob, token_
     random_label = generate_random_label()
     days = token_economics.minimum_locked_periods // 2
     now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
-    expiration = maya.MayaDT(now).add(days=days-1)  # now + (days - 1) * token_economics.hours_per_period * 60 * 60
+    expiration = maya.MayaDT(now).add(days=days-1)
     n = 3
     m = 2
     policy = blockchain_alice.create_policy(blockchain_bob,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -253,17 +253,20 @@ def enacted_federated_policy(idle_federated_policy, federated_ursulas):
 
 
 @pytest.fixture(scope="module")
-def idle_blockchain_policy(blockchain_alice, blockchain_bob, token_economics):
+def idle_blockchain_policy(testerchain, blockchain_alice, blockchain_bob, token_economics):
     """
     Creates a Policy, in a manner typical of how Alice might do it, with a unique label
     """
     random_label = generate_random_label()
     days = token_economics.minimum_locked_periods // 2
-    expiration = maya.now().add(days=days)
+    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    expiration = maya.MayaDT(now).add(days=days-1)  # now + (days - 1) * token_economics.hours_per_period * 60 * 60
+    n = 3
+    m = 2
     policy = blockchain_alice.create_policy(blockchain_bob,
                                             label=random_label,
-                                            m=2, n=3,
-                                            value=3 * days * 100,
+                                            m=m, n=n,
+                                            value=n * days * 100,
                                             expiration=expiration)
     return policy
 

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -312,11 +312,14 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     policy_id_2 = os.urandom(int(Policy.POLICY_ID_LENGTH))
     number_of_periods = 10
     value = 10000
+    one_period = 60 * 60
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 10 periods), 1st",
-                     policy_functions.createPolicy(policy_id_1, number_of_periods, 0, [ursula1]),
+                     policy_functions.createPolicy(policy_id_1, end_timestamp, [ursula1]),
                      {'from': alice1, 'value': value})
     transact_and_log("Creating policy (1 node, 10 periods), 2nd",
-                     policy_functions.createPolicy(policy_id_2, number_of_periods, 0, [ursula1]),
+                     policy_functions.createPolicy(policy_id_2, end_timestamp, [ursula1]),
                      {'from': alice1, 'value': value})
 
     #
@@ -332,17 +335,18 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     policy_id_2 = os.urandom(int(Policy.POLICY_ID_LENGTH))
     policy_id_3 = os.urandom(int(Policy.POLICY_ID_LENGTH))
     number_of_periods = 100
-    value = 10050
-    first_reward = 50
-    transact_and_log("Creating policy (1 node, 100 periods, first reward), 1st",
-                     policy_functions.createPolicy(policy_id_1, number_of_periods, first_reward, [ursula2]),
+    value = number_of_periods * 100
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
+    transact_and_log("Creating policy (1 node, 100 periods), 1st",
+                     policy_functions.createPolicy(policy_id_1, end_timestamp, [ursula2]),
                      {'from': alice1, 'value': value})
     testerchain.time_travel(periods=1)
-    transact_and_log("Creating policy (1 node, 100 periods, first reward), 2nd",
-                     policy_functions.createPolicy(policy_id_2, number_of_periods, first_reward, [ursula2]),
+    transact_and_log("Creating policy (1 node, 100 periods), 2nd",
+                     policy_functions.createPolicy(policy_id_2, end_timestamp, [ursula2]),
                      {'from': alice1, 'value': value})
-    transact_and_log("Creating policy (1 node, 100 periods, first reward), 3rd",
-                     policy_functions.createPolicy(policy_id_3, number_of_periods, first_reward, [ursula1]),
+    transact_and_log("Creating policy (1 node, 100 periods), 3rd",
+                     policy_functions.createPolicy(policy_id_3, end_timestamp, [ursula1]),
                      {'from': alice1, 'value': value})
 
     #
@@ -372,17 +376,18 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     policy_id_2 = os.urandom(int(Policy.POLICY_ID_LENGTH))
     policy_id_3 = os.urandom(int(Policy.POLICY_ID_LENGTH))
     number_of_periods = 100
-    value = 30150
-    first_reward = 50
-    transact_and_log("Creating policy (3 nodes, 100 periods, first reward), 1st",
-                     policy_functions.createPolicy(policy_id_1, number_of_periods, first_reward, [ursula1, ursula2, ursula3]),
+    value = 3 * number_of_periods * 100
+    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
+    transact_and_log("Creating policy (3 nodes, 100 periods), 1st",
+                     policy_functions.createPolicy(policy_id_1, end_timestamp, [ursula1, ursula2, ursula3]),
                      {'from': alice1, 'value': value})
-    transact_and_log("Creating policy (3 nodes, 100 periods, first reward), 2nd",
-                     policy_functions.createPolicy(policy_id_2, number_of_periods, first_reward, [ursula1, ursula2, ursula3]),
+    transact_and_log("Creating policy (3 nodes, 100 periods), 2nd",
+                     policy_functions.createPolicy(policy_id_2, end_timestamp, [ursula1, ursula2, ursula3]),
                      {'from': alice1, 'value': value})
-    value = 20100
-    transact_and_log("Creating policy (2 nodes, 100 periods, first reward), 3rd",
-                     policy_functions.createPolicy(policy_id_3, number_of_periods, first_reward, [ursula1, ursula2]),
+    value = 2 * number_of_periods * 100
+    transact_and_log("Creating policy (2 nodes, 100 periods), 3rd",
+                     policy_functions.createPolicy(policy_id_3, end_timestamp, [ursula1, ursula2]),
                      {'from': alice1, 'value': value})
 
     for index in range(5):

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -168,7 +168,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     web3 = testerchain.w3
 
     # Accounts
-    origin, ursula1, ursula2, ursula3, alice1, *everyone_else = testerchain.client.accounts
+    origin, ursula1, ursula2, ursula3, alice1, alice2, *everyone_else = testerchain.client.accounts
 
     ursula_with_stamp = mock_ursula(testerchain, ursula1)
 
@@ -301,10 +301,10 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 10 periods, pre-confirmed), 1st",
-                     policy_functions.createPolicy(policy_id_1, end_timestamp, [ursula1]),
+                     policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [ursula1]),
                      {'from': alice1, 'value': value})
     transact_and_log("Creating policy (1 node, 10 periods, pre-confirmed), 2nd",
-                     policy_functions.createPolicy(policy_id_2, end_timestamp, [ursula1]),
+                     policy_functions.createPolicy(policy_id_2, alice1, end_timestamp, [ursula1]),
                      {'from': alice1, 'value': value})
 
     #
@@ -344,14 +344,14 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (3 nodes, 100 periods, pre-confirmed), 1st",
-                     policy_functions.createPolicy(policy_id_1, end_timestamp, [ursula1, ursula2, ursula3]),
+                     policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [ursula1, ursula2, ursula3]),
                      {'from': alice1, 'value': value})
     transact_and_log("Creating policy (3 nodes, 100 periods, pre-confirmed), 2nd",
-                     policy_functions.createPolicy(policy_id_2, end_timestamp, [ursula1, ursula2, ursula3]),
+                     policy_functions.createPolicy(policy_id_2, alice1, end_timestamp, [ursula1, ursula2, ursula3]),
                      {'from': alice1, 'value': value})
     value = 2 * number_of_periods * rate
     transact_and_log("Creating policy (2 nodes, 100 periods, pre-confirmed), 3rd",
-                     policy_functions.createPolicy(policy_id_3, end_timestamp, [ursula1, ursula2]),
+                     policy_functions.createPolicy(policy_id_3, alice1, end_timestamp, [ursula1, ursula2]),
                      {'from': alice1, 'value': value})
 
     #
@@ -372,16 +372,16 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 100 periods), 1st",
-                     policy_functions.createPolicy(policy_id_1, end_timestamp, [ursula2]),
+                     policy_functions.createPolicy(policy_id_1, alice2, end_timestamp, [ursula2]),
                      {'from': alice1, 'value': value})
     testerchain.time_travel(periods=1)
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 100 periods), 2nd",
-                     policy_functions.createPolicy(policy_id_2, end_timestamp, [ursula2]),
+                     policy_functions.createPolicy(policy_id_2, alice2, end_timestamp, [ursula2]),
                      {'from': alice1, 'value': value})
     transact_and_log("Creating policy (1 node, 100 periods), 3rd",
-                     policy_functions.createPolicy(policy_id_3, end_timestamp, [ursula1]),
+                     policy_functions.createPolicy(policy_id_3, alice2, end_timestamp, [ursula1]),
                      {'from': alice1, 'value': value})
 
     #
@@ -396,13 +396,13 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     testerchain.time_travel(periods=10)
     transact_and_log("Revoking policy after downtime, 1st",
                      policy_functions.revokePolicy(policy_id_1),
-                     {'from': alice1})
+                     {'from': alice2})
     transact_and_log("Revoking policy after downtime, 2nd",
                      policy_functions.revokePolicy(policy_id_2),
-                     {'from': alice1})
+                     {'from': alice2})
     transact_and_log("Revoking policy after downtime, 3rd",
                      policy_functions.revokePolicy(policy_id_3),
-                     {'from': alice1})
+                     {'from': alice2})
 
     for index in range(5):
         transact(staker_functions.confirmActivity(), {'from': ursula1})


### PR DESCRIPTION
Based on #1470
Refs #1188 
Closes #1063 
Refs #1406
Refs #1492

| WARNING: Not upgradeable changes |
| --- |

* discrete payment for all policy periods: if policy starts today, ends tomorrow then fee must be for 2 periods
* flexible end timestamp
* Ursula pays more for confirmActivity (~15k-20k gas) to minimize Alice gas fee (save ~15k per node)
* split creator role into creator and owner
* revocation using owner's signature 

PolicyManager `v1.1.2` -> `v 2.1.1`
StakingEscrow `v1.4.1` -> `v2.1.1`