### PR TITLE
[WIP] Have Ursula idle when there is no bonded worker

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1200,6 +1200,18 @@ class Worker(NucypherTokenActor):
             if start_working_now:
                 self.work_tracker.start(act_now=False)
 
+    @staticmethod
+    def worker_is_bonded(worker_address: str, registry: 'BaseContractRegistry') -> bool:
+        """
+        Checks that the Worker's bonded staking address isn't a null address
+        and returns a boolean.
+        """
+        staking_agent = ContractAgency.get_agent(StakingEscrowAgent,
+                                                 registry=registry)
+
+        staking_addr = staking_agent.get_staker_from_worker(worker_address)
+        return staking_addr != BlockchainInterface.NULL_ADDRESS
+
     @property
     def eth_balance(self) -> Decimal:
         """Return this workers's current ETH balance"""

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -19,6 +19,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import csv
 import json
 import os
+import time
 from decimal import Decimal
 from pathlib import Path
 from typing import Tuple, List, Dict, Union
@@ -1191,26 +1192,32 @@ class Worker(NucypherTokenActor):
 
         # Workers cannot be started without being assigned a stake first.
         if is_me:
+            if check_active_worker:
+                self._checksum_address = self.block_until_bonded(worker_address, self.registry)
             self.stakes = StakeList(registry=self.registry, checksum_address=self.checksum_address)
             self.stakes.refresh()
-            if check_active_worker and not len(self.stakes):
-                raise self.DetachedWorker(f"{self.__worker_address} is not bonded to {self.checksum_address}.")
 
             self.work_tracker = work_tracker or WorkTracker(worker=self)
             if start_working_now:
                 self.work_tracker.start(act_now=False)
 
     @staticmethod
-    def worker_is_bonded(worker_address: str, registry: 'BaseContractRegistry') -> bool:
+    def block_until_bonded(worker_address: str,
+                           registry: 'BaseContractRegistry',
+                           poll_rate: int = 10) -> str:
         """
-        Checks that the Worker's bonded staking address isn't a null address
-        and returns a boolean.
+        Polls the staking_agent and blocks until the staking address is not
+        a null address for the given worker_address.
+        Once the worker is bonded, it returns the staker address.
         """
         staking_agent = ContractAgency.get_agent(StakingEscrowAgent,
                                                  registry=registry)
 
         staking_addr = staking_agent.get_staker_from_worker(worker_address)
-        return staking_addr != BlockchainInterface.NULL_ADDRESS
+        while staking_addr == BlockchainInterface.NULL_ADDRESS:
+            time.sleep(poll_rate)
+            staking_addr = staking_agent.get_staker_from_worker(worker_address)
+        return staking_addr
 
     @property
     def eth_balance(self) -> Decimal:

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -21,6 +21,7 @@ import json
 import os
 import shutil
 from json import JSONDecodeError
+import time
 from typing import List, Tuple, Dict, Set, Optional
 
 import click
@@ -213,6 +214,21 @@ def get_external_ip_from_centralized_source() -> str:
         return ip_request.text
     raise UnknownIPAddress(f"There was an error determining the IP address automatically. "
                            f"(status code {ip_request.status_code})")
+
+
+def block_until_worker_is_bonded(emitter,
+                                 worker: 'Worker',
+                                 poll_rate: int = 300):
+    """
+    Checks that the specified worker is bonded. If the worker is not bonded,
+    then this call blocks until it is. The call checks the blockchain every
+    five minutes by default via `poll_rate`.
+    """
+    while not worker.worker_is_bonded(worker.learning_domains[0], worker.registry):
+        emitter.message(f"There is no stake bonded to this worker! Will check again in {poll_rate} seconds...", color='yellow', bold=True)
+        time.sleep(poll_rate)
+    emitter.message("Wworker is bonded!", color='green', bold=True)
+
 
 
 def determine_external_ip_address(emitter, force: bool = False) -> str:

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -216,21 +216,6 @@ def get_external_ip_from_centralized_source() -> str:
                            f"(status code {ip_request.status_code})")
 
 
-def block_until_worker_is_bonded(emitter,
-                                 worker: 'Worker',
-                                 poll_rate: int = 300):
-    """
-    Checks that the specified worker is bonded. If the worker is not bonded,
-    then this call blocks until it is. The call checks the blockchain every
-    five minutes by default via `poll_rate`.
-    """
-    while not worker.worker_is_bonded(worker.learning_domains[0], worker.registry):
-        emitter.message(f"There is no stake bonded to this worker! Will check again in {poll_rate} seconds...", color='yellow', bold=True)
-        time.sleep(poll_rate)
-    emitter.message("Wworker is bonded!", color='green', bold=True)
-
-
-
 def determine_external_ip_address(emitter, force: bool = False) -> str:
     """
     Attempts to automatically get the external IP from ifconfig.me

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -15,9 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 """
-import json
 import os
-from json import JSONDecodeError
 
 import click
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
@@ -235,6 +233,7 @@ class UrsulaCharacterOptions:
                                                       envvar=NUCYPHER_ENVVAR_WORKER_ETH_PASSWORD)
 
         try:
+            emitter.message("Waiting for bonded worker...", color="yellow", bold=True)
             URSULA = actions.make_cli_character(character_config=ursula_config,
                                                 emitter=emitter,
                                                 min_stake=self.min_stake,
@@ -244,6 +243,7 @@ class UrsulaCharacterOptions:
                                                 client_password=client_password,
                                                 load_preferred_teachers=load_seednodes and not self.lonely,
                                                 start_learning_now=load_seednodes)
+            emitter.message(f"Worker is bonded to {URSULA.checksum_address}!", color='green', bold=True)
 
             return ursula_config, URSULA
 
@@ -336,9 +336,10 @@ def run(general_config, character_options, config_file, interactive, dry_run, me
 
     emitter = _setup_emitter(general_config, character_options.config_options.worker_address)
     _pre_launch_warnings(emitter, dev=character_options.config_options.dev, force=None)
-    ursula_config, URSULA = character_options.create_character(emitter=emitter,
-                                                               config_file=config_file,
-                                                               json_ipc=general_config.json_ipc)
+    ursula_config, URSULA = character_options.create_character(
+            emitter=emitter,
+            config_file=config_file,
+            json_ipc=general_config.json_ipc)
 
     #
     # Additional Services

--- a/tests/blockchain/eth/entities/actors/test_worker.py
+++ b/tests/blockchain/eth/entities/actors/test_worker.py
@@ -32,14 +32,8 @@ def test_worker_auto_confirmations(testerchain,
     clock = Clock()
     WorkTracker.CLOCK = clock
 
-    # Check that the worker is unbonded
-    assert not Worker.worker_is_bonded(worker_address, test_registry)
-
     # Bond the Worker and Staker
     staker.set_worker(worker_address=worker_address)
-
-    # Ensure the worker is now bonded
-    assert Worker.worker_is_bonded(worker_address, test_registry)
 
     # Make the Worker
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,

--- a/tests/blockchain/eth/entities/actors/test_worker.py
+++ b/tests/blockchain/eth/entities/actors/test_worker.py
@@ -3,6 +3,7 @@ import pytest_twisted
 from twisted.internet import threads
 from twisted.internet.task import Clock
 
+from nucypher.blockchain.eth.actors import Worker
 from nucypher.blockchain.eth.token import NU, WorkTracker
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
@@ -31,8 +32,14 @@ def test_worker_auto_confirmations(testerchain,
     clock = Clock()
     WorkTracker.CLOCK = clock
 
+    # Check that the worker is unbonded
+    assert not Worker.worker_is_bonded(worker_address, test_registry)
+
     # Bond the Worker and Staker
     staker.set_worker(worker_address=worker_address)
+
+    # Ensure the worker is now bonded
+    assert Worker.worker_is_bonded(worker_address, test_registry)
 
     # Make the Worker
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,


### PR DESCRIPTION
### What this does:
1. Creates a new blocking `staticmethod` on `Worker` called `block_until_bonded`.
    - Returns the staking address of the provided worker.
    - Blocks for a set `poll_rate` (by default, checks every 10 seconds)
2. Resolves #1656.

### TODO:
1. Remove prompts for the Staker address on `nucypher ursula init`.
    - We want to ask the blockchain for the staking address instead.