### PR TITLE
Force ansible to explicitly use python3 on local/remote hosts

### DIFF
--- a/deploy/ansible/worker/inventory.yml
+++ b/deploy/ansible/worker/inventory.yml
@@ -43,6 +43,7 @@ all:
             geth_dir: '/home/nucypher/geth/.ethereum/goerli/'
             geth_container_datadir: "/root/.ethereum/goerli"
             etherscan_domain: goerli.etherscan.io
+            ansible_python_interpreter: /usr/bin/python3
 
             # these can be overridden at the instance level if desired
             NUCYPHER_KEYRING_PASSWORD: xxxxxxxxxxxxxxxxxxxxxxxpanda


### PR DESCRIPTION
This provides greater flexibility on mixed environments and allows the following playbooks to be more explicit.