### PR TITLE
[Concept] External Signer Support (Clef POC)

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -33,7 +33,7 @@ from constant_sorrow.constants import (
 from eth_tester.exceptions import TransactionFailed
 from eth_utils import keccak, is_checksum_address, to_checksum_address
 from twisted.logger import Logger
-from web3 import Web3
+from web3 import Web3, IPCProvider
 
 from nucypher.blockchain.economics import TokenEconomics, StandardTokenEconomics, TokenEconomicsFactory
 from nucypher.blockchain.eth.agents import (
@@ -44,6 +44,7 @@ from nucypher.blockchain.eth.agents import (
     ContractAgency,
     PreallocationEscrowAgent,
 )
+from nucypher.blockchain.eth.clients import ClefClient
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.deployers import (
     NucypherTokenDeployer,
@@ -1228,10 +1229,16 @@ class StakeHolder(Staker):
         def __init__(self,
                      registry: BaseContractRegistry,
                      client_addresses: set = None,
-                     keyfiles: List[str] = None):
+                     keyfiles: List[str] = None,
+                     signer=None):
 
-            # Wallet
-            self.__keyfiles = keyfiles
+            if signer:
+               provider = IPCProvider(signer)
+               w3 = Web3(provider=provider)
+               signer = ClefClient(w3=w3)
+
+            self.__signer = signer
+            self.__keyfiles = keyfiles or list()
             self.__local_accounts = dict()
             self.__client_accounts = set()  # Note: Account index is meaningless here
             self.__transacting_powers = dict()
@@ -1254,10 +1261,9 @@ class StakeHolder(Staker):
             return self.blockchain.transacting_power.account
 
         def __get_accounts(self) -> None:
-            # chain_name = self.blockchain.client.chain_name.lower()
-            # keystore = f'{os.path.expanduser("~")}/.ethereum/{chain_name}/keystore'
-            # keyfiles = os.listdir(keystore)
-            # for keyfile in keyfiles:
+            if self.__signer:
+                signer_accounts = self.__signer.accounts()
+                self.__client_accounts.update(signer_accounts)
             for keyfile in self.__keyfiles:
                 try:
                     account = to_checksum_address(keyfile.split('--')[-1])
@@ -1281,7 +1287,10 @@ class StakeHolder(Staker):
                 transacting_power = self.__transacting_powers[checksum_address]
             except KeyError:
                 keyfile = self.__local_accounts.get(checksum_address)
-                transacting_power = TransactingPower(password=password, account=checksum_address, keyfile=keyfile)
+                transacting_power = TransactingPower(password=password,
+                                                     account=checksum_address,
+                                                     client=self.__signer,
+                                                     keyfile=keyfile)
                 self.__transacting_powers[checksum_address] = transacting_power
             transacting_power.activate(password=password)
 
@@ -1303,6 +1312,7 @@ class StakeHolder(Staker):
                  initial_address: str = None,
                  checksum_addresses: set = None,
                  keyfiles: List[str] = None,
+                 signer: str = None,
                  password: str = None,
                  *args, **kwargs):
 
@@ -1314,7 +1324,8 @@ class StakeHolder(Staker):
         # Wallet
         self.wallet = self.StakingWallet(registry=self.registry,
                                          client_addresses=checksum_addresses,
-                                         keyfiles=keyfiles)
+                                         keyfiles=keyfiles,
+                                         signer=signer)
         if initial_address:
             # If an initial address was passed,
             # it is safe to understand that it has already been used at a higher level.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -213,7 +213,7 @@ class ContractAdministrator(NucypherTokenActor):
     @validate_checksum_address
     def recruit_sidekick(self, sidekick_address: str, sidekick_password: str):
         self.sidekick_power = TransactingPower(account=sidekick_address, password=sidekick_password, cache=True)
-        if self.sidekick_power.device:
+        if self.sidekick_power.is_device:
             raise ValueError("Holy Wallet! Sidekicks can only be SW accounts")
         self.sidekick_address = sidekick_address
 
@@ -1227,10 +1227,13 @@ class StakeHolder(Staker):
 
         def __init__(self,
                      registry: BaseContractRegistry,
-                     checksum_addresses: set = None):
+                     client_addresses: set = None,
+                     keyfiles: List[str] = None):
 
             # Wallet
-            self.__accounts = set()  # Note: Account index is meaningless here
+            self.__keyfiles = keyfiles
+            self.__local_accounts = dict()
+            self.__client_accounts = set()  # Note: Account index is meaningless here
             self.__transacting_powers = dict()
 
             # Blockchain
@@ -1239,24 +1242,34 @@ class StakeHolder(Staker):
             self.token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=self.registry)
 
             self.__get_accounts()
-            if checksum_addresses:
-                self.__accounts.update(checksum_addresses)
+            if client_addresses:
+                self.__client_accounts.update(client_addresses)
 
         @validate_checksum_address
         def __contains__(self, checksum_address: str) -> bool:
-            return bool(checksum_address in self.__accounts)
+            return bool(checksum_address in self.accounts)
 
         @property
         def active_account(self) -> str:
             return self.blockchain.transacting_power.account
 
         def __get_accounts(self) -> None:
-            accounts = self.blockchain.client.accounts
-            self.__accounts.update(accounts)
+            # chain_name = self.blockchain.client.chain_name.lower()
+            # keystore = f'{os.path.expanduser("~")}/.ethereum/{chain_name}/keystore'
+            # keyfiles = os.listdir(keystore)
+            # for keyfile in keyfiles:
+            for keyfile in self.__keyfiles:
+                try:
+                    account = to_checksum_address(keyfile.split('--')[-1])
+                    self.__local_accounts[account] = keyfile
+                except ValueError:
+                    raise ValueError(f"Key files must be in the geth wallet format; {keyfile} is invalid.")
+            client_accounts = self.blockchain.client.accounts  # Accounts via connected provider
+            self.__client_accounts.update(client_accounts)
 
         @property
         def accounts(self) -> set:
-            return self.__accounts
+            return {*self.__client_accounts, *self.__local_accounts}
 
         @validate_checksum_address
         def activate_account(self, checksum_address: str, password: str = None) -> None:
@@ -1267,7 +1280,8 @@ class StakeHolder(Staker):
             try:
                 transacting_power = self.__transacting_powers[checksum_address]
             except KeyError:
-                transacting_power = TransactingPower(password=password, account=checksum_address)
+                keyfile = self.__local_accounts.get(checksum_address)
+                transacting_power = TransactingPower(password=password, account=checksum_address, keyfile=keyfile)
                 self.__transacting_powers[checksum_address] = transacting_power
             transacting_power.activate(password=password)
 
@@ -1288,6 +1302,7 @@ class StakeHolder(Staker):
                  is_me: bool = True,
                  initial_address: str = None,
                  checksum_addresses: set = None,
+                 keyfiles: List[str] = None,
                  password: str = None,
                  *args, **kwargs):
 
@@ -1297,7 +1312,9 @@ class StakeHolder(Staker):
         self.log = Logger(f"stakeholder")
 
         # Wallet
-        self.wallet = self.StakingWallet(registry=self.registry, checksum_addresses=checksum_addresses)
+        self.wallet = self.StakingWallet(registry=self.registry,
+                                         client_addresses=checksum_addresses,
+                                         keyfiles=keyfiles)
         if initial_address:
             # If an initial address was passed,
             # it is safe to understand that it has already been used at a higher level.
@@ -1318,7 +1335,7 @@ class StakeHolder(Staker):
         if self.individual_allocation:
             if checksum_address != self.individual_allocation.beneficiary_address:
                 raise ValueError(f"Beneficiary {self.individual_allocation.beneficiary_address} in individual "
-                                 f"allocation doesn't match this checksum address ({checksum_address})")
+                                 f"allocation doesnt match this checksum address ({checksum_address})")
             staking_address = self.individual_allocation.contract_address
             self.beneficiary_address = self.individual_allocation.beneficiary_address
             self.preallocation_escrow_agent = PreallocationEscrowAgent(registry=self.registry,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -44,7 +44,7 @@ from nucypher.blockchain.eth.agents import (
     ContractAgency,
     PreallocationEscrowAgent,
 )
-from nucypher.blockchain.eth.clients import ClefClient
+from nucypher.blockchain.eth.clients import ClefSigner
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.deployers import (
     NucypherTokenDeployer,
@@ -1235,7 +1235,7 @@ class StakeHolder(Staker):
             if signer:
                provider = IPCProvider(signer)
                w3 = Web3(provider=provider)
-               signer = ClefClient(w3=w3)
+               signer = ClefSigner(w3=w3)
 
             self.__signer = signer
             self.__keyfiles = keyfiles or list()

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -387,10 +387,10 @@ class ClefClient:
     def sign_message(self, account: str, message: bytes) -> str:
         return self.w3.manager.request_blocking("account_signData", [message])
 
-    def unlock_account(self) -> bool:
+    def unlock_account(self, address: str, password: str, duration: int = None) -> bool:
         return True
 
-    def lock_account(self):
+    def lock_account(self, address: str):
         return True
 
 

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -2,14 +2,14 @@ import json
 import os
 import shutil
 import time
-from typing import Union
+from typing import Union, List
 
 import maya
 from constant_sorrow.constants import NOT_RUNNING, UNKNOWN_DEVELOPMENT_CHAIN_ID
 from cytoolz.dicttoolz import dissoc
 from eth_account import Account
 from eth_account.messages import encode_defunct
-from eth_utils import to_canonical_address
+from eth_utils import to_canonical_address, to_normalized_address
 from eth_utils import to_checksum_address
 from geth import LoggingMixin
 from geth.accounts import get_accounts, create_new_account
@@ -72,6 +72,7 @@ class Web3Client:
     ALT_PARITY = 'Parity-Ethereum'
     GANACHE = 'EthereumJS TestRPC'
     ETHEREUM_TESTER = 'EthereumTester'  # (PyEVM)
+    CLEF = 'Clef'  # Signer-only
     SYNC_TIMEOUT_DURATION = 60 # seconds to wait for various blockchain syncing endeavors
     PEERING_TIMEOUT = 30
     SYNC_SLEEP_DURATION = 5
@@ -124,6 +125,9 @@ class Web3Client:
             # Test Clients
             cls.GANACHE: GanacheClient,
             cls.ETHEREUM_TESTER: EthereumTesterClient,
+
+            # Singers
+            cls.CLEF: ClefClient
         }
 
         try:
@@ -132,6 +136,9 @@ class Web3Client:
             ClientSubclass = clients[node_technology]
 
         except (ValueError, IndexError):
+            # check if this is a clef signer  TODO: move this?
+            if 'clef' in getattr(w3.provider, 'ipc_path', ''):
+                return ClefClient(w3=w3)
             raise ValueError(f"Invalid client version string. Got '{w3.clientVersion}'")
 
         except KeyError:
@@ -350,6 +357,41 @@ class GethClient(Web3Client):
     @property
     def wallets(self):
         return self.w3.manager.request_blocking("personal_listWallets", [])
+
+
+class ClefClient:
+
+    def __init__(self, w3):
+        self.w3 = w3
+        self.log = Logger(self.__class__.__name__)
+
+    def is_connected(self):
+        return True
+
+    def accounts(self) -> List[str]:
+        normalized_addresses = self.w3.manager.request_blocking("account_list", [])
+        checksum_addresses = [to_checksum_address(addr) for addr in normalized_addresses]
+        return checksum_addresses
+
+    def sign_transaction(self, transaction: dict):
+        # FIXME: SO LAME
+        transaction['value'] = self.w3.toHex(transaction['value'])
+        transaction['gas'] = self.w3.toHex(transaction['gas'])
+        transaction['gasPrice'] = self.w3.toHex(transaction['gasPrice'])
+        transaction['chainId'] = self.w3.toHex(transaction['chainId'])
+        transaction['nonce'] = self.w3.toHex(transaction['nonce'])
+        transaction['from'] = to_normalized_address(transaction['from'])
+        signed = self.w3.manager.request_blocking("account_signTransaction", [transaction])
+        return signed.raw
+
+    def sign_message(self, account: str, message: bytes) -> str:
+        return self.w3.manager.request_blocking("account_signData", [message])
+
+    def unlock_account(self) -> bool:
+        return True
+
+    def lock_account(self):
+        return True
 
 
 class ParityClient(Web3Client):

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -1,15 +1,15 @@
 import json
 import os
 import shutil
-import time
 from typing import Union, List
 
 import maya
+import time
 from constant_sorrow.constants import NOT_RUNNING, UNKNOWN_DEVELOPMENT_CHAIN_ID
 from cytoolz.dicttoolz import dissoc
 from eth_account import Account
 from eth_account.messages import encode_defunct
-from eth_utils import to_canonical_address, to_normalized_address
+from eth_utils import to_canonical_address, apply_formatters_to_dict, to_normalized_address
 from eth_utils import to_checksum_address
 from geth import LoggingMixin
 from geth.accounts import get_accounts, create_new_account
@@ -24,7 +24,6 @@ from twisted.logger import Logger
 from web3 import Web3
 
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, DEPLOY_DIR, USER_LOG_DIR
-
 
 UNKNOWN_DEVELOPMENT_CHAIN_ID.bool_value(True)
 
@@ -127,7 +126,7 @@ class Web3Client:
             cls.ETHEREUM_TESTER: EthereumTesterClient,
 
             # Singers
-            cls.CLEF: ClefClient
+            cls.CLEF: ClefSigner
         }
 
         try:
@@ -138,7 +137,7 @@ class Web3Client:
         except (ValueError, IndexError):
             # check if this is a clef signer  TODO: move this?
             if 'clef' in getattr(w3.provider, 'ipc_path', ''):
-                return ClefClient(w3=w3)
+                return ClefSigner(w3=w3)
             raise ValueError(f"Invalid client version string. Got '{w3.clientVersion}'")
 
         except KeyError:
@@ -359,33 +358,35 @@ class GethClient(Web3Client):
         return self.w3.manager.request_blocking("personal_listWallets", [])
 
 
-class ClefClient:
+class ClefSigner:
 
     def __init__(self, w3):
         self.w3 = w3
         self.log = Logger(self.__class__.__name__)
 
-    def is_connected(self):
-        return True
+    def is_connected(self) -> bool:
+        return True  # TODO: Determine if the socket is reachable
 
     def accounts(self) -> List[str]:
         normalized_addresses = self.w3.manager.request_blocking("account_list", [])
         checksum_addresses = [to_checksum_address(addr) for addr in normalized_addresses]
         return checksum_addresses
 
-    def sign_transaction(self, transaction: dict):
-        # FIXME: SO LAME
-        transaction['value'] = self.w3.toHex(transaction['value'])
-        transaction['gas'] = self.w3.toHex(transaction['gas'])
-        transaction['gasPrice'] = self.w3.toHex(transaction['gasPrice'])
-        transaction['chainId'] = self.w3.toHex(transaction['chainId'])
-        transaction['nonce'] = self.w3.toHex(transaction['nonce'])
-        transaction['from'] = to_normalized_address(transaction['from'])
+    def sign_transaction(self, transaction: dict) -> bytes:
+        formatters = {
+            'nonce': Web3.toHex,
+            'gasPrice': Web3.toHex,
+            'gas': Web3.toHex,
+            'value': Web3.toHex,
+            'chainId': Web3.toHex,
+            'from': to_normalized_address
+        }
+        transaction = apply_formatters_to_dict(formatters, transaction)
         signed = self.w3.manager.request_blocking("account_signTransaction", [transaction])
         return signed.raw
 
     def sign_message(self, account: str, message: bytes) -> str:
-        return self.w3.manager.request_blocking("account_signData", [message])
+        return self.w3.manager.request_blocking("account_signData", [account, message])
 
     def unlock_account(self, address: str, password: str, duration: int = None) -> bool:
         return True

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -38,6 +38,8 @@ from eth_utils import to_checksum_address
 from flask import request, Response
 from twisted.internet import threads
 from twisted.logger import Logger
+
+from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from umbral import pre
 from umbral.keys import UmbralPublicKey
 from umbral.kfrags import KFrag
@@ -125,9 +127,10 @@ class Alice(Character, BlockchainPolicyAuthor):
                            *args, **kwargs)
 
         if is_me and not federated_only:  # TODO: #289
+            blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=self.provider_uri)
             transacting_power = TransactingPower(account=self.checksum_address,
                                                  password=client_password,
-                                                 provider_uri=self.provider_uri)
+                                                 client=blockchain.client)
             self._crypto_power.consume_power_up(transacting_power)
             BlockchainPolicyAuthor.__init__(self,
                                             registry=self.registry,

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -382,7 +382,8 @@ def select_stake(stakeholder, emitter, divisible: bool = False) -> Stake:
 
 
 def select_client_account(emitter,
-                          provider_uri: str,
+                          provider_uri: str = None,
+                          wallet = None,
                           prompt: str = None,
                           default: int = 0,
                           registry=None,
@@ -393,8 +394,11 @@ def select_client_account(emitter,
     Note: Setting show_balances to True, causes an eager contract and blockchain connection.
     """
 
+    if not (provider_uri or wallet):
+        raise ValueError("Provider URI or wallet must be provided to select an account.")
+
     if not provider_uri:
-        raise ValueError("Provider URI must be provided to select a wallet account.")
+        provider_uri = wallet.blockchain.provider_uri
 
     # Lazy connect the blockchain interface
     if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
@@ -408,8 +412,11 @@ def select_client_account(emitter,
             registry = InMemoryContractRegistry.from_latest_publication(network)
         token_agent = NucypherTokenAgent(registry=registry)
 
-    # Real wallet accounts
-    enumerated_accounts = dict(enumerate(blockchain.client.accounts))
+    if wallet:
+        wallet_accounts = wallet.accounts
+    else:
+        wallet_accounts = blockchain.client.accounts
+    enumerated_accounts = dict(enumerate(wallet_accounts))
     if len(enumerated_accounts) < 1:
         emitter.echo("No ETH accounts were found.", color='red', bold=True)
         raise click.Abort()
@@ -465,7 +472,7 @@ def handle_client_account_for_staking(emitter,
                                                    emitter=emitter,
                                                    registry=stakeholder.registry,
                                                    network=stakeholder.network,
-                                                   provider_uri=stakeholder.wallet.blockchain.provider_uri)
+                                                   wallet=stakeholder.wallet)
             staking_address = client_account
 
     return client_account, staking_address

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -130,7 +130,7 @@ class StakerOptions:
         self.config_options = config_options
         self.staking_address = staking_address
 
-    def create_character(self, emitter, config_file, individual_allocation=None, initial_address=None, keyfiles=None):
+    def create_character(self, emitter, config_file, initial_address=None, *args, **kwargs):
         stakeholder_config = self.config_options.create_config(emitter, config_file)
 
         if initial_address is None:
@@ -138,8 +138,7 @@ class StakerOptions:
 
         return stakeholder_config.produce(
             initial_address=initial_address,
-            individual_allocation=individual_allocation,
-            keyfiles=keyfiles
+            *args, **kwargs
         )
 
     def get_blockchain(self):
@@ -157,12 +156,13 @@ class TransactingStakerOptions:
 
     __option_name__ = 'transacting_staker_options'
 
-    def __init__(self, staker_options, hw_wallet, beneficiary_address, allocation_filepath, keyfile=None):
+    def __init__(self, staker_options, hw_wallet, beneficiary_address, allocation_filepath, keyfile, signer):
         self.staker_options = staker_options
         self.hw_wallet = hw_wallet
         self.beneficiary_address = beneficiary_address
         self.allocation_filepath = allocation_filepath
         self.keyfile = keyfile
+        self.signer = signer
 
     def create_character(self, emitter, config_file):
 
@@ -203,7 +203,8 @@ class TransactingStakerOptions:
             config_file,
             individual_allocation=individual_allocation,
             initial_address=initial_address,
-            keyfiles=[self.keyfile]  # TODO: Accept multiple?
+            keyfiles=[self.keyfile] if self.keyfile else None,  # TODO: Accept multiple?,
+            signer=self.signer,
         )
 
     def get_blockchain(self):
@@ -222,8 +223,10 @@ group_transacting_staker_options = group_options(
     hw_wallet=option_hw_wallet,
     beneficiary_address=click.option('--beneficiary-address', help="Address of a pre-allocation beneficiary", type=EIP55_CHECKSUM_ADDRESS),
     allocation_filepath=click.option('--allocation-filepath', help="Path to individual allocation file", type=EXISTING_READABLE_FILE),
-    keyfile=click.option('--keyfile', default=None, type=EXISTING_READABLE_FILE)
-    )
+    keyfile=click.option('--keyfile', default=None, type=EXISTING_READABLE_FILE),
+    signer=click.option('--signer', default=None, type=EXISTING_READABLE_FILE)
+
+)
 
 
 @click.group()

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -245,12 +245,12 @@ def stake():
 @group_config_options
 @group_general_config
 @option_network
-def init_stakeholder(general_config, config_root, force, config_options, keyfile):
+def init_stakeholder(general_config, config_root, force, config_options):
     """
     Create a new stakeholder configuration.
     """
     emitter = _setup_emitter(general_config)
-    new_stakeholder = config_options.generate_config(config_root, keyfile)
+    new_stakeholder = config_options.generate_config(config_root)
     filepath = new_stakeholder.to_configuration_file(override=force)
     emitter.echo(f"Wrote new stakeholder configuration to {filepath}", color='green')
 

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -130,7 +130,7 @@ class StakerOptions:
         self.config_options = config_options
         self.staking_address = staking_address
 
-    def create_character(self, emitter, config_file, individual_allocation=None, initial_address=None):
+    def create_character(self, emitter, config_file, individual_allocation=None, initial_address=None, keyfiles=None):
         stakeholder_config = self.config_options.create_config(emitter, config_file)
 
         if initial_address is None:
@@ -138,7 +138,9 @@ class StakerOptions:
 
         return stakeholder_config.produce(
             initial_address=initial_address,
-            individual_allocation=individual_allocation)
+            individual_allocation=individual_allocation,
+            keyfiles=keyfiles
+        )
 
     def get_blockchain(self):
         return BlockchainInterfaceFactory.get_interface(provider_uri=self.config_options.provider_uri)  # Eager connection
@@ -155,11 +157,12 @@ class TransactingStakerOptions:
 
     __option_name__ = 'transacting_staker_options'
 
-    def __init__(self, staker_options, hw_wallet, beneficiary_address, allocation_filepath):
+    def __init__(self, staker_options, hw_wallet, beneficiary_address, allocation_filepath, keyfile=None):
         self.staker_options = staker_options
         self.hw_wallet = hw_wallet
         self.beneficiary_address = beneficiary_address
         self.allocation_filepath = allocation_filepath
+        self.keyfile = keyfile
 
     def create_character(self, emitter, config_file):
 
@@ -199,7 +202,9 @@ class TransactingStakerOptions:
             emitter,
             config_file,
             individual_allocation=individual_allocation,
-            initial_address=initial_address)
+            initial_address=initial_address,
+            keyfiles=[self.keyfile]  # TODO: Accept multiple?
+        )
 
     def get_blockchain(self):
         return self.staker_options.get_blockchain()
@@ -217,6 +222,7 @@ group_transacting_staker_options = group_options(
     hw_wallet=option_hw_wallet,
     beneficiary_address=click.option('--beneficiary-address', help="Address of a pre-allocation beneficiary", type=EIP55_CHECKSUM_ADDRESS),
     allocation_filepath=click.option('--allocation-filepath', help="Path to individual allocation file", type=EXISTING_READABLE_FILE),
+    keyfile=click.option('--keyfile', default=None, type=EXISTING_READABLE_FILE)
     )
 
 
@@ -234,12 +240,12 @@ def stake():
 @group_config_options
 @group_general_config
 @option_network
-def init_stakeholder(general_config, config_root, force, config_options):
+def init_stakeholder(general_config, config_root, force, config_options, keyfile):
     """
     Create a new stakeholder configuration.
     """
     emitter = _setup_emitter(general_config)
-    new_stakeholder = config_options.generate_config(config_root)
+    new_stakeholder = config_options.generate_config(config_root, keyfile)
     filepath = new_stakeholder.to_configuration_file(override=force)
     emitter.echo(f"Wrote new stakeholder configuration to {filepath}", color='green')
 

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -58,14 +58,16 @@ from nucypher.config.characters import StakeHolderConfiguration
 option_value = click.option('--value', help="Token value of stake", type=click.INT)
 option_lock_periods = click.option('--lock-periods', help="Duration of stake in periods.", type=click.INT)
 option_worker_address = click.option('--worker-address', help="Address to assign as an Ursula-Worker", type=EIP55_CHECKSUM_ADDRESS)
+option_signer = click.option('--signer', default=None, type=EXISTING_READABLE_FILE)
 
 
 class StakeHolderConfigOptions:
 
     __option_name__ = 'config_options'
 
-    def __init__(self, provider_uri, poa, light, registry_filepath, network):
+    def __init__(self, provider_uri, poa, light, registry_filepath, network, signer):
         self.provider_uri = provider_uri
+        self.signer = signer
         self.poa = poa
         self.light = light
         self.registry_filepath = registry_filepath
@@ -118,8 +120,10 @@ group_config_options = group_options(
     poa=option_poa,
     light=option_light,
     registry_filepath=option_registry_filepath,
-    network=option_network
-    )
+    network=option_network,
+    signer=option_signer
+
+)
 
 
 class StakerOptions:
@@ -138,6 +142,7 @@ class StakerOptions:
 
         return stakeholder_config.produce(
             initial_address=initial_address,
+            signer=self.config_options.signer,
             *args, **kwargs
         )
 
@@ -156,13 +161,12 @@ class TransactingStakerOptions:
 
     __option_name__ = 'transacting_staker_options'
 
-    def __init__(self, staker_options, hw_wallet, beneficiary_address, allocation_filepath, keyfile, signer):
+    def __init__(self, staker_options, hw_wallet, beneficiary_address, allocation_filepath, keyfile):
         self.staker_options = staker_options
         self.hw_wallet = hw_wallet
         self.beneficiary_address = beneficiary_address
         self.allocation_filepath = allocation_filepath
         self.keyfile = keyfile
-        self.signer = signer
 
     def create_character(self, emitter, config_file):
 
@@ -204,7 +208,6 @@ class TransactingStakerOptions:
             individual_allocation=individual_allocation,
             initial_address=initial_address,
             keyfiles=[self.keyfile] if self.keyfile else None,  # TODO: Accept multiple?,
-            signer=self.signer,
         )
 
     def get_blockchain(self):
@@ -224,7 +227,6 @@ group_transacting_staker_options = group_options(
     beneficiary_address=click.option('--beneficiary-address', help="Address of a pre-allocation beneficiary", type=EIP55_CHECKSUM_ADDRESS),
     allocation_filepath=click.option('--allocation-filepath', help="Path to individual allocation file", type=EXISTING_READABLE_FILE),
     keyfile=click.option('--keyfile', default=None, type=EXISTING_READABLE_FILE),
-    signer=click.option('--signer', default=None, type=EXISTING_READABLE_FILE)
 
 )
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -207,9 +207,7 @@ class TransactingPower(CryptoPowerUp):
         elif self.is_local:
             unlocked = self.__import_keyfile(password=password)
         else:
-            if self.__client is NO_BLOCKCHAIN_CONNECTION:
-                raise self.NoBlockchainConnection
-            unlocked = self.blockchain.client.unlock_account(address=self.account, password=password, duration=duration)
+            unlocked = self.__client.unlock_account(address=self.account, password=password, duration=duration)
         self.__unlocked = unlocked
         return self.__unlocked
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -24,6 +24,7 @@ from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
 from hexbytes import HexBytes
 from umbral import pre
 from umbral.keys import UmbralPublicKey, UmbralPrivateKey, UmbralKeyingMaterial
+from web3 import Web3
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.keystore import keypairs
@@ -117,34 +118,39 @@ class TransactingPower(CryptoPowerUp):
                  account: str,
                  provider_uri: str = None,
                  password: str = None,
-                 cache: bool = False,):
+                 cache: bool = False,
+                 keyfile: str = None):
         """
         Instantiates a TransactingPower for the given checksum_address.
         """
         self.blockchain = BlockchainInterfaceFactory.get_or_create_interface(provider_uri=provider_uri)
         self.__account = account
-
-        # TODO: Temporary fix for #1128 and #1385. It's ugly af, but it works. Move somewhere else?
-        try:
-            wallets = self.blockchain.client.wallets
-        except AttributeError:
-            is_from_hw_wallet = False
-        else:
-            HW_WALLET_URL_PREFIXES = ('trezor', 'ledger')
-            hw_accounts = [w['accounts'] for w in wallets if w['url'].startswith(HW_WALLET_URL_PREFIXES)]
-            hw_addresses = [to_checksum_address(account['address']) for sublist in hw_accounts for account in sublist]
-            is_from_hw_wallet = account in hw_addresses
-
-        self.device = is_from_hw_wallet
-
         self.__password = password
         self.__unlocked = False
         self.__activated = False
         self.__cache = cache
+        self.__key = None
+        self.__keyfile = keyfile
 
     @property
-    def is_unlocked(self) -> bool:
-        return self.__unlocked
+    def is_device(self):
+        if self.__keyfile is not None:
+            return False
+        try:
+            # TODO: Temporary fix for #1128 and #1385. It's ugly af, but it works. Move somewhere else?
+            wallets = self.blockchain.client.wallets
+        except AttributeError:
+            return False
+        else:
+            HW_WALLET_URL_PREFIXES = ('trezor', 'ledger')
+            hw_accounts = [w['accounts'] for w in wallets if w['url'].startswith(HW_WALLET_URL_PREFIXES)]
+            hw_addresses = [to_checksum_address(account['address']) for sublist in hw_accounts for account in sublist]
+            return self.__account in hw_addresses
+
+    @property
+    def is_local(self) -> bool:
+        """Returns True if this transacting power uses a local private key for signing."""
+        return self.__keyfile is not None
 
     @property
     def is_active(self) -> bool:
@@ -162,18 +168,43 @@ class TransactingPower(CryptoPowerUp):
             self.__password = None
         self.blockchain.transacting_power = self
 
-    def lock_account(self):
-        if self.device:
-            pass  # TODO: Force Disconnect Devices?
+    def __import_keyfile(self, password: str) -> bool:
+        """
+        Import geth formatted key file to the transacting power.
+        WARNING: Do not save the key or password anywhere, especially into a shared source file
+        """
+        try:
+            with open(self.__keyfile) as keyfile:
+                encrypted_key = keyfile.read()
+                private_key = self.blockchain.client.w3.eth.account.decrypt(encrypted_key, password)
+        except FileNotFoundError:
+            raise  # TODO
+        except Exception:
+            raise  # TODO
         else:
-            _result = self.blockchain.client.lock_account(address=self.account)
+            self.__key = private_key
+            return True
+
+    @property
+    def is_unlocked(self) -> bool:
+        return self.__unlocked
+
+    def lock_account(self):
+        if self.is_device:
+            pass  # TODO: Force Disconnect Devices?
+        elif self.is_local:
+            self.__key = None
+        else:
+            self.blockchain.client.lock_account(address=self.account)
         self.__unlocked = False
         return self.__unlocked
 
     def unlock_account(self, password: str = None, duration: int = None):
         password = password or self.__password
-        if self.device:
+        if self.is_device:
             unlocked = True
+        elif self.is_local:
+            unlocked = self.__import_keyfile(password=password)
         else:
             if self.blockchain.client is NO_BLOCKCHAIN_CONNECTION:
                 raise self.NoBlockchainConnection
@@ -196,7 +227,12 @@ class TransactingPower(CryptoPowerUp):
         """
         if not self.is_unlocked:
             raise self.AccountLocked("Failed to unlock account {}".format(self.account))
-        signed_raw_transaction = self.blockchain.client.sign_transaction(transaction=unsigned_transaction)
+        if self.is_local:
+            w3 = self.blockchain.w3
+            signed_transaction = w3.eth.account.sign_transaction(transaction_dict=unsigned_transaction, private_key=self.__key)
+            signed_raw_transaction = signed_transaction['rawTransaction']
+        else:
+            signed_raw_transaction = self.blockchain.client.sign_transaction(transaction=unsigned_transaction)
         return signed_raw_transaction
 
     def __enter__(self):


### PR DESCRIPTION
Basic clef support as external signer, see further scoping in #1630 

Give it a try:

0. If you dont already have an account, create one with the geth CLI:
```
$ geth account create --datadir <DATADIR>
```

1. Start an interactive Clef session using the geth keystore:
```
$ clef --keystore <DATADIR>/keystore --chainid 5 --advanced
...
```

2. Execute Staker Transactions:
```
$ nucypher stake restake --disable --network cassandra --provider <REMOTE URI> --signer ~/.clef/clef.ipc --hw-wallet
```

3. Interact with clef prompts while using nucypher (10 second timeout)