### PR TITLE
Forces ansible playbook to specifically use pip3 for python3

### DIFF
--- a/deploy/ansible/worker/include/setup_docker.yml
+++ b/deploy/ansible/worker/include/setup_docker.yml
@@ -27,6 +27,7 @@
     - name: Install Docker Module for Python
       pip:
         name: docker
+        executable: pip3
 
     - name: Ensure group "docker" exists
       group:

--- a/deploy/ansible/worker/inventory.yml
+++ b/deploy/ansible/worker/inventory.yml
@@ -43,6 +43,7 @@ all:
             geth_dir: '/home/nucypher/geth/.ethereum/goerli/'
             geth_container_datadir: "/root/.ethereum/goerli"
             etherscan_domain: goerli.etherscan.io
+            ansible_python_interpreter: /usr/bin/python3
 
             # these can be overridden at the instance level if desired
             NUCYPHER_KEYRING_PASSWORD: xxxxxxxxxxxxxxxxxxxxxxxpanda


### PR DESCRIPTION
This adds greater portability for users with mixed environments, allowing ansible to explicitly state which pip version to use. Ansible will typically default to 'python/pip' whichever is set beforehand but that may not be the case for remote hosts where we want to deploy workers.