### PR TITLE
Update solidity to 0.6.x

### DIFF
--- a/nucypher/blockchain/eth/sol/__conf__.py
+++ b/nucypher/blockchain/eth/sol/__conf__.py
@@ -15,4 +15,4 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-SOLIDITY_COMPILER_VERSION = '0.5.16'
+SOLIDITY_COMPILER_VERSION = '0.6.4'

--- a/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
@@ -189,17 +189,17 @@ contract Adjudicator is Upgradeable {
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
     function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
-        require(address(delegateGet(_testTarget, "escrow()")) == address(escrow));
-        require(SignatureVerifier.HashAlgorithm(delegateGet(_testTarget, "hashAlgorithm()")) == hashAlgorithm);
-        require(delegateGet(_testTarget, "basePenalty()") == basePenalty);
-        require(delegateGet(_testTarget, "penaltyHistoryCoefficient()") == penaltyHistoryCoefficient);
-        require(delegateGet(_testTarget, "percentagePenaltyCoefficient()") == percentagePenaltyCoefficient);
-        require(delegateGet(_testTarget, "rewardCoefficient()") == rewardCoefficient);
-        require(delegateGet(_testTarget, "penaltyHistory(address)", bytes32(bytes20(RESERVED_ADDRESS))) ==
+        require(address(delegateGet(_testTarget, this.escrow.selector)) == address(escrow));
+        require(SignatureVerifier.HashAlgorithm(delegateGet(_testTarget, this.hashAlgorithm.selector)) == hashAlgorithm);
+        require(delegateGet(_testTarget, this.basePenalty.selector) == basePenalty);
+        require(delegateGet(_testTarget, this.penaltyHistoryCoefficient.selector) == penaltyHistoryCoefficient);
+        require(delegateGet(_testTarget, this.percentagePenaltyCoefficient.selector) == percentagePenaltyCoefficient);
+        require(delegateGet(_testTarget, this.rewardCoefficient.selector) == rewardCoefficient);
+        require(delegateGet(_testTarget, this.penaltyHistory.selector, bytes32(bytes20(RESERVED_ADDRESS))) ==
             penaltyHistory[RESERVED_ADDRESS]);
         bytes32 evaluationCFragHash = SignatureVerifier.hash(
             abi.encodePacked(RESERVED_CAPSULE_AND_CFRAG_BYTES), hashAlgorithm);
-        require(delegateGet(_testTarget, "evaluatedCFrags(bytes32)", evaluationCFragHash) ==
+        require(delegateGet(_testTarget, this.evaluatedCFrags.selector, evaluationCFragHash) ==
             (evaluatedCFrags[evaluationCFragHash] ? 1 : 0));
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 import "contracts/lib/ReEncryptionValidator.sol";
 import "contracts/lib/SignatureVerifier.sol";
@@ -187,7 +187,7 @@ contract Adjudicator is Upgradeable {
     }
 
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
         require(address(delegateGet(_testTarget, "escrow()")) == address(escrow));
         require(SignatureVerifier.HashAlgorithm(delegateGet(_testTarget, "hashAlgorithm()")) == hashAlgorithm);
@@ -204,7 +204,7 @@ contract Adjudicator is Upgradeable {
     }
 
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `finishUpgrade`
-    function finishUpgrade(address _target) public {
+    function finishUpgrade(address _target) public override virtual {
         super.finishUpgrade(_target);
         Adjudicator targetContract = Adjudicator(_target);
         escrow = targetContract.escrow();

--- a/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/NuCypherToken.sol";
@@ -13,7 +13,7 @@ import "zeppelin/token/ERC20/SafeERC20.sol";
 * @notice Contract for calculate issued tokens
 * @dev |v1.1.4|
 */
-contract Issuer is Upgradeable {
+abstract contract Issuer is Upgradeable {
     using SafeERC20 for NuCypherToken;
     using SafeMath for uint256;
     using AdditionalMath for uint32;
@@ -116,7 +116,7 @@ contract Issuer is Upgradeable {
     * @param _lockedValue The amount of tokens that were locked by user in specified period.
     * @param _totalLockedValue The amount of tokens that were locked by all users in specified period.
     * @param _allLockedPeriods The max amount of periods during which tokens will be locked after specified period.
-    * @return Amount of minted tokens.
+    * @return amount Amount of minted tokens.
     */
     function mint(
         uint16 _currentPeriod,
@@ -190,7 +190,7 @@ contract Issuer is Upgradeable {
     }
 
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
         require(address(uint160(delegateGet(_testTarget, "token()"))) == address(token));
         require(delegateGet(_testTarget, "miningCoefficient()") == miningCoefficient);
@@ -204,7 +204,7 @@ contract Issuer is Upgradeable {
     }
 
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `finishUpgrade`
-    function finishUpgrade(address _target) public {
+    function finishUpgrade(address _target) public override virtual {
         super.finishUpgrade(_target);
         Issuer issuer = Issuer(_target);
         totalSupply = issuer.totalSupply();

--- a/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
@@ -192,15 +192,15 @@ abstract contract Issuer is Upgradeable {
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
     function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
-        require(address(uint160(delegateGet(_testTarget, "token()"))) == address(token));
-        require(delegateGet(_testTarget, "miningCoefficient()") == miningCoefficient);
-        require(delegateGet(_testTarget, "lockedPeriodsCoefficient()") == lockedPeriodsCoefficient);
-        require(uint32(delegateGet(_testTarget, "secondsPerPeriod()")) == secondsPerPeriod);
-        require(uint16(delegateGet(_testTarget, "rewardedPeriods()")) == rewardedPeriods);
-        require(uint16(delegateGet(_testTarget, "currentMintingPeriod()")) == currentMintingPeriod);
-        require(delegateGet(_testTarget, "currentSupply1()") == currentSupply1);
-        require(delegateGet(_testTarget, "currentSupply2()") == currentSupply2);
-        require(delegateGet(_testTarget, "totalSupply()") == totalSupply);
+        require(address(uint160(delegateGet(_testTarget, this.token.selector))) == address(token));
+        require(delegateGet(_testTarget, this.miningCoefficient.selector) == miningCoefficient);
+        require(delegateGet(_testTarget, this.lockedPeriodsCoefficient.selector) == lockedPeriodsCoefficient);
+        require(uint32(delegateGet(_testTarget, this.secondsPerPeriod.selector)) == secondsPerPeriod);
+        require(uint16(delegateGet(_testTarget, this.rewardedPeriods.selector)) == rewardedPeriods);
+        require(uint16(delegateGet(_testTarget, this.currentMintingPeriod.selector)) == currentMintingPeriod);
+        require(delegateGet(_testTarget, this.currentSupply1.selector) == currentSupply1);
+        require(delegateGet(_testTarget, this.currentSupply2.selector) == currentSupply2);
+        require(delegateGet(_testTarget, this.totalSupply.selector) == totalSupply);
     }
 
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `finishUpgrade`

--- a/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "zeppelin/math/SafeMath.sol";
@@ -28,7 +28,9 @@ contract MultiSig {
         _;
     }
 
-    function () external payable {}
+    // TODO #1809
+//    receive() external payable {}
+    fallback() external payable {}
 
     /**
     * @param _required Number of required signings
@@ -103,7 +105,7 @@ contract MultiSig {
 
         emit Executed(msg.sender, nonce, _destination, _value);
         nonce = nonce.add(1);
-        (bool callSuccess,) = _destination.call.value(_value)(_data);
+        (bool callSuccess,) = _destination.call{value: _value}(_data);
         require(callSuccess);
     }
 
@@ -141,7 +143,7 @@ contract MultiSig {
                 break;
             }
         }
-        owners.length -= 1;
+        owners.pop();
         emit OwnerRemoved(_owner);
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/NuCypherToken.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/NuCypherToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "zeppelin/token/ERC20/ERC20.sol";
@@ -40,7 +40,7 @@ contract NuCypherToken is ERC20, ERC20Detailed('NuCypher', 'NU', 18) {
 /**
 * @dev Interface to use the receiveApproval method
 */
-contract TokenRecipient {
+interface TokenRecipient {
 
     /**
     * @notice Receives a notification of approval of the transfer

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -650,7 +650,7 @@ contract PolicyManager is Upgradeable {
     function delegateGetPolicy(address _target, bytes16 _policyId)
         internal returns (Policy memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, "policies(bytes16)", 1, bytes32(_policyId), 0);
+        bytes32 memoryAddress = delegateGetData(_target, this.policies.selector, 1, bytes32(_policyId), 0);
         assembly {
             result := memoryAddress
         }
@@ -663,7 +663,7 @@ contract PolicyManager is Upgradeable {
         internal returns (ArrangementInfo memory result)
     {
         bytes32 memoryAddress = delegateGetData(
-            _target, "getArrangementInfo(bytes16,uint256)", 2, bytes32(_policyId), bytes32(_index));
+            _target, this.getArrangementInfo.selector, 2, bytes32(_policyId), bytes32(_index));
         assembly {
             result := memoryAddress
         }
@@ -675,7 +675,7 @@ contract PolicyManager is Upgradeable {
     function delegateGetNodeInfo(address _target, address _node)
         internal returns (NodeInfo memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, "nodes(address)", 1, bytes32(uint256(_node)), 0);
+        bytes32 memoryAddress = delegateGetData(_target, this.nodes.selector, 1, bytes32(uint256(_node)), 0);
         assembly {
             result := memoryAddress
         }
@@ -685,7 +685,7 @@ contract PolicyManager is Upgradeable {
     * @dev Get minRewardRateRange structure by delegatecall
     */
     function delegateGetMinRewardRateRange(address _target) internal returns (Range memory result) {
-        bytes32 memoryAddress = delegateGetData(_target, "minRewardRateRange()", 0, 0, 0);
+        bytes32 memoryAddress = delegateGetData(_target, this.minRewardRateRange.selector, 0, 0, 0);
         assembly {
             result := memoryAddress
         }
@@ -694,8 +694,8 @@ contract PolicyManager is Upgradeable {
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
     function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
-        require(address(delegateGet(_testTarget, "escrow()")) == address(escrow));
-        require(uint32(delegateGet(_testTarget, "secondsPerPeriod()")) == secondsPerPeriod);
+        require(address(delegateGet(_testTarget, this.escrow.selector)) == address(escrow));
+        require(uint32(delegateGet(_testTarget, this.secondsPerPeriod.selector)) == secondsPerPeriod);
         Range memory rangeToCheck = delegateGetMinRewardRateRange(_testTarget);
         require(minRewardRateRange.min == rangeToCheck.min &&
             minRewardRateRange.defaultValue == rangeToCheck.defaultValue &&
@@ -709,7 +709,7 @@ contract PolicyManager is Upgradeable {
             policyToCheck.endTimestamp == policy.endTimestamp &&
             policyToCheck.disabled == policy.disabled);
 
-        require(delegateGet(_testTarget, "getArrangementsLength(bytes16)", RESERVED_POLICY_ID) ==
+        require(delegateGet(_testTarget, this.getArrangementsLength.selector, RESERVED_POLICY_ID) ==
             policy.arrangements.length);
         if (policy.arrangements.length > 0) {
             ArrangementInfo storage arrangement = policy.arrangements[0];
@@ -727,7 +727,7 @@ contract PolicyManager is Upgradeable {
             nodeInfoToCheck.lastMinedPeriod == nodeInfo.lastMinedPeriod &&
             nodeInfoToCheck.minRewardRate == nodeInfo.minRewardRate);
 
-        require(int256(delegateGet(_testTarget, "getNodeRewardDelta(address,uint16)",
+        require(int256(delegateGet(_testTarget, this.getNodeRewardDelta.selector,
             bytes32(bytes20(RESERVED_NODE)), bytes32(uint256(11)))) == nodeInfo.rewardDelta[11]);
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/Seeder.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Seeder.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "zeppelin/ownership/Ownable.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -1317,7 +1317,7 @@ contract StakingEscrow is Issuer {
     function delegateGetStakerInfo(address _target, bytes32 _staker)
         internal returns (StakerInfo memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, "stakerInfo(address)", 1, _staker, 0);
+        bytes32 memoryAddress = delegateGetData(_target, this.stakerInfo.selector, 1, _staker, 0);
         assembly {
             result := memoryAddress
         }
@@ -1330,7 +1330,7 @@ contract StakingEscrow is Issuer {
         internal returns (SubStakeInfo memory result)
     {
         bytes32 memoryAddress = delegateGetData(
-            _target, "getSubStakeInfo(address,uint256)", 2, _staker, bytes32(_index));
+            _target, this.getSubStakeInfo.selector, 2, _staker, bytes32(_index));
         assembly {
             result := memoryAddress
         }
@@ -1343,7 +1343,7 @@ contract StakingEscrow is Issuer {
         internal returns (Downtime memory result)
     {
         bytes32 memoryAddress = delegateGetData(
-            _target, "getPastDowntime(address,uint256)", 2, _staker, bytes32(_index));
+            _target, this.getPastDowntime.selector, 2, _staker, bytes32(_index));
         assembly {
             result := memoryAddress
         }
@@ -1352,24 +1352,24 @@ contract StakingEscrow is Issuer {
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
     function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
-        require((delegateGet(_testTarget, "isTestContract()") == 0) == !isTestContract);
-        require(uint16(delegateGet(_testTarget, "minWorkerPeriods()")) == minWorkerPeriods);
-        require(delegateGet(_testTarget, "minAllowableLockedTokens()") == minAllowableLockedTokens);
-        require(delegateGet(_testTarget, "maxAllowableLockedTokens()") == maxAllowableLockedTokens);
-        require(address(delegateGet(_testTarget, "policyManager()")) == address(policyManager));
-        require(address(delegateGet(_testTarget, "adjudicator()")) == address(adjudicator));
-        require(address(delegateGet(_testTarget, "workLock()")) == address(workLock));
-        require(delegateGet(_testTarget, "lockedPerPeriod(uint16)",
+        require((delegateGet(_testTarget, this.isTestContract.selector) == 0) == !isTestContract);
+        require(uint16(delegateGet(_testTarget, this.minWorkerPeriods.selector)) == minWorkerPeriods);
+        require(delegateGet(_testTarget, this.minAllowableLockedTokens.selector) == minAllowableLockedTokens);
+        require(delegateGet(_testTarget, this.maxAllowableLockedTokens.selector) == maxAllowableLockedTokens);
+        require(address(delegateGet(_testTarget, this.policyManager.selector)) == address(policyManager));
+        require(address(delegateGet(_testTarget, this.adjudicator.selector)) == address(adjudicator));
+        require(address(delegateGet(_testTarget, this.workLock.selector)) == address(workLock));
+        require(delegateGet(_testTarget, this.lockedPerPeriod.selector,
             bytes32(bytes2(RESERVED_PERIOD))) == lockedPerPeriod[RESERVED_PERIOD]);
-        require(address(delegateGet(_testTarget, "workerToStaker(address)", bytes32(0))) ==
+        require(address(delegateGet(_testTarget, this.workerToStaker.selector, bytes32(0))) ==
             workerToStaker[address(0)]);
 
-        require(delegateGet(_testTarget, "getStakersLength()") == stakers.length);
+        require(delegateGet(_testTarget, this.getStakersLength.selector) == stakers.length);
         if (stakers.length == 0) {
             return;
         }
         address stakerAddress = stakers[0];
-        require(address(uint160(delegateGet(_testTarget, "stakers(uint256)", 0))) == stakerAddress);
+        require(address(uint160(delegateGet(_testTarget, this.stakers.selector, 0))) == stakerAddress);
         StakerInfo storage info = stakerInfo[stakerAddress];
         bytes32 staker = bytes32(uint256(stakerAddress));
         StakerInfo memory infoToCheck = delegateGetStakerInfo(_testTarget, staker);
@@ -1385,7 +1385,7 @@ contract StakingEscrow is Issuer {
             infoToCheck.workerStartPeriod == info.workerStartPeriod &&
             infoToCheck.windDown == info.windDown);
 
-        require(delegateGet(_testTarget, "getPastDowntimeLength(address)", staker) ==
+        require(delegateGet(_testTarget, this.getPastDowntimeLength.selector, staker) ==
             info.pastDowntime.length);
         for (uint256 i = 0; i < info.pastDowntime.length && i < MAX_CHECKED_VALUES; i++) {
             Downtime storage downtime = info.pastDowntime[i];
@@ -1394,7 +1394,7 @@ contract StakingEscrow is Issuer {
                 downtimeToCheck.endPeriod == downtime.endPeriod);
         }
 
-        require(delegateGet(_testTarget, "getSubStakesLength(address)", staker) == info.subStakes.length);
+        require(delegateGet(_testTarget, this.getSubStakesLength.selector, staker) == info.subStakes.length);
         for (uint256 i = 0; i < info.subStakes.length && i < MAX_CHECKED_VALUES; i++) {
             SubStakeInfo storage subStakeInfo = info.subStakes[i];
             SubStakeInfo memory subStakeInfoToCheck = delegateGetSubStakeInfo(_testTarget, staker, i);
@@ -1405,7 +1405,7 @@ contract StakingEscrow is Issuer {
         }
 
         if (info.worker != address(0)) {
-            require(address(delegateGet(_testTarget, "workerToStaker(address)", bytes32(uint256(info.worker)))) ==
+            require(address(delegateGet(_testTarget, this.workerToStaker.selector, bytes32(uint256(info.worker)))) ==
                 workerToStaker[info.worker]);
         }
     }

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/Issuer.sol";
@@ -7,7 +7,7 @@ import "contracts/Issuer.sol";
 /**
 * @notice PolicyManager interface
 */
-contract PolicyManagerInterface {
+interface PolicyManagerInterface {
     function register(address _node, uint16 _period) external;
     function updateReward(address _node, uint16 _period) external;
     function escrow() external view returns (address);
@@ -18,7 +18,7 @@ contract PolicyManagerInterface {
 /**
 * @notice Adjudicator interface
 */
-contract AdjudicatorInterface {
+interface AdjudicatorInterface {
     function escrow() external view returns (address);
 }
 
@@ -26,7 +26,7 @@ contract AdjudicatorInterface {
 /**
 * @notice WorkLock interface
 */
-contract WorkLockInterface {
+interface WorkLockInterface {
     function escrow() external view returns (address);
 }
 
@@ -1279,7 +1279,8 @@ contract StakingEscrow is Issuer {
     function getSubStakeInfo(address _staker, uint256 _index)
     // TODO change to structure when ABIEncoderV2 is released (#1501)
 //        public view returns (SubStakeInfo)
-        external view returns (uint16 firstPeriod, uint16 lastPeriod, uint16 periods, uint256 lockedValue)
+        // TODO "virtual" only for tests, probably will be removed after #1512
+        external view virtual returns (uint16 firstPeriod, uint16 lastPeriod, uint16 periods, uint256 lockedValue)
     {
         SubStakeInfo storage info = stakerInfo[_staker].subStakes[_index];
         firstPeriod = info.firstPeriod;
@@ -1349,7 +1350,7 @@ contract StakingEscrow is Issuer {
     }
 
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `verifyState`
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
         require((delegateGet(_testTarget, "isTestContract()") == 0) == !isTestContract);
         require(uint16(delegateGet(_testTarget, "minWorkerPeriods()")) == minWorkerPeriods);
@@ -1410,7 +1411,7 @@ contract StakingEscrow is Issuer {
     }
 
     /// @dev the `onlyWhileUpgrading` modifier works through a call to the parent `finishUpgrade`
-    function finishUpgrade(address _target) public {
+    function finishUpgrade(address _target) public override virtual {
         super.finishUpgrade(_target);
         StakingEscrow escrow = StakingEscrow(_target);
         minLockedPeriods = escrow.minLockedPeriods();

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "zeppelin/math/SafeMath.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -47,7 +47,7 @@ contract WorkLock is Ownable {
     /*
     * @dev WorkLock calculations:
     * bid = minBid + bonusETHPart
-    * bonusTokenSupply = tokenSupply - bidders.length * minBid
+    * bonusTokenSupply = tokenSupply - bidders.length * minAllowableLockedTokens
     * bonusDepositRate = bonusTokenSupply / bonusETHSupply
     * claimedTokens = minAllowableLockedTokens + bonusETHPart * bonusDepositRate
     * bonusRefundRate = bonusDepositRate * SLOWING_REFUND / boostingRefund

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/AdditionalMath.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/AdditionalMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "zeppelin/math/SafeMath.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 import "contracts/lib/UmbralDeserializer.sol";
 import "contracts/lib/SignatureVerifier.sol";
@@ -410,7 +410,7 @@ library ReEncryptionValidator {
     /// @dev Based on the addition formulas from http://www.hyperelliptic.org/EFD/g1p/auto-code/shortw/jacobian-0/addition/add-2001-b.op3
     /// @param P An EC point in affine coordinates
     /// @param Q An EC point in affine coordinates
-    /// @return An EC point in Jacobian coordinates with the sum, represented by an array of 3 uint256
+    /// @return R An EC point in Jacobian coordinates with the sum, represented by an array of 3 uint256
     function addAffineJacobian(
     	uint[2] memory P,
     	uint[2] memory Q
@@ -437,7 +437,7 @@ library ReEncryptionValidator {
 
     /// @notice Point doubling in Jacobian coordinates
     /// @param P An EC point in Jacobian coordinates.
-    /// @return An EC point in Jacobian coordinates
+    /// @return Q An EC point in Jacobian coordinates
     function doubleJacobian(uint[3] memory P) internal pure returns (uint[3] memory Q) {
         uint256 z = P[2];
         if (z == 0)

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "./Upgradeable.sol";
@@ -102,7 +102,7 @@ contract Dispatcher is Upgradeable {
         require(callSuccess);
     }
 
-    function verifyState(address _testTarget) public onlyWhileUpgrading {
+    function verifyState(address _testTarget) public override onlyWhileUpgrading {
         //checks equivalence accessing state through new contract and current storage
         require(address(uint160(delegateGet(_testTarget, "owner()"))) == owner());
         require(address(uint160(delegateGet(_testTarget, "target()"))) == target);
@@ -114,12 +114,12 @@ contract Dispatcher is Upgradeable {
     /**
     * @dev Override function using empty code because no reason to call this function in Dispatcher
     */
-    function finishUpgrade(address) public {}
+    function finishUpgrade(address) public override {}
 
     /**
     * @dev Fallback function send all requests to the target contract
     */
-    function () external payable {
+    fallback() external payable {
         assert(target.isContract());
         // execute requested function from target contract using storage of the dispatcher
         (bool callSuccess,) = target.delegatecall(msg.data);
@@ -128,8 +128,8 @@ contract Dispatcher is Upgradeable {
             // we can use the second return value from `delegatecall` (bytes memory)
             // but it will consume a little more gas
             assembly {
-                returndatacopy(0x0, 0x0, returndatasize)
-                return(0x0, returndatasize)
+                returndatacopy(0x0, 0x0, returndatasize())
+                return(0x0, returndatasize())
             }
         } else {
             revert();

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
@@ -90,7 +90,7 @@ contract Dispatcher is Upgradeable {
     * @dev Call verifyState method for Upgradeable contract
     */
     function verifyUpgradeableState(address _from, address _to) private {
-        (bool callSuccess,) = _from.delegatecall(abi.encodeWithSignature("verifyState(address)", _to));
+        (bool callSuccess,) = _from.delegatecall(abi.encodeWithSelector(this.verifyState.selector, _to));
         require(callSuccess);
     }
 
@@ -98,17 +98,17 @@ contract Dispatcher is Upgradeable {
     * @dev Call finishUpgrade method from the Upgradeable contract
     */
     function finishUpgrade() private {
-        (bool callSuccess,) = target.delegatecall(abi.encodeWithSignature("finishUpgrade(address)", target));
+        (bool callSuccess,) = target.delegatecall(abi.encodeWithSelector(this.finishUpgrade.selector, target));
         require(callSuccess);
     }
 
     function verifyState(address _testTarget) public override onlyWhileUpgrading {
         //checks equivalence accessing state through new contract and current storage
-        require(address(uint160(delegateGet(_testTarget, "owner()"))) == owner());
-        require(address(uint160(delegateGet(_testTarget, "target()"))) == target);
-        require(address(uint160(delegateGet(_testTarget, "previousTarget()"))) == previousTarget);
-        require(bytes32(delegateGet(_testTarget, "secretHash()")) == secretHash);
-        require(uint8(delegateGet(_testTarget, "isUpgrade()")) == isUpgrade);
+        require(address(uint160(delegateGet(_testTarget, this.owner.selector))) == owner());
+        require(address(uint160(delegateGet(_testTarget, this.target.selector))) == target);
+        require(address(uint160(delegateGet(_testTarget, this.previousTarget.selector))) == previousTarget);
+        require(bytes32(delegateGet(_testTarget, this.secretHash.selector)) == secretHash);
+        require(uint8(delegateGet(_testTarget, this.isUpgrade.selector)) == isUpgrade);
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
@@ -70,7 +70,7 @@ abstract contract Upgradeable is Ownable {
     /**
     * @dev Base method to get data
     * @param _target Target to call
-    * @param _signature Method signature
+    * @param _selector Method selector
     * @param _numberOfArguments Number of used arguments
     * @param _argument1 First method argument
     * @param _argument2 Second method argument
@@ -78,17 +78,16 @@ abstract contract Upgradeable is Ownable {
     */
     function delegateGetData(
         address _target,
-        string memory _signature,
+        bytes4 _selector,
         uint8 _numberOfArguments,
         bytes32 _argument1,
         bytes32 _argument2
     )
         internal returns (bytes32 memoryAddress)
     {
-        bytes4 targetCall = bytes4(keccak256(bytes(_signature)));
         assembly {
             memoryAddress := mload(0x40)
-            mstore(memoryAddress, targetCall)
+            mstore(memoryAddress, _selector)
             if gt(_numberOfArguments, 0) {
                 mstore(add(memoryAddress, 0x04), _argument1)
             }
@@ -109,10 +108,10 @@ abstract contract Upgradeable is Ownable {
     * @dev Call "getter" without parameters.
     * Result should not exceed 32 bytes
     */
-    function delegateGet(address _target, string memory _signature)
+    function delegateGet(address _target, bytes4 _selector)
         internal returns (uint256 result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 0, 0, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 0, 0, 0);
         assembly {
             result := mload(memoryAddress)
         }
@@ -122,10 +121,10 @@ abstract contract Upgradeable is Ownable {
     * @dev Call "getter" with one parameter.
     * Result should not exceed 32 bytes
     */
-    function delegateGet(address _target, string memory _signature, bytes32 _argument)
+    function delegateGet(address _target, bytes4 _selector, bytes32 _argument)
         internal returns (uint256 result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 1, _argument, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 1, _argument, 0);
         assembly {
             result := mload(memoryAddress)
         }
@@ -137,13 +136,13 @@ abstract contract Upgradeable is Ownable {
     */
     function delegateGet(
         address _target,
-        string memory _signature,
+        bytes4 _selector,
         bytes32 _argument1,
         bytes32 _argument2
     )
         internal returns (uint256 result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 2, _argument1, _argument2);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 2, _argument1, _argument2);
         assembly {
             result := mload(memoryAddress)
         }

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "zeppelin/ownership/Ownable.sol";
@@ -45,7 +45,7 @@ contract StakingInterfaceRouter is Ownable {
 * @dev Implement `isFallbackAllowed()` or override fallback function
 * Implement `withdrawTokens(uint256)` and `withdrawETH()` functions
 */
-contract AbstractStakingContract {
+abstract contract AbstractStakingContract {
     using Address for address;
     using Address for address payable;
     using SafeERC20 for NuCypherToken;
@@ -65,22 +65,23 @@ contract AbstractStakingContract {
     /**
     * @dev Checks permission for calling fallback function
     */
-    function isFallbackAllowed() public returns (bool);
+    function isFallbackAllowed() public virtual returns (bool);
 
     /**
     * @dev Withdraw tokens from staking contract
     */
-    function withdrawTokens(uint256 _value) public;
+    function withdrawTokens(uint256 _value) public virtual;
 
     /**
     * @dev Withdraw ETH from staking contract
     */
-    function withdrawETH() public;
+    function withdrawETH() public virtual;
 
     /**
     * @dev Function sends all requests to the target contract
     */
-    function () external payable {
+    // TODO #1809
+    fallback() external payable {
         if (msg.data.length == 0) {
             return;
         }
@@ -95,8 +96,8 @@ contract AbstractStakingContract {
             // we can use the second return value from `delegatecall` (bytes memory)
             // but it will consume a little more gas
             assembly {
-                returndatacopy(0x0, 0x0, returndatasize)
-                return(0x0, returndatasize)
+                returndatacopy(0x0, 0x0, returndatasize())
+                return(0x0, returndatasize())
             }
         } else {
             revert();

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "zeppelin/ownership/Ownable.sol";
@@ -105,7 +105,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     * @notice Withdraw available amount of tokens to owner
     * @param _value Amount of token to withdraw
     */
-    function withdrawTokens(uint256 _value) public onlyOwner {
+    function withdrawTokens(uint256 _value) public override onlyOwner {
         uint256 balance = token.balanceOf(address(this));
         require(balance >= _value);
         // Withdrawal invariant for PreallocationEscrow:
@@ -118,7 +118,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     /**
     * @notice Withdraw available ETH to the owner
     */
-    function withdrawETH() public onlyOwner {
+    function withdrawETH() public override onlyOwner {
         uint256 balance = address(this).balance;
         require(balance != 0);
         msg.sender.sendValue(balance);
@@ -128,7 +128,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     /**
     * @notice Calling fallback function is allowed only for the owner
     */
-    function isFallbackAllowed() public returns (bool) {
+    function isFallbackAllowed() public override returns (bool) {
         return msg.sender == owner();
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/staking_contracts/AbstractStakingContract.sol";
@@ -49,7 +49,7 @@ contract BaseStakingInterface {
     * @dev Assume that `this` is the staking contract
     */
     function getStateContract() internal view returns (BaseStakingInterface) {
-        address payable stakingContractAddress = address(bytes20(address(this)));
+        address payable stakingContractAddress = payable(address(this));
         StakingInterfaceRouter router = AbstractStakingContract(stakingContractAddress).router();
         return BaseStakingInterface(router.target());
     }
@@ -228,7 +228,7 @@ contract StakingInterface is BaseStakingInterface {
     function bid(uint256 _value) public payable {
         WorkLock workLockFromState = getStateContract().workLock();
         require(address(workLockFromState) != address(0));
-        workLockFromState.bid.value(_value)();
+        workLockFromState.bid{value: _value}();
         emit Bid(msg.sender, _value);
     }
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/math/Math.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/math/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/zeppelin/math/SafeMath.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/math/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/zeppelin/ownership/Ownable.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/ownership/Ownable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "./IERC20.sol";
@@ -29,7 +29,7 @@ contract ERC20 is IERC20 {
     /**
      * @dev Total number of tokens in existence
      */
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() public view override returns (uint256) {
         return _totalSupply;
     }
 
@@ -38,7 +38,7 @@ contract ERC20 is IERC20 {
      * @param owner The address to query the balance of.
      * @return An uint256 representing the amount owned by the passed address.
      */
-    function balanceOf(address owner) public view returns (uint256) {
+    function balanceOf(address owner) public view override returns (uint256) {
         return _balances[owner];
     }
 
@@ -48,7 +48,7 @@ contract ERC20 is IERC20 {
      * @param spender address The address which will spend the funds.
      * @return A uint256 specifying the amount of tokens still available for the spender.
      */
-    function allowance(address owner, address spender) public view returns (uint256) {
+    function allowance(address owner, address spender) public view override returns (uint256) {
         return _allowed[owner][spender];
     }
 
@@ -57,7 +57,7 @@ contract ERC20 is IERC20 {
      * @param to The address to transfer to.
      * @param value The amount to be transferred.
      */
-    function transfer(address to, uint256 value) public returns (bool) {
+    function transfer(address to, uint256 value) public override returns (bool) {
         _transfer(msg.sender, to, value);
         return true;
     }
@@ -71,7 +71,7 @@ contract ERC20 is IERC20 {
      * @param spender The address which will spend the funds.
      * @param value The amount of tokens to be spent.
      */
-    function approve(address spender, uint256 value) public returns (bool) {
+    function approve(address spender, uint256 value) public override returns (bool) {
 
         // To change the approve amount you first have to reduce the addresses`
         //  allowance to zero by calling `approve(_spender, 0)` if it is not
@@ -91,7 +91,7 @@ contract ERC20 is IERC20 {
      * @param to address The address which you want to transfer to
      * @param value uint256 the amount of tokens to be transferred
      */
-    function transferFrom(address from, address to, uint256 value) public returns (bool) {
+    function transferFrom(address from, address to, uint256 value) public override returns (bool) {
         _transfer(from, to, value);
         _approve(from, msg.sender, _allowed[from][msg.sender].sub(value));
         return true;

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20Detailed.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20Detailed.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "./IERC20.sol";
@@ -10,7 +10,7 @@ import "./IERC20.sol";
  * All the operations are done using the smallest and indivisible token unit,
  * just as on Ethereum all the operations are done in wei.
  */
-contract ERC20Detailed is IERC20 {
+abstract contract ERC20Detailed is IERC20 {
     string private _name;
     string private _symbol;
     uint8 private _decimals;

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/IERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/IERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/SafeERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/SafeERC20.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "./IERC20.sol";

--- a/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 /**
  * @dev Collection of functions related to the address type
@@ -7,19 +7,21 @@ library Address {
     /**
      * @dev Returns true if `account` is a contract.
      *
-     * This test is non-exhaustive, and there may be false-negatives: during the
-     * execution of a contract's constructor, its address will be reported as
-     * not containing a contract.
+     * [IMPORTANT]
+     * ====
+     * It is unsafe to assume that an address for which this function returns
+     * false is an externally-owned account (EOA) and not a contract.
      *
-     * IMPORTANT: It is unsafe to assume that an address for which this
-     * function returns false is an externally-owned account (EOA) and not a
-     * contract.
+     * Among others, `isContract` will return false for the following
+     * types of addresses:
+     *
+     *  - an externally-owned account
+     *  - a contract in construction
+     *  - an address where a contract will be created
+     *  - an address where a contract lived, but was destroyed
+     * ====
      */
     function isContract(address account) internal view returns (bool) {
-        // This method relies in extcodesize, which returns 0 for contracts in
-        // construction, since the code is only stored at the end of the
-        // constructor execution.
-
         // According to EIP-1052, 0x0 is the value returned for not-yet created accounts
         // and 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470 is returned
         // for accounts without code, i.e. `keccak256('')`
@@ -27,17 +29,7 @@ library Address {
         bytes32 accountHash = 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470;
         // solhint-disable-next-line no-inline-assembly
         assembly { codehash := extcodehash(account) }
-        return (codehash != 0x0 && codehash != accountHash);
-    }
-
-    /**
-     * @dev Converts an `address` into `address payable`. Note that this is
-     * simply a type cast: the actual underlying value is not changed.
-     *
-     * _Available since v2.4.0._
-     */
-    function toPayable(address account) internal pure returns (address payable) {
-        return address(uint160(account));
+        return (codehash != accountHash && codehash != 0x0);
     }
 
     /**
@@ -62,7 +54,7 @@ library Address {
         require(address(this).balance >= amount, "Address: insufficient balance");
 
         // solhint-disable-next-line avoid-call-value
-        (bool success, ) = recipient.call.value(amount)("");
+        (bool success, ) = recipient.call{value: amount}("");
         require(success, "Address: unable to send value, recipient may have reverted");
     }
 }

--- a/tests/blockchain/eth/contracts/base/test_issuer.py
+++ b/tests/blockchain/eth/contracts/base/test_issuer.py
@@ -231,7 +231,7 @@ def test_upgrading(testerchain, token, deploy_contract):
 
     # Deploy contract
     contract_library_v1, _ = deploy_contract(
-        contract_name='Issuer',
+        contract_name='IssuerMock',
         _token=token.address,
         _hoursPerPeriod=1,
         _miningCoefficient=1,

--- a/tests/blockchain/eth/contracts/contracts/AdjudicatorTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/AdjudicatorTestSet.sol
@@ -98,6 +98,6 @@ contract AdjudicatorV2Mock is Adjudicator {
 
     function verifyState(address _testTarget) override public {
         super.verifyState(_testTarget);
-        require(uint256(delegateGet(_testTarget, "valueToCheck()")) == valueToCheck);
+        require(uint256(delegateGet(_testTarget, this.valueToCheck.selector)) == valueToCheck);
     }
 }

--- a/tests/blockchain/eth/contracts/contracts/AdjudicatorTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/AdjudicatorTestSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/Adjudicator.sol";
@@ -96,7 +96,7 @@ contract AdjudicatorV2Mock is Adjudicator {
         valueToCheck = _valueToCheck;
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) override public {
         super.verifyState(_testTarget);
         require(uint256(delegateGet(_testTarget, "valueToCheck()")) == valueToCheck);
     }

--- a/tests/blockchain/eth/contracts/contracts/IssuerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/IssuerTestSet.sol
@@ -97,6 +97,6 @@ contract IssuerV2Mock is Issuer {
 
     function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "valueToCheck()") == valueToCheck);
+        require(delegateGet(_testTarget, this.valueToCheck.selector) == valueToCheck);
     }
 }

--- a/tests/blockchain/eth/contracts/contracts/IssuerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/IssuerTestSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/Issuer.sol";
@@ -95,7 +95,7 @@ contract IssuerV2Mock is Issuer {
         valueToCheck = _valueToCheck;
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "valueToCheck()") == valueToCheck);
     }

--- a/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/LibTestSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/lib/SignatureVerifier.sol";

--- a/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
@@ -34,7 +34,7 @@ contract PolicyManagerV2Mock is PolicyManager {
 
     function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "valueToCheck()") == valueToCheck);
+        require(delegateGet(_testTarget, this.valueToCheck.selector) == valueToCheck);
     }
 }
 

--- a/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/PolicyManagerTestSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/PolicyManager.sol";
@@ -13,9 +13,7 @@ contract PolicyManagerBad is PolicyManager {
     constructor(StakingEscrow _escrow) public PolicyManager(_escrow) {
     }
 
-    function getNodeRewardDelta(address, uint16) public view returns (int256)
-    {
-    }
+    function getNodeRewardDelta(address, uint16) public view override returns (int256) {}
 
 }
 
@@ -34,7 +32,7 @@ contract PolicyManagerV2Mock is PolicyManager {
         valueToCheck = _valueToCheck;
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "valueToCheck()") == valueToCheck);
     }

--- a/tests/blockchain/eth/contracts/contracts/ReceiveApprovalMethodMock.sol
+++ b/tests/blockchain/eth/contracts/contracts/ReceiveApprovalMethodMock.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/tests/blockchain/eth/contracts/contracts/ReentrancyTest.sol
+++ b/tests/blockchain/eth/contracts/contracts/ReentrancyTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**
@@ -19,13 +19,15 @@ contract ReentrancyTest {
         data = _data;
     }
 
-    function () payable external {
-        // call only once
+    // TODO #1809
+//    receive() external payable {
+    fallback() external payable {
+        // call no more than maxDepth times
         if (lockCounter >= maxDepth) {
             return;
         }
         lockCounter++;
-        (bool callSuccess,) = target.call.value(value)(data);
+        (bool callSuccess,) = target.call{value: value}(data);
         require(callSuccess);
         lockCounter--;
     }

--- a/tests/blockchain/eth/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingContractsTestSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/NuCypherToken.sol";
@@ -112,7 +112,9 @@ contract PolicyManagerForStakingContractMock {
         minRewardRate = _minRewardRate;
     }
 
-    function () external payable {}
+    // TODO #1809
+//    receive() external payable {}
+    fallback() external payable {}
 }
 
 
@@ -191,7 +193,9 @@ contract StakingInterfaceMockV2 {
     address public token = address(1);
     address public escrow = address(1);
 
-    function () external payable {
+    // TODO #1809
+//    receive() external payable {}
+    fallback() external payable {
         // can only use with ETH
         require(msg.value > 0);
     }
@@ -240,14 +244,14 @@ contract SimpleStakingContract is AbstractStakingContract, Ownable {
     * @notice Withdraw available amount of tokens to owner
     * @param _value Amount of token to withdraw
     */
-    function withdrawTokens(uint256 _value) public onlyOwner {
+    function withdrawTokens(uint256 _value) public override onlyOwner {
         token.safeTransfer(msg.sender, _value);
     }
 
     /**
     * @notice Withdraw available ETH to the owner
     */
-    function withdrawETH() public onlyOwner {
+    function withdrawETH() public override onlyOwner {
         uint256 balance = address(this).balance;
         require(balance != 0);
         msg.sender.sendValue(balance);
@@ -256,7 +260,7 @@ contract SimpleStakingContract is AbstractStakingContract, Ownable {
     /**
     * @notice Calling fallback function is allowed only for the owner
     */
-    function isFallbackAllowed() public returns (bool) {
+    function isFallbackAllowed() public override returns (bool) {
         return msg.sender == owner();
     }
 

--- a/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
@@ -86,7 +86,7 @@ contract StakingEscrowV2Mock is StakingEscrow {
 
     function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "valueToCheck()") == valueToCheck);
+        require(delegateGet(_testTarget, this.valueToCheck.selector) == valueToCheck);
     }
 
     function finishUpgrade(address _target) public override onlyWhileUpgrading {

--- a/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/StakingEscrowTestSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/StakingEscrow.sol";
@@ -38,9 +38,7 @@ contract StakingEscrowBad is StakingEscrow {
     {
     }
 
-    function getSubStakeInfo(address, uint256) public view returns (uint16, uint16, uint16, uint256)
-    {
-    }
+    function getSubStakeInfo(address, uint256) public view override returns (uint16, uint16, uint16, uint256) {}
 
 }
 
@@ -86,12 +84,12 @@ contract StakingEscrowV2Mock is StakingEscrow {
         valueToCheck = _valueToCheck;
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "valueToCheck()") == valueToCheck);
     }
 
-    function finishUpgrade(address _target) public onlyWhileUpgrading {
+    function finishUpgrade(address _target) public override onlyWhileUpgrading {
         StakingEscrowV2Mock escrow = StakingEscrowV2Mock(_target);
         valueToCheck = escrow.valueToCheck();
         isTestContract = escrow.isTestContract();

--- a/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/blockchain/eth/contracts/contracts/WorkLockTestSet.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/NuCypherToken.sol";

--- a/tests/blockchain/eth/contracts/contracts/proxy/BadContracts.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/BadContracts.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "./ContractV1.sol";
@@ -51,8 +51,8 @@ contract ContractV2BadStorage is Upgradeable {
     mapping (uint256 => Structure2) public mappingStructures;
     uint256 public mappingStructuresLength;
 
-    function verifyState(address) public {}
-    function finishUpgrade(address) public {}
+    function verifyState(address) public override {}
+    function finishUpgrade(address) public override {}
 
 }
 
@@ -62,7 +62,7 @@ contract ContractV2BadStorage is Upgradeable {
 */
 contract ContractV2BadVerifyState is ContractV1(1) {
 
-    function verifyState(address) public {
+    function verifyState(address) public override {
         revert();
     }
 

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV1.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV1.sol
@@ -105,53 +105,53 @@ contract ContractV1 is Upgradeable {
 
     function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "storageValue()") == storageValue);
-        bytes memory value = delegateGetBytes(_testTarget, "dynamicallySizedValue()");
+        require(delegateGet(_testTarget, this.storageValue.selector) == storageValue);
+        bytes memory value = delegateGetBytes(_testTarget, this.dynamicallySizedValue.selector);
         // WARNING: sometimes execution of keccak256(string storage) on a long string (more than 31 bytes)
         // leads to out of gas or exception
         require(value.length == bytes(dynamicallySizedValue).length &&
             keccak256(value) == keccak256(bytes(dynamicallySizedValue)));
 
-        require(delegateGet(_testTarget, "getArrayValueLength()") == arrayValues.length);
+        require(delegateGet(_testTarget, this.getArrayValueLength.selector) == arrayValues.length);
         for (uint256 i = 0; i < arrayValues.length; i++) {
-            require(delegateGet(_testTarget, "arrayValues(uint256)", bytes32(i)) == arrayValues[i]);
+            require(delegateGet(_testTarget, this.arrayValues.selector, bytes32(i)) == arrayValues[i]);
         }
         for (uint256 i = 0; i < mappingIndices.length; i++) {
             uint256 index = mappingIndices[i];
-            require(delegateGet(_testTarget, "mappingValues(uint256)", bytes32(index)) == mappingValues[index]);
+            require(delegateGet(_testTarget, this.mappingValues.selector, bytes32(index)) == mappingValues[index]);
         }
 
-        require(delegateGet(_testTarget, "getStructureLength1()") == arrayStructures.length);
+        require(delegateGet(_testTarget, this.getStructureLength1.selector) == arrayStructures.length);
         for (uint256 i = 0; i < arrayStructures.length; i++) {
-            require(delegateGet(_testTarget, "arrayStructures(uint256)", bytes32(i)) == arrayStructures[i].value);
+            require(delegateGet(_testTarget, this.arrayStructures.selector, bytes32(i)) == arrayStructures[i].value);
 
-            require(delegateGet(_testTarget, "getStructureArrayLength1(uint256)", bytes32(i)) ==
+            require(delegateGet(_testTarget, this.getStructureArrayLength1.selector, bytes32(i)) ==
                 arrayStructures[i].arrayValues.length);
             for (uint256 j = 0; j < arrayStructures[i].arrayValues.length; j++) {
                 require(delegateGet(
-                        _testTarget, "getStructureArrayValue1(uint256,uint256)", bytes32(i), bytes32(j)) ==
+                        _testTarget, this.getStructureArrayValue1.selector, bytes32(i), bytes32(j)) ==
                     arrayStructures[i].arrayValues[j]);
             }
         }
 
-        require(delegateGet(_testTarget, "getStructureLength2()") == mappingStructuresLength);
+        require(delegateGet(_testTarget, this.getStructureLength2.selector) == mappingStructuresLength);
         for (uint256 i = 0; i < mappingStructuresLength; i++) {
-            require(delegateGet(_testTarget, "mappingStructures(uint256)", bytes32(i)) == mappingStructures[i].value);
+            require(delegateGet(_testTarget, this.mappingStructures.selector, bytes32(i)) == mappingStructures[i].value);
 
-            require(delegateGet(_testTarget, "getStructureArrayLength2(uint256)", bytes32(i)) ==
+            require(delegateGet(_testTarget, this.getStructureArrayLength2.selector, bytes32(i)) ==
                 mappingStructures[i].arrayValues.length);
             for (uint256 j = 0; j < mappingStructures[i].arrayValues.length; j++) {
                 require(delegateGet(
-                        _testTarget, "getStructureArrayValue2(uint256,uint256)", bytes32(i), bytes32(j)) ==
+                        _testTarget, this.getStructureArrayValue2.selector, bytes32(i), bytes32(j)) ==
                     mappingStructures[i].arrayValues[j]);
             }
         }
     }
 
-    function delegateGetBytes(address _target, string memory _signature)
+    function delegateGetBytes(address _target, bytes4 _selector)
         internal returns (bytes memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 0, 0, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 0, 0, 0);
         assembly {
             result := add(memoryAddress, mload(memoryAddress))
         }

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV1.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV1.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -103,7 +103,7 @@ contract ContractV1 is Upgradeable {
         return mappingStructures[_index].arrayValues[_arrayIndex];
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "storageValue()") == storageValue);
         bytes memory value = delegateGetBytes(_testTarget, "dynamicallySizedValue()");
@@ -157,7 +157,7 @@ contract ContractV1 is Upgradeable {
         }
     }
 
-    function finishUpgrade(address _target) public {
+    function finishUpgrade(address _target) public override {
         super.finishUpgrade(_target);
         storageValue = ContractV1(_target).storageValue();
     }

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV2.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV2.sol
@@ -112,52 +112,52 @@ contract ContractV2 is Upgradeable {
 
     function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "storageValue()") == storageValue);
-        bytes memory value = delegateGetBytes(_testTarget, "dynamicallySizedValue()");
+        require(delegateGet(_testTarget, this.storageValue.selector) == storageValue);
+        bytes memory value = delegateGetBytes(_testTarget, this.dynamicallySizedValue.selector);
         require(value.length == bytes(dynamicallySizedValue).length &&
             keccak256(value) == keccak256(bytes(dynamicallySizedValue)));
 
-        require(delegateGet(_testTarget, "getArrayValueLength()") == arrayValues.length);
+        require(delegateGet(_testTarget, this.getArrayValueLength.selector) == arrayValues.length);
         for (uint256 i = 0; i < arrayValues.length; i++) {
-            require(delegateGet(_testTarget, "arrayValues(uint256)", bytes32(i)) == arrayValues[i]);
+            require(delegateGet(_testTarget, this.arrayValues.selector, bytes32(i)) == arrayValues[i]);
         }
         for (uint256 i = 0; i < mappingIndices.length; i++) {
             uint256 index = mappingIndices[i];
-            require(delegateGet(_testTarget, "mappingValues(uint256)", bytes32(index)) ==
+            require(delegateGet(_testTarget, this.mappingValues.selector, bytes32(index)) ==
                 mappingValues[index]);
         }
 
-        require(delegateGet(_testTarget, "getStructureLength1()") == arrayStructures.length);
+        require(delegateGet(_testTarget, this.getStructureLength1.selector) == arrayStructures.length);
         for (uint256 i = 0; i < arrayStructures.length; i++) {
-            require(delegateGet(_testTarget, "arrayStructures(uint256)", bytes32(i)) == arrayStructures[i].value);
+            require(delegateGet(_testTarget, this.arrayStructures.selector, bytes32(i)) == arrayStructures[i].value);
 
-            uint256[] memory values = delegateGetArray(_testTarget, "getStructure1ArrayValues(uint256)", bytes32(i));
+            uint256[] memory values = delegateGetArray(_testTarget, this.getStructure1ArrayValues.selector, bytes32(i));
             require(values.length == arrayStructures[i].arrayValues.length);
             for (uint256 j = 0; j < arrayStructures[i].arrayValues.length; j++) {
                 require(values[j] == arrayStructures[i].arrayValues[j]);
             }
         }
 
-        require(delegateGet(_testTarget, "getStructureLength2()") == mappingStructuresLength);
+        require(delegateGet(_testTarget, this.getStructureLength2.selector) == mappingStructuresLength);
         for (uint256 i = 0; i < mappingStructuresLength; i++) {
-            Structure2 memory structure2 = delegateGetStructure2(_testTarget, "mappingStructures(uint256)", bytes32(i));
+            Structure2 memory structure2 = delegateGetStructure2(_testTarget, this.mappingStructures.selector, bytes32(i));
             require(structure2.value == mappingStructures[i].value);
             require(structure2.valueToCheck == mappingStructures[i].valueToCheck);
 
-            uint256[] memory values = delegateGetArray(_testTarget, "getStructure2ArrayValues(uint256)", bytes32(i));
+            uint256[] memory values = delegateGetArray(_testTarget, this.getStructure2ArrayValues.selector, bytes32(i));
             require(values.length == mappingStructures[i].arrayValues.length);
             for (uint256 j = 0; j < mappingStructures[i].arrayValues.length; j++) {
                 require(values[j] == mappingStructures[i].arrayValues[j]);
             }
         }
 
-        require(delegateGet(_testTarget, "storageValueToCheck()") == storageValueToCheck);
+        require(delegateGet(_testTarget, this.storageValueToCheck.selector) == storageValueToCheck);
     }
 
-    function delegateGetStructure2(address _target, string memory _signature, bytes32 _argument)
+    function delegateGetStructure2(address _target, bytes4 _selector, bytes32 _argument)
         internal returns (Structure2 memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 1, _argument, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 1, _argument, 0);
         assembly {
             result := memoryAddress
             // copy data to the right position because of it is the array pointer place (arrayValues)
@@ -165,10 +165,10 @@ contract ContractV2 is Upgradeable {
         }
     }
 
-    function delegateGetBytes(address _target, string memory _signature)
+    function delegateGetBytes(address _target, bytes4 _selector)
         internal returns (bytes memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 0, 0, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 0, 0, 0);
         assembly {
             result := add(memoryAddress, mload(memoryAddress))
         }
@@ -179,12 +179,12 @@ contract ContractV2 is Upgradeable {
     */
     function delegateGetArray(
         address _target,
-        string memory _signature,
+        bytes4 _selector,
         bytes32 _argument
     )
         public returns (uint256[] memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 1, _argument, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 1, _argument, 0);
         assembly {
             result := add(memoryAddress, mload(memoryAddress))
         }

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV2.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV2.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -110,7 +110,7 @@ contract ContractV2 is Upgradeable {
         return mappingStructures[_index].arrayValues;
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "storageValue()") == storageValue);
         bytes memory value = delegateGetBytes(_testTarget, "dynamicallySizedValue()");
@@ -190,7 +190,7 @@ contract ContractV2 is Upgradeable {
         }
     }
 
-    function finishUpgrade(address _target) public {
+    function finishUpgrade(address _target) public override {
         super.finishUpgrade(_target);
         storageValueToCheck = ContractV2(_target).storageValueToCheck();
     }

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV3.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV3.sol
@@ -20,6 +20,6 @@ contract ContractV3 is ContractV2 {
 
     function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "anotherStorageValue()") == anotherStorageValue);
+        require(delegateGet(_testTarget, this.anotherStorageValue.selector) == anotherStorageValue);
     }
 }

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV3.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV3.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "./ContractV2.sol";
@@ -18,7 +18,7 @@ contract ContractV3 is ContractV2 {
         anotherStorageValue = _value;
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "anotherStorageValue()") == anotherStorageValue);
     }

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV4.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV4.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -210,7 +210,7 @@ contract ContractV4 is Upgradeable {
         }
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "storageValue()") == storageValue());
         bytes memory value = delegateGetBytes(_testTarget, "dynamicallySizedValue()");
@@ -288,7 +288,7 @@ contract ContractV4 is Upgradeable {
         }
     }
 
-    function finishUpgrade(address _target) public {
+    function finishUpgrade(address _target) public override {
         super.finishUpgrade(_target);
         setStorageValueToCheck(ContractV4(_target).storageValueToCheck());
     }

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV4.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV4.sol
@@ -212,79 +212,81 @@ contract ContractV4 is Upgradeable {
 
     function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "storageValue()") == storageValue());
-        bytes memory value = delegateGetBytes(_testTarget, "dynamicallySizedValue()");
+        require(delegateGet(_testTarget, this.storageValue.selector) == storageValue());
+        bytes memory value = delegateGetBytes(_testTarget, this.dynamicallySizedValue.selector);
         bytes memory originalValue = bytes(dynamicallySizedValue());
         require(value.length == originalValue.length &&
             keccak256(value) == keccak256(originalValue));
 
         uint256 length = getArrayValueLength();
-        require(delegateGet(_testTarget, "getArrayValueLength()") == length);
+        require(delegateGet(_testTarget, this.getArrayValueLength.selector) == length);
         for (uint256 i = 0; i < length; i++) {
-            require(delegateGet(_testTarget, "arrayValues(uint256)", bytes32(i)) == arrayValues(i));
+            require(delegateGet(_testTarget, this.arrayValues.selector, bytes32(i)) == arrayValues(i));
         }
         length = getMappingIndicesLength();
         for (uint256 i = 0; i < length; i++) {
             uint256 index = mappingIndices(i);
-            require(delegateGet(_testTarget, "mappingValues(uint256)", bytes32(index)) == mappingValues(index));
+            require(delegateGet(_testTarget, this.mappingValues.selector, bytes32(index)) == mappingValues(index));
         }
 
         length = getStructureLength1();
-        require(delegateGet(_testTarget, "getStructureLength1()") == length);
+        require(delegateGet(_testTarget, this.getStructureLength1.selector) == length);
         for (uint256 i = 0; i < length; i++) {
-            require(delegateGet(_testTarget, "arrayStructures(uint256)", bytes32(i)) == arrayStructures(i));
+            require(delegateGet(_testTarget, this.arrayStructures.selector, bytes32(i)) == arrayStructures(i));
 
             uint256 structuresLength = getStructureArrayLength1(i);
-            require(delegateGet(_testTarget, "getStructureArrayLength1(uint256)", bytes32(i)) == structuresLength);
+            require(delegateGet(_testTarget, this.getStructureArrayLength1.selector, bytes32(i)) == structuresLength);
             for (uint256 j = 0; j < structuresLength; j++) {
                 require(delegateGet(
-                        _testTarget, "getStructureArrayValue1(uint256,uint256)", bytes32(i), bytes32(j)) ==
+                        _testTarget, this.getStructureArrayValue1.selector, bytes32(i), bytes32(j)) ==
                     getStructureArrayValue1(i, j));
             }
         }
 
         length = getStructureLength2();
-        require(delegateGet(_testTarget, "getStructureLength2()") == length);
+        require(delegateGet(_testTarget, this.getStructureLength2.selector) == length);
         for (uint256 i = 0; i < length; i++) {
-            Structure2 memory structure2 = delegateGetStructure2(_testTarget, "mappingStructures(uint256)", bytes32(i));
+            Structure2 memory structure2 = delegateGetStructure2(_testTarget, this.mappingStructures.selector, bytes32(i));
             (uint256 structureValue, uint256 structureValueToCheck) = mappingStructures(i);
             require(structureValue == structure2.value && structureValueToCheck == structure2.valueToCheck);
 
             uint256 structuresLength = getStructureArrayLength2(i);
-            require(delegateGet(_testTarget, "getStructureArrayLength2(uint256)", bytes32(i)) == structuresLength);
+            require(delegateGet(_testTarget, this.getStructureArrayLength2.selector, bytes32(i)) == structuresLength);
             for (uint256 j = 0; j < structuresLength; j++) {
                 require(delegateGet(
-                        _testTarget, "getStructureArrayValue2(uint256,uint256)", bytes32(i), bytes32(j)) ==
+                        _testTarget, this.getStructureArrayValue2.selector, bytes32(i), bytes32(j)) ==
                     getStructureArrayValue2(i, j));
             }
         }
 
-        require(delegateGet(_testTarget, "storageValueToCheck()") == storageValueToCheck());
-        require(delegateGet(_testTarget, "anotherStorageValue()") == anotherStorageValue);
+        require(delegateGet(_testTarget, this.storageValueToCheck.selector) == storageValueToCheck());
+        require(delegateGet(_testTarget, this.anotherStorageValue.selector) == anotherStorageValue);
     }
 
-    function delegateGetStructure2(address _target, string memory _signature, bytes32 _argument)
+    function delegateGetStructure2(address _target, bytes4 _selector, bytes32 _argument)
         internal returns (Structure2 memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 1, _argument, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 1, _argument, 0);
         assembly {
             mstore(result, mload(memoryAddress))
             mstore(add(result, 64), mload(add(memoryAddress, 32)))
         }
     }
 
-    function delegateGetBytes(address _target, string memory _signature)
+    function delegateGetBytes(address _target, bytes4 _selector)
         internal returns (bytes memory result)
     {
-        bytes32 memoryAddress = delegateGetData(_target, _signature, 0, 0, 0);
+        bytes32 memoryAddress = delegateGetData(_target, _selector, 0, 0, 0);
         assembly {
             // weird problems with copying the memory pointer:
             // result := add(memoryAddress, mload(memoryAddress))
 
-            // quick fix for tests - copy the beginning of the array
-            let start := add(memoryAddress, mload(memoryAddress))
-            mstore(result, mload(start))
-            mstore(add(result, 32), mload(add(start, 32)))
+            // and with quick fix for tests - copy the beginning of the array
+            // let start := add(memoryAddress, mload(memoryAddress))
+            // mstore(result, mload(start))
+            // mstore(add(result, 32), mload(add(start, 32)))
+
+            result := memoryAddress
         }
     }
 

--- a/tests/blockchain/eth/contracts/contracts/proxy/Destroyable.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/Destroyable.sol
@@ -22,8 +22,8 @@ contract Destroyable is Upgradeable {
 
     function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
-        require(delegateGet(_testTarget, "constructorValue()") == constructorValue);
-        require(delegateGet(_testTarget, "functionValue()") == functionValue);
+        require(delegateGet(_testTarget, this.constructorValue.selector) == constructorValue);
+        require(delegateGet(_testTarget, this.functionValue.selector) == functionValue);
     }
 
     function finishUpgrade(address _target) public override {

--- a/tests/blockchain/eth/contracts/contracts/proxy/Destroyable.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/Destroyable.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -20,13 +20,13 @@ contract Destroyable is Upgradeable {
         functionValue = _functionValue;
     }
 
-    function verifyState(address _testTarget) public {
+    function verifyState(address _testTarget) public override {
         super.verifyState(_testTarget);
         require(delegateGet(_testTarget, "constructorValue()") == constructorValue);
         require(delegateGet(_testTarget, "functionValue()") == functionValue);
     }
 
-    function finishUpgrade(address _target) public {
+    function finishUpgrade(address _target) public override {
         super.finishUpgrade(_target);
         constructorValue = Destroyable(_target).constructorValue();
     }

--- a/tests/blockchain/eth/interfaces/contracts/multiversion/v1/VersionTest.sol
+++ b/tests/blockchain/eth/interfaces/contracts/multiversion/v1/VersionTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**

--- a/tests/blockchain/eth/interfaces/contracts/multiversion/v2/VersionTest.sol
+++ b/tests/blockchain/eth/interfaces/contracts/multiversion/v2/VersionTest.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.3;
+pragma solidity ^0.6.1;
 
 
 /**


### PR DESCRIPTION
Fixes #1541
Opens #1809

Upgrading test is failing because can't compile previous version of contracts with new compiler