### PR TITLE
Bump version: 2.0.0-beta.11 → 2.1.0-beta.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.0-beta.11
+current_version = 2.1.0-beta.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.0.0-beta.11'
+release = '2.1.0-beta.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "2.0.0-beta.11"
+__version__ = "2.1.0-beta.0"
 
 __author__ = "NuCypher"
 


### PR DESCRIPTION
<https://app.circleci.com/pipelines/github/nucypher/nucypher/4095/workflows/5b6ba213-4abe-4f39-b486-9df8d52436a6>