### PR TITLE
update inventory to include azure deployments

### DIFF
--- a/deploy/ansible/worker/inventory.yml
+++ b/deploy/ansible/worker/inventory.yml
@@ -17,6 +17,19 @@ all:
                   # NUCYPHER_WORKER_ADDRESS: "0x02e8cbf55E781AD4cA331fe5274Be93814D760D0"
                   NUCYPHER_STAKER_ADDRESS: "0xD9b6B55b005f1B23b45a9a4aC9669deFac6dAd67"
 
+            #### azure configures new instances with a .pem keypair based auth
+            # so we need this ansible_ssh_private_key_file variable
+            azure:
+              vars:
+                ansible_ssh_private_key_file: ~/Downloads/damon-ansible-testing.pem
+                default_user: "azureuser"  # default for azure deployments
+              hosts:
+                # add a host for each worker/staker
+                50.22.41.3:
+                  # WORKER_ACCT_KEYSTORE_PATH: "/home/ubuntu/.ethereum/goerli/keystore/UTC--2020-01-21T02-15-33.342507000Z--d9e7eC6fddde58c739CDdbAD5c38F170F1571077"
+                  # NUCYPHER_WORKER_ADDRESS: "0xd9e7eC6fddde58c739CDdbAD5c38F170F1571077"
+                  NUCYPHER_STAKER_ADDRESS: "0x7QkaEAe8aaee6f2C810F048877fbe1FBB2B27828"
+            
             #### amazon configures new instances with a .pem keypair based auth
             # so we need this ansible_ssh_private_key_file variable
             amazon:


### PR DESCRIPTION
Not much is changed or is different than AWS, however default for azure users regardless of distribution is azureuser, you cannot deploy vms with base user root.