### PR TITLE
Sorry Alice, your credit is strained far too thin.

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1185,6 +1185,9 @@ class Worker(NucypherTokenActor):
         # Agency
         self.staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=self.registry)
 
+        # Someday, when we have Workers for tasks other than PRE, this might instead be composed on Ursula.
+        self.policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=self.registry)
+
         # Stakes
         self.__start_time = WORKER_NOT_RUNNING
         self.__uptime_period = WORKER_NOT_RUNNING

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -652,16 +652,12 @@ class PolicyManagerAgent(EthereumContractAgent):
         blockchain_record = self.contract.functions.policies(policy_id).call()
         return blockchain_record
 
-    def fetch_policy_from_txid(self, txid, timeout=600):
-        receipt = self.blockchain.wait_for_receipt(txid, timeout=timeout)
-        policy_created_event = self.contract.events.PolicyCreated().processReceipt(receipt)
-        return policy_created_event
-
-    def fetch_arrangements_from_policy_txid(self, txid, timeout=600):
-        policy_created_event = self.fetch_policy_from_txid(txid, timeout)
-        policy_id_bytes = policy_created_event[0]['args']['policyId']
-        arrangements = self.fetch_policy_arrangements(policy_id_bytes)
-        return arrangements
+    def fetch_arrangement_addresses_from_policy_txid(self, txhash, timeout=600):
+        # TODO: Won't it be great when this is impossible?  #1274
+        _receipt = self.blockchain.wait_for_receipt(txhash, timeout=timeout)
+        transaction = self.blockchain.client.w3.eth.getTransaction(txhash)
+        _signature, parameters = self.contract.decode_function_input(transaction.data)
+        return parameters['_nodes']
 
     @validate_checksum_address
     def revoke_policy(self, policy_id: bytes, author_address: str):

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -652,6 +652,17 @@ class PolicyManagerAgent(EthereumContractAgent):
         blockchain_record = self.contract.functions.policies(policy_id).call()
         return blockchain_record
 
+    def fetch_policy_from_txid(self, txid, timeout=600):
+        receipt = self.blockchain.wait_for_receipt(txid, timeout=timeout)
+        policy_created_event = self.contract.events.PolicyCreated().processReceipt(receipt)
+        return policy_created_event
+
+    def fetch_arrangements_from_policy_txid(self, txid, timeout=600):
+        policy_created_event = self.fetch_policy_from_txid(txid, timeout)
+        policy_id_bytes = policy_created_event[0]['args']['policyId']
+        arrangements = self.fetch_policy_arrangements(policy_id_bytes)
+        return arrangements
+
     @validate_checksum_address
     def revoke_policy(self, policy_id: bytes, author_address: str):
         """Revoke by arrangement ID; Only the policy's author_address can revoke the policy."""

--- a/nucypher/characters/control/interfaces.py
+++ b/nucypher/characters/control/interfaces.py
@@ -9,7 +9,6 @@ from nucypher.characters.control.specifications import alice, bob, enrico
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import DecryptingPower, SigningPower
 from nucypher.crypto.utils import construct_policy_id
-from nucypher.network.middleware import NotFound
 
 
 def attach_schema(schema):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -323,10 +323,10 @@ class Alice(Character, BlockchainPolicyAuthor):
                 revocation = policy.revocation_kit[node_id]
                 try:
                     response = self.network_middleware.revoke_arrangement(ursula, revocation)
-                except NotFound:
-                    failed_revocations[node_id] = (revocation, NotFound)
-                except UnexpectedResponse:
-                    failed_revocations[node_id] = (revocation, UnexpectedResponse)
+                except self.network_middleware.NotFound:
+                    failed_revocations[node_id] = (revocation, self.network_middleware.NotFound)
+                except self.network_middleware.UnexpectedResponse:
+                    failed_revocations[node_id] = (revocation, self.network_middleware.UnexpectedResponse)
                 else:
                     if response.status_code != 200:
                         raise self.ActorError(f"Failed to revoke {policy.id} with status code {response.status_code}")
@@ -564,7 +564,7 @@ class Bob(Character):
                 response = network_middleware.get_treasure_map_from_node(node=node, map_id=map_id)
             except NodeSeemsToBeDown:
                 continue
-            except NotFound:
+            except network_middleware.NotFound:
                 self.log.info(f"Node {node} claimed not to have TreasureMap {map_id}")
                 continue
 
@@ -580,7 +580,7 @@ class Bob(Character):
         else:
             # TODO: Work out what to do in this scenario -
             #       if Bob can't get the TreasureMap, he needs to rest on the learning mutex or something.
-            raise TreasureMap.NowhereToBeFound
+            raise TreasureMap.NowhereToBeFound(f"Asked {len(self.known_nodes)} nodes, but nonw had map {map_id} ")
 
         return treasure_map
 
@@ -784,7 +784,7 @@ class Bob(Character):
                     self.log.info(
                         f"Ursula ({work_order.ursula}) seems to be down while trying to complete WorkOrder: {work_order}")
                     continue
-                except NotFound:
+                except self.network_middleware.NotFound:
                     # This Ursula claims not to have a matching KFrag.  Maybe this has been revoked?
                     # TODO: What's the thing to do here?  Do we want to track these Ursulas in some way in case they're lying?
                     self.log.warn(

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -580,7 +580,7 @@ class Bob(Character):
         else:
             # TODO: Work out what to do in this scenario -
             #       if Bob can't get the TreasureMap, he needs to rest on the learning mutex or something.
-            raise TreasureMap.NowhereToBeFound(f"Asked {len(self.known_nodes)} nodes, but nonw had map {map_id} ")
+            raise TreasureMap.NowhereToBeFound(f"Asked {len(self.known_nodes)} nodes, but none had map {map_id} ")
 
         return treasure_map
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -58,7 +58,7 @@ from nucypher.crypto.signing import InvalidSignature
 from nucypher.keystore.keypairs import HostingKeypair
 from nucypher.keystore.threading import ThreadedSession
 from nucypher.network.exceptions import NodeSeemsToBeDown
-from nucypher.network.middleware import RestMiddleware, UnexpectedResponse, NotFound
+from nucypher.network.middleware import RestMiddleware
 from nucypher.network.nicknames import nickname_from_seed
 from nucypher.network.nodes import Teacher, NodeSprout
 from nucypher.network.protocols import InterfaceInfo, parse_node_uri

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -987,7 +987,9 @@ class Ursula(Teacher, Character, Worker):
             # Ephemeral Self-Ursula
             #
             if is_me:
-                self.suspicious_activities_witnessed = {'vladimirs': [], 'bad_treasure_maps': []}
+                self.suspicious_activities_witnessed = {'vladimirs': [],
+                                                        'bad_treasure_maps': [],
+                                                        'freeriders': []}
 
                 #
                 # REST Server (Ephemeral Self-Ursula)

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -99,7 +99,16 @@ class Amonia(Alice):
         return alice_clone
 
     def grant_without_paying(self, *args, **kwargs):
+        """
+        I take what I want for free.
+        """
         def what_do_you_mean_you_dont_tip(policy, *args, **kwargs):
             policy.publish_transaction = b"He convinced me, gimme back my $"
         with patch("nucypher.policy.policies.BlockchainPolicy.publish_to_blockchain", what_do_you_mean_you_dont_tip):
             super().grant(*args, **kwargs)
+
+    def grant_while_paying_the_wrong_nodes(self, *args, **kwargs):
+        """
+        Instead of paying the nodes with whom I've made
+        """
+        pass

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -105,10 +105,28 @@ class Amonia(Alice):
         def what_do_you_mean_you_dont_tip(policy, *args, **kwargs):
             policy.publish_transaction = b"He convinced me, gimme back my $"
         with patch("nucypher.policy.policies.BlockchainPolicy.publish_to_blockchain", what_do_you_mean_you_dont_tip):
-            super().grant(*args, **kwargs)
+           return super().grant(*args, **kwargs)
+
+    def circumvent_safegaurds_and_grant_without_paying(self, *args, **kwargs):
+        """
+        I am not Alice, and I needn't abide by her sensibilities or raise her Exceptions.
+
+        Can I grant for free if I change the client code to my liking?
+        """
+        def enact_without_tabulating_responses(policy, network_middleware, *args, **kwargs):
+            for arrangement in policy._Policy__assign_kfrags():
+                arrangement_message_kit = arrangement.encrypt_payload_for_ursula()
+                try:
+                    network_middleware.enact_policy(arrangement.ursula,
+                                                    arrangement.id,
+                                                    arrangement_message_kit.to_bytes())
+                except Exception as e:
+                    # I don't care what went wrong - I will keep trying to ram arrangements through.
+                    continue
+        with patch("nucypher.policy.policies.Policy.enact", enact_without_tabulating_responses):
+            return self.grant_without_paying(*args, **kwargs)
 
     def grant_while_paying_the_wrong_nodes(self, *args, **kwargs):
         """
         Instead of paying the nodes with whom I've made
         """
-        pass

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -14,9 +14,12 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+from copy import copy
+from unittest.mock import patch
+
 from eth_tester.exceptions import ValidationError
 
-from nucypher.characters.lawful import Ursula
+from nucypher.characters.lawful import Ursula, Alice
 from nucypher.crypto.powers import CryptoPower, SigningPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD, MOCK_URSULA_DB_FILEPATH
 from nucypher.utilities.sandbox.middleware import EvilMiddleWare
@@ -83,3 +86,20 @@ class Vladimir(Ursula):
             else:
                 raise
         return True
+
+
+class Amonia(Alice):
+    """
+    Separated at birth, Alice's sister is lighter than air and has a pungent smell.
+    """
+    @classmethod
+    def from_lawful_alice(cls, alice):
+        alice_clone = copy(alice)
+        alice_clone.__class__ = cls
+        return alice_clone
+
+    def grant_without_paying(self, *args, **kwargs):
+        def what_do_you_mean_you_dont_tip(policy, *args, **kwargs):
+            policy.publish_transaction = b"He convinced me, gimme back my $"
+        with patch("nucypher.policy.policies.BlockchainPolicy.publish_to_blockchain", what_do_you_mean_you_dont_tip):
+            super().grant(*args, **kwargs)

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -192,7 +192,7 @@ class RestMiddleware:
                                     path=f'kFrag/{kfrag_id.hex()}',
                                     data=payload,
                                     timeout=2)
-        return True, ursula.stamp.as_umbral_pubkey()
+        return response
 
     def reencrypt(self, work_order):
         ursula_rest_response = self.send_work_order_payload_to_ursula(work_order)

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -151,7 +151,8 @@ class RestMiddleware:
             self.status = status
 
     class NotFound(UnexpectedResponse):
-        pass
+        def __init__(self, message):
+            super().__init__(message, 404)
 
     def __init__(self, registry=None):
         self.client = self._client_class()

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -146,13 +146,13 @@ class RestMiddleware:
     _client_class = NucypherMiddlewareClient
 
     class UnexpectedResponse(Exception):
-        def __init__(self, message, status):
-            super().__init__(message)
+        def __init__(self, status, *args, **kwargs):
+            super().__init__(*args, **kwargs)
             self.status = status
 
     class NotFound(UnexpectedResponse):
-        def __init__(self, message):
-            super().__init__(message, 404)
+        def __init__(self, *args, **kwargs):
+            super().__init__(status=404, *args, **kwargs)
 
     def __init__(self, registry=None):
         self.client = self._client_class()

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -146,8 +146,8 @@ class RestMiddleware:
     _client_class = NucypherMiddlewareClient
 
     class UnexpectedResponse(Exception):
-        def __init__(self, status, *args, **kwargs):
-            super().__init__(*args, **kwargs)
+        def __init__(self, message, status, *args, **kwargs):
+            super().__init__(message, *args, **kwargs)
             self.status = status
 
     class NotFound(UnexpectedResponse):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -36,14 +36,6 @@ from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 EXEMPT_FROM_VERIFICATION.bool_value(False)
 
 
-class UnexpectedResponse(Exception):
-    pass
-
-
-class NotFound(UnexpectedResponse):
-    pass
-
-
 class NucypherMiddlewareClient:
     library = requests
     timeout = 1.2
@@ -133,10 +125,10 @@ class NucypherMiddlewareClient:
             if cleaned_response.status_code >= 300:
                 if cleaned_response.status_code == 404:
                     m = f"While trying to {method_name} {args} ({kwargs}), server 404'd.  Response: {cleaned_response.content}"
-                    raise NotFound(m)
+                    raise RestMiddleware.NotFound(m)
                 else:
                     m = f"Unexpected response while trying to {method_name} {args},{kwargs}: {cleaned_response.status_code} {cleaned_response.content}"
-                    raise UnexpectedResponse(m)
+                    raise RestMiddleware.UnexpectedResponse(m, status=cleaned_response.status_code)
             return cleaned_response
 
         return method_wrapper
@@ -152,6 +144,14 @@ class RestMiddleware:
     log = Logger()
 
     _client_class = NucypherMiddlewareClient
+
+    class UnexpectedResponse(Exception):
+        def __init__(self, message, status):
+            super().__init__(message)
+            self.status = status
+
+    class NotFound(UnexpectedResponse):
+        pass
 
     def __init__(self, registry=None):
         self.client = self._client_class()

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -943,6 +943,7 @@ class Teacher:
     TEACHER_VERSION = LEARNING_LOOP_VERSION
     _interface_info_splitter = (int, 4, {'byteorder': 'big'})
     log = Logger("teacher")
+    synchronous_query_timeout = 20  # How long to wait during REST endpoints for blockchain queries to resolve
     __DEFAULT_MIN_SEED_STAKE = 0
 
     def __init__(self,

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -251,7 +251,7 @@ def make_rest_app(
 
             this_node_has_been_arranged = this_node.checksum_address in arranged_addresses
             if not this_node_has_been_arranged:
-                this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"The tranaction {tx} does not list me as a Worker - it lists {arranged_addresses}."))
+                this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"The transaction {tx} does not list me as a Worker - it lists {arranged_addresses}."))
                 return Response(status=402)
         else:
             _tx = NO_BLOCKCHAIN_CONNECTION

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -236,7 +236,7 @@ def make_rest_app(
         if not this_node.federated_only:
             # This splitter probably belongs somewhere canonical.
             transaction_splitter = BytestringSplitter(32)
-            tx, cleartext = transaction_splitter(cleartext, return_remainder=True)
+            tx, kfrag_bytes = transaction_splitter(cleartext, return_remainder=True)
 
             try:
                 # Get all of the arrangements and verify that we'll be paid.
@@ -254,8 +254,9 @@ def make_rest_app(
                 this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"The tranaction {tx} does not list me as a Worker - it lists {arranged_addresses}."))
                 return Response(status=402)
         else:
-            tx = NO_BLOCKCHAIN_CONNECTION  # TODO: constant?
-        kfrag = KFrag.from_bytes(cleartext)
+            _tx = NO_BLOCKCHAIN_CONNECTION
+            kfrag_bytes = cleartext
+        kfrag = KFrag.from_bytes(kfrag_bytes)
 
         if not kfrag.verify(signing_pubkey=alices_verifying_key):
             raise InvalidSignature("{} is invalid".format(kfrag))

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -27,6 +27,7 @@ from flask import request
 from hendrix.experience import crosstown_traffic
 from jinja2 import Template, TemplateError
 from twisted.logger import Logger
+from web3.exceptions import TimeExhausted
 
 import nucypher
 from nucypher.config.storages import ForgetfulNodeStorage
@@ -238,7 +239,7 @@ def make_rest_app(
 
             try:
                 receipt = this_node.policy_agent.blockchain.wait_for_receipt(tx, timeout=this_node.synchronous_query_timeout)
-            except:
+            except TimeExhausted:
                 # Alice didn't pay.  Return response with that weird status code.
                 return Response(status=402)
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -198,6 +198,7 @@ def make_rest_app(
         from nucypher.policy.policies import Arrangement
         arrangement = Arrangement.from_bytes(request.data)
 
+        # TODO: Look at the expiration and figure out if we're even staking that long.  1701
         with ThreadedSession(db_engine) as session:
             new_policy_arrangement = datastore.add_policy_arrangement(
                 arrangement.expiration.datetime(),
@@ -205,8 +206,8 @@ def make_rest_app(
                 alice_verifying_key=arrangement.alice.stamp,
                 session=session,
             )
-        # TODO: Make the rest of this logic actually work - do something here
-        # to decide if this Arrangement is worth accepting.
+        # TODO: Fine, we'll add the arrangement here, but if we never hear from Alice again to enact it,
+        # we need to prune it at some point.  #1700
 
         headers = {'Content-Type': 'application/octet-stream'}
         # TODO: Make this a legit response #234.
@@ -311,6 +312,7 @@ def make_rest_app(
             return Response(response=arrangement_id, status=404)
 
         # Get KFrag
+        # TODO: Yeah, well, what if this arrangement hasn't been enacted?  1702
         kfrag = KFrag.from_bytes(arrangement.kfrag)
 
         # Get Work Order

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -236,8 +236,12 @@ def make_rest_app(
             transaction_splitter = BytestringSplitter(32)
             tx, cleartext = transaction_splitter(cleartext, return_remainder=True)
 
-            receipt = this_node.policy_agent.blockchain.wait_for_receipt(tx)
-            this_node.policy_agent.contract.abi  # This is a thing
+            try:
+                receipt = this_node.policy_agent.blockchain.wait_for_receipt(tx, timeout=this_node.synchronous_query_timeout)
+            except:
+                # Alice didn't pay.  Return response with that weird status code.
+                return Response(status=402)
+
             maybe_policy_created_event = this_node.policy_agent.contract.events.PolicyCreated().processReceipt(receipt)
 
             # TODO: We'd love for this part to be impossible.  #1274

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -241,13 +241,11 @@ def make_rest_app(
             try:
                 # Get all of the arrangements and verify that we'll be paid.
                 # TODO: We'd love for this part to be impossible to reduce the risk of collusion.  #1274
-                arrangements = this_node.policy_agent.fetch_arrangements_from_policy_txid(tx, timeout=20)
+                arranged_addresses = this_node.policy_agent.fetch_arrangement_addresses_from_policy_txid(tx, timeout=this_node.synchronous_query_timeout)
             except TimeExhausted:
                 # Alice didn't pay.  Return response with that weird status code.
                 this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"No transaction matching {tx}."))
                 return Response(status=402)
-            else:
-                arranged_addresses = [a[0] for a in arrangements]
 
             this_node_has_been_arranged = this_node.checksum_address in arranged_addresses
             if not this_node_has_been_arranged:

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -242,7 +242,7 @@ def make_rest_app(
                 receipt = this_node.policy_agent.blockchain.wait_for_receipt(tx, timeout=this_node.synchronous_query_timeout)
             except TimeExhausted:
                 # Alice didn't pay.  Return response with that weird status code.
-                this_node.suspicious_activities_witnessed['freeriders'].append(alice)
+                this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"No transaction matching {tx}."))
                 return Response(status=402)
 
             maybe_policy_created_event = this_node.policy_agent.contract.events.PolicyCreated().processReceipt(receipt)
@@ -252,7 +252,7 @@ def make_rest_app(
             arranged_addresses = [a[0] for a in this_node.policy_agent.fetch_policy_arrangements(policy_id_bytes)]
             this_node_has_been_arranged = this_node.checksum_address in arranged_addresses
             if not this_node_has_been_arranged:
-                this_node.suspicious_activities_witnessed['freeriders'].append(alice)
+                this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"The tranaction {tx} does not list me as a Worker - it lists {arranged_addresses}."))
                 return Response(status=402)
         else:
             tx = NO_BLOCKCHAIN_CONNECTION  # TODO: constant?

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -212,9 +212,11 @@ class TreasureMap:
                 self._destinations = dict(self.node_id_splitter.repeat(map_in_the_clear[1:]))
             except BytestringSplittingError:
                 self._destinations = {}
+            self.check_for_sufficient_destinations()
 
-            if len(self._destinations) < self._m or self._m == 0:
-                raise self.IsDisorienting(f"TreasureMap lists only {len(self._destinations)} destination, but requires interaction with {self._m} nodes.")
+    def check_for_sufficient_destinations(self):
+        if len(self._destinations) < self._m or self._m == 0:
+            raise self.IsDisorienting(f"TreasureMap lists only {len(self._destinations)} destination, but requires interaction with {self._m} nodes.")
 
     def __eq__(self, other):
         return bytes(self) == bytes(other)

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -44,7 +44,7 @@ from nucypher.crypto.splitters import key_splitter, capsule_splitter
 from nucypher.crypto.utils import (canonical_address_from_umbral_key,
                                    get_coordinates_as_bytes,
                                    get_signature_recovery_value)
-from nucypher.network.middleware import NotFound
+from nucypher.network.middleware import RestMiddleware
 
 
 class TreasureMap:
@@ -56,14 +56,15 @@ class TreasureMap:
                                   (UmbralMessageKit, VariableLengthBytestring)
                                   )
 
-    class NowhereToBeFound(NotFound):
+    class NowhereToBeFound(RestMiddleware.NotFound):
         """
         Called when no known nodes have it.
         """
 
-    class IsDisorienting(NotFound):
+    class IsDisorienting(Bob.NotEnoughNodes):
         """
-        Called when an oriented TreasureMap lists fewer than m destinations.
+        Called when an oriented TreasureMap lists fewer than m destinations, which
+        leaves Bob disoriented.
         """
 
     node_id_splitter = BytestringSplitter((to_checksum_address, int(PUBLIC_ADDRESS_LENGTH)), ID_LENGTH)

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -643,10 +643,6 @@ class BlockchainPolicy(Policy):
         self.publish_transaction = receipt['transactionHash']
         self.is_published = True  # TODO: For real: TX / Swarm confirmations needed?
 
-        # Not in love with this block here, but I want 121 closed.
-        for arrangement in self._accepted_arrangements:
-            arrangement.publish_transaction = self.publish_transaction
-
         return receipt
 
     def make_arrangement(self, ursula: Ursula, *args, **kwargs):
@@ -664,4 +660,9 @@ class BlockchainPolicy(Policy):
         """
         if publish is True:
             self.publish_to_blockchain()
+
+            # Not in love with this block here, but I want 121 closed.
+            for arrangement in self._accepted_arrangements:
+                arrangement.publish_transaction = self.publish_transaction
+
         return super().enact(network_middleware, publish)

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -333,15 +333,12 @@ class Policy(ABC):
         Assign kfrags to ursulas_on_network, and distribute them via REST,
         populating enacted_arrangements
         """
-        # TODO: #121 - Consider tweaking the order of the enactment steps:
-        # first create the policy on chain and then send the kfrags together with the TX receipt
-
         for arrangement in self.__assign_kfrags():
-            policy_message_kit = arrangement.encrypt_payload_for_ursula()
+            arrangement_message_kit = arrangement.encrypt_payload_for_ursula()
 
             response = network_middleware.enact_policy(arrangement.ursula,
                                                        arrangement.id,
-                                                       policy_message_kit.to_bytes())
+                                                       arrangement_message_kit.to_bytes())
 
             if not response:
                 pass  # TODO: Parse response for confirmation.
@@ -355,7 +352,7 @@ class Policy(ABC):
             self.alice.add_active_policy(self)
 
             if publish is True:
-                return self.publish(network_middleware=network_middleware)
+                return self.publish_treasure_map(network_middleware=network_middleware)
 
     def consider_arrangement(self, network_middleware, ursula, arrangement) -> bool:
         negotiation_response = network_middleware.consider_arrangement(arrangement=arrangement)

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -96,10 +96,6 @@ class Arrangement:
         return self.alice.encrypt_for(self.ursula, self.payload())[0]
 
     def payload(self):
-        # TODO #127 - Ship the expiration again?
-        # Or some other way of alerting Ursula to
-        # recall her previous dialogue regarding this Arrangement.
-        # Update: We'll probably have her store the Arrangement by hrac.  See #127.
         return bytes(self.kfrag)
 
     @abstractmethod
@@ -157,6 +153,10 @@ class BlockchainArrangement(Arrangement):
         self.revoke_transaction = txhash
         self.is_revoked = True
         return txhash
+
+    def payload(self):
+        partial_payload = super().payload()
+        return bytes(self.publish_transaction) + partial_payload
 
 
 class Policy(ABC):

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -336,9 +336,16 @@ class Policy(ABC):
         for arrangement in self.__assign_kfrags():
             arrangement_message_kit = arrangement.encrypt_payload_for_ursula()
 
-            response = network_middleware.enact_policy(arrangement.ursula,
-                                                       arrangement.id,
-                                                       arrangement_message_kit.to_bytes())
+            try:
+                response = network_middleware.enact_policy(arrangement.ursula,
+                                                           arrangement.id,
+                                                           arrangement_message_kit.to_bytes())
+            except network_middleware.UnexpectedResponse as e:
+                if e.status == 402:
+                    # Ursula is claiming Alice hasn't paid.
+                    continue  # TODO
+                else:
+                    continue  # TODO
 
             if not response:
                 pass  # TODO: Parse response for confirmation.

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -353,7 +353,13 @@ class Policy(ABC):
             # Assuming response is what we hope for.
             self.treasure_map.add_arrangement(arrangement)
 
-        else:  # ...After *all* the arrangements are enacted
+        else:
+            self.treasure_map.check_for_sufficient_destinations()
+
+            # TODO: Leave a note to try any failures later.
+            pass
+
+            # ...After *all* the arrangements are enacted
             # Create Alice's revocation kit
             self.revocation_kit = RevocationKit(self, self.alice.stamp)
             self.alice.add_active_policy(self)

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -292,16 +292,6 @@ class Policy(ABC):
 
         return responses
 
-    def publish(self, network_middleware: RestMiddleware) -> dict:
-        """
-        Spread word of this Policy far and wide.
-
-        Base publication method for spreading news of the policy.
-        If this is a blockchain policy, this includes writing to
-        PolicyManager contract storage.
-        """
-        return self.publish_treasure_map(network_middleware=network_middleware)
-
     def credential(self, with_treasure_map=True):
         """
         Creates a PolicyCredential for portable access to the policy via
@@ -625,7 +615,7 @@ class BlockchainPolicy(Policy):
         found_ursulas = self.__find_ursulas(sampled_addresses, quantity)
         return found_ursulas
 
-    def publish(self, **kwargs) -> dict:
+    def publish_to_blockchain(self) -> dict:
 
         prearranged_ursulas = list(a.ursula.checksum_address for a in self._accepted_arrangements)
 

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -630,8 +630,10 @@ class BlockchainPolicy(Policy):
         self.publish_transaction = receipt['transactionHash']
         self.is_published = True  # TODO: For real: TX / Swarm confirmations needed?
 
-        # Call super publish (currently publishes TMap)
-        super().publish(network_middleware=self.alice.network_middleware)
+        # Not in love with this block here, but I want 121 closed.
+        for arrangement in self._accepted_arrangements:
+            arrangement.publish_transaction = self.publish_transaction
+
         return receipt
 
     def make_arrangement(self, ursula: Ursula, *args, **kwargs):
@@ -641,3 +643,12 @@ class BlockchainPolicy(Policy):
                                        rate=self.rate,
                                        duration_periods=self.duration_periods,
                                        *args, **kwargs)
+
+    def enact(self, network_middleware, publish=True) -> dict:
+        """
+        Assign kfrags to ursulas_on_network, and distribute them via REST,
+        populating enacted_arrangements
+        """
+        if publish is True:
+            self.publish_to_blockchain()
+        return super().enact(network_middleware, publish)

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -350,6 +350,14 @@ class Policy(ABC):
             self.treasure_map.add_arrangement(arrangement)
 
         else:
+            # OK, let's check: if two or more Ursulas claimed we didn't pay,
+            # we need to re-evaulate our situation here.
+            arrangement_statuses = [a.status for a in self._accepted_arrangements]
+            number_of_claims_of_freeloading = sum(status==402 for status in arrangement_statuses)
+
+            if number_of_claims_of_freeloading > 2:
+                raise self.alice.NotEnoughNodes  # TODO: Clean this up and enable re-tries.
+
             self.treasure_map.check_for_sufficient_destinations()
 
             # TODO: Leave a note to try any failures later.

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -72,6 +72,7 @@ class Arrangement:
             self.id = secure_random(self.ID_LENGTH)
         self.expiration = expiration
         self.alice = alice
+        self.status = None
 
         """
         These will normally not be set if Alice is drawing up this arrangement - she hasn't assigned a kfrag yet
@@ -341,14 +342,9 @@ class Policy(ABC):
                                                            arrangement.id,
                                                            arrangement_message_kit.to_bytes())
             except network_middleware.UnexpectedResponse as e:
-                if e.status == 402:
-                    # Ursula is claiming Alice hasn't paid.
-                    continue  # TODO
-                else:
-                    continue  # TODO
-
-            if not response:
-                pass  # TODO: Parse response for confirmation.
+                arrangement.status = e.status
+            else:
+                arrangement.status = response.status_code
 
             # Assuming response is what we hope for.
             self.treasure_map.add_arrangement(arrangement)

--- a/nucypher/utilities/sandbox/policy.py
+++ b/nucypher/utilities/sandbox/policy.py
@@ -31,7 +31,7 @@ from nucypher.policy.policies import Arrangement, Policy
 class MockArrangement(Arrangement):
     _arrangements = OrderedDict()
 
-    def publish(self) -> None:
+    def publish_treasure_map(self) -> None:
         self._arrangements[self.id()] = self
 
     def revoke(self):

--- a/tests/characters/control/blockchain/conftest.py
+++ b/tests/characters/control/blockchain/conftest.py
@@ -22,8 +22,8 @@ def bob_web_controller_test_client(blockchain_bob):
 
 @pytest.fixture(scope='module')
 def enrico_web_controller_test_client(capsule_side_channel_blockchain):
-    _message_kit, enrico = capsule_side_channel_blockchain()
-    web_controller = enrico.make_web_controller(crash_on_error=True)
+    _message_kit = capsule_side_channel_blockchain()
+    web_controller = capsule_side_channel_blockchain.enrico.make_web_controller(crash_on_error=True)
     yield web_controller.test_client()
 
 
@@ -54,10 +54,10 @@ def bob_rpc_controller(blockchain_bob):
 def enrico_rpc_controller_test_client(capsule_side_channel_blockchain):
 
     # Side Channel
-    _message_kit, enrico = capsule_side_channel_blockchain()
+    _message_kit = capsule_side_channel_blockchain()
 
     # RPC Controler
-    rpc_controller = enrico.make_rpc_controller(crash_on_error=True)
+    rpc_controller = capsule_side_channel_blockchain.enrico.make_rpc_controller(crash_on_error=True)
     yield rpc_controller.test_client()
 
 
@@ -115,7 +115,7 @@ def join_control_request(blockchain_bob, enacted_blockchain_policy):
 def retrieve_control_request(blockchain_bob, enacted_blockchain_policy, capsule_side_channel_blockchain):
     capsule_side_channel_blockchain.reset()
     method_name = 'retrieve'
-    message_kit, data_source = capsule_side_channel_blockchain()
+    message_kit = capsule_side_channel_blockchain()
 
     params = {
         'label': enacted_blockchain_policy.label.decode(),

--- a/tests/characters/control/blockchain/test_web_control_blockchain.py
+++ b/tests/characters/control/blockchain/test_web_control_blockchain.py
@@ -129,7 +129,7 @@ def test_alice_character_control_revoke(alice_web_controller_test_client, blockc
 def test_alice_character_control_decrypt(alice_web_controller_test_client,
                                          enacted_blockchain_policy,
                                          capsule_side_channel_blockchain):
-    message_kit, data_source = capsule_side_channel_blockchain()
+    message_kit = capsule_side_channel_blockchain()
 
     label = enacted_blockchain_policy.label.decode()
     # policy_encrypting_key = bytes(enacted_blockchain_policy.public_key).hex()

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -15,16 +15,14 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
-import os
-
 import datetime
+import os
+from unittest.mock import patch
+
 import maya
 import pytest
-
 from umbral.kfrags import KFrag
 
-from nucypher.blockchain.eth.token import NU
 from nucypher.characters.lawful import Bob, Enrico
 from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.api import keccak_digest
@@ -32,12 +30,89 @@ from nucypher.crypto.powers import SigningPower, DecryptingPower
 from nucypher.policy.collections import Revocation, PolicyCredential
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
-from nucypher.utilities.sandbox.policy import MockPolicyCreation
+
+
+@pytest.mark.usefixtures('blockchain_ursulas')
+def test_policy_sinpa(blockchain_alice, blockchain_bob, agency, testerchain):
+    """
+    Making a Policy without paying.
+    """
+
+    # Setup the policy details
+    n = 3
+    policy_end_datetime = maya.now() + datetime.timedelta(days=5)
+    label = b"this_is_the_path_to_which_access_is_being_granted"
+
+    # Create the Policy, Granting access to Bob
+    policy = blockchain_alice.grant(bob=blockchain_bob,
+                                    label=label,
+                                    m=2,
+                                    n=n,
+                                    rate=int(1e18),  # one ether
+                                    expiration=policy_end_datetime)
+
+    # Check the policy ID
+    policy_id = keccak_digest(policy.label + bytes(policy.bob.stamp))
+    assert policy_id == policy.id
+
+    # The number of accepted arrangements at least the number of Ursulas we're using (n)
+    assert len(policy._accepted_arrangements) >= n
+
+    # The number of actually enacted arrangements is exactly equal to n.
+    assert len(policy._enacted_arrangements) == n
+
+    # Let's look at the enacted arrangements.
+    for kfrag in policy.kfrags:
+        arrangement = policy._enacted_arrangements[kfrag]
+
+        # Get the Arrangement from Ursula's datastore, looking up by the Arrangement ID.
+        retrieved_policy = arrangement.ursula.datastore.get_policy_arrangement(arrangement.id.hex().encode())
+        retrieved_kfrag = KFrag.from_bytes(retrieved_policy.kfrag)
+
+        assert kfrag == retrieved_kfrag
+
+    _token, _staking, policy_agent = agency
+    policy_from_blockchain = policy_agent.fetch_policy(policy_id=bytes(policy.hrac())[:16])
+    assert policy_from_blockchain[0] == blockchain_alice.checksum_address  # Alice payed for the policy
+    assert policy_from_blockchain[2] > 0  # The daily rate for the policy paid by Alice
+
+    #
+    # "Alice hace un sinpa" (https://en.wiktionary.org/wiki/sinpa), or Alice does a dine-and-dash.
+    #
+
+    before_balance = testerchain.client.get_balance(blockchain_alice.checksum_address)
+    label = b"I'm not paying for that"
+
+    # Instead of creating the policy on-chain and paying for it, Alice decides to do nothing.
+    with patch("nucypher.policy.policies.BlockchainPolicy.publish",
+               new=lambda *args, **kwargs: "I said I'm not paying for that"):
+        free_policy = blockchain_alice.grant(bob=blockchain_bob,
+                                             label=label,
+                                             m=2,
+                                             n=n,
+                                             rate=int(1e18),  # one ether
+                                             expiration=policy_end_datetime)
+
+    # Let's look at the enacted arrangements.
+    for kfrag in free_policy.kfrags:
+        arrangement = free_policy._enacted_arrangements[kfrag]
+
+        # Get the Arrangement from Ursula's datastore, looking up by the Arrangement ID.
+        retrieved_policy = arrangement.ursula.datastore.get_policy_arrangement(arrangement.id.hex().encode())
+        retrieved_kfrag = KFrag.from_bytes(retrieved_policy.kfrag)
+
+        assert kfrag == retrieved_kfrag
+
+    # ... and yet, the policy was not paid :(
+    policy_from_blockchain = policy_agent.fetch_policy(policy_id=bytes(free_policy.hrac())[:16])
+    assert policy_from_blockchain[0] == blockchain_alice.checksum_address  # Alice payed for the policy
+    assert policy_from_blockchain[2] > 0  # The daily rate for the policy paid by Alice
+    after_balance = testerchain.client.get_balance(blockchain_alice.checksum_address)
+    assert before_balance > after_balance
 
 
 @pytest.mark.usefixtures('blockchain_ursulas')
 def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
-
     # Setup the policy details
     n = 3
     policy_end_datetime = maya.now() + datetime.timedelta(days=5)
@@ -95,9 +170,9 @@ def test_decentralized_grant(blockchain_alice, blockchain_bob, agency):
     deserialized_cred = PolicyCredential.from_json(cred_json)
     assert credential == deserialized_cred
 
+
 @pytest.mark.usefixtures('federated_ursulas')
 def test_federated_grant(federated_alice, federated_bob):
-
     # Setup the policy details
     m, n = 2, 3
     policy_end_datetime = maya.now() + datetime.timedelta(days=5)
@@ -203,7 +278,6 @@ def test_revocation(federated_alice, federated_bob):
 
 
 def test_alices_powers_are_persistent(federated_ursulas, tmpdir):
-
     # Create a non-learning AliceConfiguration
     alice_config = AliceConfiguration(
         config_root=os.path.join(tmpdir, 'nucypher-custom-alice-config'),

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -23,60 +23,12 @@ import pytest
 from umbral.kfrags import KFrag
 
 from nucypher.characters.lawful import Bob, Enrico
-from nucypher.characters.unlawful import Amonia
 from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.powers import SigningPower, DecryptingPower
-from nucypher.keystore.db.models import PolicyArrangement
 from nucypher.policy.collections import Revocation, PolicyCredential
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
-
-
-@pytest.mark.usefixtures('blockchain_ursulas')
-def test_policy_simple_sinpa(blockchain_alice, blockchain_bob, agency, testerchain):
-    """
-    Making a Policy without paying.
-    """
-    amonia = Amonia.from_lawful_alice(blockchain_alice)
-    # Setup the policy details
-    n = 3
-    policy_end_datetime = maya.now() + datetime.timedelta(days=5)
-    label = b"this_is_the_path_to_which_access_is_being_granted"
-
-    with pytest.raises(amonia.NotEnoughNodes):
-        amonia.grant_without_paying(bob=blockchain_bob,
-                                    label=label,
-                                    m=2,
-                                    n=n,
-                                    rate=int(1e18),  # one ether
-                                    expiration=policy_end_datetime)
-
-
-def test_try_to_post_free_arrangement_by_hacking_enact(blockchain_ursulas, blockchain_alice, blockchain_bob, agency, testerchain):
-    """
-    This time we won't rely on the tabulation in Alice's enact to catch the problem.
-    """
-    amonia = Amonia.from_lawful_alice(blockchain_alice)
-    # Setup the policy details
-    n = 3
-    policy_end_datetime = maya.now() + datetime.timedelta(days=5)
-    label = b"this_is_the_path_to_which_access_is_being_granted"
-
-    bupkiss_policy = amonia.circumvent_safegaurds_and_grant_without_paying(bob=blockchain_bob,
-                                                          label=label,
-                                                          m=2,
-                                                          n=n,
-                                                          rate=int(1e18),  # one ether
-                                                          expiration=policy_end_datetime)
-
-    for ursula in blockchain_ursulas:
-        # Even though the grant executed without error, no Ursula saved a KFrag.
-        all_arrangements = ursula.datastore._session_on_init_thread.query(PolicyArrangement).all()
-        if all_arrangements:
-            assert len(all_arrangements) == 1  # Just the single arrangement has been considered.
-            arrangement = all_arrangements[0]
-            assert arrangement.kfrag is None
 
 
 @pytest.mark.usefixtures('blockchain_ursulas')

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -33,8 +33,7 @@ from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
 @pytest.mark.usefixtures('blockchain_ursulas')
-def test_policy_sinpa(blockchain_alice, blockchain_bob, agency, testerchain,
-                      capsule_side_channel_blockchain):
+def test_policy_sinpa(blockchain_alice, blockchain_bob, agency, testerchain):
     """
     Making a Policy without paying.
     """

--- a/tests/characters/test_alice_can_grant_and_revoke.py
+++ b/tests/characters/test_alice_can_grant_and_revoke.py
@@ -27,13 +27,14 @@ from nucypher.characters.unlawful import Amonia
 from nucypher.config.characters import AliceConfiguration
 from nucypher.crypto.api import keccak_digest
 from nucypher.crypto.powers import SigningPower, DecryptingPower
+from nucypher.keystore.db.models import PolicyArrangement
 from nucypher.policy.collections import Revocation, PolicyCredential
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 
 
 @pytest.mark.usefixtures('blockchain_ursulas')
-def test_policy_sinpa(blockchain_alice, blockchain_bob, agency, testerchain):
+def test_policy_simple_sinpa(blockchain_alice, blockchain_bob, agency, testerchain):
     """
     Making a Policy without paying.
     """
@@ -50,6 +51,32 @@ def test_policy_sinpa(blockchain_alice, blockchain_bob, agency, testerchain):
                                     n=n,
                                     rate=int(1e18),  # one ether
                                     expiration=policy_end_datetime)
+
+
+def test_try_to_post_free_arrangement_by_hacking_enact(blockchain_ursulas, blockchain_alice, blockchain_bob, agency, testerchain):
+    """
+    This time we won't rely on the tabulation in Alice's enact to catch the problem.
+    """
+    amonia = Amonia.from_lawful_alice(blockchain_alice)
+    # Setup the policy details
+    n = 3
+    policy_end_datetime = maya.now() + datetime.timedelta(days=5)
+    label = b"this_is_the_path_to_which_access_is_being_granted"
+
+    bupkiss_policy = amonia.circumvent_safegaurds_and_grant_without_paying(bob=blockchain_bob,
+                                                          label=label,
+                                                          m=2,
+                                                          n=n,
+                                                          rate=int(1e18),  # one ether
+                                                          expiration=policy_end_datetime)
+
+    for ursula in blockchain_ursulas:
+        # Even though the grant executed without error, no Ursula saved a KFrag.
+        all_arrangements = ursula.datastore._session_on_init_thread.query(PolicyArrangement).all()
+        if all_arrangements:
+            assert len(all_arrangements) == 1  # Just the single arrangement has been considered.
+            arrangement = all_arrangements[0]
+            assert arrangement.kfrag is None
 
 
 @pytest.mark.usefixtures('blockchain_ursulas')

--- a/tests/characters/test_freerider_attacks.py
+++ b/tests/characters/test_freerider_attacks.py
@@ -1,0 +1,71 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import datetime
+
+import maya
+import pytest
+
+from nucypher.characters.unlawful import Amonia
+from nucypher.keystore.db.models import PolicyArrangement
+
+
+@pytest.mark.usefixtures('blockchain_ursulas')
+def test_policy_simple_sinpa(blockchain_alice, blockchain_bob, agency, testerchain):
+    """
+    Making a Policy without paying.
+    """
+    amonia = Amonia.from_lawful_alice(blockchain_alice)
+    # Setup the policy details
+    n = 3
+    policy_end_datetime = maya.now() + datetime.timedelta(days=5)
+    label = b"this_is_the_path_to_which_access_is_being_granted"
+
+    with pytest.raises(amonia.NotEnoughNodes):
+        amonia.grant_without_paying(bob=blockchain_bob,
+                                    label=label,
+                                    m=2,
+                                    n=n,
+                                    rate=int(1e18),  # one ether
+                                    expiration=policy_end_datetime)
+
+
+def test_try_to_post_free_arrangement_by_hacking_enact(blockchain_ursulas, blockchain_alice, blockchain_bob, agency,
+                                                       testerchain):
+    """
+    This time we won't rely on the tabulation in Alice's enact to catch the problem.
+    """
+    amonia = Amonia.from_lawful_alice(blockchain_alice)
+    # Setup the policy details
+    n = 3
+    policy_end_datetime = maya.now() + datetime.timedelta(days=5)
+    label = b"this_is_the_path_to_which_access_is_being_granted"
+
+    bupkiss_policy = amonia.circumvent_safegaurds_and_grant_without_paying(bob=blockchain_bob,
+                                                                           label=label,
+                                                                           m=2,
+                                                                           n=n,
+                                                                           rate=int(1e18),  # one ether
+                                                                           expiration=policy_end_datetime)
+
+    for ursula in blockchain_ursulas:
+        # Even though the grant executed without error, no Ursula saved a KFrag.
+        all_arrangements = ursula.datastore._session_on_init_thread.query(PolicyArrangement).all()
+        if all_arrangements:
+            assert len(all_arrangements) == 1  # Just the single arrangement has been considered.
+            arrangement = all_arrangements[0]
+            assert arrangement.kfrag is None

--- a/tests/characters/test_freerider_attacks.py
+++ b/tests/characters/test_freerider_attacks.py
@@ -76,7 +76,7 @@ def test_try_to_post_free_arrangement_by_hacking_enact(blockchain_ursulas, block
             # Additionally, Ursula logged Amonia as a freerider:
             freeriders = ursula.suspicious_activities_witnessed['freeriders']
             assert len(freeriders) == 1
-            assert freeriders[0] == amonia
+            assert freeriders[0][0] == amonia
 
             # Reset the Ursula for the next test.
             ursula.suspicious_activities_witnessed['freeriders'] = []
@@ -115,7 +115,7 @@ def test_pay_a_flunky_instead_of_the_arranged_ursula(blockchain_alice, blockchai
             # Additionally, Ursula logged Amonia as a freerider:
             freeriders = ursula.suspicious_activities_witnessed['freeriders']
             assert len(freeriders) == 1
-            assert freeriders[0] == amonia
+            assert freeriders[0][0] == amonia
 
             # Reset the Ursula for the next test.
             ursula.suspicious_activities_witnessed['freeriders'] = []


### PR DESCRIPTION
Closes #121 - presently our oldest open issue.

Ursula now checks both that there is a valid transaction placing the Policy in PolicyManager and also that she is specifically named as a Worker for the Policy.

**Introducing `Amonia`**, the unlawful sibling to `Alice`.

`Amonia` grants without paying, employing a number of tricks to try to sneak a Policy onto the network for free.

Other notes:
* The status code from the `enact()` middleware step is now composed on the `Arrangement`.
* `Alice` handles `UnexpectedResponse`, although additional elegance will be welcome when we're more focused on Alice.
* `Amonia's` freerider attacks are saved as `suspicious_activity` by `Ursula`.
* Breaks ground on events API by providing agent-level methods to get Policy and Arrangement metadata from a transaction ID.