### PR TITLE
Fixes bug in PolicyManager #1671

### DIFF
--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -261,13 +261,13 @@ contract PolicyManager is Upgradeable {
             return;
         }
         for (uint16 i = node.lastMinedPeriod + 1; i <= _period; i++) {
-            if (node.rewardDelta[i] == DEFAULT_REWARD_DELTA) {
+            int256 delta = node.rewardDelta[i];
+            if (delta == DEFAULT_REWARD_DELTA) {
                 // gas refund
                 node.rewardDelta[i] = 0;
                 continue;
             }
 
-            int256 delta = node.rewardDelta[i];
             // broken state
             if (delta < 0 && uint256(-delta) > node.rewardRate) {
                 node.rewardDelta[i] += int256(node.rewardRate);

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -14,7 +14,7 @@ import "contracts/proxy/Upgradeable.sol";
 
 /**
 * @notice Contract holds policy data and locks fees
-* @dev |v2.1.1|
+* @dev |v2.1.2|
 */
 contract PolicyManager is Upgradeable {
     using SafeERC20 for NuCypherToken;
@@ -137,7 +137,7 @@ contract PolicyManager is Upgradeable {
     */
     function register(address _node, uint16 _period) external onlyEscrowContract {
         NodeInfo storage nodeInfo = nodes[_node];
-        require(nodeInfo.lastMinedPeriod == 0);
+        require(nodeInfo.lastMinedPeriod == 0 && _period < getCurrentPeriod());
         nodeInfo.lastMinedPeriod = _period;
     }
 
@@ -189,7 +189,9 @@ contract PolicyManager is Upgradeable {
             address node = _nodes[i];
             require(node != RESERVED_NODE);
             NodeInfo storage nodeInfo = nodes[node];
-            require(nodeInfo.lastMinedPeriod != 0 && policy.rewardRate >= nodeInfo.minRewardRate);
+            require(nodeInfo.lastMinedPeriod != 0 &&
+                nodeInfo.lastMinedPeriod < currentPeriod &&
+                policy.rewardRate >= nodeInfo.minRewardRate);
             // Check default value for rewardDelta
             if (nodeInfo.rewardDelta[currentPeriod] == DEFAULT_REWARD_DELTA) {
                 nodeInfo.rewardDelta[currentPeriod] = int256(policy.rewardRate);

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -34,7 +34,7 @@ contract WorkLockInterface {
 /**
 * @notice Contract holds and locks stakers tokens.
 * Each staker that locks their tokens will receive some compensation
-* @dev |v2.2.1|
+* @dev |v2.2.2|
 */
 contract StakingEscrow is Issuer {
     using AdditionalMath for uint256;
@@ -583,7 +583,7 @@ contract StakingEscrow is Issuer {
         // initial stake of the staker
         if (info.subStakes.length == 0) {
             stakers.push(_staker);
-            policyManager.register(_staker, getCurrentPeriod());
+            policyManager.register(_staker, getCurrentPeriod() - 1);
         }
         token.safeTransferFrom(_payer, address(this), _value);
         info.value += _value;

--- a/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
@@ -151,3 +151,18 @@ contract StakingEscrowForPolicyMock {
     }
 
 }
+
+
+/**
+* @notice Helper to prepare broken state
+*/
+contract ExtendedPolicyManager is PolicyManager {
+
+    constructor(StakingEscrow _escrow) public PolicyManager(_escrow) {
+    }
+
+    function setNodeRewardDelta(address _node, uint16 _period, int256 _value) external {
+        NodeInfo storage node = nodes[_node];
+        node.rewardDelta[_period] = _value;
+    }
+}

--- a/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
@@ -128,8 +128,12 @@ contract StakingEscrowForPolicyMock {
         return lastActivePeriod;
     }
 
+    function register(address _node, uint16 _period) public {
+        policyManager.register(_node, _period);
+    }
+
     function register(address _node) external {
-        policyManager.register(_node, getCurrentPeriod() - 1);
+        register(_node, getCurrentPeriod() - 1);
     }
 
     function findIndexOfPastDowntime(address, uint16 _period) external view returns (uint256 index) {

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
@@ -61,6 +61,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
     arrangement_refund_log = policy_manager.events.RefundForArrangement.createFilter(fromBlock='latest')
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
+    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
 
     # Only past periods is allowed in register method
     current_period = policy_manager.functions.getCurrentPeriod().call()
@@ -404,6 +405,8 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     events = policy_refund_log.get_all_entries()
     assert 0 == len(events)
 
+    assert len(warn_log.get_all_entries()) == 0
+
 
 @pytest.mark.slow
 def test_upgrading(testerchain, deploy_contract):
@@ -502,3 +505,100 @@ def test_upgrading(testerchain, deploy_contract):
     event_args = events[2]['args']
     assert contract_library_v1.address == event_args['target']
     assert creator == event_args['sender']
+
+
+@pytest.mark.slow
+def test_handling_wrong_state(testerchain, deploy_contract):
+    creator, node1, node2, *everyone_else = testerchain.client.accounts
+
+    # Prepare enhanced version of contract
+    escrow, _ = deploy_contract('StakingEscrowForPolicyMock', 1)
+    policy_manager, _ = deploy_contract('ExtendedPolicyManager', escrow.address)
+    tx = escrow.functions.setPolicyManager(policy_manager.address).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+
+    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
+
+    current_period = policy_manager.functions.getCurrentPeriod().call()
+    initial_period = current_period - 1
+    tx = escrow.functions.register(node1, initial_period).transact()
+    testerchain.wait_for_receipt(tx)
+
+    # Prepare broken state, emulates creating policy in the same period as node was registered
+    number_of_periods = 2
+    tx = policy_manager.functions.setNodeRewardDelta(node1, initial_period, 1).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = policy_manager.functions.setNodeRewardDelta(node1, initial_period + number_of_periods, -1).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setDefaultRewardDelta(node1, current_period, 1).transact()
+    testerchain.wait_for_receipt(tx)
+
+    # Emulate confirm activity actions
+    for i in range(1, number_of_periods + 2):
+        testerchain.time_travel(hours=1)
+        current_period = policy_manager.functions.getCurrentPeriod().call()
+        tx = escrow.functions.setDefaultRewardDelta(node1, current_period + 1, 1).transact()
+        testerchain.wait_for_receipt(tx)
+        tx = escrow.functions.mint(current_period - 1, 1).transact({'from': node1})
+        testerchain.wait_for_receipt(tx)
+
+    reward, reward_rate, last_mined_period, _min_reward_rate = policy_manager.functions.nodes(node1).call()
+    assert reward == 0
+    assert reward_rate == 0
+    assert last_mined_period == current_period - 1
+    assert policy_manager.functions.getNodeRewardDelta(node1, initial_period).call() == 1
+    for i in range(1, number_of_periods):
+        assert policy_manager.functions.getNodeRewardDelta(node1, initial_period + i).call() == 0
+    assert policy_manager.functions.getNodeRewardDelta(node1, initial_period + number_of_periods).call() == -1
+
+    events = warn_log.get_all_entries()
+    assert 1 == len(events)
+    event_args = events[0]['args']
+    assert event_args['node'] == node1
+    assert event_args['period'] == initial_period + number_of_periods
+
+    # Same case but with more diverse values
+    current_period = policy_manager.functions.getCurrentPeriod().call()
+    initial_period = current_period - 1
+    tx = escrow.functions.register(node2, initial_period).transact()
+    testerchain.wait_for_receipt(tx)
+    number_of_periods = 5
+    tx = escrow.functions.setDefaultRewardDelta(node2, current_period, 1).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = policy_manager.functions.setNodeRewardDelta(node2, initial_period, 100).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = policy_manager.functions.setNodeRewardDelta(node2, initial_period + number_of_periods, -100).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = policy_manager.functions.setNodeRewardDelta(node2, initial_period + 2, 50).transact()
+    testerchain.wait_for_receipt(tx)
+    tx = policy_manager.functions.setNodeRewardDelta(node2, initial_period + 2 + number_of_periods, -50).transact()
+    testerchain.wait_for_receipt(tx)
+
+    # Emulate confirm activity actions
+    for i in range(1, number_of_periods + 4):
+        testerchain.time_travel(hours=1)
+        current_period = policy_manager.functions.getCurrentPeriod().call()
+        tx = escrow.functions.setDefaultRewardDelta(node2, current_period + 1, 1).transact()
+        testerchain.wait_for_receipt(tx)
+        tx = escrow.functions.mint(current_period - 1, 1).transact({'from': node2})
+        testerchain.wait_for_receipt(tx)
+
+    reward, reward_rate, last_mined_period, _min_reward_rate = policy_manager.functions.nodes(node2).call()
+    assert reward == 50 * (number_of_periods - 2)
+    assert reward_rate == 0
+    assert last_mined_period == current_period - 1
+    assert policy_manager.functions.getNodeRewardDelta(node2, initial_period).call() == 100
+    for i in range(1, number_of_periods - 2):
+        assert policy_manager.functions.getNodeRewardDelta(node2, initial_period + i).call() == 0
+    assert policy_manager.functions.getNodeRewardDelta(node2, initial_period + number_of_periods).call() == -50
+    assert policy_manager.functions.getNodeRewardDelta(node2, initial_period + number_of_periods + 1).call() == 0
+    assert policy_manager.functions.getNodeRewardDelta(node2, initial_period + number_of_periods + 2).call() == -50
+
+    events = warn_log.get_all_entries()
+    assert 3 == len(events)
+    event_args = events[1]['args']
+    assert event_args['node'] == node2
+    assert event_args['period'] == initial_period + number_of_periods
+    event_args = events[2]['args']
+    assert event_args['node'] == node2
+    assert event_args['period'] == initial_period + number_of_periods + 2

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
@@ -50,6 +50,7 @@ def test_reward(testerchain, escrow, policy_manager):
     creator, policy_sponsor, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
     node_balance = testerchain.client.get_balance(node1)
     withdraw_log = policy_manager.events.Withdrawn.createFilter(fromBlock='latest')
+    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
 
     # Mint period without policies
     period = escrow.functions.getCurrentPeriod().call()
@@ -163,6 +164,8 @@ def test_reward(testerchain, escrow, policy_manager):
     assert node1 == event_args['recipient']
     assert 200 == event_args['value']
 
+    assert len(warn_log.get_all_entries()) == 0
+
 
 @pytest.mark.slow
 def test_refund(testerchain, escrow, policy_manager):
@@ -174,6 +177,7 @@ def test_refund(testerchain, escrow, policy_manager):
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
     arrangement_refund_log = policy_manager.events.RefundForArrangement.createFilter(fromBlock='latest')
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
+    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
 
     # Create policy
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
@@ -543,6 +547,8 @@ def test_refund(testerchain, escrow, policy_manager):
     events = policy_created_log.get_all_entries()
     assert 4 == len(events)
 
+    assert len(warn_log.get_all_entries()) == 0
+
 
 @pytest.mark.slow
 def test_reentrancy(testerchain, escrow, policy_manager, deploy_contract):
@@ -551,6 +557,7 @@ def test_reentrancy(testerchain, escrow, policy_manager, deploy_contract):
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
     arrangement_refund_log = policy_manager.events.RefundForArrangement.createFilter(fromBlock='latest')
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
+    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
 
     reentrancy_contract, _ = deploy_contract('ReentrancyTest')
     contract_address = reentrancy_contract.address
@@ -611,3 +618,5 @@ def test_reentrancy(testerchain, escrow, policy_manager, deploy_contract):
     assert 0 == len(policy_revoked_log.get_all_entries())
     assert 0 == len(arrangement_refund_log.get_all_entries())
     assert 0 == len(policy_refund_log.get_all_entries())
+
+    assert len(warn_log.get_all_entries()) == 0

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager_operations.py
@@ -480,12 +480,13 @@ def test_refund(testerchain, escrow, policy_manager):
     assert returned == event_args['value']
 
     # Minting is useless after policy is revoked
-    tx = escrow.functions.mint(period + 1, 20).transact({'from': node1})
+    tx = escrow.functions.mint(period + 1, number_of_periods + 1).transact({'from': node1})
     testerchain.wait_for_receipt(tx)
     period += 20
     assert 160 == policy_manager.functions.nodes(node1).call()[REWARD_FIELD]
 
     # Create policy again to test double call of `refund` with specific conditions
+    testerchain.time_travel(hours=number_of_periods + 2)
     policy_id_4 = os.urandom(POLICY_ID_LENGTH)
     number_of_periods_4 = 3
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking.py
@@ -105,8 +105,8 @@ def test_mining(testerchain, token, escrow_contract, token_economics):
     # Check parameters in call of the policy manager mock
     assert 2 == policy_manager.functions.getPeriodsLength(ursula1).call()
     assert 2 == policy_manager.functions.getPeriodsLength(ursula2).call()
-    assert current_period == policy_manager.functions.getPeriod(ursula1, 0).call()
-    assert current_period == policy_manager.functions.getPeriod(ursula2, 0).call()
+    assert current_period - 1 == policy_manager.functions.getPeriod(ursula1, 0).call()
+    assert current_period - 1 == policy_manager.functions.getPeriod(ursula2, 0).call()
     assert current_period + 1 == policy_manager.functions.getPeriod(ursula1, 1).call()
     assert current_period + 1 == policy_manager.functions.getPeriod(ursula2, 1).call()
     # Check downtime parameters


### PR DESCRIPTION
Fixes #1671

Problem possible reproduce only when grant happens in the same period as first deposit of node. Automaticaly it's impossible because `sampling()` returns only active node in the current period. But manually nothing prevents from the bug. 

This PR contains two fixes: 
* `register` and `createPolicy` check consistency of all nodes + `deposit` satisfies new conditions
* partially ignoring wrong state - that leads to losing some historical policy rewards

After fix all affected nodes will be able to `confirmActivity()`

Versions:
StakingEscrow `2.2.1` -> `2.2.2`
PolicyManager `2.1.1` -> `2.1.2`