### PR TITLE
Dehydrate PreallocationEscrow deployment

### DIFF
--- a/docs/source/guides/staking_guide.rst
+++ b/docs/source/guides/staking_guide.rst
@@ -196,12 +196,13 @@ Initialize a new stake
     Accept ursula node operator obligation? [y/N]: y
     Publish staged stake to the blockchain? [y/N]: y
 
-    Escrow Address ... 0xBc6297c0781C25A9Bc44eEe22181C98a30DC0229
-    Approve .......... 0xa74ac03a5500fc549636f9b0c44d0dc415e8fc0df4c648cb7386e4b95c4f3a3e
-    Deposit .......... 0x341e406b77ff0f3a0e98982d61814fd8af82d90c5cfe7bad5353e2b757c2d96e
+    Stake initialization transaction was successful.
 
+    Transaction details:
+    OK | deposit stake | 0xe05babab52d00157d0c6e95b7c5165a95adc0ee7ff64ca4d89807805f0ef0fcf (229181 gas)
+    Block #16 | 0xbf8252bc84831c26fc91a2272047e394ec0356af515d785d4a179596e722d836
 
-    Successfully transmitted stake initialization transactions.
+    StakingEscrow address: 0xDe09E74d4888Bc4e65F589e8c13Bce9F71DdF4c7
 
 If you used a hardware wallet, you will need to confirm two transactions here.
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -208,6 +208,7 @@ class ContractAdministrator(NucypherTokenActor):
         r = '{name} - {deployer_address})'.format(name=self.__class__.__name__, deployer_address=self.deployer_address)
         return r
 
+    @validate_checksum_address
     def recruit_sidekick(self, sidekick_address: str, sidekick_password: str):
         self.sidekick_power = TransactingPower(account=sidekick_address, password=sidekick_password, cache=True)
         if self.sidekick_power.device:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -180,6 +180,23 @@ class NucypherTokenAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=sender_address)
         return receipt
 
+    @validate_checksum_address
+    def approve_and_call(self,
+                         amount: int,
+                         target_address: str,
+                         sender_address: str,
+                         call_data: bytes = b'',
+                         gas_limit: int = None):
+        payload = None
+        if gas_limit:  # TODO: Gas management - #842
+            payload = {'gas': gas_limit}
+
+        approve_and_call = self.contract.functions.approveAndCall(target_address, amount, call_data)
+        approve_and_call_receipt = self.blockchain.send_transaction(contract_function=approve_and_call,
+                                                                    sender_address=sender_address,
+                                                                    payload=payload)
+        return approve_and_call_receipt
+
 
 class StakingEscrowAgent(EthereumContractAgent):
 

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -865,6 +865,7 @@ class PreallocationEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin
     _router_deployer = StakingInterfaceRouterDeployer
     __allocation_registry = AllocationRegistry
 
+    @validate_checksum_address
     def __init__(self,
                  allocation_registry: AllocationRegistry = None,
                  sidekick_address: str = None,

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -923,22 +923,6 @@ class PreallocationEscrowDeployer(BaseContractDeployer, UpgradeableContractMixin
                                           contract_address=self.contract.address,
                                           contract_abi=self.contract.abi)
 
-    @validate_checksum_address
-    def deliver(self, value: int, duration: int, beneficiary_address: str, progress=None):
-        """
-        Hand-off the contract to the beneficiary, transfer allocated tokens and lock.
-
-         Encapsulates three operations:
-            - Transfer Ownership
-            - Initial Deposit & Lock
-            - Enroll in Allocation Registry
-
-        """
-
-        self.assign_beneficiary(checksum_address=beneficiary_address, progress=progress)
-        self.initial_deposit(value=value, duration_seconds=duration, progress=progress)
-        self.enroll_principal_contract()
-
     def deploy(self, initial_deployment: bool = True, gas_limit: int = None, progress=None) -> dict:
         """Deploy a new instance of PreallocationEscrow to the blockchain."""
         self.check_deployment_readiness()

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -510,7 +510,7 @@ contract StakingEscrow is Issuer {
         // 0x04: _from                 32 bytes after encoding
         // 0x24: _value                32 bytes after encoding
         // 0x44: _tokenContract        32 bytes after encoding
-        // 0x64: _extraData pointer    32 bytes. Value should be 0x84 (address of _extraData's data in calldata)
+        // 0x64: _extraData pointer    32 bytes. Value must be 0x80 (offset of _extraData wrt to 1st parameter)
         // 0x84: _extraData length     32 bytes
         // 0xA4: _extraData data       Length determined by previous variable
         //

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -503,9 +503,19 @@ contract StakingEscrow is Issuer {
         external
     {
         require(_tokenContract == address(token) && msg.sender == address(token));
-        // copy first 32 bytes from _extraData. Position is calculated as
-        // 4 bytes method signature plus 32 * 3 bytes for previous params and
-        // addition 32 bytes to skip _extraData pointer
+
+        // Copy first 32 bytes from _extraData, according to calldata memory layout:
+        //
+        // 0x00: method signature      4 bytes
+        // 0x04: _from                 32 bytes after encoding
+        // 0x24: _value                32 bytes after encoding
+        // 0x44: _tokenContract        32 bytes after encoding
+        // 0x64: _extraData pointer    32 bytes. Value should be 0x84 (address of _extraData's data in calldata)
+        // 0x84: _extraData length     32 bytes
+        // 0xA4: _extraData data       Length determined by previous variable
+        //
+        // See https://solidity.readthedocs.io/en/latest/abi-spec.html#examples
+
         uint256 payloadSize;
         uint256 payload;
         assembly {

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -54,15 +54,55 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
 
     /**
     * @notice Initial tokens deposit
+    * @param _sender Token sender
+    * @param _value Amount of token to deposit
+    * @param _duration Duration of tokens locking
+    */
+    function initialDeposit(address _sender, uint256 _value, uint256 _duration) internal {
+        require(lockedValue == 0 && _value > 0);
+        endLockTimestamp = block.timestamp.add(_duration);
+        lockedValue = _value;
+        token.safeTransferFrom(_sender, address(this), _value);
+        emit TokensDeposited(_sender, _value, _duration);
+    }
+
+    /**
+    * @notice Initial tokens deposit
     * @param _value Amount of token to deposit
     * @param _duration Duration of tokens locking
     */
     function initialDeposit(uint256 _value, uint256 _duration) public {
-        require(lockedValue == 0 && _value > 0);
-        endLockTimestamp = block.timestamp.add(_duration);
-        lockedValue = _value;
-        token.safeTransferFrom(msg.sender, address(this), _value);
-        emit TokensDeposited(msg.sender, _value, _duration);
+        initialDeposit(msg.sender, _value, _duration);
+    }
+
+    /**
+    * @notice Implementation of the receiveApproval(address,uint256,address,bytes) method
+    * (see NuCypherToken contract). Initial tokens deposit
+    * @param _from Sender
+    * @param _value Amount of tokens to deposit
+    * @param _tokenContract Token contract address
+    * @notice (param _extraData) Amount of seconds during which tokens will be locked
+    */
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _tokenContract,
+        bytes calldata /* _extraData */
+    )
+        external
+    {
+        require(_tokenContract == address(token) && msg.sender == address(token));
+        // copy first 32 bytes from _extraData. Position is calculated as
+        // 4 bytes method signature plus 32 * 3 bytes for previous params and
+        // addition 32 bytes to skip _extraData pointer
+        uint256 payloadSize;
+        uint256 payload;
+        assembly {
+            payloadSize := calldataload(0x84)
+            payload := calldataload(0xA4)
+        }
+        payload = payload >> 8*(32 - payloadSize);
+        initialDeposit(_from, _value, payload);
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -99,7 +99,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
         // 0x04: _from                 32 bytes after encoding
         // 0x24: _value                32 bytes after encoding
         // 0x44: _tokenContract        32 bytes after encoding
-        // 0x64: _extraData pointer    32 bytes. Value should be 0x84 (address of _extraData's data in calldata)
+        // 0x64: _extraData pointer    32 bytes. Value must be 0x80 (offset of _extraData wrt to 1st parameter)
         // 0x84: _extraData length     32 bytes
         // 0xA4: _extraData data       Length determined by previous variable
         //

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -92,9 +92,19 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
         external
     {
         require(_tokenContract == address(token) && msg.sender == address(token));
-        // copy first 32 bytes from _extraData. Position is calculated as
-        // 4 bytes method signature plus 32 * 3 bytes for previous params and
-        // addition 32 bytes to skip _extraData pointer
+
+        // Copy first 32 bytes from _extraData, according to calldata memory layout:
+        //
+        // 0x00: method signature      4 bytes
+        // 0x04: _from                 32 bytes after encoding
+        // 0x24: _value                32 bytes after encoding
+        // 0x44: _tokenContract        32 bytes after encoding
+        // 0x64: _extraData pointer    32 bytes. Value should be 0x84 (address of _extraData's data in calldata)
+        // 0x84: _extraData length     32 bytes
+        // 0xA4: _extraData data       Length determined by previous variable
+        //
+        // See https://solidity.readthedocs.io/en/latest/abi-spec.html#examples
+
         uint256 payloadSize;
         uint256 payload;
         assembly {

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -214,7 +214,6 @@ class Stake:
         if validate_now:
             self.validate_duration()
 
-        self.transactions = NO_STAKING_RECEIPT
         self.receipt = NO_STAKING_RECEIPT
 
     def __repr__(self) -> str:
@@ -448,13 +447,8 @@ class Stake:
         stake.validate_value()
         stake.validate_duration()
 
-        # Transmit
-        approve_receipt, initial_deposit_receipt = staker.deposit(amount=int(amount), lock_periods=lock_periods)
-
-        # Store the staking transactions on the instance
-        staking_transactions = dict(approve=approve_receipt, deposit=initial_deposit_receipt)
-        stake.transactions = staking_transactions
-        stake.receipt = staking_transactions
+        # Create stake on-chain
+        stake.receipt = staker.deposit(amount=int(amount), lock_periods=lock_periods)
 
         # Log and return Stake instance
         log = Logger(f'stake-{staker.checksum_address}-creation')

--- a/nucypher/cli/characters/stake.py
+++ b/nucypher/cli/characters/stake.py
@@ -437,9 +437,7 @@ def create(click_config,
     emitter.echo("Broadcasting stake...", color='yellow')
     new_stake = STAKEHOLDER.initialize_stake(amount=value, lock_periods=lock_periods)
 
-    painting.paint_staking_confirmation(emitter=emitter,
-                                        ursula=STAKEHOLDER,
-                                        transactions=new_stake.transactions)
+    painting.paint_staking_confirmation(emitter=emitter, staker=STAKEHOLDER, new_stake=new_stake)
 
 
 @stake.command()

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -34,7 +34,7 @@ from nucypher.blockchain.eth.agents import (
     StakingEscrowAgent,
     PreallocationEscrowAgent
 )
-from nucypher.blockchain.eth.constants import NUCYPHER_TOKEN_CONTRACT_NAME
+from nucypher.blockchain.eth.constants import NUCYPHER_TOKEN_CONTRACT_NAME, STAKING_ESCROW_CONTRACT_NAME
 from nucypher.blockchain.eth.deployers import DispatcherDeployer, StakingInterfaceRouterDeployer
 from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import BaseContractRegistry
@@ -365,17 +365,16 @@ Staking address: {staking_address}
     emitter.echo('=========================================================================', bold=True)
 
 
-def paint_staking_confirmation(emitter, ursula, transactions):
-    emitter.echo(f'\nEscrow Address ... {ursula.staking_agent.contract_address}', color='blue')
-    for tx_name, receipt in transactions.items():
-        emitter.echo(f'{tx_name.capitalize()} .......... {receipt["transactionHash"].hex()}', color='green')
-    emitter.echo(f'''
-
-Successfully transmitted stake initialization transactions.
-
-View your stakes by running 'nucypher stake list'
+def paint_staking_confirmation(emitter, staker, new_stake):
+    emitter.echo("\nStake initialization transaction was successful.", color='green')
+    emitter.echo(f'\nTransaction details:')
+    paint_receipt_summary(emitter=emitter, receipt=new_stake.receipt, transaction_type="deposit stake")
+    emitter.echo(f'\n{STAKING_ESCROW_CONTRACT_NAME} address: {staker.staking_agent.contract_address}', color='blue')
+    next_steps = f'''\nView your stakes by running 'nucypher stake list'
 or set your Ursula worker node address by running 'nucypher stake set-worker'.
-''', color='green')
+
+See https://docs.nucypher.com/en/latest/guides/staking_guide.html'''
+    emitter.echo(next_steps, color='green')
 
 
 def prettify_stake(stake, index: int = None) -> str:

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -137,7 +137,6 @@ class TransactingPower(CryptoPowerUp):
 
         self.device = is_from_hw_wallet
 
-
         self.__password = password
         self.__unlocked = False
         self.__activated = False

--- a/tests/cli/test_deploy.py
+++ b/tests/cli/test_deploy.py
@@ -355,7 +355,8 @@ def test_nucypher_deploy_allocation_contracts(click_runner,
 
     account_index = '0\n'
     yes = 'Y\n'
-    user_input = account_index + yes + yes
+    no = 'N\n'
+    user_input = account_index + yes + no + yes
 
     result = click_runner.invoke(deploy,
                                  deploy_command,


### PR DESCRIPTION
* "Simplified" deployment of `PreallocationEscrow` contracts, using a SW controlled account (a.k.a _the Sidekick_) to handle the initial steps of deployment (contract creation). The funding & locking is still controlled by the main deployer account (IRL, a HW account).
* Uses `approveAndCall()` instead of `approve()` and an additional method for calling `token.safeTransferFrom()`. This reduces costs when depositing funds into `PreallocationEscrow` and `StakingEscrow`. Closes #1534 
* After applying previous measures, and tweaking the ordering of deployment steps,  the number of confirmations in the HW device when deploying a preallocation contract is reduced from 4 to 1.