### PR TITLE
Ansible worker deploy tweak: Don't wait for geth sync if we are just updating the node

### DIFF
--- a/deploy/ansible/worker/include/init_worker.yml
+++ b/deploy/ansible/worker/include/init_worker.yml
@@ -3,7 +3,6 @@
   remote_user: "{{default_user}}"
   gather_facts: no
   tasks:
-
     - name: "create geth directory"
       become: yes
       file:

--- a/deploy/ansible/worker/include/run_geth.yml
+++ b/deploy/ansible/worker/include/run_geth.yml
@@ -14,7 +14,7 @@
       docker_container:
         name: geth-sync
         state: absent
-      when: geth_running.stat.exists == False
+      when: geth_running.stat.exists == False and restarting_geth is undefined
       ignore_errors: yes
 
     - name: "run geth until it finishes syncing (time to get up and go for a walk)"
@@ -23,13 +23,13 @@
       async: 100000
       poll: 0
       register: geth_sync_status
-      when: geth_running.stat.exists == False
+      when: geth_running.stat.exists == False and restarting_geth is undefined
 
     - name: 'check if geth is finished syncing...'
       become: yes
       until: job_result.finished
       retries: 10000
-      when: geth_running.stat.exists == False
+      when: geth_running.stat.exists == False and restarting_geth is undefined
       register: job_result
       async_status:
         jid: "{{ geth_sync_status['ansible_job_id'] }}"

--- a/deploy/ansible/worker/include/update_existing_ursula.yml
+++ b/deploy/ansible/worker/include/update_existing_ursula.yml
@@ -18,6 +18,7 @@
         name: ursula
         state: stopped
 
+    - set_fact: restarting_geth=True
     - name: Stop Geth
       become: yes
       docker_container:


### PR DESCRIPTION
When updating multiple machines, geth sync could take disparate amounts of time and cause the different nodes to actually _lose_ sync while waiting for a straggler.  Better to just restart them quickly.