### PR TITLE
Fixes to `nucypher worklock`

### DIFF
--- a/docs/source/guides/worklock_guide.rst
+++ b/docs/source/guides/worklock_guide.rst
@@ -28,14 +28,14 @@ Replace ``<YOUR PROVIDER URI>`` with a valid node web3 node provider string, for
 Show current WorkLock information
 ---------------------------------
 
-You can obtain information of current state of WorkLock by running:
+You can obtain information about the current state of WorkLock by running:
 
 .. code::
 
     (nucypher)$ nucypher worklock status --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
 
 
-If you want to see detailed information of your current bid, you can also introduce your bidder address with the ``--bidder-address`` flag:
+If you want to see detailed information about your current bid, you can specify your bidder address with the ``--bidder-address`` flag:
 
 .. code::
 
@@ -72,7 +72,7 @@ If your bid was successful, you can claim your tokens as a stake in NuCypher:
     (nucypher)$ nucypher worklock claim --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
 
 
-Once claimed, you can check that the stake was created correctly by running:
+Once claimed, you can check that the stake was created successfully by running:
 
 .. code::
 

--- a/docs/source/guides/worklock_guide.rst
+++ b/docs/source/guides/worklock_guide.rst
@@ -1,0 +1,62 @@
+=======================
+NuCypher WorkLock Guide
+=======================
+
+Overview
+--------
+
+TODO
+
+To better understand the commands and their options, use the ``--help`` option.
+
+Common CLI flags
+----------------
+
+All ``nucypher worklock`` commands share a similar structure:
+
+.. code::
+
+    (nucypher)$ nucypher worklock <ACTION> [OPTIONS] --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
+
+TODO
+
+Replace ``<YOUR PROVIDER URI>`` with a valid node web3 node provider string, for example:
+
+    - ``ipc:///home/ubuntu/.ethereum/goerli/geth.ipc`` - Geth Node on Görli testnet running under user ``ubuntu`` (most probably that's what you need).
+
+
+Show current WorkLock information
+---------------------------------
+
+You can obtain information of current state of WorkLock by running:
+
+.. code::
+
+    (nucypher)$ nucypher worklock status --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
+
+
+If you want to see detailed information of your current bid, you can also introduce your bidder address with the ``--bidder-address`` flag:
+
+.. code::
+
+    (nucypher)$ nucypher worklock status --bidder-address <YOUR BIDDER ADDRESS> --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
+
+
+Place a bid
+-----------
+
+You can place a bid to WorkLock by running:
+
+.. code::
+
+    (nucypher)$ nucypher worklock bid --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
+
+
+Cancel a bid
+------------
+
+You can cancel a bid to WorkLock by running:
+
+.. code::
+
+    (nucypher)$ nucypher worklock cancel-bid --network <NETWORK> --provider <YOUR PROVIDER URI> --poa

--- a/docs/source/guides/worklock_guide.rst
+++ b/docs/source/guides/worklock_guide.rst
@@ -60,3 +60,20 @@ You can cancel a bid to WorkLock by running:
 .. code::
 
     (nucypher)$ nucypher worklock cancel-bid --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
+
+
+Claim your stake
+----------------
+
+If your bid was successful, you can claim your tokens as a stake in NuCypher:
+
+.. code::
+
+    (nucypher)$ nucypher worklock claim --network <NETWORK> --provider <YOUR PROVIDER URI> --poa
+
+
+Once claimed, you can check that the stake was created correctly by running:
+
+.. code::
+
+    (nucypher)$ nucypher status stakers --staking-address <YOUR BIDDER ADDRESS> --network {network} --provider <YOUR PROVIDER URI> --poa

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -127,6 +127,7 @@ Whitepapers
    guides/staking_guide
    guides/ursula_configuration_guide
    guides/cli_guide
+   guides/worklock_guide
    guides/character_control_guide
    guides/contribution_guide
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1519,6 +1519,7 @@ class Bidder(NucypherTokenActor):
     class BidingIsClosed(BidderError):
         pass
 
+    @validate_checksum_address
     def __init__(self, checksum_address: str, client_password: str = None, *args, **kwargs):
         super().__init__(checksum_address=checksum_address, *args, **kwargs)
         self.worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=self.registry)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1519,11 +1519,15 @@ class Bidder(NucypherTokenActor):
     class BidingIsClosed(BidderError):
         pass
 
-    def __init__(self, checksum_address: str, *args, **kwargs):
+    def __init__(self, checksum_address: str, client_password: str = None, *args, **kwargs):
         super().__init__(checksum_address=checksum_address, *args, **kwargs)
         self.worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=self.registry)
         self.staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=self.registry)
         self.economics = EconomicsFactory.get_economics(registry=self.registry)
+
+        if client_password:
+            self.transacting_power = TransactingPower(password=client_password, account=checksum_address)
+            self.transacting_power.activate()
 
     def _ensure_bidding_is_open(self) -> None:
         highest_block = self.worklock_agent.blockchain.w3.eth.getBlock('latest')

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -644,7 +644,7 @@ class PolicyManagerAgent(EthereumContractAgent):
                                                                  node_addresses)
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                    payload=payload,
-                                                   sender_address=author_address)
+                                                   sender_address=author_address)  # TODO: Gas management - #842
         return receipt
 
     def fetch_policy(self, policy_id: str) -> list:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -989,7 +989,6 @@ class WorkLockAgent(EthereumContractAgent):
         """
         contract_function = self.contract.functions.claim()
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
-
         return receipt
 
     @validate_checksum_address

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -59,6 +59,8 @@ from nucypher.blockchain.eth.providers import (
 )
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
+from nucypher.blockchain.eth.utils import prettify_eth_amount
+
 
 Web3Providers = Union[IPCProvider, WebsocketProvider, HTTPProvider, EthereumTester]
 
@@ -372,6 +374,7 @@ class BlockchainInterface:
 
         payload_pprint = dict(payload)
         payload_pprint['from'] = to_checksum_address(payload['from'])
+        payload_pprint.update({f: prettify_eth_amount(v) for f, v in payload.items() if f in ('gasPrice', 'value')})
         payload_pprint = ', '.join("{}: {}".format(k, v) for k, v in payload_pprint.items())
         self.log.debug(f"[TX-{transaction_name}] | {payload_pprint}")
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -84,6 +84,7 @@ class Alice(Character, BlockchainPolicyAuthor):
                  # Ownership
                  checksum_address: str = None,
                  client_password: str = None,
+                 cache_password: bool = False,
 
                  # Ursulas
                  m: int = None,
@@ -124,7 +125,8 @@ class Alice(Character, BlockchainPolicyAuthor):
         if is_me and not federated_only:  # TODO: #289
             transacting_power = TransactingPower(account=self.checksum_address,
                                                  password=client_password,
-                                                 provider_uri=self.provider_uri)
+                                                 provider_uri=self.provider_uri,
+                                                 cache=cache_password)
             self._crypto_power.consume_power_up(transacting_power)
             BlockchainPolicyAuthor.__init__(self,
                                             registry=self.registry,

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -403,6 +403,7 @@ def select_client_account(emitter,
     """
     Note: Setting show_balances to True, causes an eager contract and blockchain connection.
     """
+    # TODO: Break show_balances into show_eth_balance and show_token_balance
 
     if not provider_uri:
         raise ValueError("Provider URI must be provided to select a wallet account.")
@@ -416,7 +417,7 @@ def select_client_account(emitter,
     token_agent = None
     if show_balances or show_staking:
         if not registry:
-            registry = InMemoryContractRegistry.from_latest_publication(network)
+            registry = InMemoryContractRegistry.from_latest_publication(network=network)
         token_agent = NucypherTokenAgent(registry=registry)
 
     # Real wallet accounts

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -326,7 +326,6 @@ def make_cli_character(character_config,
     # Handle Keyring
 
     if unlock_keyring:
-        character_config.attach_keyring()
         unlock_nucypher_keyring(emitter,
                                 character_configuration=character_config,
                                 password=get_nucypher_password(confirm=False))

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -449,7 +449,7 @@ def select_client_account(emitter,
     emitter.echo(tabulate(rows, headers=headers, showindex='always'))
 
     # Prompt the user for selection, and return
-    prompt = prompt or "Select Account"
+    prompt = prompt or "Select index of account"
     account_range = click.IntRange(min=0, max=len(enumerated_accounts)-1)
     choice = click.prompt(prompt, type=account_range, default=default)
     chosen_account = enumerated_accounts[choice]
@@ -485,7 +485,7 @@ def handle_client_account_for_staking(emitter,
         if staking_address:
             client_account = staking_address
         else:
-            client_account = select_client_account(prompt="Select staking account",
+            client_account = select_client_account(prompt="Select index of staking account",
                                                    emitter=emitter,
                                                    registry=stakeholder.registry,
                                                    network=stakeholder.network,

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -454,7 +454,7 @@ def select_client_account(emitter,
     choice = click.prompt(prompt, type=account_range, default=default)
     chosen_account = enumerated_accounts[choice]
 
-    emitter.echo(f"Selected {choice}:{chosen_account}", color='blue')
+    emitter.echo(f"Selected {choice}: {chosen_account}", color='blue')
     return chosen_account
 
 

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -187,7 +187,12 @@ def claim(general_config, worklock_options, registry_options, force):
     emitter = _setup_emitter(general_config)
     if not worklock_options.bidder_address:
         worklock_options.bidder_address = select_client_account(emitter=emitter,
-                                                                provider_uri=general_config.provider_uri)
+                                                                provider_uri=registry_options.provider_uri,
+                                                                network=registry_options.network,
+                                                                show_balances=True)
+
+    # TODO: Show amount of tokens to claim
+
     if not force:
         emitter.echo("Note: Claiming WorkLock NU tokens will initialize a new stake.", color='blue')
         click.confirm(f"Continue worklock claim for bidder {worklock_options.bidder_address}?", abort=True)
@@ -196,7 +201,10 @@ def claim(general_config, worklock_options, registry_options, force):
     bidder = worklock_options.create_bidder(registry=registry)
     receipt = bidder.claim()
     paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=bidder.staking_agent.blockchain.client.chain_name)
-    paint_worklock_claim(emitter, bidder_address=worklock_options.bidder_address)
+    paint_worklock_claim(emitter=emitter,
+                         bidder_address=worklock_options.bidder_address,
+                         network=registry_options.network,
+                         provider_uri=registry_options.provider_uri)
     return  # Exit
 
 
@@ -207,7 +215,10 @@ def claim(general_config, worklock_options, registry_options, force):
 def remaining_work(general_config, worklock_options, registry_options):
     emitter = _setup_emitter(general_config)
     if not worklock_options.bidder_address:
-        worklock_options.bidder_address = select_client_account(emitter=emitter, provider_uri=general_config.provider_uri)
+        worklock_options.bidder_address = select_client_account(emitter=emitter,
+                                                                provider_uri=registry_options.provider_uri,
+                                                                network=registry_options.network,
+                                                                show_balances=True)
     registry = registry_options.get_registry(emitter, general_config.debug)
     bidder = worklock_options.create_bidder(registry=registry)
     _remaining_work = bidder.remaining_work
@@ -223,7 +234,10 @@ def remaining_work(general_config, worklock_options, registry_options):
 def refund(general_config, worklock_options, registry_options, force):
     emitter = _setup_emitter(general_config)
     if not worklock_options.bidder_address:
-        worklock_options.bidder_address = select_client_account(emitter=emitter, provider_uri=general_config.provider_uri)
+        worklock_options.bidder_address = select_client_account(emitter=emitter,
+                                                                provider_uri=registry_options.provider_uri,
+                                                                network=registry_options.network,
+                                                                show_balances=True)
     if not force:
         click.confirm(f"Collect ETH refund for bidder {worklock_options.bidder_address}?", abort=True)
     emitter.message("Submitting WorkLock refund request...")
@@ -243,7 +257,10 @@ def burn_unclaimed_tokens(general_config, registry_options, checksum_address):
     registry = registry_options.get_registry(emitter, general_config.debug)
     worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=registry)
     if not checksum_address:
-        checksum_address = select_client_account(emitter=emitter, provider_uri=general_config.provider_uri)
+        checksum_address = select_client_account(emitter=emitter,
+                                                 provider_uri=registry_options.provider_uri,
+                                                 network=registry_options.network,
+                                                 show_balances=True)
     receipt = worklock_agent.burn_unclaimed(sender_address=checksum_address)
     paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=worklock_agent.blockchain.client.chain_name)
     return  # Exit

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -165,7 +165,7 @@ def claim(general_config, worklock_options, registry_options, force):
         worklock_options.bidder_address = select_client_account(emitter=emitter,
                                                                 provider_uri=general_config.provider_uri)
     if not force:
-        emitter.message("Note: Claiming WorkLock NU tokens will initialize a new stake.", color='blue')
+        emitter.echo("Note: Claiming WorkLock NU tokens will initialize a new stake.", color='blue')
         click.confirm(f"Continue worklock claim for bidder {worklock_options.bidder_address}?", abort=True)
     emitter.message("Submitting Claim...")
     registry = registry_options.get_registry(emitter, general_config.debug)
@@ -187,7 +187,7 @@ def remaining_work(general_config, worklock_options, registry_options):
     registry = registry_options.get_registry(emitter, general_config.debug)
     bidder = worklock_options.create_bidder(registry=registry)
     _remaining_work = bidder.remaining_work
-    emitter.message(f"Work Remaining for {worklock_options.bidder_address}: {_remaining_work}")
+    emitter.echo(f"Work Remaining for {worklock_options.bidder_address}: {_remaining_work}")
     return  # Exit
 
 

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -55,8 +55,8 @@ class WorkLockOptions:
     def __init__(self, bidder_address: str):
         self.bidder_address = bidder_address
 
-    def create_bidder(self, registry):
-        bidder = Bidder(checksum_address=self.bidder_address, registry=registry)
+    def create_bidder(self, registry, password=None):
+        bidder = Bidder(checksum_address=self.bidder_address, registry=registry, client_password=password)
         return bidder
 
 

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -89,6 +89,8 @@ def worklock():
 @group_worklock_options
 @group_general_config
 def status(general_config, registry_options, worklock_options):
+    """Show current WorkLock information"""
+
     emitter = _setup_emitter(general_config)
     registry = registry_options.get_registry(emitter, general_config.debug)
     paint_worklock_status(emitter=emitter, registry=registry)
@@ -107,6 +109,7 @@ def status(general_config, registry_options, worklock_options):
 @click.option('--value', help="ETH value of bid", type=click.STRING)
 def bid(general_config, worklock_options, registry_options,
         force, hw_wallet, value):
+    """Place a bid"""
     emitter = _setup_emitter(general_config)
 
     if not worklock_options.bidder_address:
@@ -155,6 +158,7 @@ def bid(general_config, worklock_options, registry_options,
 @option_force
 @option_hw_wallet
 def cancel_bid(general_config, registry_options, worklock_options, force, hw_wallet):
+    """Cancel your bid"""
     emitter = _setup_emitter(general_config)
     if not worklock_options.bidder_address:  # TODO: Consider bundle this in worklock_options
         worklock_options.bidder_address = select_client_account(emitter=emitter,
@@ -179,6 +183,7 @@ def cancel_bid(general_config, registry_options, worklock_options, force, hw_wal
 @group_worklock_options
 @group_general_config
 def claim(general_config, worklock_options, registry_options, force):
+    """Claim tokens for a successful bid, and start staking them"""
     emitter = _setup_emitter(general_config)
     if not worklock_options.bidder_address:
         worklock_options.bidder_address = select_client_account(emitter=emitter,

--- a/nucypher/cli/main.py
+++ b/nucypher/cli/main.py
@@ -19,7 +19,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import click
 
-from nucypher.cli.commands import ursula, alice, bob, enrico, felix, stake, status
+from nucypher.cli.commands import ursula, alice, bob, enrico, felix, stake, status, worklock
 from nucypher.cli.painting import echo_version
 
 
@@ -66,7 +66,8 @@ ENTRY_POINTS = (
     enrico.enrico,  # Encryptor of Data
     stake.stake,  # Stake Management
     ursula.ursula,  # Untrusted Re-Encryption Proxy
-    felix.felix     # Faucet
+    felix.felix,    # Faucet
+    worklock.worklock  # WorkLock
 )
 
 for entry_point in ENTRY_POINTS:

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -902,20 +902,25 @@ Accept WorkLock terms and node operator obligation?"""  # TODO: Show a special m
     return
 
 
-def paint_worklock_claim(emitter, bidder_address: str):
+def paint_worklock_claim(emitter, bidder_address: str, network: str, provider_uri: str):
     message = f"""
 
 Successfully claimed WorkLock tokens for {bidder_address}.
 
+You can check that the stake was created correctly by running:
+
+  nucypher status stakers --staking-address {bidder_address} --network {network} --provider {provider_uri}
+
 Next Steps for Worklock Winners
 ===============================
 
-See the official nucypher documentation for a comprehensive guide!
+Congratulations! You're officially a Staker in the NuCypher network.
 
-Create a stake with your allocation contract: 
-'nucypher stake create --provider <URI> --staking-address {bidder_address}'
+See the official NuCypher documentation for a comprehensive guide on next steps!
 
-Bond a worker to your stake: 'nucypher stake set-worker --worker-address <WORKER ADDRESS>'
+As a first step, you need to bond a worker to your stake by running:
+
+  nucypher stake set-worker --worker-address <WORKER ADDRESS>
 
 """
     emitter.echo(message, color='green')

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -41,7 +41,7 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainIn
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.sol import SOLIDITY_COMPILER_VERSION
 from nucypher.blockchain.eth.token import NU
-from nucypher.blockchain.eth.utils import datetime_at_period, etherscan_url
+from nucypher.blockchain.eth.utils import datetime_at_period, etherscan_url, prettify_eth_amount
 from nucypher.characters.banners import NUCYPHER_BANNER, NU_BANNER
 from nucypher.config.constants import SEEDNODES
 from nucypher.network.nicknames import nickname_from_seed
@@ -880,12 +880,12 @@ def paint_bidding_notice(emitter, bidder):
 
 - WorkLock token rewards are claimed in the form of a stake and will be locked for the stake duration.
 
-- WorkLock ETH deposits will be available for refund at a rate of {bidder.worklock_agent.economics.worklock_refund_rate} 
-  wei per confirmed period - This rate will become frozen on {maya.MayaDT(bidder.worklock_agent.end_date).local_datetime()}.
+- WorkLock ETH deposits will be available for refund at a rate of {prettify_eth_amount(bidder.worklock_agent.get_refund_rate())} 
+  per confirmed period. This rate will become frozen on {maya.MayaDT(bidder.economics.bidding_end_date).local_datetime()}.
 
 - Once claiming WorkLock tokens, you are obligated to maintain a networked
-  and available Ursula-Worker node bonded to the staker address {bidder.checksum_address} for the duration 
-  of the stake(s) ({bidder.worklock_agent.economics.worklock_commitment_duration} periods).
+  and available Ursula-Worker node bonded to the staker address {bidder.checksum_address} for the duration
+  of the stake(s) ({bidder.economics.worklock_commitment_duration} periods).
 
 - Allow NuCypher network users to carry out uninterrupted re-encryption
   work orders at-will without interference. Failure to keep your node online, 
@@ -896,7 +896,7 @@ def paint_bidding_notice(emitter, bidder):
   producing correct re-encryption work orders will result in rewards
   paid out in ethers retro-actively and on-demand.
 
-Accept worklock terms and node operator obligation?"""
+Accept WorkLock terms and node operator obligation?"""  # TODO: Show a special message for first bidder, since there's no refund rate yet?
 
     emitter.echo(obligation)
     return

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -255,7 +255,7 @@ Registry  ................ {registry.filepath}
 
     try:
         token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=registry)
-        token_contract_info = """
+        token_contract_info = f"""
 
 {token_agent.contract_name} ........... {token_agent.contract_address}
     ~ Ethers ............ {Web3.fromWei(blockchain.client.get_balance(token_agent.contract_address), 'ether')} ETH

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -851,7 +851,7 @@ Slowing Refund .... {worklock_agent.contract.functions.SLOWING_REFUND().call()}
 Refund Rate ....... {worklock_agent.get_refund_rate()}
 Deposit Rate ...... {worklock_agent.get_deposit_rate()}
     """
-    emitter.message(payload)
+    emitter.echo(payload)
     return
 
 
@@ -865,7 +865,7 @@ Completed Work ....... {bidder.completed_work}
 Remaining Work ....... {bidder.remaining_work}
 Refunded Work ........ {bidder.refunded_work}
 """
-    emitter.message(message)
+    emitter.echo(message)
     return
 
 
@@ -898,7 +898,7 @@ def paint_bidding_notice(emitter, bidder):
 
 Accept worklock terms and node operator obligation?"""
 
-    emitter.message(obligation)
+    emitter.echo(obligation)
     return
 
 
@@ -918,4 +918,4 @@ Create a stake with your allocation contract:
 Bond a worker to your stake: 'nucypher stake set-worker --worker-address <WORKER ADDRESS>'
 
 """
-    emitter.message(message, color='green')
+    emitter.echo(message, color='green')

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -27,7 +27,10 @@ class ChecksumAddress(click.ParamType):
     name = 'checksum_address'
 
     def convert(self, value, param, ctx):
-        return to_checksum_address(value=value)  # TODO: More robust validation here?
+        try:
+            return to_checksum_address(value=value)
+        except ValueError as e:
+            self.fail(str(e))
 
 
 class IPv4Address(click.ParamType):

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -121,7 +121,6 @@ class NodeStorage(ABC):
             public_pem_bytes = certificate.public_bytes(self.TLS_CERTIFICATE_ENCODING)
             certificate_file.write(public_pem_bytes)
 
-        self.certificate_filepath = certificate_filepath
         self.log.debug(f"Saved TLS certificate for {checksum_address}: {certificate_filepath}")
 
         return certificate_filepath
@@ -225,8 +224,7 @@ class ForgetfulNodeStorage(NodeStorage):
     def store_node_certificate(self, certificate: Certificate):
         checksum_address = read_certificate_pseudonym(certificate=certificate)
         self.__certificates[checksum_address] = certificate
-        self._write_tls_certificate(certificate=certificate)
-        filepath = self.generate_certificate_filepath(checksum_address=checksum_address)
+        filepath = self._write_tls_certificate(certificate=certificate)
         return filepath
 
     def store_node_metadata(self, node, filepath: str = None):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1017,6 +1017,7 @@ class Teacher:
         This is the most mature form, so we do nothing.
         """
 
+    # TODO: Unused method. Remove?
     def save_cert_for_this_stranger_node(stranger, certificate):
         return stranger._cert_store_function(certificate)
 

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -343,6 +343,9 @@ class Policy(ABC):
         Assign kfrags to ursulas_on_network, and distribute them via REST,
         populating enacted_arrangements
         """
+        # TODO: #121 - Consider tweaking the order of the enactment steps:
+        # first create the policy on chain and then send the kfrags together with the TX receipt
+
         for arrangement in self.__assign_kfrags():
             policy_message_kit = arrangement.encrypt_payload_for_ursula()
 
@@ -626,7 +629,7 @@ class BlockchainPolicy(Policy):
 
         prearranged_ursulas = list(a.ursula.checksum_address for a in self._accepted_arrangements)
 
-        # Transact
+        # Transact  # TODO: Move this logic to BlockchainPolicyActor
         receipt = self.author.policy_agent.create_policy(
                        policy_id=self.hrac()[:16],          # bytes16 _policyID
                        author_address=self.author.checksum_address,

--- a/nucypher/utilities/sandbox/policy.py
+++ b/nucypher/utilities/sandbox/policy.py
@@ -58,7 +58,7 @@ class MockPolicy(Policy):
                                       ursula=ursula,
                                       arrangement=arrangement)
 
-
+# TODO: Remove. Seems unused
 class MockPolicyCreation:
     """
     Simple mock logic to avoid repeated hammering of blockchain policies.

--- a/tests/cli/test_felix.py
+++ b/tests/cli/test_felix.py
@@ -59,13 +59,7 @@ def test_run_felix(click_runner, testerchain, agency_local_registry, deploy_user
                  '--provider', TEST_PROVIDER_URI)
     _original_read_function = LocalContractRegistry.read
 
-    try:
-        # Mock live contract registry reads
-        LocalContractRegistry.read = lambda *a, **kw: test_registry.read()
-        result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False, env=envvars)
-    finally:
-        # Restore original read function.
-        LocalContractRegistry.read = _original_read_function
+    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False, env=envvars)
     assert result.exit_code == 0
 
     configuration_file_location = os.path.join(MOCK_CUSTOM_INSTALLATION_PATH_2, FelixConfiguration.generate_filename())

--- a/tests/cli/test_worklock_cli.py
+++ b/tests/cli/test_worklock_cli.py
@@ -23,24 +23,27 @@ from nucypher.blockchain.eth.agents import (
     ContractAgency,
     WorkLockAgent
 )
+from nucypher.blockchain.eth.token import NU
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.commands.worklock import worklock
 from nucypher.utilities.sandbox.constants import (
+    INSECURE_DEVELOPMENT_PASSWORD,
     TEST_PROVIDER_URI,
     MOCK_IP_ADDRESS,
     select_test_port
 )
 
 
-def test_status(click_runner, testerchain, agency_local_registry):
+def test_status(click_runner, testerchain, agency_local_registry, token_economics):
     command = ('status',
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
-               '--poa',
-               '--debug')
+               '--poa',)
 
     result = click_runner.invoke(worklock, command, catch_exceptions=False)
+
     assert result.exit_code == 0
+    assert f"Lot Size .......... {NU.from_nunits(token_economics.worklock_supply)}" in result.output
 
 
 def test_bid(click_runner, testerchain, agency_local_registry, token_economics):
@@ -48,13 +51,12 @@ def test_bid(click_runner, testerchain, agency_local_registry, token_economics):
     # Wait until biding window starts
     testerchain.time_travel(seconds=90)
 
-    bid_value = to_wei(4, 'ether')
+    bid_eth_value = 4
     base_command = ('bid',
-                    '--value', bid_value,
+                    '--value', bid_eth_value,
                     '--registry-filepath', agency_local_registry.filepath,
                     '--provider', TEST_PROVIDER_URI,
                     '--poa',
-                    '--debug',
                     '--force')
 
     worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=agency_local_registry)
@@ -62,16 +64,18 @@ def test_bid(click_runner, testerchain, agency_local_registry, token_economics):
     # Multiple bidders
     for bidder in testerchain.unassigned_accounts[:3]:
         pre_bid_balance = testerchain.client.get_balance(bidder)
+        assert pre_bid_balance > to_wei(bid_eth_value, 'ether')
 
         command = (*base_command, '--bidder-address', bidder)
-        result = click_runner.invoke(worklock, command, catch_exceptions=False)
+        user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + 'Y\n'
+        result = click_runner.invoke(worklock, command, input=user_input, catch_exceptions=False)
         assert result.exit_code == 0
 
         post_bid_balance = testerchain.client.get_balance(bidder)
         difference = pre_bid_balance - post_bid_balance
-        assert difference >= bid_value
+        assert difference >= to_wei(bid_eth_value, 'ether')
 
-        total_bids += bid_value
+        total_bids += to_wei(bid_eth_value, 'ether')
         assert testerchain.client.get_balance(worklock_agent.contract_address) == total_bids
 
 
@@ -84,10 +88,10 @@ def test_cancel_bid(click_runner, testerchain, agency_local_registry, token_econ
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--poa',
-               '--force',
-               '--debug')
+               '--force')
 
-    result = click_runner.invoke(worklock, command, catch_exceptions=False)
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + 'Y\n'
+    result = click_runner.invoke(worklock, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
     assert not agent.get_deposited_eth(bidder)    # No more bid
 
@@ -105,8 +109,11 @@ def test_claim(click_runner, testerchain, agency_local_registry, token_economics
                '--poa',
                '--force')
 
-    result = click_runner.invoke(worklock, command, catch_exceptions=False)
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + 'Y\n'
+    result = click_runner.invoke(worklock, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
+
+    # TODO: Check successful new stake in StakingEscrow
 
 
 def test_remaining_work(click_runner, testerchain, agency_local_registry, token_economics):
@@ -121,8 +128,7 @@ def test_remaining_work(click_runner, testerchain, agency_local_registry, token_
                '--bidder-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
-               '--poa',
-               '--debug')
+               '--poa')
 
     result = click_runner.invoke(worklock, command, catch_exceptions=False)
     assert result.exit_code == 0
@@ -170,10 +176,10 @@ def test_refund(click_runner, testerchain, agency_local_registry, token_economic
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--poa',
-               '--debug',
                '--force')
 
-    result = click_runner.invoke(worklock, command, catch_exceptions=False)
+    user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + 'Y\n'
+    result = click_runner.invoke(worklock, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
     # Less work to do...
@@ -188,8 +194,7 @@ def test_participant_status(click_runner, testerchain, agency_local_registry, to
                '--registry-filepath', agency_local_registry.filepath,
                '--bidder-address', bidder.checksum_address,
                '--provider', TEST_PROVIDER_URI,
-               '--poa',
-               '--debug')
+               '--poa')
 
     result = click_runner.invoke(worklock, command, catch_exceptions=False)
     assert result.exit_code == 0
@@ -216,8 +221,7 @@ def test_burn_unclaimed_tokens(click_runner, testerchain, agency_local_registry)
                '--registry-filepath', agency_local_registry,
                '--checksum-address', philanthropist,
                '--provider', TEST_PROVIDER_URI,
-               '--poa',
-               '--debug')
+               '--poa')
 
     worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=agency_local_registry)
 

--- a/tests/cli/test_worklock_cli.py
+++ b/tests/cli/test_worklock_cli.py
@@ -34,7 +34,7 @@ from nucypher.utilities.sandbox.constants import (
 )
 
 
-def test_status(click_runner, testerchain, agency_local_registry, token_economics):
+def test_status(click_runner, testerchain, agency_local_registry):
     command = ('status',
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
@@ -43,7 +43,7 @@ def test_status(click_runner, testerchain, agency_local_registry, token_economic
     result = click_runner.invoke(worklock, command, catch_exceptions=False)
 
     assert result.exit_code == 0
-    assert f"Lot Size .......... {NU.from_nunits(token_economics.worklock_supply)}" in result.output
+    assert f"Lot Size .......... {NU.from_tokens(1_000_000)}" in result.output  # TODO: Amount hard-coded in token economics fixture
 
 
 def test_bid(click_runner, testerchain, agency_local_registry, token_economics):


### PR DESCRIPTION
* Makes `nucypher worklock` operative, since it had a series of minor bugs. 
  * Successful `bid`, `cancel-bid` and `claim`
* Skeleton of WorkLock guide in the docs
* Added several TODOs throughout the codebase
* Some janitorial work here and there

Other:
* Fixes #1660 
* Fixes #1647
* Really closes #1346