### PR TITLE
[Do Not Merge] Worklock updates (option 2)

### DIFF
--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -81,6 +81,7 @@ class BaseEconomics:
     _default_worklock_boosting_refund_rate: int = NotImplemented
     _default_worklock_commitment_duration: int = NotImplemented
     _default_worklock_min_allowed_bid: int = NotImplemented
+    _default_worklock_max_allowed_bid: int = NotImplemented
 
     def __init__(self,
 
@@ -110,7 +111,8 @@ class BaseEconomics:
                  cancellation_end_date: int = _default_cancellation_end_date,
                  worklock_boosting_refund_rate: int = _default_worklock_boosting_refund_rate,
                  worklock_commitment_duration: int = _default_worklock_commitment_duration,
-                 worklock_min_allowed_bid: int = _default_worklock_min_allowed_bid):
+                 worklock_min_allowed_bid: int = _default_worklock_min_allowed_bid,
+                 worklock_max_allowed_bid: int = _default_worklock_max_allowed_bid):
 
         """
         :param initial_supply: Tokens at t=0
@@ -142,6 +144,7 @@ class BaseEconomics:
         self.worklock_boosting_refund_rate = worklock_boosting_refund_rate
         self.worklock_commitment_duration = worklock_commitment_duration
         self.worklock_min_allowed_bid = worklock_min_allowed_bid
+        self.worklock_max_allowed_bid = worklock_max_allowed_bid
 
         #
         # NucypherToken & Staking Escrow
@@ -228,13 +231,15 @@ class BaseEconomics:
         5 boostingRefund - Coefficient to boost refund ETH
         6 stakingPeriods - Duration of tokens locking
         7 minAllowedBid - Minimum allowed ETH amount for bidding
+        8 maxAllowedBid - Maximum allowed ETH amount for bidding
         """
         deployment_parameters = [self.bidding_start_date,
                                  self.bidding_end_date,
                                  self.cancellation_end_date,
                                  self.worklock_boosting_refund_rate,
                                  self.worklock_commitment_duration,
-                                 self.worklock_min_allowed_bid]
+                                 self.worklock_min_allowed_bid,
+                                 self.worklock_max_allowed_bid]
         return tuple(map(int, deployment_parameters))
 
     @property

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -79,6 +79,7 @@ class BaseEconomics:
     _default_bidding_end_date: int = NotImplemented
     _default_worklock_boosting_refund_rate: int = NotImplemented
     _default_worklock_commitment_duration: int = NotImplemented
+    _default_worklock_min_allowed_bid: int = NotImplemented
 
     def __init__(self,
 
@@ -106,7 +107,8 @@ class BaseEconomics:
                  bidding_start_date: int = _default_bidding_start_date,
                  bidding_end_date: int = _default_bidding_end_date,
                  worklock_boosting_refund_rate: int = _default_worklock_boosting_refund_rate,
-                 worklock_commitment_duration: int = _default_worklock_commitment_duration):
+                 worklock_commitment_duration: int = _default_worklock_commitment_duration,
+                 worklock_min_allowed_bid: int = _default_worklock_min_allowed_bid):
 
         """
         :param initial_supply: Tokens at t=0
@@ -136,6 +138,7 @@ class BaseEconomics:
         self.worklock_supply = worklock_supply
         self.worklock_boosting_refund_rate = worklock_boosting_refund_rate
         self.worklock_commitment_duration = worklock_commitment_duration
+        self.worklock_min_allowed_bid = worklock_min_allowed_bid
 
         #
         # NucypherToken & Staking Escrow
@@ -220,11 +223,13 @@ class BaseEconomics:
         3 endBidDate - Timestamp when bidding will end
         4 boostingRefund - Coefficient to boost refund ETH
         5 stakingPeriods - Duration of tokens locking
+        6 minAllowedBid - Minimum allowed ETH amount for bidding
         """
         deployment_parameters = [self.bidding_start_date,
                                  self.bidding_end_date,
                                  self.worklock_boosting_refund_rate,
-                                 self.worklock_commitment_duration]
+                                 self.worklock_commitment_duration,
+                                 self.worklock_min_allowed_bid]
         return tuple(map(int, deployment_parameters))
 
     @property

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -77,6 +77,7 @@ class BaseEconomics:
     _default_worklock_supply: int = NotImplemented
     _default_bidding_start_date: int = NotImplemented
     _default_bidding_end_date: int = NotImplemented
+    _default_cancellation_end_date: int = NotImplemented
     _default_worklock_boosting_refund_rate: int = NotImplemented
     _default_worklock_commitment_duration: int = NotImplemented
     _default_worklock_min_allowed_bid: int = NotImplemented
@@ -106,6 +107,7 @@ class BaseEconomics:
                  worklock_supply: int = _default_worklock_supply,
                  bidding_start_date: int = _default_bidding_start_date,
                  bidding_end_date: int = _default_bidding_end_date,
+                 cancellation_end_date: int = _default_cancellation_end_date,
                  worklock_boosting_refund_rate: int = _default_worklock_boosting_refund_rate,
                  worklock_commitment_duration: int = _default_worklock_commitment_duration,
                  worklock_min_allowed_bid: int = _default_worklock_min_allowed_bid):
@@ -135,6 +137,7 @@ class BaseEconomics:
 
         self.bidding_start_date = bidding_start_date
         self.bidding_end_date = bidding_end_date
+        self.cancellation_end_date = cancellation_end_date
         self.worklock_supply = worklock_supply
         self.worklock_boosting_refund_rate = worklock_boosting_refund_rate
         self.worklock_commitment_duration = worklock_commitment_duration
@@ -221,12 +224,14 @@ class BaseEconomics:
         ...
         2 startBidDate - Timestamp when bidding starts
         3 endBidDate - Timestamp when bidding will end
-        4 boostingRefund - Coefficient to boost refund ETH
-        5 stakingPeriods - Duration of tokens locking
-        6 minAllowedBid - Minimum allowed ETH amount for bidding
+        4 endBidDate - Timestamp when cancellation window will end
+        5 boostingRefund - Coefficient to boost refund ETH
+        6 stakingPeriods - Duration of tokens locking
+        7 minAllowedBid - Minimum allowed ETH amount for bidding
         """
         deployment_parameters = [self.bidding_start_date,
                                  self.bidding_end_date,
+                                 self.cancellation_end_date,
                                  self.worklock_boosting_refund_rate,
                                  self.worklock_commitment_duration,
                                  self.worklock_min_allowed_bid]
@@ -236,6 +241,11 @@ class BaseEconomics:
     def bidding_duration(self) -> int:
         """Returns the total bidding window duration in seconds."""
         return self.bidding_end_date - self.bidding_start_date
+
+    @property
+    def cancellation_window_duration(self) -> int:
+        """Returns the total cancellation window duration in seconds."""
+        return self.cancellation_end_date - self.bidding_end_date
 
 
 class StandardTokenEconomics(BaseEconomics):

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -227,7 +227,7 @@ class BaseEconomics:
         ...
         2 startBidDate - Timestamp when bidding starts
         3 endBidDate - Timestamp when bidding will end
-        4 endBidDate - Timestamp when cancellation window will end
+        4 endCancellationDate - Timestamp when cancellation window will end
         5 boostingRefund - Coefficient to boost refund ETH
         6 stakingPeriods - Duration of tokens locking
         7 minAllowedBid - Minimum allowed ETH amount for bidding

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -51,15 +51,15 @@ class BaseEconomics:
     nunits_per_token = 10 ** __token_decimals  # Smallest unit designation
 
     # Period Definition
-    __default_hours_per_period = 24
+    _default_hours_per_period = 24
 
     # Time Constraints
-    __default_minimum_worker_periods = 2
-    __default_minimum_locked_periods = 30  # 720 Hours minimum
+    _default_minimum_worker_periods = 2
+    _default_minimum_locked_periods = 30  # 720 Hours minimum
 
     # Value Constraints
-    __default_minimum_allowed_locked = NU(15_000, 'NU').to_nunits()
-    __default_maximum_allowed_locked = NU(4_000_000, 'NU').to_nunits()
+    _default_minimum_allowed_locked = NU(15_000, 'NU').to_nunits()
+    _default_maximum_allowed_locked = NU(4_000_000, 'NU').to_nunits()
 
     # Slashing parameters
     HASH_ALGORITHM_KECCAK256 = 0
@@ -67,11 +67,11 @@ class BaseEconomics:
     HASH_ALGORITHM_RIPEMD160 = 2
 
     # Adjudicator
-    __default_hash_algorithm = HASH_ALGORITHM_SHA256
-    __default_base_penalty = 100
-    __default_penalty_history_coefficient = 10
-    __default_percentage_penalty_coefficient = 8
-    __default_reward_coefficient = 2
+    _default_hash_algorithm = HASH_ALGORITHM_SHA256
+    _default_base_penalty = 100
+    _default_penalty_history_coefficient = 10
+    _default_percentage_penalty_coefficient = 8
+    _default_reward_coefficient = 2
 
     # Worklock
     _default_worklock_supply: int = NotImplemented
@@ -91,18 +91,18 @@ class BaseEconomics:
                  staking_coefficient: int,
                  locked_periods_coefficient: int,
                  maximum_rewarded_periods: int,
-                 hours_per_period: int = __default_hours_per_period,
-                 minimum_locked_periods: int = __default_minimum_locked_periods,
-                 minimum_allowed_locked: int = __default_minimum_allowed_locked,
-                 maximum_allowed_locked: int = __default_maximum_allowed_locked,
-                 minimum_worker_periods: int = __default_minimum_worker_periods,
+                 hours_per_period: int = _default_hours_per_period,
+                 minimum_locked_periods: int = _default_minimum_locked_periods,
+                 minimum_allowed_locked: int = _default_minimum_allowed_locked,
+                 maximum_allowed_locked: int = _default_maximum_allowed_locked,
+                 minimum_worker_periods: int = _default_minimum_worker_periods,
 
                  # Adjudicator
-                 hash_algorithm: int = __default_hash_algorithm,
-                 base_penalty: int = __default_base_penalty,
-                 penalty_history_coefficient: int = __default_penalty_history_coefficient,
-                 percentage_penalty_coefficient: int = __default_percentage_penalty_coefficient,
-                 reward_coefficient: int = __default_reward_coefficient,
+                 hash_algorithm: int = _default_hash_algorithm,
+                 base_penalty: int = _default_base_penalty,
+                 penalty_history_coefficient: int = _default_penalty_history_coefficient,
+                 percentage_penalty_coefficient: int = _default_percentage_penalty_coefficient,
+                 reward_coefficient: int = _default_reward_coefficient,
 
                  # WorkLock
                  worklock_supply: int = _default_worklock_supply,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1757,11 +1757,7 @@ class Bidder(NucypherTokenActor):
 
     @property
     def available_refund(self) -> int:
-        refund_eth = self.worklock_agent.get_available_refund(completed_work=self.completed_work)
-        bid = self.get_deposited_eth
-        if refund_eth > bid:
-            # Overachiever: This bidder has worked more than required.
-            refund_eth = bid
+        refund_eth = self.worklock_agent.get_available_refund(checksum_address=self.checksum_address)
         return refund_eth
 
     @property

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1685,10 +1685,14 @@ class Bidder(NucypherTokenActor):
 
     def place_bid(self, value: int) -> dict:
         self._ensure_bidding_is_open()
-        minimum = self.worklock_agent.minimum_allowed_bid
+        minimum = self.economics.worklock_min_allowed_bid
+        maximum = self.economics.worklock_max_allowed_bid
         if value < minimum:
             raise self.BidderError(f"Too small value {prettify_eth_amount(value)} for bidding, "
                                    f"bid must be at least {prettify_eth_amount(minimum)}")
+        if value > maximum:
+            raise self.BidderError(f"Too high value {prettify_eth_amount(value)} for bidding, "
+                                   f"bid must be at most {prettify_eth_amount(maximum)}")
         receipt = self.worklock_agent.bid(checksum_address=self.checksum_address, value=value)
         return receipt
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1637,6 +1637,15 @@ class Bidder(NucypherTokenActor):
     class BiddingIsClosed(BidderError):
         pass
 
+    class CancellationWindowIsOpen(BidderError):
+        pass
+
+    class CancellationWindowIsClosed(BidderError):
+        pass
+
+    class ClaimError(BidderError):
+        pass
+
     @validate_checksum_address
     def __init__(self,
                  checksum_address: str,
@@ -1680,10 +1689,10 @@ class Bidder(NucypherTokenActor):
         end = self.worklock_agent.end_cancellation_date
         if ensure_closed and now < end:
             message = message or f"Operation cannot be performed while the cancellation window is still open (closes at {end})."
-            raise self.BidderError(message)
+            raise self.CancellationWindowIsOpen(message)
         elif not ensure_closed and now >= end:
             message = message or f"Operation is allowed only while the cancellation window is open (closed at {end})."
-            raise self.BidderError(message)
+            raise self.CancellationWindowIsClosed(message)
 
     #
     # Transactions
@@ -1708,20 +1717,15 @@ class Bidder(NucypherTokenActor):
         self._ensure_cancellation_window(ensure_closed=True)
 
         if not self.worklock_agent.is_claiming_available():
-            raise self.BidderError(f"Claiming is not available yet")
+            raise self.ClaimError(f"Claiming is not available yet")
 
         # Ensure the claim was not already placed
         if self._has_claimed:
-            raise self.BidderError(f"Bidder {self.checksum_address} already placed a claim.")
+            raise self.ClaimError(f"Bidder {self.checksum_address} already placed a claim.")
 
         # Require an active bid
         if not self.get_deposited_eth:
-            raise self.BidderError(f"No claims available for {self.checksum_address}")
-
-        # Ensure the claim is at least large enough for min. stake
-        minimum = self.economics.minimum_allowed_locked
-        if self.available_claim < minimum:
-            raise ValueError(f"Claim is too small. Claim amount must be worth at least {NU.from_nunits(minimum)})")
+            raise self.ClaimError(f"No claims available for {self.checksum_address}")
 
         receipt = self.worklock_agent.claim(checksum_address=self.checksum_address)
         return receipt
@@ -1732,10 +1736,6 @@ class Bidder(NucypherTokenActor):
         # Require an active bid
         if not self.get_deposited_eth:
             self.BidderError(f"No bids available for {self.checksum_address}")
-
-        # Ensure the claim was not already placed
-        if self._has_claimed:
-            raise self.BidderError(f"Bidder {self.checksum_address} already placed a claim.")
 
         receipt = self.worklock_agent.cancel_bid(checksum_address=self.checksum_address)
         return receipt
@@ -1822,7 +1822,7 @@ class Bidder(NucypherTokenActor):
         self._ensure_cancellation_window(ensure_closed=True)
 
         if self.worklock_agent.bidders_checked():
-            raise self.BidderError(f"Check has already done")
+            raise self.BidderError(f"Check was already done")
 
         whales = self.get_whales()
         if whales:
@@ -1840,7 +1840,7 @@ class Bidder(NucypherTokenActor):
     def enable_claiming(self) -> dict:
         """Enable claiming after verification"""
         if not self.worklock_agent.bidders_checked():
-            raise self.BidderError(f"Claiming can be enabled only after bidding verification")
+            raise self.BidderError(f"Claiming can only be enabled after bidding verification")
         receipt = self.worklock_agent.enable_claiming(checksum_address=self.checksum_address)
         return receipt
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1037,16 +1037,6 @@ class WorkLockAgent(EthereumContractAgent):
         return receipt
 
     @validate_checksum_address
-    def burn_unclaimed(self, checksum_address: str) -> dict:
-        """
-        Burn unclaimed tokens - Out of the goodness of your heart...
-        of course the caller must pay for the transaction gas.
-        """
-        contract_function = self.contract.functions.burnUnclaimed()
-        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
-        return receipt
-
-    @validate_checksum_address
     def refund(self, checksum_address: str) -> dict:
         """Refund ETH for completed work."""
         contract_function = self.contract.functions.refund()
@@ -1114,8 +1104,8 @@ class WorkLockAgent(EthereumContractAgent):
             return 0
         return deposit_rate
 
-    def get_unclaimed_tokens(self) -> int:
-        tokens = self.contract.functions.unclaimedTokens().call()
+    def get_minimum_allowed_bid(self) -> int:
+        tokens = self.contract.functions.minAllowedBid().call()
         return tokens
 
     def eth_to_tokens(self, value: int) -> int:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1067,13 +1067,14 @@ class WorkLockAgent(EthereumContractAgent):
         work = self.contract.functions.workInfo(checksum_address).call()[1]
         return work
 
-    def get_available_refund(self, completed_work: str) -> int:
-        refund_eth = self.contract.functions.workToETH(completed_work).call()
-        return refund_eth
-
     #
     # Calls
     #
+
+    @validate_checksum_address
+    def get_available_refund(self, checksum_address: str) -> int:
+        refund_eth = self.contract.functions.getAvailableRefund(checksum_address).call()
+        return refund_eth
 
     @validate_checksum_address
     def get_deposited_eth(self, checksum_address: str) -> int:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1040,6 +1040,13 @@ class WorkLockAgent(EthereumContractAgent):
         return receipt
 
     @validate_checksum_address
+    def enable_claiming(self, checksum_address: str) -> dict:
+        """Enable claiming after verification"""
+        contract_function = self.contract.functions.enableClaiming()
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
+        return receipt
+
+    @validate_checksum_address
     def claim(self, checksum_address: str) -> dict:
         """
         Claim tokens - will be deposited and locked as stake in the StakingEscrow contract.
@@ -1139,8 +1146,13 @@ class WorkLockAgent(EthereumContractAgent):
         return bidders
 
     def is_claiming_available(self) -> bool:
-        """Returns True if bidders have been checked and claiming is available"""
+        """Returns True if claiming is available"""
         return self.contract.functions.isClaimingAvailable().call()
+
+    def bidders_checked(self) -> bool:
+        """Returns True if bidders have been checked"""
+        bidders_population = self.get_bidders_population()
+        return self.contract.functions.nextBidderToCheck().call() == bidders_population
 
     @property
     def minimum_allowed_bid(self) -> int:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1027,6 +1027,13 @@ class WorkLockAgent(EthereumContractAgent):
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
         return receipt
 
+    def force_refund(self, checksum_address: str, addresses: List[str]) -> dict:
+        """Force refund to bidders who can get tokens more than maximum allowed."""
+        addresses = sorted(addresses, key=str.casefold)
+        contract_function = self.contract.functions.forceRefund(addresses)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
+        return receipt
+
     @validate_checksum_address
     def verify_bidding_correctness(self,
                                    checksum_address: str,

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1104,10 +1104,6 @@ class WorkLockAgent(EthereumContractAgent):
             return 0
         return deposit_rate
 
-    def get_minimum_allowed_bid(self) -> int:
-        tokens = self.contract.functions.minAllowedBid().call()
-        return tokens
-
     def eth_to_tokens(self, value: int) -> int:
         tokens = self.contract.functions.ethToTokens(value).call()
         return tokens
@@ -1121,13 +1117,23 @@ class WorkLockAgent(EthereumContractAgent):
         return tokens
 
     @property
-    def start_date(self) -> int:
+    def minimum_allowed_bid(self) -> int:
+        tokens = self.contract.functions.minAllowedBid().call()
+        return tokens
+
+    @property
+    def start_bidding_date(self) -> int:
         date = self.contract.functions.startBidDate().call()
         return date
 
     @property
-    def end_date(self) -> int:
+    def end_bidding_date(self) -> int:
         date = self.contract.functions.endBidDate().call()
+        return date
+
+    @property
+    def end_cancellation_date(self) -> int:
+        date = self.contract.functions.endCancellationDate().call()
         return date
 
     def worklock_parameters(self) -> Tuple:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1148,6 +1148,11 @@ class WorkLockAgent(EthereumContractAgent):
         return min_bid
 
     @property
+    def maximum_allowed_bid(self) -> int:
+        max_bid = self.contract.functions.maxAllowedBid().call()
+        return max_bid
+
+    @property
     def start_bidding_date(self) -> int:
         date = self.contract.functions.startBidDate().call()
         return date
@@ -1171,6 +1176,7 @@ class WorkLockAgent(EthereumContractAgent):
             'boostingRefund',
             'stakingPeriods',
             'minAllowedBid',
+            'maxAllowedBid',
         )
 
         def _call_function_by_name(name: str):

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -34,12 +34,13 @@ contract WorkLockInterface {
 /**
 * @notice Contract holds and locks stakers tokens.
 * Each staker that locks their tokens will receive some compensation
-* @dev |v2.2.3|
+* @dev |v2.3.1|
 */
 contract StakingEscrow is Issuer {
     using AdditionalMath for uint256;
     using AdditionalMath for uint16;
 
+    event AllowableLockedTokensUpdated(uint256 min, uint256 max);
     event Deposited(address indexed staker, uint256 value, uint16 periods);
     event Locked(address indexed staker, uint256 value, uint16 firstPeriod, uint16 periods);
     event Divided(
@@ -431,8 +432,32 @@ contract StakingEscrow is Issuer {
     }
 
     //------------------------Main methods------------------------
+
+    /**
+    * @notice Update bounds of allowed locked tokens if values are less than previously defined
+    * @dev Only from worklock contract
+    * @param _min New value for `minAllowableLockedTokens`
+    * @param _max New value for `maxAllowableLockedTokens`
+    */
+    function updateAllowableLockedTokens(uint256 _min, uint256 _max) external {
+        require(msg.sender == address(workLock));
+        bool updated = false;
+        if (minAllowableLockedTokens > _min) {
+            minAllowableLockedTokens = _min;
+            updated = true;
+        }
+        if (maxAllowableLockedTokens > _max) {
+            maxAllowableLockedTokens = _max;
+            updated = true;
+        }
+        if (updated) {
+            emit AllowableLockedTokensUpdated(minAllowableLockedTokens, maxAllowableLockedTokens);
+        }
+    }
+
     /**
     * @notice Start or stop measuring the work of a staker
+    * @dev Only from worklock contract
     * @param _staker Staker
     * @param _measureWork Value for `measureWork` parameter
     * @return Work that was previously done

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -74,7 +74,7 @@ contract WorkLock {
     modifier afterCancellationWindow()
     {
         require(block.timestamp >= endCancellationDate,
-            "Operation is allowed when bidding and cancellation phases are over");
+            "Operation is allowed when cancellation phase is over");
         _;
     }
 
@@ -201,8 +201,8 @@ contract WorkLock {
         }
 
         info.depositedETH = info.depositedETH.add(msg.value);
-        require(info.depositedETH >= minAllowedBid, "Bid must be more than minimum");
-        require(info.depositedETH <= maxAllowedBid, "Bid must be less than maximum");
+        require(info.depositedETH >= minAllowedBid, "Bid must be at least minimum");
+        require(info.depositedETH <= maxAllowedBid, "Bid must be at most maximum");
         ethSupply = ethSupply.add(msg.value);
         emit Bid(msg.sender, msg.value);
     }
@@ -211,7 +211,8 @@ contract WorkLock {
     * @notice Cancel bid and refund deposited ETH
     */
     function cancelBid() external {
-        require(block.timestamp < endCancellationDate, "Cancellation allowed only during bidding");
+        require(block.timestamp < endCancellationDate,
+            "Cancellation allowed only during cancellation window");
         WorkInfo storage info = workInfo[msg.sender];
         require(info.depositedETH > 0, "No bid to cancel");
         require(!info.claimed, "Tokens are already claimed");
@@ -336,7 +337,7 @@ contract WorkLock {
 
         while (index < bidders.length && gasleft() > _gasToSaveState) {
             address bidder = bidders[index];
-            require(workInfo[bidder].depositedETH <= maxBidFromMaxStake);
+            require(workInfo[bidder].depositedETH <= maxBidFromMaxStake, "Bid is greater than max allowable bid");
             index++;
         }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -68,7 +68,7 @@ contract WorkLock {
     * @param _escrow Escrow contract
     * @param _startBidDate Timestamp when bidding starts
     * @param _endBidDate Timestamp when bidding will end
-    * @param _endBidDate Timestamp when cancellation will ends
+    * @param _endCancellationDate Timestamp when cancellation will ends
     * @param _boostingRefund Coefficient to boost refund ETH
     * @param _stakingPeriods Amount of periods during which tokens will be locked after claiming
     * @param _minAllowedBid Minimum allowed ETH amount for bidding

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -231,7 +231,7 @@ contract WorkLock {
     }
 
     /**
-    * @notice Make force refund for bidders who can get tokens more than maximum allowed
+    * @notice Make force refund to bidders who can get tokens more than maximum allowed
     * @param _biddersForRefund Sorted list of unique bidders. Only bidders who must receive a refund
     */
     function forceRefund(address payable[] calldata _biddersForRefund) external afterCancellationWindow {

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -267,7 +267,7 @@ def refund(general_config, worklock_options, registry_options, force, hw_wallet)
 @option_force
 @option_hw_wallet
 @click.option('--gas-limit', help="Gas limit per each verification transaction", type=click.IntRange(min=60000))
-# TODO: Consider moving to administrator (nucypher-deploy)
+# TODO: Consider moving to administrator (nucypher-deploy) #1758
 def post_init(general_config, registry_options, worklock_options, force, hw_wallet, gas_limit):
     """Ensure correctness of bidding and enable claiming"""
     emitter = _setup_emitter(general_config)

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -266,9 +266,11 @@ def refund(general_config, worklock_options, registry_options, force, hw_wallet)
 @group_worklock_options
 @option_force
 @option_hw_wallet
-@click.option('--gas-limit', help="Gas limit per transaction", type=click.IntRange(min=1))
-def verify_correctness(general_config, registry_options, worklock_options, force, hw_wallet, gas_limit):
-    """Verify correctness of bidding"""
+@click.option('--gas-limit', help="Gas limit per each verification transaction", type=click.IntRange(min=60000))
+# TODO: Consider moving to administrator (nucypher-deploy)
+# TODO: interactive mode for each step, choosing only specified steps
+def post_initialization(general_config, registry_options, worklock_options, force, hw_wallet, gas_limit):
+    """Ensure correctness of bidding and enable claiming"""
     emitter = _setup_emitter(general_config)
     if not worklock_options.bidder_address:  # TODO: Consider bundle this in worklock_options
         worklock_options.bidder_address = select_client_account(emitter=emitter,
@@ -280,17 +282,29 @@ def verify_correctness(general_config, registry_options, worklock_options, force
 
     if not gas_limit:
         # TODO print gas estimations
-        gas_limit = click.prompt(f"Enter gas limit per each transaction", type=click.IntRange(min=1))
+        gas_limit = click.prompt(f"Enter gas limit per each verification transaction", type=click.IntRange(min=60000))
 
     if not force:
         click.confirm(f"Confirm verifying of bidding from {worklock_options.bidder_address} "
                       f"using {gas_limit} gas per each transaction?", abort=True)
 
-    receipts = bidder.verify_bidding_correctness(gas_limit=gas_limit)
+    verification_receipts = bidder.verify_bidding_correctness(gas_limit=gas_limit)
     emitter.echo("Bidding has been checked\n", color='green')
-    for iteration, receipt in receipts.items():
+
+    for iteration, receipt in verification_receipts.items():
         paint_receipt_summary(receipt=receipt,
                               emitter=emitter,
                               chain_name=bidder.staking_agent.blockchain.client.chain_name,
                               transaction_type=f"verify-correctness[{iteration}]")
+
+    if not force:
+        click.confirm(f"Confirm enabling of claiming from {worklock_options.bidder_address}", abort=True)
+
+    enabling_receipt = bidder.enable_claiming()
+    emitter.echo("Claiming has been enabled\n", color='green')
+
+    paint_receipt_summary(receipt=enabling_receipt,
+                          emitter=emitter,
+                          chain_name=bidder.staking_agent.blockchain.client.chain_name,
+                          transaction_type=f"enable-claiming")
     return  # Exit

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -257,3 +257,39 @@ def refund(general_config, worklock_options, registry_options, force, hw_wallet)
     receipt = bidder.refund_deposit()
     paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=bidder.staking_agent.blockchain.client.chain_name)
     return  # Exit
+
+
+@worklock.command()
+@group_general_config
+@group_registry_options
+@group_worklock_options
+@option_force
+@option_hw_wallet
+@click.option('--gas-limit', help="Gas limit per transaction", type=click.IntRange(min=1))
+def verify_correctness(general_config, registry_options, worklock_options, force, hw_wallet, gas_limit):
+    """Verify correctness of bidding"""
+    emitter = _setup_emitter(general_config)
+    if not worklock_options.bidder_address:  # TODO: Consider bundle this in worklock_options
+        worklock_options.bidder_address = select_client_account(emitter=emitter,
+                                                                provider_uri=registry_options.provider_uri,
+                                                                network=registry_options.network,
+                                                                show_balances=True)
+    registry = registry_options.get_registry(emitter, general_config.debug)
+    bidder = worklock_options.create_bidder(registry=registry, hw_wallet=hw_wallet)
+
+    if not gas_limit:
+        # TODO print gas estimations
+        gas_limit = click.prompt(f"Enter gas limit per each transaction", type=click.IntRange(min=1))
+
+    if not force:
+        click.confirm(f"Confirm verifying of bidding from {worklock_options.bidder_address} "
+                      f"using {gas_limit} gas per each transaction?", abort=True)
+
+    receipts = bidder.verify_bidding_correctness(gas_limit=gas_limit)
+    emitter.echo("Bidding has been checked\n", color='green')
+    for iteration, receipt in receipts.items():
+        paint_receipt_summary(receipt=receipt,
+                              emitter=emitter,
+                              chain_name=bidder.staking_agent.blockchain.client.chain_name,
+                              transaction_type=f"verify-correctness[{iteration}]")
+    return  # Exit

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -124,14 +124,16 @@ def bid(general_config, worklock_options, registry_options, force, hw_wallet, va
                                                                 provider_uri=registry_options.provider_uri,
                                                                 network=registry_options.network,
                                                                 show_balances=True)
-    if not value:
-        if force:
-            raise click.MissingParameter("Missing --value.")
-        value = click.prompt("Enter bid amount in ETH", type=click.STRING)
-    value = int(Web3.toWei(Decimal(value), 'ether'))
 
     registry = registry_options.get_registry(emitter, general_config.debug)
     bidder = worklock_options.create_bidder(registry=registry, hw_wallet=hw_wallet)
+
+    if not value:
+        if force:
+            raise click.MissingParameter("Missing --value.")
+        minimum_bid = bidder.worklock_agent.get_minimum_allowed_bid()
+        value = click.prompt(f"Enter bid amount in ETH (at least {Web3.fromWei(minimum_bid, 'ether')})", type=click.STRING)
+    value = int(Web3.toWei(Decimal(value), 'ether'))
 
     if not force:
         paint_bidding_notice(emitter=emitter, bidder=bidder)
@@ -254,23 +256,4 @@ def refund(general_config, worklock_options, registry_options, force, hw_wallet)
     bidder = worklock_options.create_bidder(registry=registry, hw_wallet=hw_wallet)
     receipt = bidder.refund_deposit()
     paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=bidder.staking_agent.blockchain.client.chain_name)
-    return  # Exit
-
-
-@worklock.command()
-@group_registry_options
-@group_general_config
-@option_checksum_address
-def burn_unclaimed_tokens(general_config, registry_options, checksum_address):
-    emitter = _setup_emitter(general_config)
-    registry = registry_options.get_registry(emitter, general_config.debug)
-    worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=registry)
-    if not checksum_address:
-        checksum_address = select_client_account(emitter=emitter,
-                                                 provider_uri=registry_options.provider_uri,
-                                                 network=registry_options.network,
-                                                 show_balances=True)
-    # FIXME: This won't work in real life, it needs TransactingPowers and stuff
-    receipt = worklock_agent.burn_unclaimed(sender_address=checksum_address)
-    paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=worklock_agent.blockchain.client.chain_name)
     return  # Exit

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -131,7 +131,7 @@ def bid(general_config, worklock_options, registry_options, force, hw_wallet, va
     if not value:
         if force:
             raise click.MissingParameter("Missing --value.")
-        minimum_bid = bidder.worklock_agent.get_minimum_allowed_bid()
+        minimum_bid = bidder.worklock_agent.minimum_allowed_bid
         value = click.prompt(f"Enter bid amount in ETH (at least {Web3.fromWei(minimum_bid, 'ether')})", type=click.STRING)
     value = int(Web3.toWei(Decimal(value), 'ether'))
 

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -131,8 +131,9 @@ def bid(general_config, worklock_options, registry_options, force, hw_wallet, va
     if not value:
         if force:
             raise click.MissingParameter("Missing --value.")
-        minimum_bid = bidder.worklock_agent.minimum_allowed_bid
-        value = click.prompt(f"Enter bid amount in ETH (at least {Web3.fromWei(minimum_bid, 'ether')})", type=click.STRING)
+        minimum_bid = Web3.fromWei(bidder.economics.worklock_min_allowed_bid, 'ether')
+        maximum_bid = Web3.fromWei(bidder.economics.worklock_max_allowed_bid, 'ether')
+        value = click.prompt(f"Enter bid amount in ETH [{minimum_bid} - {maximum_bid}])",  type=click.STRING)
     value = int(Web3.toWei(Decimal(value), 'ether'))
 
     if not force:

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -868,6 +868,8 @@ def paint_worklock_status(emitter, registry: BaseContractRegistry):
     now = maya.now()
     bidding_remaining = bidding_end - now if bidding_end > now else timedelta()
     cancellation_remaining = cancellation_end - now if cancellation_end > now else timedelta()
+    # TODO checking for StakingEscrow initialization?
+    claiming_available = worklock_agent.is_claiming_available()
 
     payload = f"""
 
@@ -880,11 +882,12 @@ Bidding Duration ..................... {bidding_duration}
 Cancellation Window Duration ......... {cancellation_duration}
 Bidding Time Remaining ............... {bidding_remaining} 
 Cancellation Window Time Remaining ... {cancellation_remaining} 
-Claiming is available ................ {'Yes' if worklock_agent.is_claiming_available() else 'No'} 
+Claiming is available ................ {'Yes' if claiming_available else 'No'} 
 
 Economics
 ======================================================        
 Min allowed bid ... {prettify_eth_amount(worklock_agent.minimum_allowed_bid)}
+Max allowed bid ... {prettify_eth_amount(worklock_agent.maximum_allowed_bid)}
 ETH Pool .......... {prettify_eth_amount(blockchain.client.get_balance(worklock_agent.contract_address))}
 ETH Supply ........ {prettify_eth_amount(worklock_agent.get_eth_supply())}
 

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -864,7 +864,7 @@ def paint_worklock_status(emitter, registry: BaseContractRegistry):
     cancellation_end = MayaDT(worklock_agent.contract.functions.endCancellationDate().call())
 
     bidding_duration = bidding_end - bidding_start
-    cancellation_duration = cancellation_end - bidding_end
+    cancellation_duration = cancellation_end - bidding_start
     now = maya.now()
     bidding_remaining = bidding_end - now if bidding_end > now else timedelta()
     cancellation_remaining = cancellation_end - now if cancellation_end > now else timedelta()

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -859,25 +859,31 @@ def paint_worklock_status(emitter, registry: BaseContractRegistry):
     blockchain = worklock_agent.blockchain
 
     # Time
-    start = MayaDT(worklock_agent.contract.functions.startBidDate().call())
-    end = MayaDT(worklock_agent.contract.functions.endBidDate().call())
+    bidding_start = MayaDT(worklock_agent.contract.functions.startBidDate().call())
+    bidding_end = MayaDT(worklock_agent.contract.functions.endBidDate().call())
+    cancellation_end = MayaDT(worklock_agent.contract.functions.endCancellationDate().call())
 
-    duration = end - start
+    bidding_duration = bidding_end - bidding_start
+    cancellation_duration = cancellation_end - bidding_end
     now = maya.now()
-    remaining = end - now if end > now else timedelta()
+    bidding_remaining = bidding_end - now if bidding_end > now else timedelta()
+    cancellation_remaining = cancellation_end - now if cancellation_end > now else timedelta()
 
     payload = f"""
 
 Time
 ======================================================
-Start Date ........ {start}
-End Date .......... {end}
-Duration .......... {duration}
-Time Remaining .... {remaining} 
+Bidding Start Date ................... {bidding_start}
+Bidding End Date ..................... {bidding_end}
+Cancellation Window End Date ......... {cancellation_end}
+Bidding Duration ..................... {bidding_duration}
+Cancellation Window Duration ......... {cancellation_duration}
+Bidding Time Remaining ............... {bidding_remaining} 
+Cancellation Window Time Remaining ... {cancellation_remaining} 
 
 Economics
 ======================================================        
-Min allowed bid ... {prettify_eth_amount(worklock_agent.get_minimum_allowed_bid())}
+Min allowed bid ... {prettify_eth_amount(worklock_agent.minimum_allowed_bid)}
 ETH Pool .......... {prettify_eth_amount(blockchain.client.get_balance(worklock_agent.contract_address))}
 ETH Supply ........ {prettify_eth_amount(worklock_agent.get_eth_supply())}
 

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -880,6 +880,7 @@ Bidding Duration ..................... {bidding_duration}
 Cancellation Window Duration ......... {cancellation_duration}
 Bidding Time Remaining ............... {bidding_remaining} 
 Cancellation Window Time Remaining ... {cancellation_remaining} 
+Claiming is available ................ {'Yes' if worklock_agent.is_claiming_available() else 'No'} 
 
 Economics
 ======================================================        

--- a/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
@@ -171,16 +171,16 @@ contract Intermediary {
         escrow = _escrow;
     }
 
-    function setWorker(address _worker) public {
+    function setWorker(address _worker) external {
         escrow.setWorker(_worker);
     }
 
-    function deposit(uint256 _value, uint16 _periods) public {
+    function deposit(uint256 _value, uint16 _periods) external {
         token.approve(address(escrow), _value);
         escrow.deposit(_value, _periods);
     }
 
-    function confirmActivity() public {
+    function confirmActivity() external {
         escrow.confirmActivity();
     }
 
@@ -198,8 +198,7 @@ contract WorkLockForStakingEscrowMock {
         escrow = _escrow;
     }
 
-    function setWorkMeasurement(address _staker, bool _measureWork) public returns (uint256) {
+    function setWorkMeasurement(address _staker, bool _measureWork) external returns (uint256) {
         return escrow.setWorkMeasurement(_staker, _measureWork);
     }
 }
-

--- a/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
@@ -201,4 +201,9 @@ contract WorkLockForStakingEscrowMock {
     function setWorkMeasurement(address _staker, bool _measureWork) external returns (uint256) {
         return escrow.setWorkMeasurement(_staker, _measureWork);
     }
+
+    function updateAllowableLockedTokens(uint256 _min, uint256 _max) external {
+        escrow.updateAllowableLockedTokens(_min, _max);
+    }
+
 }

--- a/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
@@ -56,8 +56,4 @@ contract StakingEscrowForWorkLockMock {
         stakerInfo[_staker].completedWork = _completedWork;
     }
 
-    function burn(uint256 _value) public {
-        token.transferFrom(msg.sender, address(this), _value);
-    }
-
 }

--- a/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
@@ -37,23 +37,28 @@ contract StakingEscrowForWorkLockMock {
         minLockedPeriods = _minLockedPeriods;
     }
 
-    function getCompletedWork(address _staker) public view returns (uint256) {
+    function getCompletedWork(address _staker) external view returns (uint256) {
         return stakerInfo[_staker].completedWork;
     }
 
-    function setWorkMeasurement(address _staker, bool _measureWork) public returns (uint256) {
+    function setWorkMeasurement(address _staker, bool _measureWork) external returns (uint256) {
         stakerInfo[_staker].measureWork = _measureWork;
         return stakerInfo[_staker].completedWork;
     }
 
-    function deposit(address _staker, uint256 _value, uint16 _periods) public {
+    function deposit(address _staker, uint256 _value, uint16 _periods) external {
         stakerInfo[_staker].value = _value;
         stakerInfo[_staker].periods = _periods;
         token.transferFrom(msg.sender, address(this), _value);
     }
 
-    function setCompletedWork(address _staker, uint256 _completedWork) public {
+    function setCompletedWork(address _staker, uint256 _completedWork) external {
         stakerInfo[_staker].completedWork = _completedWork;
+    }
+
+    function updateAllowableLockedTokens(uint256 _min, uint256 _max) external {
+        minAllowableLockedTokens = _min;
+        maxAllowableLockedTokens = _max;
     }
 
 }

--- a/tests/blockchain/eth/contracts/integration/test_contract_economics.py
+++ b/tests/blockchain/eth/contracts/integration/test_contract_economics.py
@@ -55,6 +55,7 @@ def test_reward(testerchain, agency, token_economics, mock_transacting_power_act
     _txhash = staking_agent.confirm_activity(worker_address=ursula)
 
     contract_reward = staking_agent.calculate_staking_reward(staker_address=ursula)
+    assert contract_reward > 0
     calculations_reward = token_economics.cumulative_rewards_at_period(1)
     error = (contract_reward - calculations_reward) / calculations_reward
     assert error > 0

--- a/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
+++ b/tests/blockchain/eth/contracts/integration/test_intercontract_integration.py
@@ -321,7 +321,7 @@ def test_all(testerchain,
     execute_multisig_transaction(testerchain, multisig, [contracts_owners[0], contracts_owners[1]], tx)
 
     # Initialize worklock
-    worklock_supply = 2200  # 2300
+    worklock_supply = 2400
     tx = token.functions.approve(worklock.address, worklock_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = worklock.functions.tokenDeposit(worklock_supply).transact({'from': creator})
@@ -401,6 +401,19 @@ def test_all(testerchain,
         tx = worklock.functions.claim().transact({'from': staker2, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
+    # Do force refund to whale
+    staker2_balance = testerchain.w3.eth.getBalance(staker2)
+    tx = worklock.functions.forceRefund([staker2]).transact()
+    testerchain.wait_for_receipt(tx)
+    staker2_bid = worklock.functions.workInfo(staker2).call()[0]
+    refund = deposited_eth_1 - staker2_bid
+    assert refund > 0
+    staker2_tokens = worklock.functions.ethToTokens(staker2_bid).call()
+    assert staker2_tokens <= token_economics.maximum_allowed_locked
+    worklock_balance -= refund
+    assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
+    assert testerchain.w3.eth.getBalance(staker2) == staker2_balance + refund
+
     # Check all bidders
     assert worklock.functions.getBiddersLength().call() == 2
     assert worklock.functions.nextBidderToCheck().call() == 0
@@ -415,7 +428,9 @@ def test_all(testerchain,
     tx = worklock.functions.enableClaiming().transact()
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.isClaimingAvailable().call()
-    assert escrow.functions.minAllowableLockedTokens().call() == worklock_supply // 20
+    staker1_tokens = worklock_supply - token_economics.maximum_allowed_locked
+    min_allowed_tokens = staker1_tokens // 2
+    assert escrow.functions.minAllowableLockedTokens().call() == min_allowed_tokens
     assert escrow.functions.maxAllowableLockedTokens().call() == token_economics.maximum_allowed_locked
 
     # Stakers claim tokens
@@ -424,15 +439,14 @@ def test_all(testerchain,
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.workInfo(staker2).call()[2]
 
-    staker2_tokens = worklock_supply * 9 // 10
     assert token.functions.balanceOf(staker2).call() == 0
     assert escrow.functions.getLockedTokens(staker2, 0).call() == 0
     assert escrow.functions.getLockedTokens(staker2, 1).call() == staker2_tokens
     assert escrow.functions.getLockedTokens(staker2, token_economics.minimum_locked_periods).call() == staker2_tokens
     assert escrow.functions.getLockedTokens(staker2, token_economics.minimum_locked_periods + 1).call() == 0
     staker2_remaining_work = staker2_tokens
-    assert worklock.functions.ethToWork(deposited_eth_1).call() == staker2_remaining_work
-    assert worklock.functions.workToETH(staker2_remaining_work).call() == deposited_eth_1
+    assert worklock.functions.ethToWork(staker2_bid).call() == staker2_remaining_work
+    assert worklock.functions.workToETH(staker2_remaining_work).call() == staker2_bid
     assert worklock.functions.getRemainingWork(staker2).call() == staker2_remaining_work
     assert token.functions.balanceOf(worklock.address).call() == worklock_supply - staker2_tokens
     tx = escrow.functions.setWorker(staker2).transact({'from': staker2})
@@ -444,7 +458,6 @@ def test_all(testerchain,
     testerchain.wait_for_receipt(tx)
     assert escrow.functions.stakerInfo(staker2).call()[WIND_DOWN_FIELD]
 
-    staker1_tokens = worklock_supply // 10
     tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.workInfo(staker1).call()[2]
@@ -1188,12 +1201,12 @@ def test_all(testerchain,
     assert staker2_completed_work < new_completed_work
     remaining_work = worklock.functions.getRemainingWork(staker2).call()
     assert 0 < remaining_work
-    assert deposited_eth_1 == worklock.functions.workInfo(staker2).call()[0]
+    assert staker2_bid == worklock.functions.workInfo(staker2).call()[0]
     staker2_balance = testerchain.w3.eth.getBalance(staker2)
     tx = worklock.functions.refund().transact({'from': staker2, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     refund = worklock.functions.workToETH(new_completed_work).call()
-    assert deposited_eth_1 - refund == worklock.functions.workInfo(staker2).call()[0]
+    assert staker2_bid - refund == worklock.functions.workInfo(staker2).call()[0]
     assert refund + staker2_balance == testerchain.w3.eth.getBalance(staker2)
     worklock_balance -= refund
     assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance

--- a/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/test_staking_escrow.py
@@ -32,8 +32,8 @@ def test_staking(testerchain, token, escrow_contract):
 
     escrow = escrow_contract(1500)
     creator = testerchain.client.accounts[0]
-    ursula1 = testerchain.client.accounts[1]
-    ursula2 = testerchain.client.accounts[2]
+    staker1 = testerchain.client.accounts[1]
+    staker2 = testerchain.client.accounts[2]
     deposit_log = escrow.events.Deposited.createFilter(fromBlock='latest')
     lock_log = escrow.events.Locked.createFilter(fromBlock='latest')
     activity_log = escrow.events.ActivityConfirmed.createFilter(fromBlock='latest')
@@ -42,144 +42,128 @@ def test_staking(testerchain, token, escrow_contract):
     withdraw_log = escrow.events.Withdrawn.createFilter(fromBlock='latest')
     wind_down_log = escrow.events.WindDownSet.createFilter(fromBlock='latest')
 
-    # Give Ursula and Ursula(2) some coins
-    tx = token.functions.transfer(ursula1, 10000).transact({'from': creator})
+    # Give Staker and Staker(2) some coins
+    tx = token.functions.transfer(staker1, 10000).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = token.functions.transfer(ursula2, 10000).transact({'from': creator})
+    tx = token.functions.transfer(staker2, 10000).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert 10000 == token.functions.balanceOf(ursula1).call()
-    assert 10000 == token.functions.balanceOf(ursula2).call()
+    assert 10000 == token.functions.balanceOf(staker1).call()
+    assert 10000 == token.functions.balanceOf(staker2).call()
 
-    # Ursula and Ursula(2) give Escrow rights to transfer
-    tx = token.functions.approve(escrow.address, 1000).transact({'from': ursula1})
+    # Staker and Staker(2) give Escrow rights to transfer
+    tx = token.functions.approve(escrow.address, 1000).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    assert 1000 == token.functions.allowance(ursula1, escrow.address).call()
-    tx = token.functions.approve(escrow.address, 500).transact({'from': ursula2})
+    assert 1000 == token.functions.allowance(staker1, escrow.address).call()
+    tx = token.functions.approve(escrow.address, 500).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 500 == token.functions.allowance(ursula2, escrow.address).call()
+    assert 500 == token.functions.allowance(staker2, escrow.address).call()
 
-    # Ursula's withdrawal attempt won't succeed because nothing to withdraw
+    # Staker's withdrawal attempt won't succeed because nothing to withdraw
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.withdraw(100).transact({'from': ursula1})
+        tx = escrow.functions.withdraw(100).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
-    # And can't lock because nothing to lock
+    # Can't lock because nothing to lock
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.lock(500, 2).transact({'from': ursula1})
+        tx = escrow.functions.lock(500, 2).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
     # Check that nothing is locked
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 0).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 0).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 0).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 0).call()
     assert 0 == escrow.functions.getLockedTokens(testerchain.client.accounts[3], 0).call()
 
-    # Ursula can't deposit tokens before Escrow initialization
+    # Staker can't deposit tokens before Escrow initialization
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(500, 2).transact({'from': ursula1})
+        tx = escrow.functions.deposit(500, 2).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
     # Initialize Escrow contract
     tx = escrow.functions.initialize(0).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
-    # Ursula can't deposit and lock too low value (less than _minAllowableLockedTokens coefficient)
+    # Can't deposit for too short a period (less than _minLockedPeriods coefficient)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(1, 10).transact({'from': ursula1})
-        testerchain.wait_for_receipt(tx)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = token.functions.approveAndCall(escrow.address, 1, testerchain.w3.toBytes(10))\
-            .transact({'from': ursula1})
-        testerchain.wait_for_receipt(tx)
-    # And can't deposit and lock too high value (more than _maxAllowableLockedTokens coefficient)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(1501, 10).transact({'from': ursula1})
-        testerchain.wait_for_receipt(tx)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = token.functions.approveAndCall(escrow.address, 1501, testerchain.w3.toBytes(10))\
-            .transact({'from': ursula1})
-        testerchain.wait_for_receipt(tx)
-    # And can't deposit for too short a period (less than _minLockedPeriods coefficient)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(1000, 1).transact({'from': ursula1})
+        tx = escrow.functions.deposit(1000, 1).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = token.functions.approveAndCall(escrow.address, 1000, testerchain.w3.toBytes(1))\
-            .transact({'from': ursula1})
+            .transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
-    # Ursula transfers some tokens to the escrow and lock them
+    # Staker transfers some tokens to the escrow and lock them
     current_period = escrow.functions.getCurrentPeriod().call()
-    tx = escrow.functions.deposit(1000, 2).transact({'from': ursula1})
+    tx = escrow.functions.deposit(1000, 2).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.setWorker(ursula1).transact({'from': ursula1})
+    tx = escrow.functions.setWorker(staker1).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.setWindDown(True).transact({'from': ursula1})
+    tx = escrow.functions.setWindDown(True).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
     assert 1000 == token.functions.balanceOf(escrow.address).call()
-    assert 9000 == token.functions.balanceOf(ursula1).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 0).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula1, 1).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula1, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 3).call()
+    assert 9000 == token.functions.balanceOf(staker1).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 0).call()
+    assert 1000 == escrow.functions.getLockedTokens(staker1, 1).call()
+    assert 1000 == escrow.functions.getLockedTokens(staker1, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 3).call()
 
     # Check that all events are emitted
     events = deposit_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert 1000 == event_args['value']
     assert 2 == event_args['periods']
     events = lock_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert 1000 == event_args['value']
     assert current_period + 1 == event_args['firstPeriod']
     assert 2 == event_args['periods']
     events = wind_down_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert event_args['windDown']
 
-    # Ursula(2) stakes tokens also
-    tx = escrow.functions.deposit(500, 2).transact({'from': ursula2})
+    # Staker(2) stakes tokens also
+    tx = escrow.functions.deposit(500, 2).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.setWorker(ursula2).transact({'from': ursula2})
+    tx = escrow.functions.setWorker(staker2).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.setWindDown(True).transact({'from': ursula2})
+    tx = escrow.functions.setWindDown(True).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
     assert 1500 == token.functions.balanceOf(escrow.address).call()
-    assert 9500 == token.functions.balanceOf(ursula2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 1).call()
+    assert 9500 == token.functions.balanceOf(staker2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 0).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 1).call()
 
     events = deposit_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 500 == event_args['value']
     assert 2 == event_args['periods']
     events = lock_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 500 == event_args['value']
     assert current_period + 1 == event_args['firstPeriod']
     assert 2 == event_args['periods']
     events = wind_down_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert event_args['windDown']
 
-    # Ursula and Ursula(2) confirm activity
-    tx = escrow.functions.confirmActivity().transact({'from': ursula1})
+    # Staker and Staker(2) confirm activity
+    tx = escrow.functions.confirmActivity().transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.confirmActivity().transact({'from': ursula2})
+    tx = escrow.functions.confirmActivity().transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert current_period + 1 == escrow.functions.getLastActivePeriod(ursula1).call()
-    assert current_period + 1 == escrow.functions.getLastActivePeriod(ursula2).call()
+    assert current_period + 1 == escrow.functions.getLastActivePeriod(staker1).call()
+    assert current_period + 1 == escrow.functions.getLastActivePeriod(staker2).call()
 
     # No active stakers before next period
     all_locked, stakers = escrow.functions.getActiveStakers(1, 0, 0).call()
@@ -189,28 +173,28 @@ def test_staking(testerchain, token, escrow_contract):
     events = activity_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[0]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert current_period + 1 == event_args['period']
     assert 1000 == event_args['value']
     events = activity_log.get_all_entries()
     event_args = events[1]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert current_period + 1 == event_args['period']
     assert 500 == event_args['value']
 
     # Checks locked tokens in the next period
     testerchain.time_travel(hours=1)
     current_period = escrow.functions.getCurrentPeriod().call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula1, 0).call()
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 0).call()
+    assert 1000 == escrow.functions.getLockedTokens(staker1, 0).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 0).call()
 
     # Both stakers are active and have locked tokens in next period
     all_locked, stakers = escrow.functions.getActiveStakers(1, 0, 0).call()
     assert 1500 == all_locked
     assert 2 == len(stakers)
-    assert ursula1 == to_checksum_address(stakers[0][0])
+    assert staker1 == to_checksum_address(stakers[0][0])
     assert 1000 == stakers[0][1]
-    assert ursula2 == to_checksum_address(stakers[1][0])
+    assert staker2 == to_checksum_address(stakers[1][0])
     assert 500 == stakers[1][1]
 
     # Test parameters of getActiveStakers method
@@ -235,59 +219,50 @@ def test_staking(testerchain, token, escrow_contract):
     assert 0 == all_locked
     assert 0 == len(stakers)
 
-    # Ursula's withdrawal attempt won't succeed because everything is locked
+    # Staker's withdrawal attempt won't succeed because everything is locked
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.withdraw(100).transact({'from': ursula1})
+        tx = escrow.functions.withdraw(100).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
     assert 1500 == token.functions.balanceOf(escrow.address).call()
-    assert 9000 == token.functions.balanceOf(ursula1).call()
+    assert 9000 == token.functions.balanceOf(staker1).call()
 
-    # Ursula can deposit more tokens
-    tx = escrow.functions.confirmActivity().transact({'from': ursula1})
+    # Staker can deposit more tokens
+    tx = escrow.functions.confirmActivity().transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    assert current_period + 1 == escrow.functions.getLastActivePeriod(ursula1).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula1, 1).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 2).call()
+    assert current_period + 1 == escrow.functions.getLastActivePeriod(staker1).call()
+    assert 1000 == escrow.functions.getLockedTokens(staker1, 1).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 2).call()
 
     events = activity_log.get_all_entries()
     assert 3 == len(events)
     event_args = events[2]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert current_period + 1 == event_args['period']
     assert 1000 == event_args['value']
 
     locked_next_period = escrow.functions.lockedPerPeriod(current_period + 1).call()
     tx = token.functions.approveAndCall(escrow.address, 500, testerchain.w3.toBytes(2))\
-        .transact({'from': ursula1})
+        .transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
     assert 2000 == token.functions.balanceOf(escrow.address).call()
-    assert 8500 == token.functions.balanceOf(ursula1).call()
-    assert 1500 == escrow.functions.getLockedTokens(ursula1, 1).call()
-    assert 500 == escrow.functions.getLockedTokens(ursula1, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 3).call()
+    assert 8500 == token.functions.balanceOf(staker1).call()
+    assert 1500 == escrow.functions.getLockedTokens(staker1, 1).call()
+    assert 500 == escrow.functions.getLockedTokens(staker1, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 3).call()
     assert locked_next_period + 500 == escrow.functions.lockedPerPeriod(current_period + 1).call()
 
     events = activity_log.get_all_entries()
     assert 4 == len(events)
     event_args = events[3]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert current_period + 1 == event_args['period']
     assert 500 == event_args['value']
-
-    # But can't deposit too high value (more than _maxAllowableLockedTokens coefficient)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(100, 2).transact({'from': ursula1})
-        testerchain.wait_for_receipt(tx)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = token.functions.approveAndCall(escrow.address, 100, testerchain.w3.toBytes(2))\
-            .transact({'from': ursula1})
-        testerchain.wait_for_receipt(tx)
 
     # Both stakers are active and only the first one locked tokens for two more periods
     all_locked, stakers = escrow.functions.getActiveStakers(2, 0, 0).call()
     assert 500 == all_locked
     assert 1 == len(stakers)
-    assert ursula1 == to_checksum_address(stakers[0][0])
+    assert staker1 == to_checksum_address(stakers[0][0])
     assert 500 == stakers[0][1]
     _, stakers = escrow.functions.getActiveStakers(2, 0, 2).call()
     assert 1 == len(stakers)
@@ -300,190 +275,185 @@ def test_staking(testerchain, token, escrow_contract):
 
     # Wait 1 period and checks locking
     testerchain.time_travel(hours=1)
-    assert 1500 == escrow.functions.getLockedTokens(ursula1, 0).call()
+    assert 1500 == escrow.functions.getLockedTokens(staker1, 0).call()
 
     # Only one staker is active
     all_locked, stakers = escrow.functions.getActiveStakers(1, 0, 0).call()
     assert 500 == all_locked
     assert 1 == len(stakers)
-    assert ursula1 == to_checksum_address(stakers[0][0])
+    assert staker1 == to_checksum_address(stakers[0][0])
     assert 500 == stakers[0][1]
 
     # Confirm activity and wait 1 period, locking will be decreased because of end of one stake
-    tx = escrow.functions.confirmActivity().transact({'from': ursula1})
+    tx = escrow.functions.confirmActivity().transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
     current_period = escrow.functions.getCurrentPeriod().call()
-    assert 500 == escrow.functions.getLockedTokens(ursula1, 0).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 1).call()
+    assert 500 == escrow.functions.getLockedTokens(staker1, 0).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 1).call()
 
     events = activity_log.get_all_entries()
     assert 5 == len(events)
     event_args = events[4]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert current_period == event_args['period']
     assert 500 == event_args['value']
 
-    # Stake is unlocked and Ursula can withdraw some tokens
-    tx = escrow.functions.withdraw(100).transact({'from': ursula1})
+    # Stake is unlocked and Staker can withdraw some tokens
+    tx = escrow.functions.withdraw(100).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
     assert 1900 == token.functions.balanceOf(escrow.address).call()
-    assert 8600 == token.functions.balanceOf(ursula1).call()
+    assert 8600 == token.functions.balanceOf(staker1).call()
     events = withdraw_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert 100 == event_args['value']
 
-    # But Ursula can't withdraw all without unlocking other stakes
+    # But Staker can't withdraw all without unlocking other stakes
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.withdraw(1400).transact({'from': ursula1})
+        tx = escrow.functions.withdraw(1400).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
-    # And Ursula can't lock again too low value
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.lock(1, 1).transact({'from': ursula1})
-        testerchain.wait_for_receipt(tx)
-
-    # Ursula can deposit and lock more tokens
+    # Staker can deposit and lock more tokens
     tx = token.functions.approveAndCall(escrow.address, 500, testerchain.w3.toBytes(2))\
-        .transact({'from': ursula1})
+        .transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.confirmActivity().transact({'from': ursula1})
+    tx = escrow.functions.confirmActivity().transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
 
     events = activity_log.get_all_entries()
     assert 6 == len(events)
     event_args = events[5]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert current_period + 1 == event_args['period']
     assert 500 == event_args['value']
 
-    tx = escrow.functions.lock(100, 2).transact({'from': ursula1})
+    tx = escrow.functions.lock(100, 2).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
 
     events = activity_log.get_all_entries()
     assert 7 == len(events)
     event_args = events[6]['args']
-    assert ursula1 == event_args['staker']
+    assert staker1 == event_args['staker']
     assert current_period + 1 == event_args['period']
     assert 100 == event_args['value']
 
     # Value of locked tokens will be updated in next period
-    assert 500 == escrow.functions.getLockedTokens(ursula1, 0).call()
-    assert 600 == escrow.functions.getLockedTokens(ursula1, 1).call()
-    assert 600 == escrow.functions.getLockedTokens(ursula1, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 3).call()
+    assert 500 == escrow.functions.getLockedTokens(staker1, 0).call()
+    assert 600 == escrow.functions.getLockedTokens(staker1, 1).call()
+    assert 600 == escrow.functions.getLockedTokens(staker1, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 3).call()
     testerchain.time_travel(hours=1)
-    assert 600 == escrow.functions.getLockedTokens(ursula1, 0).call()
-    assert 600 == escrow.functions.getLockedTokens(ursula1, 1).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 2).call()
+    assert 600 == escrow.functions.getLockedTokens(staker1, 0).call()
+    assert 600 == escrow.functions.getLockedTokens(staker1, 1).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 2).call()
 
-    # Ursula increases lock
-    tx = escrow.functions.lock(500, 2).transact({'from': ursula1})
+    # Staker increases lock
+    tx = escrow.functions.lock(500, 2).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.confirmActivity().transact({'from': ursula1})
+    tx = escrow.functions.confirmActivity().transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
-    assert 600 == escrow.functions.getLockedTokens(ursula1, 0).call()
-    assert 1100 == escrow.functions.getLockedTokens(ursula1, 1).call()
-    assert 500 == escrow.functions.getLockedTokens(ursula1, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula1, 3).call()
+    assert 600 == escrow.functions.getLockedTokens(staker1, 0).call()
+    assert 1100 == escrow.functions.getLockedTokens(staker1, 1).call()
+    assert 500 == escrow.functions.getLockedTokens(staker1, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker1, 3).call()
     testerchain.time_travel(hours=1)
-    assert 1100 == escrow.functions.getLockedTokens(ursula1, 0).call()
+    assert 1100 == escrow.functions.getLockedTokens(staker1, 0).call()
 
-    # Ursula(2) increases lock by deposit more tokens using approveAndCall
+    # Staker(2) increases lock by deposit more tokens using approveAndCall
     tx = token.functions.approveAndCall(escrow.address, 500, testerchain.w3.toBytes(2))\
-        .transact({'from': ursula2})
+        .transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.confirmActivity().transact({'from': ursula2})
+    tx = escrow.functions.confirmActivity().transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 1000 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 3).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 0).call()
+    assert 1000 == escrow.functions.getLockedTokens(staker2, 1).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 3).call()
     testerchain.time_travel(hours=1)
 
     # And increases locked time by dividing stake into two parts
     current_period = escrow.functions.getCurrentPeriod().call()
-    assert 2 == escrow.functions.getSubStakesLength(ursula2).call()
-    assert current_period + 1 == escrow.functions.getLastPeriodOfSubStake(ursula2, 1).call()
-    tx = escrow.functions.divideStake(1, 200, 1).transact({'from': ursula2})
+    assert 2 == escrow.functions.getSubStakesLength(staker2).call()
+    assert current_period + 1 == escrow.functions.getLastPeriodOfSubStake(staker2, 1).call()
+    tx = escrow.functions.divideStake(1, 200, 1).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 1000 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 200 == escrow.functions.getLockedTokens(ursula2, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 3).call()
+    assert 1000 == escrow.functions.getLockedTokens(staker2, 0).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 1).call()
+    assert 200 == escrow.functions.getLockedTokens(staker2, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 3).call()
 
     events = lock_log.get_all_entries()
     assert 8 == len(events)
     event_args = events[7]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 200 == event_args['value']
     assert current_period == event_args['firstPeriod']
     assert 2 == event_args['periods']
     events = divides_log.get_all_entries()
     assert 1 == len(events)
     event_args = events[0]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 500 == event_args['oldValue']
     assert current_period + 1 == event_args['lastPeriod']
     assert 200 == event_args['newValue']
     assert 1 == event_args['periods']
 
-    tx = escrow.functions.confirmActivity().transact({'from': ursula2})
+    tx = escrow.functions.confirmActivity().transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
     # Check number of stakes and last stake parameters
     current_period = escrow.functions.getCurrentPeriod().call()
-    assert 3 == escrow.functions.getSubStakesLength(ursula2).call()
-    assert current_period == escrow.functions.getLastPeriodOfSubStake(ursula2, 1).call()
+    assert 3 == escrow.functions.getSubStakesLength(staker2).call()
+    assert current_period == escrow.functions.getLastPeriodOfSubStake(staker2, 1).call()
 
     # Can't divide stake again because current period is the last periods for this sub stake
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.divideStake(1, 200, 2).transact({'from': ursula2})
+        tx = escrow.functions.divideStake(1, 200, 2).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
     # But can lock
-    tx = escrow.functions.lock(200, 2).transact({'from': ursula2})
+    tx = escrow.functions.lock(200, 2).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 400 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 200 == escrow.functions.getLockedTokens(ursula2, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 3).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 0).call()
+    assert 400 == escrow.functions.getLockedTokens(staker2, 1).call()
+    assert 200 == escrow.functions.getLockedTokens(staker2, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 3).call()
 
     # Check number of stakes and last stake parameters
-    assert 4 == escrow.functions.getSubStakesLength(ursula2).call()
-    assert current_period + 1 == escrow.functions.getLastPeriodOfSubStake(ursula2, 2).call()
+    assert 4 == escrow.functions.getSubStakesLength(staker2).call()
+    assert current_period + 1 == escrow.functions.getLastPeriodOfSubStake(staker2, 2).call()
 
     # Divide stake again
-    tx = escrow.functions.divideStake(2, 100, 1).transact({'from': ursula2})
+    tx = escrow.functions.divideStake(2, 100, 1).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 400 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 300 == escrow.functions.getLockedTokens(ursula2, 2).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 3).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 0).call()
+    assert 400 == escrow.functions.getLockedTokens(staker2, 1).call()
+    assert 300 == escrow.functions.getLockedTokens(staker2, 2).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 3).call()
 
     events = divides_log.get_all_entries()
     assert 2 == len(events)
     event_args = events[1]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 200 == event_args['oldValue']
     assert current_period + 1 == event_args['lastPeriod']
     assert 100 == event_args['newValue']
     assert 1 == event_args['periods']
 
     # Prolong some sub stake
-    tx = escrow.functions.prolongStake(3, 1).transact({'from': ursula2})
+    tx = escrow.functions.prolongStake(3, 1).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 400 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 300 == escrow.functions.getLockedTokens(ursula2, 2).call()
-    assert 200 == escrow.functions.getLockedTokens(ursula2, 3).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 4).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 0).call()
+    assert 400 == escrow.functions.getLockedTokens(staker2, 1).call()
+    assert 300 == escrow.functions.getLockedTokens(staker2, 2).call()
+    assert 200 == escrow.functions.getLockedTokens(staker2, 3).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 4).call()
 
     events = lock_log.get_all_entries()
     assert 11 == len(events)
     event_args = events[10]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 200 == event_args['value']
     assert current_period + 3 == event_args['firstPeriod']
     assert 1 == event_args['periods']
@@ -491,31 +461,31 @@ def test_staking(testerchain, token, escrow_contract):
     events = prolong_log.get_all_entries()
     assert len(events) == 1
     event_args = events[0]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 200 == event_args['value']
     assert current_period + 2 == event_args['lastPeriod']
     assert 1 == event_args['periods']
 
     # Prolong sub stake that will end in the next period
-    tx = escrow.functions.confirmActivity().transact({'from': ursula2})
+    tx = escrow.functions.confirmActivity().transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.prolongStake(2, 1).transact({'from': ursula2})
+    tx = escrow.functions.prolongStake(2, 1).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 500 == escrow.functions.getLockedTokens(ursula2, 0).call()
-    assert 400 == escrow.functions.getLockedTokens(ursula2, 1).call()
-    assert 400 == escrow.functions.getLockedTokens(ursula2, 2).call()
-    assert 200 == escrow.functions.getLockedTokens(ursula2, 3).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula2, 4).call()
+    assert 500 == escrow.functions.getLockedTokens(staker2, 0).call()
+    assert 400 == escrow.functions.getLockedTokens(staker2, 1).call()
+    assert 400 == escrow.functions.getLockedTokens(staker2, 2).call()
+    assert 200 == escrow.functions.getLockedTokens(staker2, 3).call()
+    assert 0 == escrow.functions.getLockedTokens(staker2, 4).call()
 
     # Check overflow in prolong stake
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.prolongStake(2, MAX_UINT16).transact({'from': ursula2})
+        tx = escrow.functions.prolongStake(2, MAX_UINT16).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
 
     events = lock_log.get_all_entries()
     assert 12 == len(events)
     event_args = events[11]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 100 == event_args['value']
     assert current_period + 2 == event_args['firstPeriod']
     assert 1 == event_args['periods']
@@ -523,46 +493,46 @@ def test_staking(testerchain, token, escrow_contract):
     events = prolong_log.get_all_entries()
     assert len(events) == 2
     event_args = events[1]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert 100 == event_args['value']
     assert current_period + 1 == event_args['lastPeriod']
     assert 1 == event_args['periods']
 
     # Can't prolong sub stake that will end in the current period
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.prolongStake(1, 2).transact({'from': ursula2})
+        tx = escrow.functions.prolongStake(1, 2).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
 
     # Just wait and confirm activity
     testerchain.time_travel(hours=1)
-    tx = escrow.functions.confirmActivity().transact({'from': ursula2})
+    tx = escrow.functions.confirmActivity().transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
-    tx = escrow.functions.confirmActivity().transact({'from': ursula2})
+    tx = escrow.functions.confirmActivity().transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
 
     # Can't divide old stake because it's already unlocked
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.divideStake(0, 200, 10).transact({'from': ursula2})
+        tx = escrow.functions.divideStake(0, 200, 10).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
     # Can't divide nonexistent stake
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.divideStake(10, 100, 1).transact({'from': ursula2})
+        tx = escrow.functions.divideStake(10, 100, 1).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
     # And can't prolong old stake
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.prolongStake(0, 10).transact({'from': ursula2})
+        tx = escrow.functions.prolongStake(0, 10).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
 
     current_period = escrow.functions.getCurrentPeriod().call()
     events = activity_log.get_all_entries()
     assert 13 == len(events)
     event_args = events[11]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert current_period == event_args['period']
     assert 400 == event_args['value']
     event_args = events[12]['args']
-    assert ursula2 == event_args['staker']
+    assert staker2 == event_args['staker']
     assert current_period + 1 == event_args['period']
     assert 200 == event_args['value']
 
@@ -570,73 +540,175 @@ def test_staking(testerchain, token, escrow_contract):
     assert 1 == len(withdraw_log.get_all_entries())
 
     # Test max locking duration
-    tx = escrow.functions.lock(200, MAX_UINT16).transact({'from': ursula2})
+    tx = escrow.functions.lock(200, MAX_UINT16).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    assert 200 == escrow.functions.getLockedTokens(ursula2, MAX_UINT16 - current_period).call()
+    assert 200 == escrow.functions.getLockedTokens(staker2, MAX_UINT16 - current_period).call()
 
 
 @pytest.mark.slow
 def test_max_sub_stakes(testerchain, token, escrow_contract):
     escrow = escrow_contract(10000)
     creator = testerchain.client.accounts[0]
-    ursula = testerchain.client.accounts[1]
+    staker = testerchain.client.accounts[1]
 
     # Initialize Escrow contract
     tx = escrow.functions.initialize(0).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Prepare before deposit
-    tx = token.functions.transfer(ursula, 4000).transact({'from': creator})
+    tx = token.functions.transfer(staker, 4000).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    tx = token.functions.approve(escrow.address, 4000).transact({'from': ursula})
+    tx = token.functions.approve(escrow.address, 4000).transact({'from': staker})
     testerchain.wait_for_receipt(tx)
 
     # Lock one sub stake from current period and others from next one
-    tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+    tx = escrow.functions.deposit(100, 2).transact({'from': staker})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.setWorker(ursula).transact({'from': ursula})
+    tx = escrow.functions.setWorker(staker).transact({'from': staker})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.setWindDown(True).transact({'from': ursula})
+    tx = escrow.functions.setWindDown(True).transact({'from': staker})
     testerchain.wait_for_receipt(tx)
-    assert 1 == escrow.functions.getSubStakesLength(ursula).call()
+    assert 1 == escrow.functions.getSubStakesLength(staker).call()
 
-    tx = escrow.functions.confirmActivity().transact({'from': ursula})
+    tx = escrow.functions.confirmActivity().transact({'from': staker})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
     for index in range(MAX_SUB_STAKES - 1):
-        tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+        tx = escrow.functions.deposit(100, 2).transact({'from': staker})
         testerchain.wait_for_receipt(tx)
-    assert MAX_SUB_STAKES == escrow.functions.getSubStakesLength(ursula).call()
-    assert 3000 == escrow.functions.getLockedTokens(ursula, 1).call()
+    assert MAX_SUB_STAKES == escrow.functions.getSubStakesLength(staker).call()
+    assert 3000 == escrow.functions.getLockedTokens(staker, 1).call()
 
     # Can't lock more because of reaching the maximum number of active sub stakes
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+        tx = escrow.functions.deposit(100, 2).transact({'from': staker})
         testerchain.wait_for_receipt(tx)
 
     # After two periods first sub stake will be unlocked and we can lock again
-    tx = escrow.functions.confirmActivity().transact({'from': ursula})
+    tx = escrow.functions.confirmActivity().transact({'from': staker})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
-    tx = escrow.functions.confirmActivity().transact({'from': ursula})
+    tx = escrow.functions.confirmActivity().transact({'from': staker})
     testerchain.wait_for_receipt(tx)
     testerchain.time_travel(hours=1)
-    assert 2900 == escrow.functions.getLockedTokens(ursula, 0).call()
-    assert 0 == escrow.functions.getLockedTokens(ursula, 1).call()
-    assert MAX_SUB_STAKES == escrow.functions.getSubStakesLength(ursula).call()
+    assert 2900 == escrow.functions.getLockedTokens(staker, 0).call()
+    assert 0 == escrow.functions.getLockedTokens(staker, 1).call()
+    assert MAX_SUB_STAKES == escrow.functions.getSubStakesLength(staker).call()
     # Before sub stake will be inactive it must be mined
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+        tx = escrow.functions.deposit(100, 2).transact({'from': staker})
         testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.mint().transact({'from': ursula})
+    tx = escrow.functions.mint().transact({'from': staker})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+    tx = escrow.functions.deposit(100, 2).transact({'from': staker})
     testerchain.wait_for_receipt(tx)
-    assert 2900 == escrow.functions.getLockedTokens(ursula, 0).call()
-    assert 100 == escrow.functions.getLockedTokens(ursula, 1).call()
-    assert MAX_SUB_STAKES == escrow.functions.getSubStakesLength(ursula).call()
+    assert 2900 == escrow.functions.getLockedTokens(staker, 0).call()
+    assert 100 == escrow.functions.getLockedTokens(staker, 1).call()
+    assert MAX_SUB_STAKES == escrow.functions.getSubStakesLength(staker).call()
 
     # Can't lock more because of reaching the maximum number of active sub stakes and they are not mined yet
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(100, 2).transact({'from': ursula})
+        tx = escrow.functions.deposit(100, 2).transact({'from': staker})
         testerchain.wait_for_receipt(tx)
+
+
+@pytest.mark.slow
+def test_allowable_locked_tokens(testerchain, token_economics, token, escrow_contract, deploy_contract):
+    maximum_allowed = 1500
+    minimum_allowed = token_economics.minimum_allowed_locked
+    escrow = escrow_contract(maximum_allowed)
+    creator, staker1, staker2, *everyone_else = testerchain.client.accounts
+
+    # Initialize Escrow contract
+    tx = escrow.functions.initialize(0).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+
+    # Prepare before deposit
+    duration = token_economics.minimum_locked_periods
+    tx = token.functions.transfer(staker1, 2 * maximum_allowed).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+    tx = token.functions.transfer(staker2, 2 * maximum_allowed).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+
+    # Staker can't deposit and lock too low value (less than _minAllowableLockedTokens coefficient)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = token.functions.approveAndCall(escrow.address, minimum_allowed - 1, testerchain.w3.toBytes(duration))\
+            .transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+    # And can't deposit and lock too high value (more than _maxAllowableLockedTokens coefficient)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = token.functions.approveAndCall(escrow.address, maximum_allowed + 1, testerchain.w3.toBytes(duration))\
+            .transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+
+    tx = token.functions.approve(escrow.address, maximum_allowed + 1).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    # Staker can't deposit and lock too low value (less than _minAllowableLockedTokens coefficient)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.deposit(minimum_allowed - 1, duration).transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+    # And can't deposit and lock too high value (more than _maxAllowableLockedTokens coefficient)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.deposit(maximum_allowed + 1, duration).transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+
+    tx = escrow.functions.deposit(minimum_allowed, duration).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    staker1_lock = minimum_allowed
+    tx = token.functions.approve(escrow.address, 0).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    tx = token.functions.approveAndCall(escrow.address, minimum_allowed, testerchain.w3.toBytes(duration)) \
+        .transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    staker1_lock += minimum_allowed
+
+    # Preparation for next cases
+    tx = token.functions.approveAndCall(escrow.address, minimum_allowed, testerchain.w3.toBytes(duration))\
+        .transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    staker1_lock += minimum_allowed
+    tx = token.functions.approveAndCall(escrow.address, maximum_allowed, testerchain.w3.toBytes(duration))\
+        .transact({'from': staker2})
+    testerchain.wait_for_receipt(tx)
+
+    # Can't deposit or lock too high value (more than _maxAllowableLockedTokens coefficient)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = token.functions.approveAndCall(escrow.address, minimum_allowed, testerchain.w3.toBytes(2 * duration))\
+            .transact({'from': staker2})
+        testerchain.wait_for_receipt(tx)
+    tx = token.functions.approve(escrow.address, minimum_allowed).transact({'from': staker2})
+    testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.deposit(minimum_allowed, 2 * duration).transact({'from': staker2})
+        testerchain.wait_for_receipt(tx)
+
+    # Prepare for testing `lock()`: staker makes new sub-staker and unlocks first sub-stake
+    tx = token.functions\
+        .approveAndCall(escrow.address, maximum_allowed - staker1_lock, testerchain.w3.toBytes(2 * duration)) \
+        .transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWindDown(True).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWorker(staker1).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    for _ in range(duration):
+        tx = escrow.functions.confirmActivity().transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+        testerchain.time_travel(hours=1)
+    testerchain.time_travel(hours=2)
+    staker1_lock = maximum_allowed - staker1_lock
+    assert escrow.functions.getLockedTokens(staker1, 0).call() == staker1_lock
+
+    # Staker can't lock again too low or too high value
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.lock(minimum_allowed - 1, duration).transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.lock(maximum_allowed - staker1_lock + 1, duration).transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+
+    tx = escrow.functions.lock(minimum_allowed, duration).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    staker1_lock += minimum_allowed
+    tx = escrow.functions.lock(maximum_allowed - staker1_lock, duration).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -52,7 +52,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     slowing_refund = 100
     staking_periods = 2 * token_economics.minimum_locked_periods
     min_allowed_bid = to_wei(1, 'ether')
-    max_allowed_bid = 8 * min_allowed_bid
+    max_allowed_bid = 20 * min_allowed_bid
     worklock, _ = deploy_contract(
         contract_name='WorkLock',
         _token=token.address,
@@ -79,10 +79,11 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     refund_log = worklock.events.Refund.createFilter(fromBlock='latest')
     canceling_log = worklock.events.Canceled.createFilter(fromBlock='latest')
     checks_log = worklock.events.BiddersChecked.createFilter(fromBlock='latest')
+    claiming_enable_log = worklock.events.ClaimingEnabled.createFilter(fromBlock='latest')
 
     # Transfer tokens to WorkLock
-    worklock_supply_1 = 2 * token_economics.maximum_allowed_locked // 10 + 1
-    worklock_supply_2 = token_economics.maximum_allowed_locked // 10 - 1
+    worklock_supply_1 = token_economics.maximum_allowed_locked // 2 + 1
+    worklock_supply_2 = token_economics.maximum_allowed_locked // 2 - 1
     worklock_supply = worklock_supply_1 + worklock_supply_2
     tx = token.functions.approve(worklock.address, worklock_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
@@ -105,7 +106,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     # Give stakers some ETH
     deposit_eth_1 = 4 * min_allowed_bid
     deposit_eth_2 = min_allowed_bid
-    staker1_balance = 10 * deposit_eth_1
+    staker1_balance = 100 * deposit_eth_1
     tx = testerchain.w3.eth.sendTransaction(
         {'from': testerchain.etherbase_account, 'to': staker1, 'value': staker1_balance})
     testerchain.wait_for_receipt(tx)
@@ -137,6 +138,9 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.enableClaiming().transact()
         testerchain.wait_for_receipt(tx)
 
     # Wait for the start of bidding
@@ -247,7 +251,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
 
     # The final bid must be less than the maximum
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.bid().transact({'from': staker1, 'value': 1, 'gas_price': 0})
+        tx = worklock.functions.bid()\
+            .transact({'from': staker1, 'value': max_allowed_bid - 2 * deposit_eth_1 + 1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Can't claim, refund or burn while bidding phase
@@ -344,6 +349,14 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
+    # Can't check before end of cancellation window
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+    # Can't enable claiming before checking
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.enableClaiming().transact()
+        testerchain.wait_for_receipt(tx)
 
     # But can cancel during cancellation window
     staker3_balance = testerchain.w3.eth.getBalance(staker3)
@@ -368,66 +381,56 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert event_args['sender'] == staker3
     assert event_args['value'] == staker3_bid
 
-    # Can't check before end of cancellation window
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
-        testerchain.wait_for_receipt(tx)
-
     # Wait for the end of cancellation window
     testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
 
-    # Can't claim before checking bidders
+    # Can't enable claiming before checking
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
+        tx = worklock.functions.enableClaiming().transact()
         testerchain.wait_for_receipt(tx)
 
-    # Too low value for remaining gas
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.verifyBiddingCorrectness(0).transact({'from': staker1, 'gas': 35000})
-        testerchain.wait_for_receipt(tx)
-
-    # Too low value for gas limit
-    assert worklock.functions.nextBidderToCheck().call() == 0
-    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact({'gas': gas_to_save_state + 5000})
-    testerchain.wait_for_receipt(tx)
-    assert worklock.functions.nextBidderToCheck().call() == 0
-
-    # Set gas only for one check
-    # TODO failed cases
-    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state)\
-        .transact({'from': staker1, 'gas': 60000, 'gas_price': 0})
-    testerchain.wait_for_receipt(tx)
-    assert worklock.functions.nextBidderToCheck().call() == 1
-
-    events = checks_log.get_all_entries()
-    assert 1 == len(events)
-    event_args = events[0]['args']
-    assert event_args['sender'] == staker1
-    assert event_args['startIndex'] == 0
-    assert event_args['endIndex'] == 1
-
-    # Still can't claim because checked only portion of bidders
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
-        testerchain.wait_for_receipt(tx)
-
-    # Check all others
+    # Check all bidders
+    # TODO failed cases with force refund
     assert not worklock.functions.isClaimingAvailable().call()
     tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.nextBidderToCheck().call() == 3
-    assert worklock.functions.isClaimingAvailable().call()
+    assert not worklock.functions.isClaimingAvailable().call()
 
     events = checks_log.get_all_entries()
-    assert 2 == len(events)
-    event_args = events[1]['args']
+    assert 1 == len(events)
+    event_args = events[-1]['args']
     assert event_args['sender'] == creator
-    assert event_args['startIndex'] == 1
+    assert event_args['startIndex'] == 0
     assert event_args['endIndex'] == 3
 
     # Can't check again
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # Claim is not enabled yet
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+
+    # Enable claiming
+    assert escrow.functions.minAllowableLockedTokens().call() == token_economics.minimum_allowed_locked
+    assert escrow.functions.maxAllowableLockedTokens().call() == token_economics.maximum_allowed_locked
+    tx = worklock.functions.enableClaiming().transact()
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.isClaimingAvailable().call()
+    assert escrow.functions.minAllowableLockedTokens().call() == worklock_supply // 10
+    assert escrow.functions.maxAllowableLockedTokens().call() == (max_allowed_bid // min_allowed_bid) * worklock_supply // 10
+
+    events = claiming_enable_log.get_all_entries()
+    assert 1 == len(events)
+    event_args = events[-1]['args']
+    assert event_args['sender'] == creator
+
+    # Can't enable again
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.enableClaiming().transact()
         testerchain.wait_for_receipt(tx)
 
     # Staker claims tokens
@@ -631,6 +634,8 @@ def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow
     testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
     tx = worklock.functions.verifyBiddingCorrectness(30000).transact()
     testerchain.wait_for_receipt(tx)
+    tx = worklock.functions.enableClaiming().transact()
+    testerchain.wait_for_receipt(tx)
 
     # Claim
     transaction = worklock.functions.claim().buildTransaction({'gas': 0})
@@ -659,34 +664,46 @@ def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow
 
 
 @pytest.mark.slow
-def test_max_allowed(testerchain, token_economics, deploy_contract, token, escrow):
-    creator, bidder1, bidder2, *everyone_else = testerchain.w3.eth.accounts
+def test_verifying_correctness(testerchain, token_economics, deploy_contract, token, escrow):
+    creator, bidder1, bidder2, bidder3, *everyone_else = testerchain.w3.eth.accounts
+    gas_to_save_state = 30000
 
     # Deploy WorkLock
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
-    start_bid_date = now
-    end_bid_date = start_bid_date + (60 * 60)
-    end_cancellation_date = end_bid_date
     boosting_refund = 100
     staking_periods = token_economics.minimum_locked_periods
     min_allowed_bid = to_wei(1, 'ether')
-    worklock, _ = deploy_contract(
-        contract_name='WorkLock',
-        _token=token.address,
-        _escrow=escrow.address,
-        _startBidDate=start_bid_date,
-        _endBidDate=end_bid_date,
-        _endCancellationDate=end_cancellation_date,
-        _boostingRefund=boosting_refund,
-        _stakingPeriods=staking_periods,
-        _minAllowedBid=min_allowed_bid,
-        _maxAllowedBid=min_allowed_bid
-    )
+
+    def deploy_worklock(supply, max_bid):
+
+        now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+        start_bid_date = now
+        end_bid_date = start_bid_date + (60 * 60)
+        end_cancellation_date = end_bid_date
+
+        contract, _ = deploy_contract(
+            contract_name='WorkLock',
+            _token=token.address,
+            _escrow=escrow.address,
+            _startBidDate=start_bid_date,
+            _endBidDate=end_bid_date,
+            _endCancellationDate=end_cancellation_date,
+            _boostingRefund=boosting_refund,
+            _stakingPeriods=staking_periods,
+            _minAllowedBid=min_allowed_bid,
+            _maxAllowedBid=max_bid
+        )
+
+        tx = token.functions.approve(contract.address, supply).transact()
+        testerchain.wait_for_receipt(tx)
+        tx = contract.functions.tokenDeposit(supply).transact()
+        testerchain.wait_for_receipt(tx)
+        log = contract.events.BiddersChecked.createFilter(fromBlock='latest')
+
+        return contract, log
+
+    # Test: bidder has too much tokens to claim
     worklock_supply = token_economics.maximum_allowed_locked + 1
-    tx = token.functions.approve(worklock.address, worklock_supply).transact()
-    testerchain.wait_for_receipt(tx)
-    tx = worklock.functions.tokenDeposit(worklock_supply).transact()
-    testerchain.wait_for_receipt(tx)
+    worklock, _checks_log = deploy_worklock(worklock_supply, min_allowed_bid)
 
     # Bid
     tx = testerchain.w3.eth.sendTransaction(
@@ -698,6 +715,104 @@ def test_max_allowed(testerchain, token_economics, deploy_contract, token, escro
 
     # Check will fail because bidder has too much tokens to claim
     testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    worklock_balance = testerchain.w3.eth.getBalance(worklock.address)
+    default_max = worklock.functions.defaultMaxAllowableLockedTokens().call()
+    assert default_max * worklock_balance // worklock_supply < min_allowed_bid
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.verifyBiddingCorrectness(30000).transact()
         testerchain.wait_for_receipt(tx)
+
+    # Test: bidder will get tokens as much as possible without force refund
+    worklock_supply = 3 * token_economics.maximum_allowed_locked
+    worklock, checks_log = deploy_worklock(worklock_supply, min_allowed_bid)
+
+    # Bids
+    for bidder in [bidder1, bidder2, bidder3]:
+        tx = testerchain.w3.eth.sendTransaction(
+            {'from': testerchain.etherbase_account, 'to': bidder, 'value': min_allowed_bid})
+        testerchain.wait_for_receipt(tx)
+        tx = worklock.functions.bid().transact({'from': bidder, 'value': min_allowed_bid, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+    assert worklock.functions.ethToTokens(min_allowed_bid).call() == token_economics.maximum_allowed_locked
+
+    # Wait exactly 1 hour
+    testerchain.time_travel(seconds=3600)
+    worklock_balance = testerchain.w3.eth.getBalance(worklock.address)
+    default_max = worklock.functions.defaultMaxAllowableLockedTokens().call()
+    assert default_max * worklock_balance // worklock_supply == min_allowed_bid
+
+    # Too low value for gas limit
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state)\
+            .transact({'from': bidder1, 'gas': gas_to_save_state + 20000})
+        testerchain.wait_for_receipt(tx)
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state)\
+        .transact({'from': bidder1, 'gas': gas_to_save_state + 25000})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.nextBidderToCheck().call() == 3
+
+    events = checks_log.get_all_entries()
+    assert 1 == len(events)
+    event_args = events[-1]['args']
+    assert event_args['sender'] == bidder1
+    assert event_args['startIndex'] == 0
+    assert event_args['endIndex'] == 3
+
+    # Test: partial verification with low amount of gas limit
+    worklock_supply = 3 * token_economics.maximum_allowed_locked
+    max_allowed_bid = 2 * min_allowed_bid
+    worklock, checks_log = deploy_worklock(worklock_supply, max_allowed_bid)
+
+    # Bids
+    for bidder in [bidder1, bidder2, bidder3]:
+        tx = testerchain.w3.eth.sendTransaction(
+            {'from': testerchain.etherbase_account, 'to': bidder, 'value': min_allowed_bid})
+        testerchain.wait_for_receipt(tx)
+        tx = worklock.functions.bid().transact({'from': bidder, 'value': min_allowed_bid, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+    assert worklock.functions.ethToTokens(min_allowed_bid).call() == worklock_supply // 3
+
+    # Wait exactly 1 hour
+    testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    worklock_balance = testerchain.w3.eth.getBalance(worklock.address)
+    default_max = worklock.functions.defaultMaxAllowableLockedTokens().call()
+    max_bid_from_max_stake = default_max * worklock_balance // worklock_supply
+    assert max_bid_from_max_stake < max_allowed_bid
+    assert max_bid_from_max_stake >= min_allowed_bid
+
+    # Too low value for remaining gas
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(0)\
+            .transact({'from': bidder1, 'gas': gas_to_save_state + 25000})
+        testerchain.wait_for_receipt(tx)
+
+    # Too low value for gas limit
+    assert worklock.functions.nextBidderToCheck().call() == 0
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact({'gas': gas_to_save_state + 25000})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.nextBidderToCheck().call() == 0
+
+    # Set gas only for one check
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state)\
+        .transact({'gas': gas_to_save_state + 30000, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.nextBidderToCheck().call() == 1
+
+    events = checks_log.get_all_entries()
+    assert 1 == len(events)
+    event_args = events[-1]['args']
+    assert event_args['sender'] == creator
+    assert event_args['startIndex'] == 0
+    assert event_args['endIndex'] == 1
+
+    # Check others
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.nextBidderToCheck().call() == 3
+
+    events = checks_log.get_all_entries()
+    assert 2 == len(events)
+    event_args = events[-1]['args']
+    assert event_args['sender'] == creator
+    assert event_args['startIndex'] == 1
+    assert event_args['endIndex'] == 3

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -14,10 +14,13 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+import random
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
 from eth_utils import to_wei
+
+from nucypher.blockchain.eth.interfaces import BlockchainInterface
 
 
 @pytest.fixture()
@@ -38,33 +41,78 @@ def escrow(testerchain, token_economics, deploy_contract, token):
     return contract
 
 
+ONE_HOUR = 60 * 60
+BIDDING_DURATION = ONE_HOUR
+MIN_ALLOWED_BID = to_wei(1, 'ether')
+
+
+@pytest.fixture()
+def worklock_factory(testerchain, token, escrow, token_economics, deploy_contract):
+    def deploy_worklock(supply, bidding_delay, cancellation_duration, boosting_refund, max_bid):
+
+        now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+        start_bid_date = now + bidding_delay
+        end_bid_date = start_bid_date + BIDDING_DURATION
+        end_cancellation_date = end_bid_date + cancellation_duration
+        staking_periods = 2 * token_economics.minimum_locked_periods
+
+        tx = escrow.functions.updateAllowableLockedTokens(token_economics.minimum_allowed_locked,
+                                                          token_economics.maximum_allowed_locked).transact()
+        testerchain.wait_for_receipt(tx)
+
+        contract, _ = deploy_contract(
+            contract_name='WorkLock',
+            _token=token.address,
+            _escrow=escrow.address,
+            _startBidDate=start_bid_date,
+            _endBidDate=end_bid_date,
+            _endCancellationDate=end_cancellation_date,
+            _boostingRefund=boosting_refund,
+            _stakingPeriods=staking_periods,
+            _minAllowedBid=MIN_ALLOWED_BID,
+            _maxAllowedBid=max_bid
+        )
+
+        if supply > 0:
+            tx = token.functions.approve(contract.address, supply).transact()
+            testerchain.wait_for_receipt(tx)
+            tx = contract.functions.tokenDeposit(supply).transact()
+            testerchain.wait_for_receipt(tx)
+
+        return contract
+    return deploy_worklock
+
+
+def do_bids(testerchain, worklock, bidders, amount):
+    for bidder in bidders:
+        tx = testerchain.w3.eth.sendTransaction(
+            {'from': testerchain.etherbase_account, 'to': bidder, 'value': amount})
+        testerchain.wait_for_receipt(tx)
+        tx = worklock.functions.bid().transact({'from': bidder, 'value': amount, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+
+
 @pytest.mark.slow
-def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
+def test_worklock(testerchain, token_economics, deploy_contract, token, escrow, worklock_factory):
     creator, staker1, staker2, staker3, staker4, *everyone_else = testerchain.w3.eth.accounts
     gas_to_save_state = 30000
 
     # Deploy WorkLock
     now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
-    start_bid_date = now + (60 * 60)  # 1 Hour
-    end_bid_date = start_bid_date + (60 * 60)
-    end_cancellation_date = end_bid_date + (60 * 60)
-    boosting_refund = 50
+    start_bid_date = now + ONE_HOUR
+    end_bid_date = start_bid_date + ONE_HOUR
+    end_cancellation_date = end_bid_date + ONE_HOUR
     slowing_refund = 100
     staking_periods = 2 * token_economics.minimum_locked_periods
-    min_allowed_bid = to_wei(1, 'ether')
-    max_allowed_bid = 20 * min_allowed_bid
-    worklock, _ = deploy_contract(
-        contract_name='WorkLock',
-        _token=token.address,
-        _escrow=escrow.address,
-        _startBidDate=start_bid_date,
-        _endCancellationDate=end_cancellation_date,
-        _endBidDate=end_bid_date,
-        _boostingRefund=boosting_refund,
-        _stakingPeriods=staking_periods,
-        _minAllowedBid=min_allowed_bid,
-        _maxAllowedBid=max_allowed_bid
-    )
+    boosting_refund = 50
+    max_allowed_bid = 20 * MIN_ALLOWED_BID
+
+    worklock = worklock_factory(supply=0,
+                                bidding_delay=ONE_HOUR,
+                                cancellation_duration=ONE_HOUR,
+                                boosting_refund=boosting_refund,
+                                max_bid=max_allowed_bid)
+
     assert worklock.functions.startBidDate().call() == start_bid_date
     assert worklock.functions.endBidDate().call() == end_bid_date
     assert worklock.functions.endCancellationDate().call() == end_cancellation_date
@@ -80,10 +128,11 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     canceling_log = worklock.events.Canceled.createFilter(fromBlock='latest')
     checks_log = worklock.events.BiddersChecked.createFilter(fromBlock='latest')
     claiming_enable_log = worklock.events.ClaimingEnabled.createFilter(fromBlock='latest')
+    force_refund_log = worklock.events.ForceRefund.createFilter(fromBlock='latest')
 
     # Transfer tokens to WorkLock
-    worklock_supply_1 = token_economics.maximum_allowed_locked // 2 + 1
-    worklock_supply_2 = token_economics.maximum_allowed_locked // 2 - 1
+    worklock_supply_1 = token_economics.maximum_allowed_locked + 1
+    worklock_supply_2 = token_economics.maximum_allowed_locked - 1
     worklock_supply = worklock_supply_1 + worklock_supply_2
     tx = token.functions.approve(worklock.address, worklock_supply).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
@@ -104,8 +153,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert event_args['value'] == worklock_supply_2
 
     # Give stakers some ETH
-    deposit_eth_1 = 4 * min_allowed_bid
-    deposit_eth_2 = min_allowed_bid
+    deposit_eth_1 = 4 * MIN_ALLOWED_BID
+    deposit_eth_2 = MIN_ALLOWED_BID
     staker1_balance = 100 * deposit_eth_1
     tx = testerchain.w3.eth.sendTransaction(
         {'from': testerchain.etherbase_account, 'to': staker1, 'value': staker1_balance})
@@ -142,14 +191,17 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.enableClaiming().transact()
         testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund([staker1]).transact()
+        testerchain.wait_for_receipt(tx)
 
     # Wait for the start of bidding
-    testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    testerchain.time_travel(seconds=ONE_HOUR)
     assert not worklock.functions.isClaimingAvailable().call()
 
     # Bid must be more than minimum
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.bid().transact({'from': staker1, 'value': min_allowed_bid - 1, 'gas_price': 0})
+        tx = worklock.functions.bid().transact({'from': staker1, 'value': MIN_ALLOWED_BID - 1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
     # And less than maximum
     with pytest.raises((TransactionFailed, ValueError)):
@@ -162,11 +214,12 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert testerchain.w3.eth.getBalance(worklock.address) == 0
     tx = worklock.functions.bid().transact({'from': staker1, 'value': deposit_eth_1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(staker1).call()[0] == deposit_eth_1
+    staker1_bid = deposit_eth_1
+    assert worklock.functions.workInfo(staker1).call()[0] == staker1_bid
     assert not worklock.functions.workInfo(staker1).call()[2]
     worklock_balance = deposit_eth_1
     assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
-    assert worklock.functions.ethToTokens(deposit_eth_1).call() == worklock_supply
+    assert worklock.functions.ethToTokens(staker1_bid).call() == worklock_supply
     assert worklock.functions.getBiddersLength().call() == 1
     assert worklock.functions.bidders(0).call() == staker1
     assert worklock.functions.workInfo(staker1).call()[3] == 0
@@ -237,7 +290,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     # Staker does second bid
     tx = worklock.functions.bid().transact({'from': staker1, 'value': deposit_eth_1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(staker1).call()[0] == 2 * deposit_eth_1
+    staker1_bid += deposit_eth_1
+    assert worklock.functions.workInfo(staker1).call()[0] == staker1_bid
     worklock_balance += deposit_eth_1
     assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
     assert worklock.functions.ethToTokens(deposit_eth_2).call() == worklock_supply // 11
@@ -252,7 +306,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     # The final bid must be less than the maximum
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.bid()\
-            .transact({'from': staker1, 'value': max_allowed_bid - 2 * deposit_eth_1 + 1, 'gas_price': 0})
+            .transact({'from': staker1, 'value': max_allowed_bid - staker1_bid + 1, 'gas_price': 0})
         testerchain.wait_for_receipt(tx)
 
     # Can't claim, refund or burn while bidding phase
@@ -335,7 +389,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
         testerchain.wait_for_receipt(tx)
 
     # Wait for the end of bidding
-    testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    testerchain.time_travel(seconds=ONE_HOUR)
 
     # Can't bid after the end of bidding
     with pytest.raises((TransactionFailed, ValueError)):
@@ -356,6 +410,10 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     # Can't enable claiming before checking
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.enableClaiming().transact()
+        testerchain.wait_for_receipt(tx)
+    # Can't force refund before end of cancellation window
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund([staker1]).transact()
         testerchain.wait_for_receipt(tx)
 
     # But can cancel during cancellation window
@@ -382,15 +440,43 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert event_args['value'] == staker3_bid
 
     # Wait for the end of cancellation window
-    testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    testerchain.time_travel(seconds=ONE_HOUR)
 
     # Can't enable claiming before checking
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.enableClaiming().transact()
         testerchain.wait_for_receipt(tx)
+    # Before verification need to adjust high bids
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # Force refund to first staker
+    staker_1_balance = testerchain.w3.eth.getBalance(staker1)
+    tx = worklock.functions.forceRefund([staker1]).transact()
+    testerchain.wait_for_receipt(tx)
+    bid = worklock.functions.workInfo(staker1).call()[0]
+    assert bid == 2 * deposit_eth_2
+    refund = staker1_bid - bid
+    staker1_bid = bid
+    assert worklock.functions.ethToTokens(bid).call() <= token_economics.maximum_allowed_locked
+    worklock_balance -= refund
+    assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
+    assert testerchain.w3.eth.getBalance(staker1) == staker_1_balance + refund
+
+    events = force_refund_log.get_all_entries()
+    assert len(events) == 1
+    event_args = events[-1]['args']
+    assert event_args['sender'] == creator
+    assert event_args['bidder'] == staker1
+    assert event_args['refundETH'] == refund
+
+    # Can't force refund again
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund([staker1]).transact()
+        testerchain.wait_for_receipt(tx)
 
     # Check all bidders
-    # TODO failed cases with force refund
     assert not worklock.functions.isClaimingAvailable().call()
     tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
     testerchain.wait_for_receipt(tx)
@@ -420,8 +506,8 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     tx = worklock.functions.enableClaiming().transact()
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.isClaimingAvailable().call()
-    assert escrow.functions.minAllowableLockedTokens().call() == worklock_supply // 10
-    assert escrow.functions.maxAllowableLockedTokens().call() == (max_allowed_bid // min_allowed_bid) * worklock_supply // 10
+    assert escrow.functions.minAllowableLockedTokens().call() == worklock_supply // 4
+    assert escrow.functions.maxAllowableLockedTokens().call() == (max_allowed_bid // MIN_ALLOWED_BID) * worklock_supply // 4
 
     events = claiming_enable_log.get_all_entries()
     assert 1 == len(events)
@@ -442,12 +528,12 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     tx = worklock.functions.claim().transact({'from': staker1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.workInfo(staker1).call()[2]
-    staker1_tokens = 8 * worklock_supply // 10
+    staker1_tokens = 2 * worklock_supply // 4
     assert token.functions.balanceOf(staker1).call() == 0
-    staker1_remaining_work = int(-(-8 * worklock_supply * slowing_refund // (boosting_refund * 10)))  # div ceil
+    staker1_remaining_work = int(-(-2 * worklock_supply * slowing_refund // (boosting_refund * 4)))  # div ceil
     assert worklock.functions.getAvailableRefund(staker1).call() == 0
-    assert worklock.functions.ethToWork(2 * deposit_eth_1).call() == staker1_remaining_work
-    assert worklock.functions.workToETH(staker1_remaining_work).call() == 2 * deposit_eth_1
+    assert worklock.functions.ethToWork(staker1_bid).call() == staker1_remaining_work
+    assert worklock.functions.workToETH(staker1_remaining_work).call() == staker1_bid
     assert worklock.functions.getRemainingWork(staker1).call() == staker1_remaining_work
     assert token.functions.balanceOf(worklock.address).call() == worklock_supply - staker1_tokens
     value, measure_work, _completed_work, periods = escrow.functions.stakerInfo(staker1).call()
@@ -483,9 +569,9 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert not measure_work
     assert value == 0
     assert periods == 0
-    staker2_tokens = worklock_supply // 10
+    staker2_tokens = worklock_supply // 4
     # staker2_tokens * slowing_refund / boosting_refund
-    staker2_remaining_work = int(-(-worklock_supply * slowing_refund // (boosting_refund * 10)))  # div ceil
+    staker2_remaining_work = int(-(-worklock_supply * slowing_refund // (boosting_refund * 4)))  # div ceil
     assert worklock.functions.ethToWork(deposit_eth_2).call() == staker2_remaining_work
     assert worklock.functions.workToETH(staker2_remaining_work).call() == deposit_eth_2
     tx = escrow.functions.setCompletedWork(staker2, staker2_remaining_work // 2).transact()
@@ -516,14 +602,14 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     tx = escrow.functions.setCompletedWork(staker1, completed_work).transact()
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.getRemainingWork(staker1).call() == remaining_work
-    assert worklock.functions.getAvailableRefund(staker1).call() == deposit_eth_1
+    assert worklock.functions.getAvailableRefund(staker1).call() == deposit_eth_2
 
     tx = worklock.functions.refund().transact({'from': staker1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(staker1).call()[0] == deposit_eth_1
+    assert worklock.functions.workInfo(staker1).call()[0] == deposit_eth_2
     assert worklock.functions.getRemainingWork(staker1).call() == remaining_work
-    assert testerchain.w3.eth.getBalance(staker1) == staker1_balance + deposit_eth_1
-    worklock_balance -= deposit_eth_1
+    assert testerchain.w3.eth.getBalance(staker1) == staker1_balance + deposit_eth_2
+    worklock_balance -= deposit_eth_2
     assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
     _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(staker1).call()
     assert measure_work
@@ -533,7 +619,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert 1 == len(events)
     event_args = events[0]['args']
     assert event_args['sender'] == staker1
-    assert event_args['refundETH'] == deposit_eth_1
+    assert event_args['refundETH'] == deposit_eth_2
     assert event_args['completedWork'] == staker1_remaining_work // 2
 
     # "Do" more work and full refund
@@ -542,14 +628,14 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     tx = escrow.functions.setCompletedWork(staker1, completed_work).transact()
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.getRemainingWork(staker1).call() == 0
-    assert worklock.functions.getAvailableRefund(staker1).call() == deposit_eth_1
+    assert worklock.functions.getAvailableRefund(staker1).call() == deposit_eth_2
 
     tx = worklock.functions.refund().transact({'from': staker1, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
     assert worklock.functions.workInfo(staker1).call()[0] == 0
     assert worklock.functions.getRemainingWork(staker1).call() == 0
-    assert testerchain.w3.eth.getBalance(staker1) == staker1_balance + deposit_eth_1
-    worklock_balance -= deposit_eth_1
+    assert testerchain.w3.eth.getBalance(staker1) == staker1_balance + deposit_eth_2
+    worklock_balance -= deposit_eth_2
     assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
     _value, measure_work, _completed_work, _periods = escrow.functions.stakerInfo(staker1).call()
     assert not measure_work
@@ -559,7 +645,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
     assert 2 == len(events)
     event_args = events[1]['args']
     assert event_args['sender'] == staker1
-    assert event_args['refundETH'] == deposit_eth_1
+    assert event_args['refundETH'] == deposit_eth_2
     assert event_args['completedWork'] == staker1_remaining_work // 2
 
     # Can't refund more tokens
@@ -571,51 +657,36 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow):
 
 
 @pytest.mark.slow
-def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow):
+def test_reentrancy(testerchain, token_economics, deploy_contract, escrow, worklock_factory):
     # Deploy WorkLock
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
-    start_bid_date = now
-    end_bid_date = start_bid_date + (60 * 60)
-    end_cancellation_date = end_bid_date
     boosting_refund = 100
-    staking_periods = token_economics.minimum_locked_periods
-    min_allowed_bid = to_wei(1, 'ether')
-    worklock, _ = deploy_contract(
-        contract_name='WorkLock',
-        _token=token.address,
-        _escrow=escrow.address,
-        _startBidDate=start_bid_date,
-        _endBidDate=end_bid_date,
-        _endCancellationDate=end_cancellation_date,
-        _boostingRefund=boosting_refund,
-        _stakingPeriods=staking_periods,
-        _minAllowedBid=min_allowed_bid,
-        _maxAllowedBid=min_allowed_bid
-    )
+    worklock_supply = 2 * token_economics.maximum_allowed_locked
+    max_allowed_bid = 2 * MIN_ALLOWED_BID
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=max_allowed_bid)
+
     refund_log = worklock.events.Refund.createFilter(fromBlock='latest')
     canceling_log = worklock.events.Canceled.createFilter(fromBlock='latest')
-    worklock_supply = 2 * token_economics.maximum_allowed_locked
-    tx = token.functions.approve(worklock.address, worklock_supply).transact()
-    testerchain.wait_for_receipt(tx)
-    tx = worklock.functions.tokenDeposit(worklock_supply).transact()
-    testerchain.wait_for_receipt(tx)
+    force_refund_log = worklock.events.ForceRefund.createFilter(fromBlock='latest')
 
     reentrancy_contract, _ = deploy_contract('ReentrancyTest')
     contract_address = reentrancy_contract.address
-    deposit_eth = min_allowed_bid
     tx = testerchain.client.send_transaction(
-        {'from': testerchain.etherbase_account, 'to': contract_address, 'value': deposit_eth})
+        {'from': testerchain.etherbase_account, 'to': contract_address, 'value': max_allowed_bid})
     testerchain.wait_for_receipt(tx)
 
     # Bid
     transaction = worklock.functions.bid().buildTransaction({'gas': 0})
-    tx = reentrancy_contract.functions.setData(1, transaction['to'], deposit_eth, transaction['data']).transact()
+    tx = reentrancy_contract.functions.setData(1, transaction['to'], max_allowed_bid, transaction['data']).transact()
     testerchain.wait_for_receipt(tx)
     tx = testerchain.client.send_transaction({'to': contract_address})
     testerchain.wait_for_receipt(tx)
-    assert worklock.functions.workInfo(contract_address).call()[0] == deposit_eth
-    assert testerchain.w3.eth.getBalance(worklock.address) == deposit_eth
-    tx = worklock.functions.bid().transact({'from': testerchain.etherbase_account, 'value': deposit_eth})
+    assert worklock.functions.workInfo(contract_address).call()[0] == max_allowed_bid
+    assert testerchain.w3.eth.getBalance(worklock.address) == max_allowed_bid
+    tx = worklock.functions.bid().transact({'from': testerchain.etherbase_account, 'value': MIN_ALLOWED_BID})
     testerchain.wait_for_receipt(tx)
 
     # Check reentrancy protection when cancelling a bid
@@ -627,11 +698,26 @@ def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow
         tx = testerchain.client.send_transaction({'to': contract_address})
         testerchain.wait_for_receipt(tx)
     assert testerchain.w3.eth.getBalance(contract_address) == balance
-    assert worklock.functions.workInfo(contract_address).call()[0] == deposit_eth
+    assert worklock.functions.workInfo(contract_address).call()[0] == max_allowed_bid
     assert len(canceling_log.get_all_entries()) == 0
 
-    # Check bidders
-    testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    # Check reentrancy protection when doing force refund
+    testerchain.time_travel(seconds=ONE_HOUR)
+    transaction = worklock.functions.forceRefund([contract_address]).buildTransaction({'gas': 0})
+    tx = reentrancy_contract.functions.setData(2, transaction['to'], 0, transaction['data']).transact()
+    testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = testerchain.client.send_transaction({'to': contract_address})
+        testerchain.wait_for_receipt(tx)
+    assert testerchain.w3.eth.getBalance(contract_address) == balance
+    assert worklock.functions.workInfo(contract_address).call()[0] == max_allowed_bid
+    assert len(force_refund_log.get_all_entries()) == 0
+
+    # Do force refund and check bidders
+    tx = reentrancy_contract.functions.setData(0, BlockchainInterface.NULL_ADDRESS, 0, b'').transact()
+    testerchain.wait_for_receipt(tx)
+    tx = worklock.functions.forceRefund([contract_address]).transact()
+    testerchain.wait_for_receipt(tx)
     tx = worklock.functions.verifyBiddingCorrectness(30000).transact()
     testerchain.wait_for_receipt(tx)
     tx = worklock.functions.enableClaiming().transact()
@@ -647,6 +733,7 @@ def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow
     assert worklock.functions.getRemainingWork(contract_address).call() == remaining_work
 
     # Prepare for refund and check reentrancy protection
+    assert worklock.functions.workInfo(contract_address).call()[0] == MIN_ALLOWED_BID
     balance = testerchain.w3.eth.getBalance(contract_address)
     completed_work = remaining_work // 4
     tx = escrow.functions.setCompletedWork(contract_address, completed_work).transact()
@@ -658,88 +745,56 @@ def test_reentrancy(testerchain, token_economics, deploy_contract, token, escrow
         tx = testerchain.client.send_transaction({'to': contract_address})
         testerchain.wait_for_receipt(tx)
     assert testerchain.w3.eth.getBalance(contract_address) == balance
-    assert worklock.functions.workInfo(contract_address).call()[0] == deposit_eth
+    assert worklock.functions.workInfo(contract_address).call()[0] == MIN_ALLOWED_BID
     assert worklock.functions.getRemainingWork(contract_address).call() == remaining_work - completed_work
     assert len(refund_log.get_all_entries()) == 0
 
 
 @pytest.mark.slow
-def test_verifying_correctness(testerchain, token_economics, deploy_contract, token, escrow):
+def test_verifying_correctness(testerchain, token_economics, escrow, deploy_contract, worklock_factory):
     creator, bidder1, bidder2, bidder3, *everyone_else = testerchain.w3.eth.accounts
     gas_to_save_state = 30000
-
-    # Deploy WorkLock
     boosting_refund = 100
-    staking_periods = token_economics.minimum_locked_periods
-    min_allowed_bid = to_wei(1, 'ether')
-
-    def deploy_worklock(supply, max_bid):
-
-        now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
-        start_bid_date = now
-        end_bid_date = start_bid_date + (60 * 60)
-        end_cancellation_date = end_bid_date
-
-        contract, _ = deploy_contract(
-            contract_name='WorkLock',
-            _token=token.address,
-            _escrow=escrow.address,
-            _startBidDate=start_bid_date,
-            _endBidDate=end_bid_date,
-            _endCancellationDate=end_cancellation_date,
-            _boostingRefund=boosting_refund,
-            _stakingPeriods=staking_periods,
-            _minAllowedBid=min_allowed_bid,
-            _maxAllowedBid=max_bid
-        )
-
-        tx = token.functions.approve(contract.address, supply).transact()
-        testerchain.wait_for_receipt(tx)
-        tx = contract.functions.tokenDeposit(supply).transact()
-        testerchain.wait_for_receipt(tx)
-        log = contract.events.BiddersChecked.createFilter(fromBlock='latest')
-
-        return contract, log
 
     # Test: bidder has too much tokens to claim
     worklock_supply = token_economics.maximum_allowed_locked + 1
-    worklock, _checks_log = deploy_worklock(worklock_supply, min_allowed_bid)
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=MIN_ALLOWED_BID)
 
     # Bid
-    tx = testerchain.w3.eth.sendTransaction(
-        {'from': testerchain.etherbase_account, 'to': bidder1, 'value': min_allowed_bid})
-    testerchain.wait_for_receipt(tx)
-    tx = worklock.functions.bid().transact({'from': bidder1, 'value': min_allowed_bid, 'gas_price': 0})
-    testerchain.wait_for_receipt(tx)
-    assert worklock.functions.ethToTokens(min_allowed_bid).call() == worklock_supply
+    do_bids(testerchain, worklock, [bidder1], MIN_ALLOWED_BID)
+    assert worklock.functions.ethToTokens(MIN_ALLOWED_BID).call() == worklock_supply
 
     # Check will fail because bidder has too much tokens to claim
-    testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    testerchain.time_travel(seconds=ONE_HOUR)
     worklock_balance = testerchain.w3.eth.getBalance(worklock.address)
     default_max = worklock.functions.defaultMaxAllowableLockedTokens().call()
-    assert default_max * worklock_balance // worklock_supply < min_allowed_bid
+    assert default_max * worklock_balance // worklock_supply < MIN_ALLOWED_BID
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.verifyBiddingCorrectness(30000).transact()
         testerchain.wait_for_receipt(tx)
 
     # Test: bidder will get tokens as much as possible without force refund
     worklock_supply = 3 * token_economics.maximum_allowed_locked
-    worklock, checks_log = deploy_worklock(worklock_supply, min_allowed_bid)
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=MIN_ALLOWED_BID)
+    checks_log = worklock.events.BiddersChecked.createFilter(fromBlock='latest')
 
     # Bids
-    for bidder in [bidder1, bidder2, bidder3]:
-        tx = testerchain.w3.eth.sendTransaction(
-            {'from': testerchain.etherbase_account, 'to': bidder, 'value': min_allowed_bid})
-        testerchain.wait_for_receipt(tx)
-        tx = worklock.functions.bid().transact({'from': bidder, 'value': min_allowed_bid, 'gas_price': 0})
-        testerchain.wait_for_receipt(tx)
-    assert worklock.functions.ethToTokens(min_allowed_bid).call() == token_economics.maximum_allowed_locked
+    do_bids(testerchain, worklock, [bidder1, bidder2, bidder3], MIN_ALLOWED_BID)
+    assert worklock.functions.ethToTokens(MIN_ALLOWED_BID).call() == token_economics.maximum_allowed_locked
 
-    # Wait exactly 1 hour
-    testerchain.time_travel(seconds=3600)
+    # Wait end of bidding
+    testerchain.time_travel(seconds=ONE_HOUR)
     worklock_balance = testerchain.w3.eth.getBalance(worklock.address)
     default_max = worklock.functions.defaultMaxAllowableLockedTokens().call()
-    assert default_max * worklock_balance // worklock_supply == min_allowed_bid
+    assert default_max * worklock_balance // worklock_supply == MIN_ALLOWED_BID
 
     # Too low value for gas limit
     with pytest.raises((TransactionFailed, ValueError)):
@@ -752,33 +807,42 @@ def test_verifying_correctness(testerchain, token_economics, deploy_contract, to
     assert worklock.functions.nextBidderToCheck().call() == 3
 
     events = checks_log.get_all_entries()
-    assert 1 == len(events)
+    assert len(events) == 1
     event_args = events[-1]['args']
     assert event_args['sender'] == bidder1
     assert event_args['startIndex'] == 0
     assert event_args['endIndex'] == 3
 
+    # Enable claiming
+    assert escrow.functions.minAllowableLockedTokens().call() == token_economics.minimum_allowed_locked
+    assert escrow.functions.maxAllowableLockedTokens().call() == token_economics.maximum_allowed_locked
+    tx = worklock.functions.enableClaiming().transact()
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.isClaimingAvailable().call()
+    assert escrow.functions.minAllowableLockedTokens().call() == token_economics.maximum_allowed_locked
+    assert escrow.functions.maxAllowableLockedTokens().call() == token_economics.maximum_allowed_locked
+
     # Test: partial verification with low amount of gas limit
     worklock_supply = 3 * token_economics.maximum_allowed_locked
-    max_allowed_bid = 2 * min_allowed_bid
-    worklock, checks_log = deploy_worklock(worklock_supply, max_allowed_bid)
+    max_allowed_bid = 2 * MIN_ALLOWED_BID
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=max_allowed_bid)
+    checks_log = worklock.events.BiddersChecked.createFilter(fromBlock='latest')
 
     # Bids
-    for bidder in [bidder1, bidder2, bidder3]:
-        tx = testerchain.w3.eth.sendTransaction(
-            {'from': testerchain.etherbase_account, 'to': bidder, 'value': min_allowed_bid})
-        testerchain.wait_for_receipt(tx)
-        tx = worklock.functions.bid().transact({'from': bidder, 'value': min_allowed_bid, 'gas_price': 0})
-        testerchain.wait_for_receipt(tx)
-    assert worklock.functions.ethToTokens(min_allowed_bid).call() == worklock_supply // 3
+    do_bids(testerchain, worklock, [bidder1, bidder2, bidder3], MIN_ALLOWED_BID)
+    assert worklock.functions.ethToTokens(MIN_ALLOWED_BID).call() == worklock_supply // 3
 
-    # Wait exactly 1 hour
-    testerchain.time_travel(seconds=3600)  # Wait exactly 1 hour
+    # Wait end of bidding
+    testerchain.time_travel(seconds=ONE_HOUR)
     worklock_balance = testerchain.w3.eth.getBalance(worklock.address)
     default_max = worklock.functions.defaultMaxAllowableLockedTokens().call()
     max_bid_from_max_stake = default_max * worklock_balance // worklock_supply
     assert max_bid_from_max_stake < max_allowed_bid
-    assert max_bid_from_max_stake >= min_allowed_bid
+    assert max_bid_from_max_stake >= MIN_ALLOWED_BID
 
     # Too low value for remaining gas
     with pytest.raises((TransactionFailed, ValueError)):
@@ -799,7 +863,7 @@ def test_verifying_correctness(testerchain, token_economics, deploy_contract, to
     assert worklock.functions.nextBidderToCheck().call() == 1
 
     events = checks_log.get_all_entries()
-    assert 1 == len(events)
+    assert len(events) == 1
     event_args = events[-1]['args']
     assert event_args['sender'] == creator
     assert event_args['startIndex'] == 0
@@ -811,8 +875,261 @@ def test_verifying_correctness(testerchain, token_economics, deploy_contract, to
     assert worklock.functions.nextBidderToCheck().call() == 3
 
     events = checks_log.get_all_entries()
-    assert 2 == len(events)
+    assert len(events) == 2
     event_args = events[-1]['args']
     assert event_args['sender'] == creator
     assert event_args['startIndex'] == 1
     assert event_args['endIndex'] == 3
+
+    # Enable claiming
+    assert escrow.functions.minAllowableLockedTokens().call() == token_economics.minimum_allowed_locked
+    assert escrow.functions.maxAllowableLockedTokens().call() == token_economics.maximum_allowed_locked
+    tx = worklock.functions.enableClaiming().transact()
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.isClaimingAvailable().call()
+    assert escrow.functions.minAllowableLockedTokens().call() == token_economics.maximum_allowed_locked
+    assert escrow.functions.maxAllowableLockedTokens().call() == 2 * token_economics.maximum_allowed_locked
+
+
+@pytest.mark.slow
+def test_force_refund(testerchain, token_economics, deploy_contract, worklock_factory):
+    creator, *bidders = testerchain.w3.eth.accounts
+    boosting_refund = 100
+    max_allowed_bid = 100 * MIN_ALLOWED_BID
+    gas_to_save_state = 30000
+
+    # All bids are allowed, can't do force refund
+    worklock_supply = len(bidders) * token_economics.maximum_allowed_locked
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=max_allowed_bid)
+
+    do_bids(testerchain, worklock, bidders, MIN_ALLOWED_BID)
+    # Wait end of bidding
+    testerchain.time_travel(seconds=ONE_HOUR)
+
+    bidders = list(sorted(bidders))
+    # There is no bidders with unacceptable bid
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund([]).transact()
+        testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund(bidders).transact()
+        testerchain.wait_for_receipt(tx)
+    for bidder in bidders:
+        with pytest.raises((TransactionFailed, ValueError)):
+            tx = worklock.functions.forceRefund([bidder]).transact()
+            testerchain.wait_for_receipt(tx)
+
+    # Prove that check is ok
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+    testerchain.wait_for_receipt(tx)
+
+    # Different bids from whales
+    hidden_whales = bidders[0:3]
+    whales = bidders[3:6]
+    normal_bidders = bidders[6:8]
+    bidders = normal_bidders + hidden_whales + whales
+
+    worklock_supply = len(bidders) * token_economics.maximum_allowed_locked
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=max_allowed_bid)
+    normal_bid = MIN_ALLOWED_BID
+    hidden_whales_bid = 2 * MIN_ALLOWED_BID
+    whales_bid = 3 * MIN_ALLOWED_BID
+    do_bids(testerchain, worklock, normal_bidders, normal_bid)
+    do_bids(testerchain, worklock, hidden_whales, hidden_whales_bid)
+    do_bids(testerchain, worklock, whales, whales_bid)
+    refund_log = worklock.events.ForceRefund.createFilter(fromBlock='latest')
+
+    # Wait end of bidding
+    testerchain.time_travel(seconds=ONE_HOUR)
+
+    # Verification founds whales
+    assert worklock.functions.ethToTokens(normal_bid).call() < token_economics.maximum_allowed_locked
+    assert worklock.functions.ethToTokens(hidden_whales_bid).call() < token_economics.maximum_allowed_locked
+    assert worklock.functions.ethToTokens(whales_bid).call() > token_economics.maximum_allowed_locked
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # Can't refund to a normal bidder or an empty address
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund([]).transact()
+        testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund([normal_bidders[0]]).transact()
+        testerchain.wait_for_receipt(tx)
+    # Or to single hidden whale
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund([hidden_whales[0]]).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # Force refund to a single whale
+    whale_1 = whales[0]
+    worklock_balance = testerchain.w3.eth.getBalance(worklock.address)
+    whale_1_balance = testerchain.w3.eth.getBalance(whale_1)
+    tx = worklock.functions.forceRefund([whale_1]).transact()
+    testerchain.wait_for_receipt(tx)
+    bid = worklock.functions.workInfo(whale_1).call()[0]
+    refund = whales_bid - bid
+    assert refund > 0
+    assert bid > normal_bid
+    assert worklock.functions.ethToTokens(bid).call() <= token_economics.maximum_allowed_locked
+    worklock_balance -= refund
+    assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
+    assert testerchain.w3.eth.getBalance(whale_1) == whale_1_balance + refund
+
+    events = refund_log.get_all_entries()
+    assert len(events) == 1
+    event_args = events[-1]['args']
+    assert event_args['sender'] == creator
+    assert event_args['bidder'] == whale_1
+    assert event_args['refundETH'] == refund
+
+    # Can't verify yet
+    assert worklock.functions.ethToTokens(whales_bid).call() > token_economics.maximum_allowed_locked
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # Group of addresses to refund can't include normal bidders
+    group = list(sorted([normal_bidders[0], whales[1]]))
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund(group).transact()
+        testerchain.wait_for_receipt(tx)
+    # Bad input: not unique addresses, nonexistent address, not sorted list
+    group = list(sorted([whales[1], *whales]))
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund(group).transact()
+        testerchain.wait_for_receipt(tx)
+    group = list(sorted([BlockchainInterface.NULL_ADDRESS, *whales]))
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund(group).transact()
+        testerchain.wait_for_receipt(tx)
+    group = list(sorted([creator, *whales]))
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund(group).transact()
+        testerchain.wait_for_receipt(tx)
+    group = list(sorted(whales))[::-1]
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.forceRefund(group).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # Force refund to a group of whales with the same bid
+    whale_2 = whales[1]
+    whale_3 = whales[2]
+    whale_2_balance = testerchain.w3.eth.getBalance(whale_2)
+    whale_3_balance = testerchain.w3.eth.getBalance(whale_3)
+    group = list(sorted([whale_2, whale_3]))
+    tx = worklock.functions.forceRefund(group).transact()
+    testerchain.wait_for_receipt(tx)
+    bid = worklock.functions.workInfo(whale_2).call()[0]
+    assert worklock.functions.workInfo(whale_3).call()[0] == bid
+    refund = whales_bid - bid
+    assert refund > 0
+    assert bid > normal_bid
+    assert worklock.functions.ethToTokens(bid).call() <= token_economics.maximum_allowed_locked
+    worklock_balance -= 2 * refund
+    assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
+    assert testerchain.w3.eth.getBalance(whale_2) == whale_2_balance + refund
+    assert testerchain.w3.eth.getBalance(whale_3) == whale_3_balance + refund
+
+    events = refund_log.get_all_entries()
+    assert len(events) == 3
+    event_args = events[-2]['args']
+    assert event_args['sender'] == creator
+    assert event_args['bidder'] == group[0]
+    assert event_args['refundETH'] == refund
+    event_args = events[-1]['args']
+    assert event_args['sender'] == creator
+    assert event_args['bidder'] == group[1]
+    assert event_args['refundETH'] == refund
+
+    # Can't verify yet
+    assert worklock.functions.ethToTokens(hidden_whales_bid).call() > token_economics.maximum_allowed_locked
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # But can verify only one of them
+    assert worklock.functions.nextBidderToCheck().call() == 0
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state)\
+        .transact({'gas': gas_to_save_state + 30000, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.nextBidderToCheck().call() == 1
+
+    # Full force refund
+    group = list(sorted(whales + hidden_whales))
+    balances = [testerchain.w3.eth.getBalance(bidder) for bidder in group]
+    bids = [worklock.functions.workInfo(bidder).call()[0] for bidder in group]
+
+    tx = worklock.functions.forceRefund(group).transact({'from': whale_1})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.ethToTokens(normal_bid).call() == token_economics.maximum_allowed_locked
+    events = refund_log.get_all_entries()
+    assert len(events) == 3 + len(group)
+
+    for i, bidder in enumerate(group):
+        assert worklock.functions.workInfo(bidder).call()[0] == normal_bid
+        refund = bids[i] - normal_bid
+        assert refund > 0
+        worklock_balance -= refund
+        assert testerchain.w3.eth.getBalance(bidder) == balances[i] + refund
+        event_args = events[3 + i]['args']
+        assert event_args['sender'] == whale_1
+        assert event_args['bidder'] == bidder
+        assert event_args['refundETH'] == refund
+
+    assert testerchain.w3.eth.getBalance(worklock.address) == worklock_balance
+
+    # Now verify will work
+    assert worklock.functions.nextBidderToCheck().call() == 0
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.nextBidderToCheck().call() == len(bidders)
+
+    # Test extreme case with random values
+    bidders = testerchain.w3.eth.accounts[1:]
+    worklock_supply = 10 * token_economics.maximum_allowed_locked
+    max_allowed_bid = 2000 * MIN_ALLOWED_BID
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=max_allowed_bid)
+
+    small_bids = [random.randrange(MIN_ALLOWED_BID, int(1.5 * MIN_ALLOWED_BID)) for _ in range(10)]
+    total_small_bids = sum(small_bids)
+    min_potential_whale_bid = (max_allowed_bid - total_small_bids) // 9
+    whales_bids = [random.randrange(min_potential_whale_bid, max_allowed_bid) for _ in range(9)]
+    initial_bids = small_bids + whales_bids
+    for i, bid in enumerate(initial_bids):
+        bidder = bidders[i]
+        do_bids(testerchain, worklock, [bidder], bid)
+
+    # Wait end of bidding
+    testerchain.time_travel(seconds=ONE_HOUR)
+
+    # Can't verify yet
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+        testerchain.wait_for_receipt(tx)
+
+    # Force refund
+    whales = bidders[len(small_bids):len(initial_bids)]
+    whales = list(sorted(whales))
+    tx = worklock.functions.forceRefund(whales).transact()
+    testerchain.wait_for_receipt(tx)
+
+    # Bids are correct now
+    for whale in whales:
+        bid = worklock.functions.workInfo(whale).call()[0]
+        assert worklock.functions.ethToTokens(bid).call() <= token_economics.maximum_allowed_locked
+    tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
+    testerchain.wait_for_receipt(tx)

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -48,12 +48,12 @@ MIN_ALLOWED_BID = to_wei(1, 'ether')
 
 @pytest.fixture()
 def worklock_factory(testerchain, token, escrow, token_economics, deploy_contract):
-    def deploy_worklock(supply, bidding_delay, cancellation_duration, boosting_refund, max_bid):
+    def deploy_worklock(supply, bidding_delay, additional_time_to_cancel, boosting_refund, max_bid):
 
         now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
         start_bid_date = now + bidding_delay
         end_bid_date = start_bid_date + BIDDING_DURATION
-        end_cancellation_date = end_bid_date + cancellation_duration
+        end_cancellation_date = end_bid_date + additional_time_to_cancel
         staking_periods = 2 * token_economics.minimum_locked_periods
 
         tx = escrow.functions.updateAllowableLockedTokens(token_economics.minimum_allowed_locked,
@@ -109,7 +109,7 @@ def test_worklock(testerchain, token_economics, deploy_contract, token, escrow, 
 
     worklock = worklock_factory(supply=0,
                                 bidding_delay=ONE_HOUR,
-                                cancellation_duration=ONE_HOUR,
+                                additional_time_to_cancel=ONE_HOUR,
                                 boosting_refund=boosting_refund,
                                 max_bid=max_allowed_bid)
 
@@ -664,7 +664,7 @@ def test_reentrancy(testerchain, token_economics, deploy_contract, escrow, workl
     max_allowed_bid = 2 * MIN_ALLOWED_BID
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=max_allowed_bid)
 
@@ -760,7 +760,7 @@ def test_verifying_correctness(testerchain, token_economics, escrow, deploy_cont
     worklock_supply = token_economics.maximum_allowed_locked + 1
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=MIN_ALLOWED_BID)
 
@@ -781,7 +781,7 @@ def test_verifying_correctness(testerchain, token_economics, escrow, deploy_cont
     worklock_supply = 3 * token_economics.maximum_allowed_locked
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=MIN_ALLOWED_BID)
     checks_log = worklock.events.BiddersChecked.createFilter(fromBlock='latest')
@@ -827,7 +827,7 @@ def test_verifying_correctness(testerchain, token_economics, escrow, deploy_cont
     max_allowed_bid = 2 * MIN_ALLOWED_BID
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=max_allowed_bid)
     checks_log = worklock.events.BiddersChecked.createFilter(fromBlock='latest')
@@ -902,7 +902,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     worklock_supply = len(bidders) * token_economics.maximum_allowed_locked
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=max_allowed_bid)
 
@@ -936,7 +936,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     worklock_supply = len(bidders) * token_economics.maximum_allowed_locked
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=max_allowed_bid)
     normal_bid = MIN_ALLOWED_BID
@@ -1100,7 +1100,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     max_allowed_bid = 2000 * MIN_ALLOWED_BID
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=max_allowed_bid)
 
@@ -1138,7 +1138,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     worklock_supply = 10 * token_economics.maximum_allowed_locked
     worklock = worklock_factory(supply=worklock_supply,
                                 bidding_delay=0,
-                                cancellation_duration=0,
+                                additional_time_to_cancel=0,
                                 boosting_refund=boosting_refund,
                                 max_bid=max_allowed_bid)
 

--- a/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
+++ b/tests/blockchain/eth/contracts/main/worklock/test_worklock.py
@@ -892,7 +892,7 @@ def test_verifying_correctness(testerchain, token_economics, escrow, deploy_cont
 
 
 @pytest.mark.slow
-def test_force_refund(testerchain, token_economics, deploy_contract, worklock_factory):
+def test_force_refund(testerchain, token_economics, deploy_contract, worklock_factory, token):
     creator, *bidders = testerchain.w3.eth.accounts
     boosting_refund = 100
     max_allowed_bid = 100 * MIN_ALLOWED_BID
@@ -910,7 +910,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     # Wait end of bidding
     testerchain.time_travel(seconds=ONE_HOUR)
 
-    bidders = list(sorted(bidders))
+    bidders = sorted(bidders, key=str.casefold)
     # There is no bidders with unacceptable bid
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.forceRefund([]).transact()
@@ -999,24 +999,24 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
         testerchain.wait_for_receipt(tx)
 
     # Group of addresses to refund can't include normal bidders
-    group = list(sorted([normal_bidders[0], whales[1]]))
+    group = sorted([normal_bidders[0], whales[1]], key=str.casefold)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.forceRefund(group).transact()
         testerchain.wait_for_receipt(tx)
     # Bad input: not unique addresses, nonexistent address, not sorted list
-    group = list(sorted([whales[1], *whales]))
+    group = sorted([whales[1], *whales], key=str.casefold)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.forceRefund(group).transact()
         testerchain.wait_for_receipt(tx)
-    group = list(sorted([BlockchainInterface.NULL_ADDRESS, *whales]))
+    group = sorted([BlockchainInterface.NULL_ADDRESS, *whales], key=str.casefold)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.forceRefund(group).transact()
         testerchain.wait_for_receipt(tx)
-    group = list(sorted([creator, *whales]))
+    group = sorted([creator, *whales], key=str.casefold)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.forceRefund(group).transact()
         testerchain.wait_for_receipt(tx)
-    group = list(sorted(whales))[::-1]
+    group = sorted(whales, key=str.casefold)[::-1]
     with pytest.raises((TransactionFailed, ValueError)):
         tx = worklock.functions.forceRefund(group).transact()
         testerchain.wait_for_receipt(tx)
@@ -1026,7 +1026,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     whale_3 = whales[2]
     whale_2_balance = testerchain.w3.eth.getBalance(whale_2)
     whale_3_balance = testerchain.w3.eth.getBalance(whale_3)
-    group = list(sorted([whale_2, whale_3]))
+    group = sorted([whale_2, whale_3], key=str.casefold)
     tx = worklock.functions.forceRefund(group).transact()
     testerchain.wait_for_receipt(tx)
     bid = worklock.functions.workInfo(whale_2).call()[0]
@@ -1065,7 +1065,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     assert worklock.functions.nextBidderToCheck().call() == 1
 
     # Full force refund
-    group = list(sorted(whales + hidden_whales))
+    group = sorted(whales + hidden_whales, key=str.casefold)
     balances = [testerchain.w3.eth.getBalance(bidder) for bidder in group]
     bids = [worklock.functions.workInfo(bidder).call()[0] for bidder in group]
 
@@ -1123,7 +1123,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
 
     # Force refund
     whales = bidders[len(small_bids):len(initial_bids)]
-    whales = list(sorted(whales))
+    whales = sorted(whales, key=str.casefold)
     tx = worklock.functions.forceRefund(whales).transact()
     testerchain.wait_for_receipt(tx)
 
@@ -1133,3 +1133,44 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
         assert worklock.functions.ethToTokens(bid).call() <= token_economics.maximum_allowed_locked
     tx = worklock.functions.verifyBiddingCorrectness(gas_to_save_state).transact()
     testerchain.wait_for_receipt(tx)
+
+    # Special case: there are less bidders than n, where n is `worklock_supply // maximum_allowed_locked`
+    worklock_supply = 10 * token_economics.maximum_allowed_locked
+    worklock = worklock_factory(supply=worklock_supply,
+                                bidding_delay=0,
+                                cancellation_duration=0,
+                                boosting_refund=boosting_refund,
+                                max_bid=max_allowed_bid)
+
+    bidders = bidders[0:9]
+    do_bids(testerchain, worklock, bidders, max_allowed_bid)
+    # Wait end of bidding
+    testerchain.time_travel(seconds=ONE_HOUR)
+
+    bidder1 = bidders[0]
+    worklock_tokens = token.functions.balanceOf(worklock.address).call()
+    creator_tokens = token.functions.balanceOf(creator).call()
+    bidder1_tokens = token.functions.balanceOf(bidder1).call()
+
+    bidders = sorted(bidders, key=str.casefold)
+    tx = worklock.functions.forceRefund(bidders).transact({'from': bidder1})
+    testerchain.wait_for_receipt(tx)
+
+    end_cancellation_date = worklock.functions.endCancellationDate().call()
+    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    assert end_cancellation_date > now
+    assert token.functions.balanceOf(worklock.address).call() == 0
+    assert token.functions.balanceOf(creator).call() == creator_tokens + worklock_tokens
+    assert token.functions.balanceOf(bidder1).call() == bidder1_tokens
+
+    # Distribution is canceled
+    with pytest.raises((TransactionFailed, ValueError)):
+        do_bids(testerchain, worklock, [bidder1], MIN_ALLOWED_BID)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.claim().transact({'from': bidder1, 'gas_price': 0})
+        testerchain.wait_for_receipt(tx)
+
+    assert worklock.functions.workInfo(bidder1).call()[0] > 0
+    tx = worklock.functions.cancelBid().transact({'from': bidder1, 'gas_price': 0})
+    testerchain.wait_for_receipt(tx)
+    assert worklock.functions.workInfo(bidder1).call()[0] == 0

--- a/tests/blockchain/eth/entities/actors/test_bidder.py
+++ b/tests/blockchain/eth/entities/actors/test_bidder.py
@@ -20,7 +20,7 @@ def test_create_bidder(testerchain, test_registry, agency, token_economics):
 
 def test_bidding(testerchain, agency, token_economics, test_registry):
     bidder_address = testerchain.unassigned_accounts[0]
-    big_bid = token_economics.maximum_allowed_locked // 100
+    big_bid = token_economics.worklock_max_allowed_bid // 10
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
 
     assert bidder.get_deposited_eth == 0
@@ -29,7 +29,7 @@ def test_bidding(testerchain, agency, token_economics, test_registry):
     assert bidder.get_deposited_eth == big_bid
 
     another_bidder_address = testerchain.unassigned_accounts[1]
-    another_bid = token_economics.maximum_allowed_locked // 50
+    another_bid = token_economics.worklock_max_allowed_bid // 50
     another_bidder = Bidder(checksum_address=another_bidder_address, registry=test_registry)
     assert another_bidder.get_deposited_eth == 0
     receipt = another_bidder.place_bid(value=another_bid)
@@ -97,7 +97,7 @@ def test_claim(testerchain, agency, token_economics, test_registry):
     with pytest.raises(Bidder.BidderError):
         _receipt = bidder.claim()
 
-    assert bidder.get_deposited_eth == 40000000000000000000000
+    assert bidder.get_deposited_eth == token_economics.worklock_max_allowed_bid // 10
     assert bidder.completed_work == 0
     assert bidder.remaining_work == 500000000000000000000000
     assert bidder.refunded_work == 0

--- a/tests/blockchain/eth/entities/actors/test_bidder.py
+++ b/tests/blockchain/eth/entities/actors/test_bidder.py
@@ -38,6 +38,9 @@ def test_bidding(testerchain, agency, token_economics, test_registry):
 
 
 def test_cancel_bid(testerchain, agency, token_economics, test_registry):
+    # Wait until the bidding window closes...
+    testerchain.time_travel(seconds=token_economics.bidding_duration+1)
+
     bidder_address = testerchain.unassigned_accounts[1]
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
     assert bidder.get_deposited_eth        # Bid
@@ -60,11 +63,11 @@ def test_get_remaining_work(testerchain, agency, token_economics, test_registry)
 def test_claim(testerchain, agency, token_economics, test_registry):
     bidder_address = testerchain.unassigned_accounts[0]
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
-    with pytest.raises(Bidder.BiddingIsOpen):
+    with pytest.raises(Bidder.BidderError):
         _receipt = bidder.claim()
 
-    # Wait until the bidding window closes...
-    testerchain.time_travel(seconds=token_economics.bidding_duration+1)
+    # Wait until the cancellation window closes...
+    testerchain.time_travel(seconds=token_economics.cancellation_window_duration+1)
     staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
 
     # Ensure that the bidder is not staking.

--- a/tests/blockchain/eth/entities/actors/test_bidder.py
+++ b/tests/blockchain/eth/entities/actors/test_bidder.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 from eth_tester.exceptions import TransactionFailed
 
@@ -19,29 +21,29 @@ def test_create_bidder(testerchain, test_registry, agency, token_economics):
 
 
 def test_bidding(testerchain, agency, token_economics, test_registry):
-    bidder_address = testerchain.unassigned_accounts[0]
-    big_bid = token_economics.worklock_max_allowed_bid // 10
-    bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
+    min_allowed_bid = token_economics.worklock_min_allowed_bid
+    max_allowed_bid = token_economics.worklock_max_allowed_bid
+    small_bids = [random.randrange(min_allowed_bid, 2 * min_allowed_bid) for _ in range(10)]
+    total_small_bids = sum(small_bids)
+    min_potential_whale_bid = (max_allowed_bid - total_small_bids) // 9
+    whales_bids = [random.randrange(min_potential_whale_bid, max_allowed_bid) for _ in range(9)]
+    initial_bids = small_bids + whales_bids
 
-    assert bidder.get_deposited_eth == 0
-    receipt = bidder.place_bid(value=big_bid)
-    assert receipt['status'] == 1
-    assert bidder.get_deposited_eth == big_bid
+    for i, bid in enumerate(initial_bids):
+        bidder_address = testerchain.client.accounts[i]
+        bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
 
-    another_bidder_address = testerchain.unassigned_accounts[1]
-    another_bid = token_economics.worklock_max_allowed_bid // 50
-    another_bidder = Bidder(checksum_address=another_bidder_address, registry=test_registry)
-    assert another_bidder.get_deposited_eth == 0
-    receipt = another_bidder.place_bid(value=another_bid)
-    assert receipt['status'] == 1
-    assert another_bidder.get_deposited_eth == another_bid
+        assert bidder.get_deposited_eth == 0
+        receipt = bidder.place_bid(value=bid)
+        assert receipt['status'] == 1
+        assert bidder.get_deposited_eth == bid
 
 
 def test_cancel_bid(testerchain, agency, token_economics, test_registry):
     # Wait until the bidding window closes...
     testerchain.time_travel(seconds=token_economics.bidding_duration+1)
 
-    bidder_address = testerchain.unassigned_accounts[1]
+    bidder_address = testerchain.client.accounts[1]
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
     assert bidder.get_deposited_eth        # Bid
     receipt = bidder.cancel_bid()    # Cancel
@@ -54,14 +56,14 @@ def test_cancel_bid(testerchain, agency, token_economics, test_registry):
 
 
 def test_get_remaining_work(testerchain, agency, token_economics, test_registry):
-    bidder_address = testerchain.unassigned_accounts[0]
+    bidder_address = testerchain.client.accounts[0]
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
     remaining = bidder.remaining_work
     assert remaining
 
 
-def test_verify_correctness(testerchain, agency, token_economics, test_registry):
-    bidder_address = testerchain.unassigned_accounts[0]
+def test_verify_correctness_before_refund(testerchain, agency, token_economics, test_registry):
+    bidder_address = testerchain.client.accounts[0]
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
     worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
@@ -70,6 +72,28 @@ def test_verify_correctness(testerchain, agency, token_economics, test_registry)
 
     # Wait until the cancellation window closes...
     testerchain.time_travel(seconds=token_economics.cancellation_window_duration+1)
+
+    with pytest.raises(Bidder.BidderError):
+        _receipt = bidder.verify_bidding_correctness(gas_limit=100000)
+    assert not worklock_agent.bidders_checked()
+    assert bidder.get_whales()
+
+
+def test_force_refund(testerchain, agency, token_economics, test_registry):
+    bidder_address = testerchain.client.accounts[0]
+    bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
+    worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
+
+    receipt = bidder.force_refund()
+    assert receipt['status'] == 1
+    assert not bidder.get_whales()
+    assert not worklock_agent.bidders_checked()
+
+
+def test_verify_correctness(testerchain, agency, token_economics, test_registry):
+    bidder_address = testerchain.client.accounts[0]
+    bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
+    worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
     assert not worklock_agent.bidders_checked()
     with pytest.raises(Bidder.BidderError):
@@ -82,7 +106,7 @@ def test_verify_correctness(testerchain, agency, token_economics, test_registry)
 
 
 def test_enable_claiming(testerchain, agency, token_economics, test_registry):
-    bidder_address = testerchain.unassigned_accounts[0]
+    bidder_address = testerchain.client.accounts[0]
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
     worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
@@ -93,9 +117,10 @@ def test_enable_claiming(testerchain, agency, token_economics, test_registry):
 
 
 def test_claim(testerchain, agency, token_economics, test_registry):
-    bidder_address = testerchain.unassigned_accounts[0]
+    bidder_address = testerchain.client.accounts[11]
     bidder = Bidder(checksum_address=bidder_address, registry=test_registry)
     staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    worklock_agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
     # Ensure that the bidder is not staking.
     locked_tokens = staking_agent.get_locked_tokens(staker_address=bidder.checksum_address, periods=10)
@@ -108,14 +133,14 @@ def test_claim(testerchain, agency, token_economics, test_registry):
     with pytest.raises(Bidder.BidderError):
         _receipt = bidder.claim()
 
-    assert bidder.get_deposited_eth == token_economics.worklock_max_allowed_bid // 10
+    assert bidder.get_deposited_eth == worklock_agent.get_eth_supply() // 10
     assert bidder.completed_work == 0
-    assert bidder.remaining_work == 500000000000000000000000
+    assert bidder.remaining_work == token_economics.maximum_allowed_locked // 2
     assert bidder.refunded_work == 0
 
     # Ensure that the claimant is now the holder of an unbonded stake.
     locked_tokens = staking_agent.get_locked_tokens(staker_address=bidder.checksum_address, periods=10)
-    assert locked_tokens == 1000000000000000000000000
+    assert locked_tokens == token_economics.maximum_allowed_locked
 
     # Confirm the stake is unbonded
     worker_address = staking_agent.get_worker_from_staker(staker_address=bidder.checksum_address)

--- a/tests/blockchain/eth/entities/agents/test_worklock_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_worklock_agent.py
@@ -13,8 +13,8 @@ def test_create_worklock_agent(testerchain, test_registry, agency, token_economi
 
 
 def test_bidding(testerchain, agency, token_economics, test_registry):
-    big_bid = token_economics.maximum_allowed_locked // 100
-    small_bid = token_economics.minimum_allowed_locked // 100
+    small_bid = token_economics.worklock_min_allowed_bid * 10
+    big_bid = token_economics.worklock_max_allowed_bid // 10
 
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
@@ -32,7 +32,7 @@ def test_bidding(testerchain, agency, token_economics, test_registry):
 
 
 def test_get_deposited_eth(testerchain, agency, token_economics, test_registry):
-    big_bid = token_economics.maximum_allowed_locked // 10
+    big_bid = token_economics.worklock_max_allowed_bid // 10
     big_bidder = testerchain.unassigned_accounts[-1]
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
     receipt = agent.bid(checksum_address=big_bidder, value=big_bid)
@@ -59,7 +59,7 @@ def test_get_remaining_work(testerchain, agency, token_economics, test_registry)
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
     bidder = testerchain.unassigned_accounts[0]
     remaining = agent.get_remaining_work(checksum_address=bidder)
-    assert remaining == 35905203136136849607983
+    assert remaining > 0
 
 
 def test_early_claim(testerchain, agency, token_economics, test_registry):

--- a/tests/blockchain/eth/entities/agents/test_worklock_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_worklock_agent.py
@@ -2,6 +2,7 @@ import pytest
 from eth_tester.exceptions import TransactionFailed
 
 from nucypher.blockchain.eth.agents import WorkLockAgent, ContractAgency, StakingEscrowAgent
+from nucypher.blockchain.eth.interfaces import BlockchainInterface
 
 
 def test_create_worklock_agent(testerchain, test_registry, agency, token_economics):
@@ -13,36 +14,36 @@ def test_create_worklock_agent(testerchain, test_registry, agency, token_economi
 
 
 def test_bidding(testerchain, agency, token_economics, test_registry):
-    small_bid = token_economics.worklock_min_allowed_bid * 10
-    big_bid = token_economics.worklock_max_allowed_bid // 10
+    small_bid = token_economics.worklock_min_allowed_bid
+    big_bid = token_economics.worklock_max_allowed_bid // 20
 
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
     # Round 1
-    for multiplier, bidder in enumerate(testerchain.unassigned_accounts[:3], start=1):
+    for multiplier, bidder in enumerate(testerchain.client.accounts[:11], start=1):
         bid = big_bid * multiplier
         receipt = agent.bid(checksum_address=bidder, value=bid)
         assert receipt['status'] == 1
 
     # Round 2
-    for multiplier, bidder in enumerate(testerchain.unassigned_accounts[:3], start=1):
+    for multiplier, bidder in enumerate(testerchain.client.accounts[:11], start=1):
         bid = (small_bid * 2) * multiplier
         receipt = agent.bid(checksum_address=bidder, value=bid)
         assert receipt['status'] == 1
 
 
 def test_get_deposited_eth(testerchain, agency, token_economics, test_registry):
-    big_bid = token_economics.worklock_max_allowed_bid // 10
-    big_bidder = testerchain.unassigned_accounts[-1]
+    small_bid = token_economics.worklock_min_allowed_bid
+    small_bidder = testerchain.client.accounts[-1]
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
-    receipt = agent.bid(checksum_address=big_bidder, value=big_bid)
+    receipt = agent.bid(checksum_address=small_bidder, value=small_bid)
     assert receipt['status'] == 1
-    bid = agent.get_deposited_eth(big_bidder)
-    assert bid == big_bid
+    bid = agent.get_deposited_eth(small_bidder)
+    assert bid == small_bid
 
 
 def test_cancel_bid(testerchain, agency, token_economics, test_registry):
-    bidder = testerchain.unassigned_accounts[1]
+    bidder = testerchain.client.accounts[1]
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
     assert agent.get_deposited_eth(bidder)        # Bid
@@ -57,14 +58,14 @@ def test_cancel_bid(testerchain, agency, token_economics, test_registry):
 
 def test_get_remaining_work(testerchain, agency, token_economics, test_registry):
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
-    bidder = testerchain.unassigned_accounts[0]
+    bidder = testerchain.client.accounts[0]
     remaining = agent.get_remaining_work(checksum_address=bidder)
     assert remaining > 0
 
 
 def test_early_claim(testerchain, agency, token_economics, test_registry):
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
-    bidder = testerchain.unassigned_accounts[0]
+    bidder = testerchain.client.accounts[0]
     with pytest.raises(TransactionFailed):
         _receipt = agent.claim(checksum_address=bidder)
 
@@ -74,7 +75,7 @@ def test_cancel_after_bidding(testerchain, agency, token_economics, test_registr
     # Wait until the bidding window closes...
     testerchain.time_travel(seconds=token_economics.bidding_duration+1)
 
-    bidder = testerchain.unassigned_accounts[2]
+    bidder = testerchain.client.accounts[0]
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
 
     assert agent.get_deposited_eth(bidder)        # Bid
@@ -85,7 +86,7 @@ def test_cancel_after_bidding(testerchain, agency, token_economics, test_registr
 
 def test_claim_before_checking(testerchain, agency, token_economics, test_registry):
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
-    bidder = testerchain.unassigned_accounts[0]
+    bidder = testerchain.client.accounts[2]
 
     assert not agent.is_claiming_available()
     with pytest.raises(TransactionFailed):
@@ -99,9 +100,20 @@ def test_claim_before_checking(testerchain, agency, token_economics, test_regist
         _receipt = agent.claim(checksum_address=bidder)
 
 
+def test_force_refund(testerchain, agency, token_economics, test_registry):
+    agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
+    caller = testerchain.client.accounts[0]
+
+    with pytest.raises(BlockchainInterface.InterfaceError):
+        _receipt = agent.verify_bidding_correctness(checksum_address=caller, gas_limit=100000)
+
+    receipt = agent.force_refund(checksum_address=caller, addresses=testerchain.client.accounts[2:11])
+    assert receipt['status'] == 1
+
+
 def test_verify_correctness(testerchain, agency, token_economics, test_registry):
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
-    caller = testerchain.unassigned_accounts[0]
+    caller = testerchain.client.accounts[0]
     assert not agent.bidders_checked()
     receipt = agent.verify_bidding_correctness(checksum_address=caller, gas_limit=100000)
     assert receipt['status'] == 1
@@ -110,7 +122,7 @@ def test_verify_correctness(testerchain, agency, token_economics, test_registry)
 
 def test_enable_claiming(testerchain, agency, token_economics, test_registry):
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
-    caller = testerchain.unassigned_accounts[0]
+    caller = testerchain.client.accounts[0]
     receipt = agent.enable_claiming(checksum_address=caller)
     assert receipt['status'] == 1
     assert agent.is_claiming_available()
@@ -121,7 +133,7 @@ def test_successful_claim(testerchain, agency, token_economics, test_registry):
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
     staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
 
-    bidder = testerchain.unassigned_accounts[0]
+    bidder = testerchain.client.accounts[2]
 
     # Ensure that the bidder is not staking.
     locked_tokens = staking_agent.get_locked_tokens(staker_address=bidder, periods=10)

--- a/tests/blockchain/eth/entities/agents/test_worklock_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_worklock_agent.py
@@ -102,7 +102,16 @@ def test_claim_before_checking(testerchain, agency, token_economics, test_regist
 def test_verify_correctness(testerchain, agency, token_economics, test_registry):
     agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
     caller = testerchain.unassigned_accounts[0]
+    assert not agent.bidders_checked()
     receipt = agent.verify_bidding_correctness(checksum_address=caller, gas_limit=100000)
+    assert receipt['status'] == 1
+    assert agent.bidders_checked()
+
+
+def test_enable_claiming(testerchain, agency, token_economics, test_registry):
+    agent = ContractAgency.get_agent(WorkLockAgent, registry=test_registry)
+    caller = testerchain.unassigned_accounts[0]
+    receipt = agent.enable_claiming(checksum_address=caller)
     assert receipt['status'] == 1
     assert agent.is_claiming_available()
 

--- a/tests/blockchain/eth/entities/deployers/test_worklock_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_worklock_deployer.py
@@ -95,9 +95,11 @@ def test_deployment_parameters(worklock_deployer, test_registry, token_economics
     # Ensure restoration of deployment parameters
     agent = worklock_deployer.make_agent()
     params = agent.worklock_parameters()
-    supply, start, end, boost, locktime = params
+    supply, start, end, end_cancellation, boost, locktime, min_bid = params
     assert token_economics.worklock_supply == supply
     assert token_economics.bidding_start_date == start
     assert token_economics.bidding_end_date == end
+    assert token_economics.cancellation_end_date == end_cancellation
     assert token_economics.worklock_boosting_refund_rate == boost
     assert token_economics.worklock_commitment_duration == locktime
+    assert token_economics.worklock_min_allowed_bid == min_bid

--- a/tests/blockchain/eth/entities/deployers/test_worklock_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_worklock_deployer.py
@@ -95,7 +95,7 @@ def test_deployment_parameters(worklock_deployer, test_registry, token_economics
     # Ensure restoration of deployment parameters
     agent = worklock_deployer.make_agent()
     params = agent.worklock_parameters()
-    supply, start, end, end_cancellation, boost, locktime, min_bid = params
+    supply, start, end, end_cancellation, boost, locktime, min_bid, max_bid = params
     assert token_economics.worklock_supply == supply
     assert token_economics.bidding_start_date == start
     assert token_economics.bidding_end_date == end
@@ -103,3 +103,4 @@ def test_deployment_parameters(worklock_deployer, test_registry, token_economics
     assert token_economics.worklock_boosting_refund_rate == boost
     assert token_economics.worklock_commitment_duration == locktime
     assert token_economics.worklock_min_allowed_bid == min_bid
+    assert token_economics.worklock_max_allowed_bid == max_bid

--- a/tests/cli/test_worklock_cli.py
+++ b/tests/cli/test_worklock_cli.py
@@ -46,6 +46,7 @@ def test_status(click_runner, testerchain, agency_local_registry, token_economic
     assert result.exit_code == 0
     assert f"Lot Size .......... {token_economics.worklock_supply}" in result.output
     assert f"Min allowed bid ... {Web3.fromWei(token_economics.worklock_min_allowed_bid, 'ether')} ETH" in result.output
+    assert f"Max allowed bid ... {Web3.fromWei(token_economics.worklock_max_allowed_bid, 'ether')} ETH" in result.output
 
 
 def test_bid(click_runner, testerchain, agency_local_registry, token_economics):

--- a/tests/cli/test_worklock_cli.py
+++ b/tests/cli/test_worklock_cli.py
@@ -116,7 +116,7 @@ def test_cancel_bid(click_runner, testerchain, agency_local_registry, token_econ
     assert not agent.get_deposited_eth(bidder)    # No more bid
 
 
-def test_verify_correctness(click_runner, testerchain, agency_local_registry, token_economics):
+def test_post_initialization(click_runner, testerchain, agency_local_registry, token_economics):
 
     # Wait until the end of the cancellation period
     testerchain.time_travel(seconds=token_economics.cancellation_window_duration+2)
@@ -124,8 +124,9 @@ def test_verify_correctness(click_runner, testerchain, agency_local_registry, to
     bidder = testerchain.unassigned_accounts[0]
     agent = ContractAgency.get_agent(WorkLockAgent, registry=agency_local_registry)
     assert not agent.is_claiming_available()
+    assert not agent.bidders_checked()
 
-    command = ('verify-correctness',
+    command = ('post-initialization',
                '--bidder-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
@@ -137,6 +138,7 @@ def test_verify_correctness(click_runner, testerchain, agency_local_registry, to
     result = click_runner.invoke(worklock, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
     assert agent.is_claiming_available()
+    assert agent.bidders_checked()
 
 
 def test_claim(click_runner, testerchain, agency_local_registry, token_economics):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -33,7 +33,7 @@ from umbral.keys import UmbralPrivateKey
 from umbral.signing import Signer
 from web3 import Web3
 
-from nucypher.blockchain.economics import StandardTokenEconomics
+from nucypher.blockchain.economics import StandardTokenEconomics, BaseEconomics
 from nucypher.blockchain.eth.actors import Staker, StakeHolder
 from nucypher.blockchain.eth.agents import NucypherTokenAgent
 from nucypher.blockchain.eth.clients import NuCypherGethDevProcess
@@ -417,8 +417,8 @@ def token_economics(testerchain):
 
     economics = StandardTokenEconomics(
         worklock_boosting_refund_rate=200,
-        worklock_commitment_duration=60*60,  # seconds
-        worklock_supply=NU.from_tokens(1_000_000),
+        worklock_commitment_duration=60,  # periods
+        worklock_supply=10*BaseEconomics._default_maximum_allowed_locked,
         bidding_start_date=bidding_start_date,
         bidding_end_date=bidding_end_date,
         cancellation_end_date=cancellation_end_date,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -413,6 +413,7 @@ def token_economics(testerchain):
     # Ends in one hour
     bidding_end_date = start_date + one_hour_in_seconds
     cancellation_end_date = bidding_end_date + one_hour_in_seconds
+    min_bid = Web3.toWei(1, "ether")
 
     economics = StandardTokenEconomics(
         worklock_boosting_refund_rate=200,
@@ -421,7 +422,8 @@ def token_economics(testerchain):
         bidding_start_date=bidding_start_date,
         bidding_end_date=bidding_end_date,
         cancellation_end_date=cancellation_end_date,
-        worklock_min_allowed_bid=Web3.toWei(1, "ether")
+        worklock_min_allowed_bid=min_bid,
+        worklock_max_allowed_bid=1000*min_bid
     )
     return economics
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -412,6 +412,7 @@ def token_economics(testerchain):
 
     # Ends in one hour
     bidding_end_date = start_date + one_hour_in_seconds
+    cancellation_end_date = bidding_end_date + one_hour_in_seconds
 
     economics = StandardTokenEconomics(
         worklock_boosting_refund_rate=200,
@@ -419,6 +420,7 @@ def token_economics(testerchain):
         worklock_supply=NU.from_tokens(1_000_000),
         bidding_start_date=bidding_start_date,
         bidding_end_date=bidding_end_date,
+        cancellation_end_date=cancellation_end_date,
         worklock_min_allowed_bid=Web3.toWei(1, "ether")
     )
     return economics

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -418,7 +418,8 @@ def token_economics(testerchain):
         worklock_commitment_duration=60*60,  # seconds
         worklock_supply=NU.from_tokens(1_000_000),
         bidding_start_date=bidding_start_date,
-        bidding_end_date=bidding_end_date
+        bidding_end_date=bidding_end_date,
+        worklock_min_allowed_bid=Web3.toWei(1, "ether")
     )
     return economics
 


### PR DESCRIPTION
Fixes #1733 
Fixes #1508 
Opens #1758

Changes:
* Suggestions from audit (mostly just comments)
* Separate method for available refund
* Min and max boundaries for allowed bid
* Cancellation window (includes bidding phase)
* Claiming is available only after post initialization
* Post initialization: found all whales, force refund, verify onchain bids, update max/min boundaries for allowed stake, enable claiming

I guess it's not final PR related to `WorkLock`, also multiple places are not ideal, so let's open issues

Versions:
`StakingEscrow`: `v2.2.3` -> `v2.3.1`

**Force refund calculation**:
worklock token supply is constant
eth supply is variable
eth bid from whale  is variable
 maximum stake size is constant (for force refund calculations)
`n` - number of whales
`x` - refund that need to calculate
`deposit_rate = token_supply / eth_supply`

Start from only one whale:
`stake = bid * deposit_rate = (bid * token_supply) / eth_supply`
Max stake size must be greater than stake size but whale has more that that
`max_stake < stake` 
`max_stake >= new_stake`

So we need to subtract `x` from whale's bid to decrease stake, also this subtraction will decrease `eth_supply`
`new_stake = ((bid - x) * token_supply) / (eth_supply - x)`
`max_stake >= ((bid - x) * token_supply) / (eth_supply - x)`
Solving this we get minimum possible `x`: 
`x >= (bid * token_supply - eth_supply  * max_stake) / (token_supply - max_stake)`

Next step: when we have multiple whales. Ideally after force refund each of them should have  `new_stake=max_stake` and this means they will have same bid.
System of equations:
`max_stake >= ((bid1 - x1) * token_supply) / (eth_supply - (x1+x2+x3+...+xn))`
...
`max_stake >= ((bidn - xn) * token_supply) / (eth_supply - (x1+x2+x3+...+xn))`

Imagine whales already have same bid then we can reduce system to one equation:
 `max_stake >= ((bid - x) * token_supply) / (eth_supply -n * x)`
And solution is: 
`x >= (bid * token_supply - eth_supply  * max_stake) / (token_supply - n * max_stake)`

But very likely all whales have different bids, so first step is reducing whales bids to the lowest of them. In the result whales still be whales because bid decreasing can only increase stake for all bids that didn't change, we have at least one whale's bid that didn't change (lowest one) so means this whale still be whale and then other whales are also whales :) And in the result we can use last equation to calculate refund.
Resume: 
- one round of force refund in 2 steps - reducing all whale bids to the smallest one (if they are different) and then calculating refund using formula
- other rounds needed if after first round will be found new whales, then need to repeat first round with old + new whales
- possible `token_supply / max_stake` rounds at most, when new 1 whale will be found on each step