### PR TITLE
Allow to deploy a network in idle mode. Activate later

### DIFF
--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -28,6 +28,7 @@ from constant_sorrow.constants import (
 
 from nucypher.blockchain.eth.actors import ContractAdministrator, Trustee
 from nucypher.blockchain.eth.agents import NucypherTokenAgent, ContractAgency, MultiSigAgent
+from nucypher.blockchain.eth.constants import STAKING_ESCROW_CONTRACT_NAME
 from nucypher.blockchain.eth.interfaces import BlockchainDeployerInterface, BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import (
     BaseContractRegistry,
@@ -365,19 +366,19 @@ def rollback(general_config, actor_options):
 @deploy.command()
 @group_general_config
 @group_actor_options
-@click.option('--mode',
-              help="Deploy a contract following all steps ('full'), up to idle status ('idle'), "
-                   "or just the bare contract ('bare'). Defaults to 'full'",
-              type=click.Choice(['full', 'idle', 'bare']),
-              #case_sensitive
-              default='full'
-              )
 @option_gas
 @option_ignore_deployed
 @click.option('--confirmations', help="Number of required block confirmations", type=click.IntRange(min=0))
 @click.option('--parameters', help="Filepath to a JSON file containing additional deployment parameters",
               type=EXISTING_READABLE_FILE)
-def contracts(general_config, actor_options, mode, gas, ignore_deployed, confirmations, parameters):
+@click.option('--mode',
+              help="Deploy a contract following all steps ('full'), up to idle status ('idle'), "
+                   "or just the bare contract ('bare'). Defaults to 'full'",
+              type=click.Choice(['full', 'idle', 'bare'], case_sensitive=False),
+              default='full'
+              )
+@click.option('--activate', help="Activate a contract that is in idle mode", is_flag=True)
+def contracts(general_config, actor_options, mode, activate, gas, ignore_deployed, confirmations, parameters):
     """
     Compile and deploy contracts.
     """
@@ -385,6 +386,7 @@ def contracts(general_config, actor_options, mode, gas, ignore_deployed, confirm
 
     emitter = general_config.emitter
     ADMINISTRATOR, _, deployer_interface, local_registry = actor_options.create_actor(emitter)
+    chain_name = deployer_interface.client.chain_name
 
     deployment_parameters = {}
     if parameters:
@@ -398,17 +400,36 @@ def contracts(general_config, actor_options, mode, gas, ignore_deployed, confirm
     deployment_mode = constants.__getattr__(mode.upper())  # TODO: constant sorrow
     if contract_name:
         try:
-            contract_deployer = ADMINISTRATOR.deployers[contract_name]
+            contract_deployer_class = ADMINISTRATOR.deployers[contract_name]
         except KeyError:
             message = f"No such contract {contract_name}. Available contracts are {ADMINISTRATOR.deployers.keys()}"
             emitter.echo(message, color='red', bold=True)
             raise click.Abort()
 
+        if activate:
+            # For the moment, only StakingEscrow can be activated
+            staking_escrow_deployer = contract_deployer_class(registry=ADMINISTRATOR.registry,
+                                                              deployer_address=ADMINISTRATOR.deployer_address)
+            if contract_name != STAKING_ESCROW_CONTRACT_NAME or not staking_escrow_deployer.ready_to_activate:
+                raise click.BadOptionUsage(option_name="--activate",
+                                           message=f"You can only activate an idle instance of {STAKING_ESCROW_CONTRACT_NAME}")
+
+            click.confirm(f"Activate {STAKING_ESCROW_CONTRACT_NAME} at "
+                          f"{staking_escrow_deployer._get_deployed_contract().address}?", abort=True)
+
+            receipts = staking_escrow_deployer.activate()
+            for tx_name, receipt in receipts.items():
+                paint_receipt_summary(emitter=emitter,
+                                      receipt=receipt,
+                                      chain_name=chain_name,
+                                      transaction_type=tx_name)
+            return  # Exit
+
         # Deploy
         emitter.echo(f"Deploying {contract_name}")
-        if contract_deployer._upgradeable and deployment_mode is not BARE:
+        if contract_deployer_class._upgradeable and deployment_mode is not BARE:
             # NOTE: Bare deployments do not engage the proxy contract
-            secret = ADMINISTRATOR.collect_deployment_secret(deployer=contract_deployer)
+            secret = ADMINISTRATOR.collect_deployment_secret(deployer=contract_deployer_class)
             receipts, agent = ADMINISTRATOR.deploy_contract(contract_name=contract_name,
                                                             plaintext_secret=secret,
                                                             gas_limit=gas,
@@ -430,7 +451,7 @@ def contracts(general_config, actor_options, mode, gas, ignore_deployed, confirm
                                   contract_address=agent.contract_address,
                                   receipts=receipts,
                                   emitter=emitter,
-                                  chain_name=deployer_interface.client.chain_name,
+                                  chain_name=chain_name,
                                   open_in_browser=actor_options.etherscan)
         return  # Exit
 

--- a/tests/blockchain/eth/entities/deployers/test_deploy_idle_network.py
+++ b/tests/blockchain/eth/entities/deployers/test_deploy_idle_network.py
@@ -1,0 +1,117 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+import os
+
+import pytest
+from eth_utils import keccak
+from constant_sorrow import constants
+
+from nucypher.blockchain.eth.actors import Staker
+from nucypher.blockchain.eth.agents import NucypherTokenAgent, StakingEscrowAgent, ContractAgency
+from nucypher.blockchain.eth.deployers import (NucypherTokenDeployer,
+                                               StakingEscrowDeployer,
+                                               PolicyManagerDeployer,
+                                               AdjudicatorDeployer,
+                                               BaseContractDeployer,
+                                               DispatcherDeployer)
+from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.sandbox.blockchain import token_airdrop
+from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUNT, INSECURE_DEVELOPMENT_PASSWORD
+
+
+@pytest.mark.slow()
+def test_deploy_idle_network(testerchain, deployment_progress, test_registry):
+    origin, *everybody_else = testerchain.client.accounts
+
+    #
+    # Nucypher Token
+    #
+    token_deployer = NucypherTokenDeployer(registry=test_registry, deployer_address=origin)
+    assert token_deployer.deployer_address == origin
+
+    with pytest.raises(BaseContractDeployer.ContractDeploymentError):
+        assert token_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
+    assert not token_deployer.is_deployed()
+
+    token_deployer.deploy(progress=deployment_progress)
+    assert token_deployer.is_deployed()
+
+    token_agent = NucypherTokenAgent(registry=test_registry)
+    assert token_agent.contract_address == token_deployer.contract_address
+
+    another_token_agent = token_deployer.make_agent()
+    assert another_token_agent.contract_address == token_deployer.contract_address == token_agent.contract_address
+
+    #
+    # StakingEscrow - in IDLE mode, i.e. without activation steps (approve_funding and initialize)
+    #
+    stakers_escrow_secret = os.urandom(DispatcherDeployer._secret_length)
+    staking_escrow_deployer = StakingEscrowDeployer(registry=test_registry, deployer_address=origin)
+    assert staking_escrow_deployer.deployer_address == origin
+
+    with pytest.raises(BaseContractDeployer.ContractDeploymentError):
+        assert staking_escrow_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
+    assert not staking_escrow_deployer.is_deployed()
+
+    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret),
+                                   progress=deployment_progress,
+                                   deployment_mode=constants.IDLE)
+    assert staking_escrow_deployer.is_deployed()
+
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    assert staking_agent.contract_address == staking_escrow_deployer.contract_address
+
+    # The contract has no tokens yet
+    assert token_agent.get_balance(staking_agent.contract_address) == 0
+
+    #
+    # Policy Manager
+    #
+    policy_manager_secret = os.urandom(DispatcherDeployer._secret_length)
+    policy_manager_deployer = PolicyManagerDeployer(registry=test_registry, deployer_address=origin)
+
+    assert policy_manager_deployer.deployer_address == origin
+
+    with pytest.raises(BaseContractDeployer.ContractDeploymentError):
+        assert policy_manager_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
+    assert not policy_manager_deployer.is_deployed()
+
+    policy_manager_deployer.deploy(secret_hash=keccak(policy_manager_secret), progress=deployment_progress)
+    assert policy_manager_deployer.is_deployed()
+
+    policy_agent = policy_manager_deployer.make_agent()
+    assert policy_agent.contract_address == policy_manager_deployer.contract_address
+
+    #
+    # Adjudicator
+    #
+    adjudicator_secret = os.urandom(DispatcherDeployer._secret_length)
+    adjudicator_deployer = AdjudicatorDeployer(registry=test_registry, deployer_address=origin)
+
+    assert adjudicator_deployer.deployer_address == origin
+
+    with pytest.raises(BaseContractDeployer.ContractDeploymentError):
+        assert adjudicator_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
+    assert not adjudicator_deployer.is_deployed()
+
+    adjudicator_deployer.deploy(secret_hash=keccak(adjudicator_secret), progress=deployment_progress)
+    assert adjudicator_deployer.is_deployed()
+
+    adjudicator_agent = adjudicator_deployer.make_agent()
+    assert adjudicator_agent.contract_address == adjudicator_deployer.contract_address
+
+

--- a/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
@@ -16,13 +16,14 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import pytest
+from constant_sorrow.constants import BARE
 from eth_utils import keccak
 
 from nucypher.blockchain.eth.agents import StakingEscrowAgent, ContractAgency
 from nucypher.blockchain.eth.deployers import (StakingEscrowDeployer,
                                                DispatcherDeployer)
 from nucypher.crypto.api import keccak_digest
-from nucypher.utilities.sandbox.constants import STAKING_ESCROW_DEPLOYMENT_SECRET, TEST_PROVIDER_URI
+from nucypher.utilities.sandbox.constants import STAKING_ESCROW_DEPLOYMENT_SECRET
 
 
 def test_staking_escrow_deployment(staking_escrow_deployer, deployment_progress):
@@ -149,7 +150,7 @@ def test_deploy_bare_upgradeable_contract_deployment(testerchain, test_registry,
     old_number_of_enrollments = enrolled_names.count(StakingEscrowDeployer.contract_name)
     old_number_of_proxy_enrollments = enrolled_names.count(StakingEscrowDeployer._proxy_deployer.contract_name)
 
-    receipts = deployer.deploy(initial_deployment=False, ignore_deployed=True)
+    receipts = deployer.deploy(deployment_mode=BARE, ignore_deployed=True)
     for title, receipt in receipts.items():
         assert receipt['status'] == 1
 

--- a/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_staking_escrow_deployer.py
@@ -169,10 +169,10 @@ def test_deployer_version_management(testerchain, test_registry, token_economics
                                      registry=test_registry,
                                      economics=token_economics)
 
-    untargeted_deployment = deployer.get_latest_enrollment(registry=test_registry)
-    latest_targeted_deployment = deployer.get_principal_contract(registry=test_registry)
+    untargeted_deployment = deployer.get_latest_enrollment()
+    latest_targeted_deployment = deployer.get_principal_contract()
 
-    proxy_deployer = deployer.get_proxy_deployer(registry=test_registry, provider_uri=TEST_PROVIDER_URI)
+    proxy_deployer = deployer.get_proxy_deployer()
     proxy_target = proxy_deployer.target_contract.address
     assert latest_targeted_deployment.address == proxy_target
     assert untargeted_deployment.address != latest_targeted_deployment.address
@@ -185,7 +185,7 @@ def test_manual_proxy_retargeting(testerchain, test_registry, token_economics):
                                      economics=token_economics)
 
     # Get Proxy-Direct
-    proxy_deployer = deployer.get_proxy_deployer(registry=test_registry, provider_uri=TEST_PROVIDER_URI)
+    proxy_deployer = deployer.get_proxy_deployer()
 
     # Re-Deploy Staking Escrow
     old_target = proxy_deployer.target_contract.address
@@ -194,7 +194,7 @@ def test_manual_proxy_retargeting(testerchain, test_registry, token_economics):
     new_secret = keccak_digest(bytes('thistimeforsure', encoding='utf-8'))
 
     # Get the latest un-targeted contract from the registry
-    latest_deployment = deployer.get_latest_enrollment(registry=test_registry)
+    latest_deployment = deployer.get_latest_enrollment()
 
     # Build retarget transaction (just for informational purposes)
     transaction = deployer.retarget(target_address=latest_deployment.address,
@@ -219,5 +219,5 @@ def test_manual_proxy_retargeting(testerchain, test_registry, token_economics):
     assert new_target == latest_deployment.address
 
     # Check address consistency
-    new_bare_contract = deployer.get_principal_contract(registry=test_registry, provider_uri=TEST_PROVIDER_URI)
+    new_bare_contract = deployer.get_principal_contract()
     assert new_bare_contract.address == latest_deployment.address == new_target

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -144,10 +144,10 @@ def test_manual_proxy_retargeting(testerchain, click_runner, token_economics):
     deployer = StakingEscrowDeployer(deployer_address=testerchain.etherbase_account,
                                      registry=local_registry,
                                      economics=token_economics)
-    proxy_deployer = deployer.get_proxy_deployer(registry=local_registry)
+    proxy_deployer = deployer.get_proxy_deployer()
 
     # Un-targeted enrollment is indeed un targeted by the proxy
-    untargeted_deployment = deployer.get_latest_enrollment(registry=local_registry)
+    untargeted_deployment = deployer.get_latest_enrollment()
     assert proxy_deployer.target_contract.address != untargeted_deployment.address
 
     # MichWill still owns this proxy.
@@ -170,6 +170,6 @@ def test_manual_proxy_retargeting(testerchain, click_runner, token_economics):
     assert result.exit_code == 0
 
     # The proxy target has been updated.
-    proxy_deployer = deployer.get_proxy_deployer(registry=local_registry)
+    proxy_deployer = deployer.get_proxy_deployer()
     assert proxy_deployer.target_contract.address == untargeted_deployment.address
 

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -111,7 +111,7 @@ def test_bare_contract_deployment_to_alternate_registry(click_runner, agency_loc
 
     command = ('contracts',
                '--contract-name', StakingEscrowDeployer.contract_name,
-               '--bare',
+               '--mode', 'bare',
                '--provider', TEST_PROVIDER_URI,
                '--registry-infile', agency_local_registry.filepath,
                '--registry-outfile', ALTERNATE_REGISTRY_FILEPATH,

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -6,9 +6,15 @@ from nucypher.blockchain.eth.agents import (
     AdjudicatorAgent,
     ContractAgency
 )
-from nucypher.blockchain.eth.constants import STAKING_ESCROW_CONTRACT_NAME
+from nucypher.blockchain.eth.constants import (
+    NUCYPHER_TOKEN_CONTRACT_NAME,
+    STAKING_ESCROW_CONTRACT_NAME,
+    POLICY_MANAGER_CONTRACT_NAME,
+    ADJUDICATOR_CONTRACT_NAME,
+    DISPATCHER_CONTRACT_NAME
+)
 from nucypher.blockchain.eth.deployers import StakingEscrowDeployer
-from nucypher.blockchain.eth.registry import LocalContractRegistry
+from nucypher.blockchain.eth.registry import LocalContractRegistry, InMemoryContractRegistry
 from nucypher.cli.commands.deploy import deploy
 from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,
@@ -17,6 +23,7 @@ from nucypher.utilities.sandbox.constants import (
 )
 
 ALTERNATE_REGISTRY_FILEPATH = '/tmp/nucypher-test-registry-alternate.json'
+ALTERNATE_REGISTRY_FILEPATH_2 = '/tmp/nucypher-test-registry-alternate-2.json'
 
 
 def test_nucypher_deploy_inspect_no_deployments(click_runner, testerchain, new_local_registry):
@@ -172,4 +179,87 @@ def test_manual_proxy_retargeting(testerchain, click_runner, token_economics):
     # The proxy target has been updated.
     proxy_deployer = deployer.get_proxy_deployer()
     assert proxy_deployer.target_contract.address == untargeted_deployment.address
+
+
+def test_manual_deployment_of_idle_network(click_runner):
+
+    if os.path.exists(ALTERNATE_REGISTRY_FILEPATH_2):
+        os.remove(ALTERNATE_REGISTRY_FILEPATH_2)
+    assert not os.path.exists(ALTERNATE_REGISTRY_FILEPATH_2)
+    registry = LocalContractRegistry(filepath=ALTERNATE_REGISTRY_FILEPATH_2)
+    registry.write(InMemoryContractRegistry().read())  # FIXME: Manual deployments from scratch require an existing but empty registry (i.e., a json file just with "[]")
+
+    # 1. Deploy NuCypherToken
+    command = ('contracts',
+               '--contract-name', NUCYPHER_TOKEN_CONTRACT_NAME,
+               '--provider', TEST_PROVIDER_URI,
+               '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
+               '--poa')
+
+    user_input = '0\n' + 'Y\n' + INSECURE_DEVELOPMENT_PASSWORD
+    result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    assert os.path.exists(ALTERNATE_REGISTRY_FILEPATH_2)
+    new_registry = LocalContractRegistry(filepath=ALTERNATE_REGISTRY_FILEPATH_2)
+
+    deployed_contracts = [NUCYPHER_TOKEN_CONTRACT_NAME]
+    assert list(new_registry.enrolled_names) == deployed_contracts
+
+    # 2. Deploy StakingEscrow in IDLE mode
+    command = ('contracts',
+               '--contract-name', STAKING_ESCROW_CONTRACT_NAME,
+               '--mode', 'idle',
+               '--provider', TEST_PROVIDER_URI,
+               '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
+               '--poa')
+
+    secret = INSECURE_DEPLOYMENT_SECRET_PLAINTEXT.decode()
+    user_input = '0\n' + 'Y\n' + (f'{secret}\n' * 2)
+    result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    deployed_contracts.extend([STAKING_ESCROW_CONTRACT_NAME, DISPATCHER_CONTRACT_NAME])
+    assert list(new_registry.enrolled_names) == deployed_contracts
+
+    # 3. Deploy PolicyManager
+    command = ('contracts',
+               '--contract-name', POLICY_MANAGER_CONTRACT_NAME,
+               '--provider', TEST_PROVIDER_URI,
+               '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
+               '--poa')
+
+    user_input = '0\n' + 'Y\n' + (f'{secret}\n' * 2)
+    result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    deployed_contracts.extend([POLICY_MANAGER_CONTRACT_NAME, DISPATCHER_CONTRACT_NAME])
+    assert list(new_registry.enrolled_names) == deployed_contracts
+
+    # 4. Deploy Adjudicator
+    command = ('contracts',
+               '--contract-name', ADJUDICATOR_CONTRACT_NAME,
+               '--provider', TEST_PROVIDER_URI,
+               '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
+               '--poa')
+
+    user_input = '0\n' + 'Y\n' + (f'{secret}\n' * 2)
+    result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+
+    deployed_contracts.extend([ADJUDICATOR_CONTRACT_NAME, DISPATCHER_CONTRACT_NAME])
+    assert list(new_registry.enrolled_names) == deployed_contracts
+
+    # 5. Activate StakingEscrow
+    command = ('contracts',
+               '--contract-name', STAKING_ESCROW_CONTRACT_NAME,
+               '--activate',
+               '--provider', TEST_PROVIDER_URI,
+               '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
+               '--poa')
+
+    user_input = '0\n' + 'Y\n' + 'Y\n'
+    result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert list(new_registry.enrolled_names) == deployed_contracts
 


### PR DESCRIPTION
Closes #1532.

Recipe to deploy a network in idle mode:

1. Deploy a NuCypher contract

```
nucypher-deploy contracts --contract-name NuCypherToken --provider $NUCYPHER_PROVIDER_URI --poa --registry-infile ...
```
2. Deploy a StakingEscrow in IDLE mode
```
nucypher-deploy contracts --contract-name StakingEscrow --mode idle --provider $NUCYPHER_PROVIDER_URI --poa --registry-infile ...
```
3. Deploy PolicyManager and Adjudicator
```
nucypher-deploy contracts --contract-name PolicyManager --provider $NUCYPHER_PROVIDER_URI --poa --registry-infile ...
nucypher-deploy contracts --contract-name Adjudicator --provider $NUCYPHER_PROVIDER_URI --poa --registry-infile ...
```
4. When you're ready, activate StakingEscrow
```
nucypher-deploy contracts --contract-name StakingEscrow --activate --provider $NUCYPHER_PROVIDER_URI --poa --registry-infile ...
```