### PR TITLE
improve ansible deployment/management/status

### DIFF
--- a/deploy/ansible/worker/include/check_running_ursula.yml
+++ b/deploy/ansible/worker/include/check_running_ursula.yml
@@ -20,6 +20,7 @@
       debug:
         msg:
           - "{{status_data.json.nickname}}"
+          - "nucypher version:      {{status_data.json.version}}"
           - "staker address:        {{status_data.json.staker_address}}"
           - "worker address:        {{status_data.json.worker_address}}"
           - "rest url:              https://{{status_data.json.rest_url}}"

--- a/deploy/ansible/worker/include/update_existing_ursula.yml
+++ b/deploy/ansible/worker/include/update_existing_ursula.yml
@@ -18,4 +18,11 @@
         name: ursula
         state: stopped
 
+    - name: Stop Geth
+      become: yes
+      docker_container:
+        name: geth
+        state: stopped
+
+- import_playbook: run_geth.yml
 - import_playbook: run_ursula.yml


### PR DESCRIPTION
When restarting ursula after an update, EC2 nodes with 4GB of RAM occasionally spaz on scrypt/keychain decryptiont because of geth taking too much memory.

So lets stop geth and clear out some RAM before restarting ursula container.  This seems to solve it.

Also adds NuCypher version to status output
```
        "MediumTurquoise Clock Purple Heart",
        "nucypher version:      2.0.0-beta.5",
        "staker address:        0xB1171EE4fd7E54ed960ccF9ECa383E0f3B1C6B06",
        "worker address:        0x94fBC43fC56d7D3A3002E85C3575009316BcCcB9",
        "rest url:              https://52.34.68.134:9151",
        "missing_confirmations: 0",
        "last active period:    18307",
        "balances:",
        "   ETH:                0.045739414712468285",
        "   NU:                 0.0"
```