### PR TITLE
Handle `InvalidSignatures` on receiving a `node_payload`

### DIFF
--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -852,8 +852,8 @@ class Learner:
         try:
             self.verify_from(current_teacher, node_payload, signature=signature)
         except current_teacher.InvalidSignature:
-            # TODO: What to do if the teacher improperly signed the node payload?  1713
-            raise
+            self.suspicious_activities_witnessed['vladimirs'].append(('Node payload improperly signed', node_payload, signature))
+            self.log.warn(f"Invalid signature ({signature}) received from teacher {current_teacher} for payload {node_payload}")
 
         # End edge case handling.
         fleet_state_checksum_bytes, fleet_state_updated_bytes, node_payload = FleetStateTracker.snapshot_splitter(

--- a/tests/learning/test_fault_tolerance.py
+++ b/tests/learning/test_fault_tolerance.py
@@ -59,6 +59,7 @@ def test_blockchain_ursula_stamp_verification_tolerance(blockchain_ursulas, mock
     # Learn about a node with a badly signed payload
     mocker.patch.object(lonely_blockchain_learner, 'verify_from', side_effect=Learner.InvalidSignature)
     lonely_blockchain_learner.learn_from_teacher_node(eager=True)
+    assert len(lonely_blockchain_learner.suspicious_activities_witnessed['vladimirs']) == 1
 
 @pytest.mark.skip("See Issue #1075")  # TODO: Issue #1075
 def test_invalid_workers_tolerance(testerchain,

--- a/tests/learning/test_fault_tolerance.py
+++ b/tests/learning/test_fault_tolerance.py
@@ -11,12 +11,12 @@ from constant_sorrow.constants import NOT_SIGNED
 from nucypher.characters.base import Character
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nicknames import nickname_from_seed
-from nucypher.network.nodes import FleetStateTracker
+from nucypher.network.nodes import FleetStateTracker, Learner
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 from nucypher.utilities.sandbox.ursula import make_federated_ursulas, make_ursula_for_staker
 
 
-def test_blockchain_ursula_stamp_verification_tolerance(blockchain_ursulas):
+def test_blockchain_ursula_stamp_verification_tolerance(blockchain_ursulas, mocker):
     #
     # Setup
     #
@@ -56,6 +56,9 @@ def test_blockchain_ursula_stamp_verification_tolerance(blockchain_ursulas):
     # assert len(lonely_blockchain_learner.known_nodes) == len(blockchain_ursulas) - 2
     assert blockchain_teacher in lonely_blockchain_learner.known_nodes
 
+    # Learn about a node with a badly signed payload
+    mocker.patch.object(lonely_blockchain_learner, 'verify_from', side_effect=Learner.InvalidSignature)
+    lonely_blockchain_learner.learn_from_teacher_node(eager=True)
 
 @pytest.mark.skip("See Issue #1075")  # TODO: Issue #1075
 def test_invalid_workers_tolerance(testerchain,


### PR DESCRIPTION
### What this does:
1. Handles an `InvalidSignature` raised when a `Teacher` gives a `Learner` an improperly signed `node_payload`.
    - Instead of raising, this will append the `node_payload` and the `signature` to `suspicious_activities_witnessed`.
2. Adds a test that checks for this case.
3. Resolves #1713 