### PR TITLE
CircleCI optimization: codecov only in nightly & jobs rearrangement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,13 +23,6 @@ workflows:
               only: /.*/
           requires:
             - pip_install_37
-      - network:
-          context: "NuCypher Tests"
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pip_install_37
       - character:
           context: "NuCypher Tests"
           filters:
@@ -71,7 +64,6 @@ workflows:
               only: /.*/
           requires:
             - basics
-            - network
             - character
             - cli
             - deployers
@@ -227,13 +219,6 @@ workflows:
               only: /.*/
           requires:
             - pip_install_37
-      - network:
-          context: "Nightly"
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - pip_install_37
       - character:
           context: "Nightly"
           filters:
@@ -275,7 +260,6 @@ workflows:
               only: /.*/
           requires:
             - basics
-            - network
             - character
             - cli
             - deployers
@@ -592,17 +576,7 @@ jobs:
       - run:
           name: Tests for Blockhain interfaces, Crypto functions, Node Configuration and Keystore
           command: |
-            pytest $(circleci tests glob "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" "tests/blockchain/eth/clients/**/test_*.py" | circleci tests split --split-by=timings)
-      - capture_test_results
-
-  network:
-    <<: *python_37_base
-    steps:
-      - prepare_environment
-      - run:
-          name: Network Tests
-          command: |
-            pytest $(circleci tests glob "tests/network/**/test_*.py" | circleci tests split --split-by=timings)
+            pytest $(circleci tests glob "tests/network/**/test_*.py" "tests/config/**/test_*.py" "tests/crypto/**/test_*.py" "tests/keystore/**/test_*.py" "tests/blockchain/eth/interfaces/**/test_*.py" "tests/blockchain/eth/clients/**/test_*.py" | circleci tests split --split-by=timings)
       - capture_test_results
 
   character:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,69 +214,61 @@ workflows:
           requires:
             - pip_install_37
       - contracts:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - basics:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - network:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - character:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - agents:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - actors:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - deployers:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - cli:
-          context: "NuCypher Tests"
+          context: "Nightly"
           filters:
             tags:
               only: /.*/
           requires:
             - pip_install_37
-          enable_codecov: true
       - tests_ok:
           filters:
             tags:
@@ -465,25 +457,24 @@ commands:
 
   capture_test_results:
     description: "Store and Upload test results; Follow-up step for tests"
-    parameters:
-      enable_codecov:
-        type: boolean
-        default: false
     steps:
-      - when:
-          condition: <<parameters.enable_codecov>>
-          steps:
-            - codecov
-            - store_test_results:
-                path: reports
-            - run:
-                name: Prepare test logs for storage as artifacts
-                command: |
-                  mkdir -p ~/test-logs/
-                  mv ~/.cache/nucypher/log/nucypher.log ~/test-logs/nucypher-container-$CIRCLE_NODE_INDEX.log
-                when: always
-            - store_artifacts:
-                path: ~/test-logs/
+      - store_test_results:
+          path: reports
+      - run:
+          name: Prepare test logs for storage as artifacts
+          command: |
+            mkdir -p ~/test-logs/
+            mv ~/.cache/nucypher/log/nucypher.log ~/test-logs/nucypher-container-$CIRCLE_NODE_INDEX.log
+          when: always
+      - store_artifacts:
+          path: ~/test-logs/
+      - run:
+          name: If $ENABLE_CODECOV, exit job without failing now to avoid uploading codecov results
+          command: |
+            if [ -z "$ENABLE_CODECOV"]; then
+                circleci-agent step halt
+            fi
+      - codecov
 
   build_and_save_test_docker:
     description: "Build dev docker image for running tests against docker"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -336,18 +336,25 @@ commands:
 
   capture_test_results:
     description: "Store and Upload test results; Follow-up step for tests"
+    parameters:
+      enable_codecov:
+        type: boolean
+        default: false
     steps:
-      - codecov
-      - store_test_results:
-          path: reports
-      - run:
-          name: Prepare test logs for storage as artifacts
-          command: |
-            mkdir -p ~/test-logs/
-            mv ~/.cache/nucypher/log/nucypher.log ~/test-logs/nucypher-container-$CIRCLE_NODE_INDEX.log
-          when: always
-      - store_artifacts:
-          path: ~/test-logs/
+      - when:
+          condition: <<parameters.enable_codecov>>
+          steps:
+            - codecov
+            - store_test_results:
+                path: reports
+            - run:
+                name: Prepare test logs for storage as artifacts
+                command: |
+                  mkdir -p ~/test-logs/
+                  mv ~/.cache/nucypher/log/nucypher.log ~/test-logs/nucypher-container-$CIRCLE_NODE_INDEX.log
+                when: always
+            - store_artifacts:
+                path: ~/test-logs/
 
   build_and_save_test_docker:
     description: "Build dev docker image for running tests against docker"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,6 +213,135 @@ workflows:
               only: /.*/
           requires:
             - pip_install_37
+      - contracts:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - basics:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - network:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - character:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - agents:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - actors:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - deployers:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - cli:
+          context: "NuCypher Tests"
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - pip_install_37
+          enable_codecov: true
+      - tests_ok:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - basics
+            - network
+            - character
+            - cli
+            - deployers
+      - build_dev_docker_images:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - basics
+      - finnegans_wake_demo:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build_dev_docker_images
+      - heartbeat_demo:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build_dev_docker_images
+      - estimate_gas:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - tests_ok
+      - build_docs:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - tests_ok
+      - test_build:
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build_docs
+            - heartbeat_demo
+            - finnegans_wake_demo
+      - build_docker:
+          filters:
+            tags:
+              only: /v[0-9]+.*/
+            branches:
+              only: master
+          requires:
+            - test_build
+      - test_deploy:
+          context: "NuCypher PyPI"
+          requires:
+            - test_build
+          filters:
+            tags:
+              only: /v[0-9]+.*/
+            branches:
+              ignore: /.*/
 
 
 python_36_base: &python_36_base

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,7 @@ workflows:
             tags:
               only: /.*/
           requires:
-            - build_docs
-            - heartbeat_demo
-            - finnegans_wake_demo
+            - tests_ok
       - build_docker:
           filters:
             tags:


### PR DESCRIPTION
Makes build go down from ~20 minutes to ~9.

* Don't do codecov in regular build; instead only do that in the nightly
   * This is controlled by the `ENABLE_CODECOV` envvar, which exists in the nightly context, but doesn't in the regular context.
* Absorb `network` job into the `basics` job, as both or them are lightweight.
   * This saves up 1 container
* Moves `test_build` job sooner in the pipeline, so it can run in parallel with other jobs.
   * This reduces the build by ~3 minutes more.