### PR TITLE
Configurable Gas Strategy / Higher Timeouts / TX Prompts

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -47,10 +47,10 @@
         },
         "autobahn": {
             "hashes": [
-                "sha256:1ec603ea374a3b9d85540c499709c41f35f7c6e288b571d12da14aba6c381211",
-                "sha256:efb1adf87b62a960c9851ab30a87b62a90838bd8f83f0d8d75174688873cc567"
+                "sha256:8ece7d16e7998c2ed6210c278b4f59588b850e071af0f3fa98d2f2dbe1f62ce5",
+                "sha256:8fb9f3e7f6de5b7ee5479a56582873b927cc25d72319d0a86f43d992048d8171"
             ],
-            "version": "==20.2.1"
+            "version": "==20.2.2"
         },
         "automat": {
             "hashes": [
@@ -332,11 +332,11 @@
         },
         "flask-limiter": {
             "hashes": [
-                "sha256:905c35cd87bf60c92fd87922ae23fe27aa5fb31980bab31fc00807adee9f5a55",
-                "sha256:9087984ae7eeb862f93bf5b18477a5e5b1e0c907647ae74fba1c7e3f1de63d6f"
+                "sha256:d984a57ef37acb6eee29edc864ff22cd4cf090845f06968c015093ffd91e96f1",
+                "sha256:db2a069402977927282b0fcf650753bfcb50488028def9f5b2398e1d525f2f9f"
             ],
             "index": "pypi",
-            "version": "==1.1.0"
+            "version": "==1.2.1"
         },
         "flask-sqlalchemy": {
             "hashes": [
@@ -419,10 +419,10 @@
         },
         "limits": {
             "hashes": [
-                "sha256:19bc9e6f6c64e8edfc7d18734a89486cdadbad816a81673c35669a1d1cac6d5d",
-                "sha256:d05ba12c94ea8ab7a54cfa9c55ec46882790fae7e389743c0abea8e58fa1f886"
+                "sha256:0e5f8b10f18dd809eb2342f5046eb9aa5e4e69a0258567b5f4aa270647d438b3",
+                "sha256:f0c3319f032c4bfad68438ed1325c0fac86dac64582c7c25cddc87a0b658fa20"
             ],
-            "version": "==1.5"
+            "version": "==1.5.1"
         },
         "lru-dict": {
             "hashes": [
@@ -649,10 +649,10 @@
         },
         "pyhamcrest": {
             "hashes": [
-                "sha256:36cda5e849e3ee9ce54628667471e5e769f596259bb3c13c3596f6059a615ef8",
-                "sha256:5959cb4ab465b303522d2e0d270a6ee581c3ad9ba419e304bb6ebe50a60ea37a"
+                "sha256:55abfc14ec38ed2bd6093add3be72385c1b7fd8e6aeb27448c00f95cb501c60e",
+                "sha256:9f12b9b3b109d4877b2a1a42a9fb8acbf350213d3b1873eecf6eb07d6ac3caef"
             ],
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "pynacl": {
             "hashes": [
@@ -904,11 +904,11 @@
         },
         "web3": {
             "hashes": [
-                "sha256:8def170567698f09f6ad1460f6a2dfba4a454b7ee30060c3f1ee7ed0273b91b8",
-                "sha256:be1b7109d6dc5b7340df79976b3e52adcaca309850b74f98f6ed8a616299c458"
+                "sha256:16f34e3af466fbdf6c3c41b05e1d7d74d71083d9189f181cc8fd352711b4c6da",
+                "sha256:59df0e25ca45cf03933c551811413e43975f36c6c2a7e5eb2fe8da11c2bfbb59"
             ],
             "index": "pypi",
-            "version": "==5.5.1"
+            "version": "==5.6.0"
         },
         "websockets": {
             "hashes": [

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -188,7 +188,10 @@ class Web3Client:
         return self.w3.eth.getBalance(account)
 
     def inject_middleware(self, middleware, **kwargs):
-        self.w3.middleware_onion.inject(middleware, **kwargs)
+        return self.w3.middleware_onion.inject(middleware, **kwargs)
+
+    def add_middleware(self, middleware):
+        return self.w3.middleware_onion.add(middleware)
 
     @property
     def chain_id(self) -> int:

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -61,7 +61,8 @@ from nucypher.blockchain.eth.providers import (
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.blockchain.eth.utils import prettify_eth_amount
-from nucypher.characters.control.emitters import StdoutEmitter
+from nucypher.characters.control.emitters import StdoutEmitter, JSONRPCStdoutEmitter
+from nucypher.utilities.logging import GlobalLoggerSettings
 
 Web3Providers = Union[IPCProvider, WebsocketProvider, HTTPProvider, EthereumTester]
 
@@ -111,6 +112,7 @@ class BlockchainInterface:
         pass
 
     def __init__(self,
+                 emitter = None,
                  poa: bool = False,
                  light: bool = False,
                  provider_process: NuCypherGethProcess = NO_PROVIDER_PROCESS,
@@ -429,7 +431,11 @@ class BlockchainInterface:
         # Setup
         #
 
-        emitter = StdoutEmitter()  # TODO: Move this to singleton?
+        if GlobalLoggerSettings._json_ipc:
+            emitter = JSONRPCStdoutEmitter()
+        else:
+            emitter = StdoutEmitter()  # TODO: Move this to singleton - I do not approve... nor does Bogdan?
+
         if self.transacting_power is READ_ONLY_INTERFACE:
             raise self.InterfaceError(str(READ_ONLY_INTERFACE))
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -438,19 +438,20 @@ class BlockchainInterface:
         #
 
         if self.transacting_power.device:
-            cost_wei = unsigned_transaction['gasPrice'] * unsigned_transaction['gas']
+            price = unsigned_transaction['gasPrice']
+            cost_wei = price * unsigned_transaction['gas']
             cost = Web3.fromWei(cost_wei, 'gwei')
             # TODO: Show the USD Price
             # Price Oracle
             # https://api.coinmarketcap.com/v1/ticker/ethereum/
-            emitter.message(f'Confirm transaction {transaction_name} on hardware wallet... ({cost} gwei)', color='yellow')
+            emitter.message(f'Confirm transaction {transaction_name} on hardware wallet... ({cost} gwei @ {price})', color='yellow')
         signed_raw_transaction = self.transacting_power.sign_transaction(unsigned_transaction)
 
         #
         # Broadcast
         #
 
-        emitter.message(f'Broadcasting {transaction_name}...', color='yellow')
+        emitter.message(f'Broadcasting {transaction_name} Transaction...', color='yellow')
         txhash = self.client.send_raw_transaction(signed_raw_transaction)
         try:
             receipt = self.client.wait_for_receipt(txhash, timeout=self.TIMEOUT)

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -438,7 +438,12 @@ class BlockchainInterface:
         #
 
         if self.transacting_power.device:
-            emitter.message(f'Confirm transaction {transaction_name} on hardware wallet...', color='yellow')
+            cost_wei = unsigned_transaction['gasPrice'] * unsigned_transaction['gas']
+            cost = Web3.fromWei(cost_wei, 'gwei')
+            # TODO: Show the USD Price
+            # Price Oracle
+            # https://api.coinmarketcap.com/v1/ticker/ethereum/
+            emitter.message(f'Confirm transaction {transaction_name} on hardware wallet... ({cost} gwei)', color='yellow')
         signed_raw_transaction = self.transacting_power.sign_transaction(unsigned_transaction)
 
         #

--- a/nucypher/blockchain/eth/providers.py
+++ b/nucypher/blockchain/eth/providers.py
@@ -23,11 +23,13 @@ def _get_IPC_provider(provider_uri):
 
 
 def _get_HTTP_provider(provider_uri):
-    return HTTPProvider(endpoint_uri=provider_uri)
+    from nucypher.blockchain.eth.interfaces import BlockchainInterface
+    return HTTPProvider(endpoint_uri=provider_uri, request_kwargs={'timeout': BlockchainInterface.TIMEOUT})
 
 
 def _get_websocket_provider(provider_uri):
-    return WebsocketProvider(endpoint_uri=provider_uri)
+    from nucypher.blockchain.eth.interfaces import BlockchainInterface
+    return WebsocketProvider(endpoint_uri=provider_uri, websocket_kwargs={'timeout': BlockchainInterface.TIMEOUT})
 
 
 def _get_infura_provider(provider_uri):

--- a/nucypher/blockchain/eth/providers.py
+++ b/nucypher/blockchain/eth/providers.py
@@ -19,7 +19,9 @@ class ProviderError(Exception):
 def _get_IPC_provider(provider_uri):
     uri_breakdown = urlparse(provider_uri)
     from nucypher.blockchain.eth.interfaces import BlockchainInterface
-    return IPCProvider(ipc_path=uri_breakdown.path, timeout=BlockchainInterface.TIMEOUT, request_kwargs={'timeout': 600})
+    return IPCProvider(ipc_path=uri_breakdown.path,
+                       timeout=BlockchainInterface.TIMEOUT,
+                       request_kwargs={'timeout': BlockchainInterface.TIMEOUT})
 
 
 def _get_HTTP_provider(provider_uri):

--- a/nucypher/blockchain/eth/providers.py
+++ b/nucypher/blockchain/eth/providers.py
@@ -19,7 +19,7 @@ class ProviderError(Exception):
 def _get_IPC_provider(provider_uri):
     uri_breakdown = urlparse(provider_uri)
     from nucypher.blockchain.eth.interfaces import BlockchainInterface
-    return IPCProvider(ipc_path=uri_breakdown.path, timeout=BlockchainInterface.TIMEOUT)
+    return IPCProvider(ipc_path=uri_breakdown.path, timeout=BlockchainInterface.TIMEOUT, request_kwargs={'timeout': 600})
 
 
 def _get_HTTP_provider(provider_uri):

--- a/nucypher/cli/commands/alice.py
+++ b/nucypher/cli/commands/alice.py
@@ -25,6 +25,7 @@ from nucypher.characters.control.interfaces import AliceInterface
 from nucypher.cli import actions, painting
 from nucypher.cli.actions import get_nucypher_password, select_client_account, get_client_password, \
     get_or_update_configuration
+from nucypher.cli.commands.deploy import option_gas_strategy
 from nucypher.cli.config import group_general_config
 from nucypher.cli.options import (
     group_options,
@@ -71,7 +72,7 @@ class AliceConfigOptions:
     __option_name__ = 'config_options'
 
     def __init__(self, dev, network, provider_uri, geth, federated_only, discovery_port,
-                 pay_with, registry_filepath, middleware):
+                 pay_with, registry_filepath, middleware, gas_strategy):
 
         if federated_only and geth:
             raise click.BadOptionUsage(
@@ -87,6 +88,7 @@ class AliceConfigOptions:
         self.dev = dev
         self.domains = {network} if network else None
         self.provider_uri = provider_uri
+        self.gas_strategy = gas_strategy
         self.geth = geth
         self.federated_only = federated_only
         self.eth_node = eth_node
@@ -112,6 +114,7 @@ class AliceConfigOptions:
                 domains={TEMPORARY_DOMAIN},
                 provider_process=self.eth_node,
                 provider_uri=self.provider_uri,
+                gas_strategy=self.gas_strategy,
                 federated_only=True)
 
         else:
@@ -123,6 +126,7 @@ class AliceConfigOptions:
                     domains=self.domains,
                     provider_process=self.eth_node,
                     provider_uri=self.provider_uri,
+                    gas_strategy=self.gas_strategy,
                     filepath=config_file,
                     rest_port=self.discovery_port,
                     checksum_address=self.pay_with,
@@ -139,13 +143,14 @@ group_config_options = group_options(
     dev=option_dev,
     network=option_network,
     provider_uri=option_provider_uri(),
+    gas_strategy=option_gas_strategy,
     geth=option_geth,
     federated_only=option_federated_only,
     discovery_port=option_discovery_port(),
     pay_with=option_pay_with,
     registry_filepath=option_registry_filepath,
     middleware=option_middleware,
-    )
+)
 
 
 class AliceFullConfigOptions:

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -73,7 +73,7 @@ option_registry_infile = click.option('--registry-infile', help="Input path for 
 option_registry_outfile = click.option('--registry-outfile', help="Output path for contract registry file", type=click.Path(file_okay=True))
 option_target_address = click.option('--target-address', help="Address of the target contract", type=EIP55_CHECKSUM_ADDRESS)
 option_gas = click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
-option_gas_strategy = click.option('--gas-strategy', help="Operate with a specified gas price strategy", type=GAS_STRATEGY_CHOICES, default=None)
+option_gas_strategy = click.option('--gas-strategy', help="Operate with a specified gas price strategy", type=click.STRING, default=None)  # TODO: GAS_STRATEGY_CHOICES
 option_network = click.option('--network', help="Name of NuCypher network", type=click.Choice(NetworksInventory.networks), default=None)
 option_ignore_deployed = click.option('--ignore-deployed', help="Ignore already deployed contracts if exist.", is_flag=True)
 option_ignore_solidity_version = click.option('--ignore-solidity-check', help="Ignore solidity version compatibility check", is_flag=True, default=None)

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -73,10 +73,10 @@ option_registry_infile = click.option('--registry-infile', help="Input path for 
 option_registry_outfile = click.option('--registry-outfile', help="Output path for contract registry file", type=click.Path(file_okay=True))
 option_target_address = click.option('--target-address', help="Address of the target contract", type=EIP55_CHECKSUM_ADDRESS)
 option_gas = click.option('--gas', help="Operate with a specified gas per-transaction limit", type=click.IntRange(min=1))
-option_gas_strategy = click.option('--gas-strategy', help="Operate with a specified gas price strategy", type=click.STRING, default=None)  # TODO: GAS_STRATEGY_CHOICES
-option_network = click.option('--network', help="Name of NuCypher network", type=click.Choice(NetworksInventory.networks), default=None)
+option_gas_strategy = click.option('--gas-strategy', help="Operate with a specified gas price strategy", type=click.STRING)  # TODO: GAS_STRATEGY_CHOICES
+option_network = click.option('--network', help="Name of NuCypher network", type=click.Choice(NetworksInventory.networks))
 option_ignore_deployed = click.option('--ignore-deployed', help="Ignore already deployed contracts if exist.", is_flag=True)
-option_ignore_solidity_version = click.option('--ignore-solidity-check', help="Ignore solidity version compatibility check", is_flag=True, default=None)
+option_ignore_solidity_version = click.option('--ignore-solidity-check', help="Ignore solidity version compatibility check", is_flag=True)
 
 
 def _pre_launch_warnings(emitter, etherscan, hw_wallet):
@@ -92,12 +92,14 @@ def _pre_launch_warnings(emitter, etherscan, hw_wallet):
                      color='yellow')
 
 
-def _initialize_blockchain(poa, provider_uri, emitter, ignore_solidity_check, gas_strategy):
+def _initialize_blockchain(poa, provider_uri, emitter, ignore_solidity_check, gas_strategy=None):
     if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
         # Note: For test compatibility.
         deployer_interface = BlockchainDeployerInterface(provider_uri=provider_uri,
                                                          poa=poa,
-                                                         ignore_solidity_check=ignore_solidity_check)
+                                                         ignore_solidity_check=ignore_solidity_check,
+                                                         gas_strategy=gas_strategy)
+
         BlockchainInterfaceFactory.register_interface(interface=deployer_interface,
                                                       sync=False,
                                                       emitter=emitter,
@@ -264,8 +266,7 @@ def download_registry(general_config, config_root, registry_outfile, network, fo
 @option_deployer_address
 @option_poa
 @option_ignore_solidity_version
-@option_gas_strategy
-def inspect(general_config, provider_uri, config_root, registry_infile, deployer_address, poa, ignore_solidity_check, gas_strategy):
+def inspect(general_config, provider_uri, config_root, registry_infile, deployer_address, poa, ignore_solidity_check):
     """
     Echo owner information and bare contract metadata.
     """
@@ -275,8 +276,7 @@ def inspect(general_config, provider_uri, config_root, registry_infile, deployer
     _initialize_blockchain(poa=poa,
                            provider_uri=provider_uri,
                            emitter=emitter,
-                           ignore_solidity_check=ignore_solidity_check,
-                           gas_strategy=gas_strategy)
+                           ignore_solidity_check=ignore_solidity_check)
 
     local_registry = establish_deployer_registry(emitter=emitter,
                                                  registry_infile=registry_infile,

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -503,7 +503,6 @@ def create(general_config, transacting_staker_options, config_file, force, value
     # Authenticate and Execute
     STAKEHOLDER.assimilate(checksum_address=client_account, password=password)
 
-    emitter.echo("Broadcasting stake...", color='yellow')
     new_stake = STAKEHOLDER.initialize_stake(amount=value, lock_periods=lock_periods)
 
     painting.paint_staking_confirmation(emitter=emitter, staker=STAKEHOLDER, new_stake=new_stake)
@@ -686,7 +685,6 @@ def divide(general_config, transacting_staker_options, config_file, force, value
 
     # Execute
     STAKEHOLDER.assimilate(checksum_address=current_stake.staker_address, password=password)
-    emitter.echo("Broadcasting Stake Division...", color='yellow')
     modified_stake, new_stake = STAKEHOLDER.divide_stake(stake_index=current_stake.index,
                                                          target_value=value,
                                                          additional_periods=extension)
@@ -759,7 +757,6 @@ def prolong(general_config, transacting_staker_options, config_file, force, lock
 
     # Authenticate and Execute
     STAKEHOLDER.assimilate(checksum_address=current_stake.staker_address, password=password)
-    emitter.echo("Broadcasting Stake Extension...", color='yellow')
     receipt = STAKEHOLDER.prolong_stake(stake_index=current_stake.index, additional_periods=lock_periods)
 
     # Report

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -32,6 +32,7 @@ from nucypher.cli.actions import (
     get_or_update_configuration,
     select_worker_config_file
 )
+from nucypher.cli.commands.deploy import option_gas_strategy
 from nucypher.cli.config import group_general_config
 from nucypher.cli.options import (
     group_options,
@@ -64,7 +65,7 @@ class UrsulaConfigOptions:
     __option_name__ = 'config_options'
 
     def __init__(self, geth, provider_uri, worker_address, federated_only, rest_host,
-            rest_port, db_filepath, network, registry_filepath, dev, poa, light):
+            rest_port, db_filepath, network, registry_filepath, dev, poa, light, gas_strategy):
 
         if federated_only:
             # TODO: consider rephrasing in a more universal voice.
@@ -94,6 +95,7 @@ class UrsulaConfigOptions:
         self.dev = dev
         self.poa = poa
         self.light = light
+        self.gas_strategy = gas_strategy
 
     def create_config(self, emitter, config_file):
         if self.dev:
@@ -106,6 +108,7 @@ class UrsulaConfigOptions:
                 registry_filepath=self.registry_filepath,
                 provider_process=self.eth_node,
                 provider_uri=self.provider_uri,
+                gas_strategy=self.gas_strategy,
                 checksum_address=self.worker_address,
                 federated_only=self.federated_only,
                 rest_host=self.rest_host,
@@ -120,6 +123,7 @@ class UrsulaConfigOptions:
                     registry_filepath=self.registry_filepath,
                     provider_process=self.eth_node,
                     provider_uri=self.provider_uri,
+                    gas_strategy=self.gas_strategy,
                     rest_host=self.rest_host,
                     rest_port=self.rest_port,
                     db_filepath=self.db_filepath,
@@ -166,6 +170,7 @@ class UrsulaConfigOptions:
                                             registry_filepath=self.registry_filepath,
                                             provider_process=self.eth_node,
                                             provider_uri=self.provider_uri,
+                                            gas_strategy=self.gas_strategy,
                                             poa=self.poa,
                                             light=self.light)
 
@@ -178,6 +183,7 @@ class UrsulaConfigOptions:
                        checksum_address=self.worker_address,
                        registry_filepath=self.registry_filepath,
                        provider_uri=self.provider_uri,
+                       gas_strategy=self.gas_strategy,
                        poa=self.poa,
                        light=self.light)
         # Depends on defaults being set on Configuration classes, filtrates None values
@@ -189,6 +195,7 @@ group_config_options = group_options(
     UrsulaConfigOptions,
     geth=option_geth,
     provider_uri=option_provider_uri(),
+    gas_strategy=option_gas_strategy,
     worker_address=click.option('--worker-address', help="Run the worker-ursula with a specified address", type=EIP55_CHECKSUM_ADDRESS),
     federated_only=option_federated_only,
     rest_host=click.option('--rest-host', help="The host IP address to run Ursula network services on", type=click.STRING),

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -77,7 +77,7 @@ class GroupGeneralConfig:
             GroupGeneralConfig.verbosity = 1
 
         if json_ipc:
-            GlobalLoggerSettings._json_ipc = True  # TODO
+            GlobalLoggerSettings._json_ipc = True  # TODO #1754
             emitter = JSONRPCStdoutEmitter(verbosity=GroupGeneralConfig.verbosity)
         else:
             emitter = StdoutEmitter(verbosity=GroupGeneralConfig.verbosity)

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -77,6 +77,7 @@ class GroupGeneralConfig:
             GroupGeneralConfig.verbosity = 1
 
         if json_ipc:
+            GlobalLoggerSettings._json_ipc = True  # TODO
             emitter = JSONRPCStdoutEmitter(verbosity=GroupGeneralConfig.verbosity)
         else:
             emitter = StdoutEmitter(verbosity=GroupGeneralConfig.verbosity)

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -20,6 +20,7 @@ from ipaddress import ip_address
 import click
 from eth_utils import to_checksum_address
 
+from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.networks import NetworksInventory
 
 
@@ -61,3 +62,5 @@ EXISTING_READABLE_FILE = click.Path(exists=True, dir_okay=False, file_okay=True,
 # Network
 NETWORK_PORT = click.IntRange(min=0, max=65535, clamp=False)
 IPV4_ADDRESS = IPv4Address()
+
+GAS_STRATEGY_CHOICES = click.Choice(list(BlockchainInterface.GAS_STRATEGIES.keys()))

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -30,16 +30,14 @@ from constant_sorrow.constants import (
 )
 from twisted.logger import Logger
 from umbral.signing import Signature
-from web3 import gas_strategies
-from web3.gas_strategies.time_based import glacial_gas_price_strategy
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
+from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.blockchain.eth.registry import (
     BaseContractRegistry,
     InMemoryContractRegistry,
     LocalContractRegistry
 )
-from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.config.base import BaseConfiguration
 from nucypher.config.keyring import NucypherKeyring
 from nucypher.config.storages import NodeStorage, ForgetfulNodeStorage, LocalFileBasedNodeStorage

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -367,8 +367,8 @@ class CharacterConfiguration(BaseConfiguration):
             if self.registry_filepath:
                 payload.update(dict(registry_filepath=self.registry_filepath))
 
-            # Gas
-            payload.update(dict(gas_price_strategy=self.gas_strategy))
+            # Gas Price
+            payload.update(dict(gas_strategy=self.gas_strategy))
 
         # Merge with base payload
         base_payload = super().static_payload()

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -18,7 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 from tempfile import TemporaryDirectory
-from typing import List, Set
+from typing import List, Set, Union, Callable
 
 from constant_sorrow.constants import (
     UNINITIALIZED_CONFIGURATION,
@@ -30,6 +30,8 @@ from constant_sorrow.constants import (
 )
 from twisted.logger import Logger
 from umbral.signing import Signature
+from web3 import gas_strategies
+from web3.gas_strategies.time_based import glacial_gas_price_strategy
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import (
@@ -58,6 +60,9 @@ class CharacterConfiguration(BaseConfiguration):
     DEFAULT_DOMAIN = NetworksInventory.DEFAULT
     DEFAULT_NETWORK_MIDDLEWARE = RestMiddleware
     TEMP_CONFIGURATION_DIR_PREFIX = 'tmp-nucypher'
+
+    # Gas
+    DEFAULT_GAS_STRATEGY = 'fast'
 
     def __init__(self,
 
@@ -100,6 +105,7 @@ class CharacterConfiguration(BaseConfiguration):
                  sync: bool = False,
                  provider_uri: str = None,
                  provider_process=None,
+                 gas_strategy: Union[Callable, str] = DEFAULT_GAS_STRATEGY,
 
                  # Registry
                  registry: BaseContractRegistry = None,
@@ -183,12 +189,14 @@ class CharacterConfiguration(BaseConfiguration):
                 self.provider_uri = None
                 self.provider_process = None
                 self.registry_filepath = None
+                self.gas_strategy = None
 
         #
         # Decentralized
         #
 
         else:
+            self.gas_strategy = gas_strategy
             is_initialized = BlockchainInterfaceFactory.is_interface_initialized(provider_uri=self.provider_uri)
             if not is_initialized and provider_uri:
                 BlockchainInterfaceFactory.initialize_interface(provider_uri=self.provider_uri,
@@ -196,7 +204,8 @@ class CharacterConfiguration(BaseConfiguration):
                                                                 light=self.is_light,
                                                                 provider_process=self.provider_process,
                                                                 sync=sync,
-                                                                emitter=emitter)
+                                                                emitter=emitter,
+                                                                gas_strategy=gas_strategy)
             else:
                 self.log.warn(f"Using existing blockchain interface connection ({self.provider_uri}).")
 
@@ -273,7 +282,7 @@ class CharacterConfiguration(BaseConfiguration):
         Warning: This method allows mutation and may result in an inconsistent configuration.
         """
         merged_parameters = {**self.static_payload(), **self.dynamic_payload, **overrides}
-        non_init_params = ('config_root', 'poa', 'light', 'provider_uri', 'registry_filepath')
+        non_init_params = ('config_root', 'poa', 'light', 'provider_uri', 'registry_filepath', 'gas_strategy')
         character_init_params = filter(lambda t: t[0] not in non_init_params, merged_parameters.items())
         return dict(character_init_params)
 
@@ -357,6 +366,9 @@ class CharacterConfiguration(BaseConfiguration):
                 payload.update(dict(provider_uri=self.provider_uri, poa=self.poa, light=self.is_light))
             if self.registry_filepath:
                 payload.update(dict(registry_filepath=self.registry_filepath))
+
+            # Gas
+            payload.update(dict(gas_price_strategy=self.gas_strategy))
 
         # Merge with base payload
         base_payload = super().static_payload()

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -176,7 +176,8 @@ class CharacterConfiguration(BaseConfiguration):
             blockchain_args = {'filepath': registry_filepath,
                                'poa': poa,
                                'provider_process': provider_process,
-                               'provider_uri': provider_uri}
+                               'provider_uri': provider_uri,
+                               'gas_strategy': gas_strategy}
             if any(blockchain_args.values()):
                 bad_args = (f"{arg}={val}" for arg, val in blockchain_args.items() if val)
                 self.log.warn(f"Arguments {bad_args} are incompatible with federated_only. "

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -75,7 +75,7 @@ def initialize_sentry(dsn: str):
 class GlobalLoggerSettings:
 
     log_level = LogLevel.levelWithName("info")
-    _json_ipc = False  # TODO: Oh no...
+    _json_ipc = False  # TODO: Oh no... #1754
 
     @classmethod
     def set_log_level(cls, log_level_name):

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -73,7 +73,9 @@ def initialize_sentry(dsn: str):
 
 
 class GlobalLoggerSettings:
+
     log_level = LogLevel.levelWithName("info")
+    _json_ipc = False  # TODO: Oh no...
 
     @classmethod
     def set_log_level(cls, log_level_name):

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -24,6 +24,7 @@ import maya
 from eth_tester.exceptions import TransactionFailed
 from twisted.logger import Logger
 from web3 import Web3
+from web3.middleware import geth_poa_middleware
 
 from nucypher.blockchain.economics import StandardTokenEconomics, StandardTokenEconomics, BaseEconomics
 from nucypher.blockchain.eth.actors import ContractAdministrator
@@ -128,7 +129,10 @@ class TesterBlockchain(BlockchainDeployerInterface):
         return 0
 
     def attach_middleware(self):
-        super().attach_middleware()
+        # For use with Proof-Of-Authority test-blockchains
+        if self.poa is True:
+            self.log.debug('Injecting POA middleware at layer 0')
+            self.client.inject_middleware(geth_poa_middleware, layer=0)
         if self.free_transactions:
             self.w3.eth.setGasPriceStrategy(self.free_gas_price_strategy)
 

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -62,12 +62,19 @@ def token_airdrop(token_agent, amount: NU, origin: str, addresses: List[str]):
     return receipts
 
 
+def free_gas_price_strategy(w3, transaction_params=None):
+    return 0
+
+
 class TesterBlockchain(BlockchainDeployerInterface):
     """
     Blockchain subclass with additional test utility methods and options.
     """
 
     _instance = None
+
+    GAS_STRATEGIES = {**BlockchainDeployerInterface.GAS_STRATEGIES,
+                      'free': free_gas_price_strategy}
 
     _PROVIDER_URI = 'tester://pyevm'
     TEST_CONTRACTS_DIR = os.path.join(BASE_DIR, 'tests', 'blockchain', 'eth', 'contracts', 'contracts')
@@ -124,17 +131,9 @@ class TesterBlockchain(BlockchainDeployerInterface):
         if eth_airdrop is True:  # ETH for everyone!
             self.ether_airdrop(amount=DEVELOPMENT_ETH_AIRDROP_AMOUNT)
 
-    @staticmethod
-    def free_gas_price_strategy(w3, transaction_params=None):
-        return 0
-
     def attach_middleware(self):
-        # For use with Proof-Of-Authority test-blockchains
-        if self.poa is True:
-            self.log.debug('Injecting POA middleware at layer 0')
-            self.client.inject_middleware(geth_poa_middleware, layer=0)
         if self.free_transactions:
-            self.w3.eth.setGasPriceStrategy(self.free_gas_price_strategy)
+            self.w3.eth.setGasPriceStrategy(free_gas_price_strategy)
 
     def __generate_insecure_unlocked_accounts(self, quantity: int) -> List[str]:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ appdirs==1.4.3
 asn1crypto==1.3.0
 attrdict==2.0.1
 attrs==19.3.0
-autobahn==20.2.1
+autobahn==20.2.2
 automat==20.2.0
 base58==2.0.0
 blake2b-py==0.1.3
@@ -30,7 +30,7 @@ eth-rlp==0.1.2
 eth-tester==0.4.0b1
 eth-typing==2.2.1
 eth-utils==1.8.4
-flask-limiter==1.1.0
+flask-limiter==1.2.1
 flask-sqlalchemy==2.4.1
 flask==1.1.1
 hendrix==3.2.5
@@ -43,7 +43,7 @@ ipfshttpclient==0.4.12
 itsdangerous==1.1.0
 jinja2==3.0.0a1
 jsonschema==3.2.0
-limits==1.5
+limits==1.5.1
 lru-dict==1.1.6
 markupsafe==1.1.1
 marshmallow==3.5.0
@@ -65,7 +65,7 @@ pychalk==2.0.1
 pycparser==2.19
 pycryptodome==3.9.7
 pyethash==0.1.27
-pyhamcrest==2.0.0
+pyhamcrest==2.0.1
 pynacl==1.3.0
 pyopenssl==19.1.0
 pyrsistent==0.15.7
@@ -91,7 +91,7 @@ umbral==0.1.3a2
 urllib3==1.25.8
 varint==1.0.2
 watchdog==0.10.2
-web3==5.5.1
+web3==5.6.0
 websockets==8.1
 werkzeug==1.0.0
 zope.interface==4.7.1

--- a/tests/config/test_character_configuration.py
+++ b/tests/config/test_character_configuration.py
@@ -38,7 +38,7 @@ def test_federated_development_character_configurations(character, configuration
     assert config.is_me is True
     assert config.dev_mode is True
     assert config.keyring == NO_KEYRING_ATTACHED
-    assert config.provider_uri == NO_BLOCKCHAIN_CONNECTION
+    assert config.provider_uri == None
 
     # Production
     thing_one = config()


### PR DESCRIPTION
- Configurable and Inline gas strategies (`--gas-strategy`)
- Increase IPC Timeout to 600 seconds
- Relocks Dependencies
- Show HW Wallet prompts for all Transactions with gas price data