### PR TITLE
Bump version: 2.0.0-beta.2 → 2.0.0-beta.3

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0-beta.2
+current_version = 2.0.0-beta.3
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -620,12 +620,12 @@ jobs:
       - run:
           name: Build Docker Image
           command: |
-            docker build -f deploy/docker/Dockerfile --cache-from=nucypher -t nucypher/nucypher:$CIRCLE_TAG .
+            docker build -f deploy/docker/Dockerfile --cache-from=nucypher -t nucypher/nucypher:circle .
       - run:
           name: Save Docker Image Layer Cache
           command: |
             mkdir -p ~/docker
-            docker save -o ~/docker/nucypher.tar nucypher/nucypher:$CIRCLE_TAG
+            docker save -o ~/docker/nucypher.tar nucypher/nucypher:circle
       - save_cache:
           key: v1-{{ .Branch }}-{{ epoch }}
           paths:
@@ -719,7 +719,7 @@ jobs:
           name: Push Latest NuCypher Docker Image
           command: |
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-            docker nucypher:$CIRCLE_TAG nucypher/nucypher:experimental
+            docker tag nucypher:circle nucypher/nucypher:experimental
             docker push nucypher/nucypher:experimental
 
   publish_docker:
@@ -743,7 +743,8 @@ jobs:
           name: Push Tagged NuCypher Docker Images
           command: |
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-            docker tag nucypher:$CIRCLE_TAG nucypher/nucypher:latest
+            docker tag nucypher:circle nucypher/nucypher:$CIRCLE_TAG
+            docker tag nucypher:circle nucypher/nucypher:latest
             docker push nucypher/nucypher:$CIRCLE_TAG
             docker push nucypher/nucypher:latest
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -719,7 +719,7 @@ jobs:
           name: Push Latest NuCypher Docker Image
           command: |
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-            docker tag nucypher:circle nucypher/nucypher:experimental
+            docker tag nucypher/nucypher:circle nucypher/nucypher:experimental
             docker push nucypher/nucypher:experimental
 
   publish_docker:
@@ -743,8 +743,8 @@ jobs:
           name: Push Tagged NuCypher Docker Images
           command: |
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-            docker tag nucypher:circle nucypher/nucypher:$CIRCLE_TAG
-            docker tag nucypher:circle nucypher/nucypher:latest
+            docker tag nucypher/nucypher:circle nucypher/nucypher:$CIRCLE_TAG
+            docker tag nucypher/nucypher:circle nucypher/nucypher:latest
             docker push nucypher/nucypher:$CIRCLE_TAG
             docker push nucypher/nucypher:latest
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.0.0-beta.2'
+release = '2.0.0-beta.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "2.0.0-beta.2"
+__version__ = "2.0.0-beta.3"
 
 __author__ = "NuCypher"
 


### PR DESCRIPTION
Publication Build: https://circleci.com/workflow-run/24ef6d50-a454-48be-a3c8-d30c867132e3

(Manually completed failed docker steps over SSH and followed up with a hot-commit)