### PR TITLE
Remove deployment secrets

### DIFF
--- a/docs/source/guides/deployment_guide.rst
+++ b/docs/source/guides/deployment_guide.rst
@@ -27,8 +27,7 @@ Additional flags can be set up to increase the block gas limit.
     ...
 
 This will deploy the main NuCypher contracts, namely ``NuCypherToken``, ``StakingEscrow``, ``PolicyManager`` and ``Adjudicator``,
-along with their proxies (or ``Dispatchers``), as well as executing initialization transactions. You will need to enter
-the contract's upgrade secrets, which can be any alphanumeric string.
+along with their proxies (or ``Dispatchers``), as well as executing initialization transactions.
 
 A summary of deployed contract addresses, transactions, and gas usage will be displayed on success, and a
 ``contract_registry.json`` file will be generated in your nucypher application directory.
@@ -42,15 +41,6 @@ A summary of deployed contract addresses, transactions, and gas usage will be di
     Selected 0x53Ecb3C7AFc7D5337a89CBd792398cd4DfAc7CE0 - Continue? [y/N]: y
 
     Deployer ETH balance: 115792089237.31
-
-    Enter StakingEscrow Deployment Secret:
-    Repeat for confirmation:
-    Enter PolicyManager Deployment Secret:
-    Repeat for confirmation:
-    Enter StakingInterface Deployment Secret:
-    Repeat for confirmation:
-    Enter Adjudicator Deployment Secret:
-    Repeat for confirmation:
 
 
 

--- a/nucypher/blockchain/eth/decorators.py
+++ b/nucypher/blockchain/eth/decorators.py
@@ -76,39 +76,6 @@ def validate_checksum_address(func: Callable) -> Callable:
     return wrapped
 
 
-def validate_secret(func: Callable) -> Callable:
-    """Decorator to enforce correct upgrade/rollback secret in upgradeable contracts"""
-
-    parameter_name = 'existing_secret_plaintext'
-    log = Logger('Upgrade-Secret-Validator')
-
-    @functools.wraps(func)
-    def wrapped(self, *args, **kwargs):
-
-        # Check for the presence of a plaintext secret in this call
-        params = inspect.getcallargs(func, self, *args, **kwargs)
-        try:
-            secret = params[parameter_name]
-        except KeyError:  # No plaintext secret present in this call
-            found_params = ', '.join("'{}'".format(p) for p in params)
-            message = f"Incorrect use of decorator: '{parameter_name}' not found. " \
-                      f"Found parameters are: {found_params}"
-            log.debug(message)
-            raise TypeError(message)
-
-        # Validate
-        secret_hash = self.contract.functions.secretHash().call()
-        is_valid_secret = secret_hash == keccak_digest(secret)
-
-        if is_valid_secret:  # Yay!  \ (•◡•) /
-            return func(self, *args, **kwargs)
-        else:
-            message = f"The secret provided for upgrade/rollback {self.contract_name} is not valid."
-            raise self.ContractDeploymentError(message)
-
-    return wrapped
-
-
 def only_me(func):
     """Decorator to enforce invocation of permissioned actor methods"""
     def wrapped(actor=None, *args, **kwargs):

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
@@ -28,11 +28,6 @@ abstract contract Upgradeable is Ownable {
     address public previousTarget;
 
     /**
-    * @dev Secret hash to proof that user owns previous version of a contract
-    */
-    bytes32 public secretHash;
-
-    /**
     * @dev Upgrade status. Explicit `uint8` type is used instead of `bool` to save gas by excluding 0 value
     */
     uint8 public isUpgrade;

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
@@ -12,29 +12,22 @@ import "contracts/staking_contracts/StakingInterface.sol";
 */
 contract StakingInterfaceRouter is Ownable {
     BaseStakingInterface public target;
-    bytes32 public secretHash;
 
     /**
     * @param _target Address of the interface contract
-    * @param _newSecretHash Secret hash (keccak256)
     */
-    constructor(BaseStakingInterface _target, bytes32 _newSecretHash) public {
+    constructor(BaseStakingInterface _target) public {
         require(address(_target.token()) != address(0));
         target = _target;
-        secretHash = _newSecretHash;
     }
 
     /**
     * @notice Upgrade interface
     * @param _target New contract address
-    * @param _secret Secret for proof of contract owning
-    * @param _newSecretHash New secret hash (keccak256)
     */
-    function upgrade(BaseStakingInterface _target, bytes calldata _secret, bytes32 _newSecretHash) external onlyOwner {
+    function upgrade(BaseStakingInterface _target) external onlyOwner {
         require(address(_target.token()) != address(0));
-        require(keccak256(_secret) == secretHash && _newSecretHash != secretHash);
         target = _target;
-        secretHash = _newSecretHash;
     }
 
 }

--- a/nucypher/utilities/sandbox/blockchain.py
+++ b/nucypher/utilities/sandbox/blockchain.py
@@ -224,10 +224,8 @@ class TesterBlockchain(BlockchainDeployerInterface):
                                          registry=registry, 
                                          economics=economics or cls._default_token_economics,
                                          staking_escrow_test_mode=True)
-        secrets = dict()
-        for deployer_class in deployer.upgradeable_deployer_classes:
-            secrets[deployer_class.contract_name] = INSECURE_DEVELOPMENT_PASSWORD
-        _receipts = deployer.deploy_network_contracts(secrets=secrets, interactive=False)
+
+        _receipts = deployer.deploy_network_contracts(interactive=False)
         return testerchain, registry
 
     @property

--- a/nucypher/utilities/sandbox/constants.py
+++ b/nucypher/utilities/sandbox/constants.py
@@ -100,19 +100,6 @@ __valid_password_chars = string.ascii_uppercase + string.ascii_lowercase + strin
 
 INSECURE_DEVELOPMENT_PASSWORD = ''.join(SystemRandom().choice(__valid_password_chars) for _ in range(16))
 
-STAKING_ESCROW_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urandom(16))
-
-POLICY_MANAGER_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urandom(16))
-
-STAKING_INTERFACE_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urandom(16))
-
-ADJUDICATOR_DEPLOYMENT_SECRET = INSECURE_DEVELOPMENT_PASSWORD + str(os.urandom(16))
-
-INSECURE_DEPLOYMENT_SECRET_PLAINTEXT = bytes(''.join(SystemRandom().choice(__valid_password_chars) for _ in range(16)), encoding='utf-8')
-
-INSECURE_DEPLOYMENT_SECRET_HASH = keccak_digest(INSECURE_DEPLOYMENT_SECRET_PLAINTEXT)
-
-
 #
 # Temporary Directories and Files
 #

--- a/tests/blockchain/eth/clients/test_geth_integration.py
+++ b/tests/blockchain/eth/clients/test_geth_integration.py
@@ -67,8 +67,4 @@ def test_geth_deployment_integration(instant_geth_dev_node, test_registry):
     assert int(blockchain.client.chain_id) == 1337
 
     # Deploy
-    secrets = dict()
-    for deployer_class in administrator.upgradeable_deployer_classes:
-        secrets[deployer_class.contract_name] = INSECURE_DEVELOPMENT_PASSWORD
-
-    administrator.deploy_network_contracts(secrets=secrets, interactive=False)
+    administrator.deploy_network_contracts(interactive=False)

--- a/tests/blockchain/eth/contracts/contracts/proxy/BadContracts.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/BadContracts.sol
@@ -13,7 +13,6 @@ contract BadDispatcherStorage {
     address public owner;
     address public target;
 //    address public previousTarget;
-    bytes32 public secretHash;
     uint8 public isUpgrade;
 
     function verifyState(address _testTarget) public {}

--- a/tests/blockchain/eth/contracts/contracts/proxy/ContractV4.sol
+++ b/tests/blockchain/eth/contracts/contracts/proxy/ContractV4.sol
@@ -15,22 +15,22 @@ contract ContractV4 is Upgradeable {
 
     // slot allocation costs nothing
     /// uint256 public storageValue;
-    uint256 reservedSlot5;
+    uint256 reservedSlot3;
     /// string public dynamicallySizedValue;
-    uint256 reservedSlot6;
+    uint256 reservedSlot4;
     /// uint256[] public arrayValues;
-    uint256 reservedSlot7;
+    uint256 reservedSlot5;
     /// mapping (uint256 => uint256) public mappingValues;
-    uint256 reservedSlot8;
+    uint256 reservedSlot6;
     /// uint256[] public mappingIndices;
-    uint256 reservedSlot9;
+    uint256 reservedSlot7;
 
     struct Structure1 {
         uint256 value;
         uint256[] arrayValues;
     }
     /// Structure1[] public arrayStructures;
-    uint256 reservedSlot10;
+    uint256 reservedSlot8;
 
     struct Structure2 {
         uint256 value;
@@ -38,12 +38,12 @@ contract ContractV4 is Upgradeable {
         uint256 valueToCheck;
     }
     /// mapping (uint256 => Structure2) public mappingStructures;
-    uint256 reservedSlot11;
+    uint256 reservedSlot9;
     /// uint256 public mappingStructuresLength;
-    uint256 reservedSlot12;
+    uint256 reservedSlot10;
 
     /// uint256 public storageValueToCheck;
-    uint256 reservedSlot13;
+    uint256 reservedSlot11;
     uint256 public anotherStorageValue;
 
     constructor(uint256 _storageValueToCheck) public {
@@ -91,12 +91,12 @@ contract ContractV4 is Upgradeable {
 
 
     function storageValue() public view returns (uint256 value) {
-        // storageValue in the slot number 5
-        return getValue(5);
+        // storageValue in the slot number 3
+        return getValue(3);
     }
 
     function dynamicallySizedValue() public view returns (string memory value) {
-        uint256 slotValue = getValue(6);
+        uint256 slotValue = getValue(4);
         // https://solidity.readthedocs.io/en/latest/miscellaneous.html#bytes-and-string
         uint8 lowestBit = uint8(slotValue & 1);
         if (lowestBit == 0) {
@@ -111,7 +111,7 @@ contract ContractV4 is Upgradeable {
             value = new string(length);
             uint256 wordsCount = (length - 1) / 32 + 1;
             for (uint256 i = 0; i < wordsCount; i++) {
-                uint256 word = getArrayValue(6, i);
+                uint256 word = getArrayValue(4, i);
                 uint256 offset = 32 * (i + 1);
                 assembly {
                     mstore(add(value, offset), word)
@@ -121,92 +121,92 @@ contract ContractV4 is Upgradeable {
     }
 
     function getArrayValueLength() public view returns (uint256) {
-        // length of the array in the slot number 7
-        return getValue(7);
+        // length of the array in the slot number 5
+        return getValue(5);
     }
     function arrayValues(uint256 _index) public view returns (uint256) {
         require(_index < getArrayValueLength());
-        // base slot for this array is 7
-        return getArrayValue(7, _index);
+        // base slot for this array is 5
+        return getArrayValue(5, _index);
     }
 
 
     function mappingValues(uint256 _index) public view returns (uint256) {
-        // base slot for this mapping is 8
-        return getMappingValue(8, _index);
+        // base slot for this mapping is 6
+        return getMappingValue(6, _index);
     }
     function getMappingIndicesLength() public view returns (uint256) {
-        // length of the array in the slot number 9
-        return getValue(9);
+        // length of the array in the slot number
+        return getValue(7);
     }
     function mappingIndices(uint256 _index) public view returns (uint256) {
         require(_index < getMappingIndicesLength());
-        return getArrayValue(9, _index);
+        return getArrayValue(7, _index);
     }
 
 
     function getStructureLength1() public view returns (uint256) {
-        // length of the array in the slot number 10
-        return getValue(10);
+        // length of the array in the slot number 8
+        return getValue(8);
     }
     function arrayStructures(uint256 _index) public view returns (uint256) {
         require(_index < getStructureLength1());
         // base slot for this array is 10
         // one value in this array is `value` and the length of the inner `arrayValues`
         // so each index represents 2 slots
-        return getArrayValue(10, 2 * _index);
+        return getArrayValue(8, 2 * _index);
     }
     function getStructureArrayLength1(uint256 _index) public view returns (uint256) {
         require(_index < getStructureLength1());
         // same as above except accessing second part of the value
-        return getArrayValue(10, 2 * _index + 1);
+        return getArrayValue(8, 2 * _index + 1);
     }
     /// @dev Array data is in the slot keccak256(keccak256(10) + 2 * _index + 1) + _arrayIndex
     function getStructureArrayValue1(uint256 _index, uint256 _arrayIndex) public view returns (uint256) {
         require(_arrayIndex < getStructureArrayLength1(_index));
-        uint256 baseSlot = getArraySlot(10, 2 * _index + 1);
+        uint256 baseSlot = getArraySlot(8, 2 * _index + 1);
         return getArrayValue(baseSlot, _arrayIndex);
     }
     function getStructure1ArrayValues(uint256 _index) public view returns (uint256[] memory result) {
         result = new uint256[](getStructureArrayLength1(_index));
-        uint256 baseSlot = getArraySlot(10, 2 * _index + 1);
+        uint256 baseSlot = getArraySlot(8, 2 * _index + 1);
         for (uint256 i = 0; i < result.length; i++) {
             result[i] = getArrayValue(baseSlot, i);
         }
     }
 
     function getStructureLength2() public view returns (uint256) {
-        return getValue(12);
+        return getValue(10);
     }
     function mappingStructures(uint256 _index) public view returns (uint256 value, uint256 valueToCheck) {
-        uint256 baseMappingSlot = getMappingSlot(11, _index);
+        uint256 baseMappingSlot = getMappingSlot(9, _index);
         // one mapping value is `value`,  the length of the inner `arrayValues` and `valueToCheck`
         value = getValue(baseMappingSlot);
         valueToCheck = getValue(baseMappingSlot + 2);
     }
     function getStructureArrayLength2(uint256 _index) public view returns (uint256) {
-        return getValue(getMappingSlot(11, _index) + 1);
+        return getValue(getMappingSlot(9, _index) + 1);
     }
     /// @dev Array data is in the slot keccak256(keccak256(concat(_index, 11)) + 1) + _arrayIndex
     function getStructureArrayValue2(uint256 _index, uint256 _arrayIndex) public view returns (uint256) {
         require(_arrayIndex < getStructureArrayLength2(_index));
-        uint256 baseArraySlot = getMappingSlot(11, _index) + 1;
+        uint256 baseArraySlot = getMappingSlot(9, _index) + 1;
         return getArrayValue(baseArraySlot, _arrayIndex);
     }
     function getStructure2ArrayValues(uint256 _index) public view returns (uint256[] memory result) {
         result = new uint256[](getStructureArrayLength2(_index));
-        uint256 baseArraySlot = getMappingSlot(11, _index) + 1;
+        uint256 baseArraySlot = getMappingSlot(9, _index) + 1;
         for (uint256 i = 0; i < result.length; i++) {
             result[i] = getArrayValue(baseArraySlot, i);
         }
     }
 
     function storageValueToCheck() public view returns (uint256) {
-        return getValue(13);
+        return getValue(11);
     }
     function setStorageValueToCheck(uint256 _value) public {
         assembly {
-            sstore(13, _value)
+            sstore(11, _value)
         }
     }
 

--- a/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
+++ b/tests/blockchain/eth/contracts/main/adjudicator/conftest.py
@@ -20,8 +20,6 @@ import os
 import pytest
 from web3.contract import Contract
 
-from nucypher.blockchain.eth.deployers import DispatcherDeployer
-from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
 
 
@@ -40,9 +38,7 @@ def adjudicator(testerchain, escrow, request, token_economics, deploy_contract):
         *token_economics.slashing_deployment_parameters)
 
     if request.param:
-        secret = os.urandom(DispatcherDeployer._secret_length)
-        secret_hash = testerchain.w3.keccak(secret)
-        dispatcher, _ = deploy_contract('Dispatcher', contract.address, secret_hash)
+        dispatcher, _ = deploy_contract('Dispatcher', contract.address)
 
         # Deploy second version of the government contract
         contract = testerchain.client.get_contract(

--- a/tests/blockchain/eth/contracts/main/policy_manager/conftest.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/conftest.py
@@ -18,10 +18,6 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import pytest
 from web3.contract import Contract
-from eth_utils import keccak
-
-
-secret = (123456).to_bytes(32, byteorder='big')
 
 
 @pytest.fixture()
@@ -44,8 +40,7 @@ def policy_manager(testerchain, escrow, request, deploy_contract):
     testerchain.wait_for_receipt(tx)
 
     if request.param:
-        secret_hash = keccak(secret)
-        dispatcher, _ = deploy_contract('Dispatcher', contract.address, secret_hash)
+        dispatcher, _ = deploy_contract('Dispatcher', contract.address)
 
         # Deploy second version of the government contract
         contract = testerchain.client.get_contract(

--- a/tests/blockchain/eth/contracts/main/staking_contracts/conftest.py
+++ b/tests/blockchain/eth/contracts/main/staking_contracts/conftest.py
@@ -18,8 +18,6 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
 import pytest
-from eth_utils import keccak
-from web3.contract import Contract
 
 from nucypher.blockchain.eth.token import NU
 
@@ -65,7 +63,5 @@ def staking_interface(testerchain, token, escrow, policy_manager, worklock, depl
 
 @pytest.fixture()
 def router(testerchain, staking_interface, deploy_contract):
-    secret = os.urandom(32)
-    secret_hash = keccak(secret)
-    contract, _ = deploy_contract('StakingInterfaceRouter', staking_interface.address, secret_hash)
+    contract, _ = deploy_contract('StakingInterfaceRouter', staking_interface.address)
     return contract

--- a/tests/blockchain/eth/contracts/main/staking_contracts/test_staking_interface.py
+++ b/tests/blockchain/eth/contracts/main/staking_contracts/test_staking_interface.py
@@ -15,10 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
-import os
 import pytest
-from eth_utils import keccak
 from eth_tester.exceptions import TransactionFailed
 from web3.contract import Contract
 
@@ -423,9 +420,7 @@ def test_interface_without_worklock(testerchain, deploy_contract, token, escrow,
 
     staking_interface, _ = deploy_contract(
         'StakingInterface', token.address, escrow.address, policy_manager.address, worklock.address)
-    secret = os.urandom(32)
-    secret_hash = keccak(secret)
-    router, _ = deploy_contract('StakingInterfaceRouter', staking_interface.address, secret_hash)
+    router, _ = deploy_contract('StakingInterfaceRouter', staking_interface.address)
 
     staking_contract, _ = deploy_contract('SimpleStakingContract', router.address)
     # Transfer ownership
@@ -450,11 +445,9 @@ def test_interface_without_worklock(testerchain, deploy_contract, token, escrow,
     testerchain.wait_for_receipt(tx)
 
     # Test interface without worklock
-    secret2 = os.urandom(32)
-    secret2_hash = keccak(secret2)
     staking_interface, _ = deploy_contract(
         'StakingInterface', token.address, escrow.address, policy_manager.address, BlockchainInterface.NULL_ADDRESS)
-    tx = router.functions.upgrade(staking_interface.address, secret, secret2_hash).transact({'from': creator})
+    tx = router.functions.upgrade(staking_interface.address).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Current version of interface doesn't have worklock contract

--- a/tests/blockchain/eth/contracts/main/staking_escrow/conftest.py
+++ b/tests/blockchain/eth/contracts/main/staking_escrow/conftest.py
@@ -15,16 +15,12 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
 import pytest
-from eth_utils import keccak
 from web3.contract import Contract
 
 from nucypher.blockchain.economics import BaseEconomics
 
 VALUE_FIELD = 0
-
-secret = (123456).to_bytes(32, byteorder='big')
 
 
 @pytest.fixture()
@@ -58,8 +54,7 @@ def escrow_contract(testerchain, token, token_economics, request, deploy_contrac
         contract, _ = deploy_contract('StakingEscrow', token.address, *deploy_parameters)
 
         if request.param:
-            secret_hash = keccak(secret)
-            dispatcher, _ = deploy_contract('Dispatcher', contract.address, secret_hash)
+            dispatcher, _ = deploy_contract('Dispatcher', contract.address)
             contract = testerchain.client.get_contract(
                 abi=contract.abi,
                 address=dispatcher.address,

--- a/tests/blockchain/eth/entities/actors/test_deployer.py
+++ b/tests/blockchain/eth/entities/actors/test_deployer.py
@@ -57,11 +57,7 @@ def test_rapid_deployment(token_economics, test_registry, tmpdir):
     administrator = ContractAdministrator(deployer_address=deployer_address,
                                           registry=test_registry)
 
-    secrets = dict()
-    for deployer_class in administrator.upgradeable_deployer_classes:
-        secrets[deployer_class.contract_name] = INSECURE_DEVELOPMENT_PASSWORD
-
-    administrator.deploy_network_contracts(secrets=secrets, emitter=StdoutEmitter())
+    administrator.deploy_network_contracts(emitter=StdoutEmitter())
 
     all_yall = blockchain.unassigned_accounts
 

--- a/tests/blockchain/eth/entities/deployers/conftest.py
+++ b/tests/blockchain/eth/entities/deployers/conftest.py
@@ -16,12 +16,12 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 import pytest
-from eth_utils import keccak
 
 from nucypher.blockchain.eth.deployers import (NucypherTokenDeployer,
-                                               StakingEscrowDeployer, PolicyManagerDeployer, AdjudicatorDeployer,
+                                               StakingEscrowDeployer,
+                                               PolicyManagerDeployer,
+                                               AdjudicatorDeployer,
                                                StakingInterfaceDeployer)
-from nucypher.utilities.sandbox.constants import STAKING_ESCROW_DEPLOYMENT_SECRET, INSECURE_DEPLOYMENT_SECRET_HASH
 
 
 @pytest.fixture(scope="module")
@@ -41,7 +41,7 @@ def staking_escrow_deployer(testerchain, token_deployer, test_registry):
 
 @pytest.fixture(scope="module")
 def policy_manager_deployer(staking_escrow_deployer, testerchain, test_registry):
-    staking_escrow_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    staking_escrow_deployer.deploy()
     policy_manager_deployer = PolicyManagerDeployer(registry=test_registry,
                                                     deployer_address=testerchain.etherbase_account)
     return policy_manager_deployer
@@ -56,7 +56,7 @@ def staking_interface_deployer(staking_escrow_deployer, testerchain, test_regist
 
 @pytest.fixture(scope="module")
 def adjudicator_deployer(policy_manager_deployer, testerchain, test_registry):
-    policy_manager_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    policy_manager_deployer.deploy()
     adjudicator_deployer = AdjudicatorDeployer(registry=test_registry,
                                                deployer_address=testerchain.etherbase_account)
     return adjudicator_deployer

--- a/tests/blockchain/eth/entities/deployers/test_adjudicator_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_adjudicator_deployer.py
@@ -15,16 +15,13 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import os
 import pytest
-from eth_utils import keccak
 
 from nucypher.blockchain.eth.agents import AdjudicatorAgent
 from nucypher.blockchain.eth.deployers import (
     AdjudicatorDeployer,
     NucypherTokenDeployer,
     StakingEscrowDeployer,
-    DispatcherDeployer
 )
 
 
@@ -39,15 +36,13 @@ def test_adjudicator_deployer(testerchain,
     token_deployer = NucypherTokenDeployer(deployer_address=origin, registry=test_registry)
     token_deployer.deploy()
 
-    stakers_escrow_secret = os.urandom(DispatcherDeployer._secret_length)
     staking_escrow_deployer = StakingEscrowDeployer(deployer_address=origin, registry=test_registry)
 
-    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret))
+    staking_escrow_deployer.deploy()
     staking_agent = staking_escrow_deployer.make_agent()  # 2 Staker Escrow
 
     deployer = AdjudicatorDeployer(deployer_address=origin, registry=test_registry)
-    deployment_receipts = deployer.deploy(secret_hash=os.urandom(DispatcherDeployer._secret_length),
-                                          progress=deployment_progress)
+    deployment_receipts = deployer.deploy(progress=deployment_progress)
 
     # deployment steps must match expected number of steps
     assert deployment_progress.num_steps == len(deployer.deployment_steps) == len(deployment_receipts) == 3

--- a/tests/blockchain/eth/entities/deployers/test_deploy_idle_network.py
+++ b/tests/blockchain/eth/entities/deployers/test_deploy_idle_network.py
@@ -18,7 +18,6 @@ import os
 
 import pytest
 from eth_tester.exceptions import TransactionFailed
-from eth_utils import keccak
 from constant_sorrow import constants
 
 from nucypher.blockchain.eth.actors import Staker
@@ -27,8 +26,7 @@ from nucypher.blockchain.eth.deployers import (NucypherTokenDeployer,
                                                StakingEscrowDeployer,
                                                PolicyManagerDeployer,
                                                AdjudicatorDeployer,
-                                               BaseContractDeployer,
-                                               DispatcherDeployer)
+                                               BaseContractDeployer)
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.blockchain import token_airdrop
 from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUNT, INSECURE_DEVELOPMENT_PASSWORD
@@ -60,7 +58,6 @@ def test_deploy_idle_network(testerchain, deployment_progress, test_registry):
     #
     # StakingEscrow - in IDLE mode, i.e. without activation steps (approve_funding and initialize)
     #
-    stakers_escrow_secret = os.urandom(DispatcherDeployer._secret_length)
     staking_escrow_deployer = StakingEscrowDeployer(registry=test_registry, deployer_address=origin)
     assert staking_escrow_deployer.deployer_address == origin
 
@@ -68,8 +65,7 @@ def test_deploy_idle_network(testerchain, deployment_progress, test_registry):
         assert staking_escrow_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not staking_escrow_deployer.is_deployed()
 
-    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret),
-                                   progress=deployment_progress,
+    staking_escrow_deployer.deploy(progress=deployment_progress,
                                    deployment_mode=constants.IDLE)
     assert staking_escrow_deployer.is_deployed()
 
@@ -82,7 +78,6 @@ def test_deploy_idle_network(testerchain, deployment_progress, test_registry):
     #
     # Policy Manager
     #
-    policy_manager_secret = os.urandom(DispatcherDeployer._secret_length)
     policy_manager_deployer = PolicyManagerDeployer(registry=test_registry, deployer_address=origin)
 
     assert policy_manager_deployer.deployer_address == origin
@@ -91,7 +86,7 @@ def test_deploy_idle_network(testerchain, deployment_progress, test_registry):
         assert policy_manager_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not policy_manager_deployer.is_deployed()
 
-    policy_manager_deployer.deploy(secret_hash=keccak(policy_manager_secret), progress=deployment_progress)
+    policy_manager_deployer.deploy(progress=deployment_progress)
     assert policy_manager_deployer.is_deployed()
 
     policy_agent = policy_manager_deployer.make_agent()
@@ -100,7 +95,6 @@ def test_deploy_idle_network(testerchain, deployment_progress, test_registry):
     #
     # Adjudicator
     #
-    adjudicator_secret = os.urandom(DispatcherDeployer._secret_length)
     adjudicator_deployer = AdjudicatorDeployer(registry=test_registry, deployer_address=origin)
 
     assert adjudicator_deployer.deployer_address == origin
@@ -109,7 +103,7 @@ def test_deploy_idle_network(testerchain, deployment_progress, test_registry):
         assert adjudicator_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not adjudicator_deployer.is_deployed()
 
-    adjudicator_deployer.deploy(secret_hash=keccak(adjudicator_secret), progress=deployment_progress)
+    adjudicator_deployer.deploy(progress=deployment_progress)
     assert adjudicator_deployer.is_deployed()
 
     adjudicator_agent = adjudicator_deployer.make_agent()

--- a/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
+++ b/tests/blockchain/eth/entities/deployers/test_interdeployer_integration.py
@@ -61,7 +61,6 @@ def test_deploy_ethereum_contracts(testerchain,
     #
     # StakingEscrow
     #
-    stakers_escrow_secret = os.urandom(DispatcherDeployer._secret_length)
     staking_escrow_deployer = StakingEscrowDeployer(
         registry=test_registry,
         deployer_address=origin)
@@ -71,7 +70,7 @@ def test_deploy_ethereum_contracts(testerchain,
         assert staking_escrow_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not staking_escrow_deployer.is_deployed()
 
-    staking_escrow_deployer.deploy(secret_hash=keccak(stakers_escrow_secret), progress=deployment_progress)
+    staking_escrow_deployer.deploy(progress=deployment_progress)
     assert staking_escrow_deployer.is_deployed()
     assert len(staking_escrow_deployer.contract_address) == 42
 
@@ -87,7 +86,6 @@ def test_deploy_ethereum_contracts(testerchain,
     #
     # Policy Manager
     #
-    policy_manager_secret = os.urandom(DispatcherDeployer._secret_length)
     policy_manager_deployer = PolicyManagerDeployer(
         registry=test_registry,
         deployer_address=origin)
@@ -98,7 +96,7 @@ def test_deploy_ethereum_contracts(testerchain,
         assert policy_manager_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not policy_manager_deployer.is_deployed()
 
-    policy_manager_deployer.deploy(secret_hash=keccak(policy_manager_secret), progress=deployment_progress)
+    policy_manager_deployer.deploy(progress=deployment_progress)
     assert policy_manager_deployer.is_deployed()
     assert len(policy_manager_deployer.contract_address) == 42
 
@@ -114,7 +112,6 @@ def test_deploy_ethereum_contracts(testerchain,
     #
     # Adjudicator
     #
-    adjudicator_secret = os.urandom(DispatcherDeployer._secret_length)
     adjudicator_deployer = AdjudicatorDeployer(
         registry=test_registry,
         deployer_address=origin)
@@ -125,7 +122,7 @@ def test_deploy_ethereum_contracts(testerchain,
         assert adjudicator_deployer.contract_address is constants.CONTRACT_NOT_DEPLOYED
     assert not adjudicator_deployer.is_deployed()
 
-    adjudicator_deployer.deploy(secret_hash=keccak(adjudicator_secret), progress=deployment_progress)
+    adjudicator_deployer.deploy(progress=deployment_progress)
     assert adjudicator_deployer.is_deployed()
     assert len(adjudicator_deployer.contract_address) == 42
 

--- a/tests/blockchain/eth/entities/deployers/test_preallocation_escrow_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_preallocation_escrow_deployer.py
@@ -28,11 +28,6 @@ from nucypher.blockchain.eth.deployers import (
     AdjudicatorDeployer
 )
 from nucypher.crypto.api import keccak_digest
-from nucypher.utilities.sandbox.constants import (
-    STAKING_INTERFACE_DEPLOYMENT_SECRET,
-    INSECURE_DEPLOYMENT_SECRET_PLAINTEXT,
-    INSECURE_DEPLOYMENT_SECRET_HASH
-)
 
 preallocation_escrow_contracts = list()
 NUMBER_OF_PREALLOCATIONS = 50
@@ -51,21 +46,20 @@ def test_staking_interface_deployer(testerchain, deployment_progress, test_regis
     token_deployer.deploy()
 
     staking_escrow_deployer = StakingEscrowDeployer(deployer_address=origin, registry=test_registry)
-    staking_escrow_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    staking_escrow_deployer.deploy()
 
     policy_manager_deployer = PolicyManagerDeployer(deployer_address=origin, registry=test_registry)
-    policy_manager_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    policy_manager_deployer.deploy()
 
     adjudicator_deployer = AdjudicatorDeployer(deployer_address=origin, registry=test_registry)
-    adjudicator_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    adjudicator_deployer.deploy()
 
     #
     # Test
     #
 
     staking_interface_deployer = StakingInterfaceDeployer(deployer_address=origin, registry=test_registry)
-    staking_interface_receipts = staking_interface_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH,
-                                                                   progress=deployment_progress)
+    staking_interface_receipts = staking_interface_deployer.deploy(progress=deployment_progress)
 
     # deployment steps must match expected number of steps
     assert deployment_progress.num_steps == len(staking_interface_deployer.deployment_steps) == 2
@@ -105,10 +99,8 @@ def test_deploy_multiple_preallocations(testerchain, test_registry):
 @pytest.mark.slow()
 def test_upgrade_staking_interface(testerchain, test_registry):
 
-    old_secret = INSECURE_DEPLOYMENT_SECRET_PLAINTEXT
-    new_secret = 'new' + STAKING_INTERFACE_DEPLOYMENT_SECRET
-    new_secret_hash = keccak_digest(new_secret.encode())
-    router = testerchain.get_contract_by_name(registry=test_registry, contract_name=StakingInterfaceRouterDeployer.contract_name)
+    router = testerchain.get_contract_by_name(registry=test_registry,
+                                              contract_name=StakingInterfaceRouterDeployer.contract_name)
 
     contract = testerchain.get_contract_by_name(registry=test_registry,
                                                 contract_name=StakingInterfaceDeployer.contract_name,
@@ -121,9 +113,7 @@ def test_upgrade_staking_interface(testerchain, test_registry):
     staking_interface_deployer = StakingInterfaceDeployer(deployer_address=testerchain.etherbase_account,
                                                           registry=test_registry)
 
-    receipts = staking_interface_deployer.upgrade(existing_secret_plaintext=old_secret,
-                                                  new_secret_hash=new_secret_hash,
-                                                  ignore_deployed=True)
+    receipts = staking_interface_deployer.upgrade(ignore_deployed=True)
 
     assert len(receipts) == 2
 

--- a/tests/blockchain/eth/entities/deployers/test_worklock_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_worklock_deployer.py
@@ -17,22 +17,16 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 
 import pytest
-from eth_utils import keccak
 
-from nucypher.blockchain.economics import StandardTokenEconomics, EconomicsFactory
-from nucypher.blockchain.eth.actors import Staker, Bidder
-from nucypher.blockchain.eth.agents import WorkLockAgent, ContractAgency, NucypherTokenAgent
+from nucypher.blockchain.economics import EconomicsFactory
+from nucypher.blockchain.eth.agents import WorkLockAgent
 from nucypher.blockchain.eth.constants import WORKLOCK_CONTRACT_NAME
-from nucypher.blockchain.eth.deployers import WorklockDeployer, StakingInterfaceDeployer, AdjudicatorDeployer
-from nucypher.blockchain.eth.registry import BaseContractRegistry
-from nucypher.crypto.powers import TransactingPower
-from nucypher.utilities.sandbox.constants import STAKING_ESCROW_DEPLOYMENT_SECRET, INSECURE_DEPLOYMENT_SECRET_HASH, \
-    POLICY_MANAGER_DEPLOYMENT_SECRET, INSECURE_DEVELOPMENT_PASSWORD
+from nucypher.blockchain.eth.deployers import WorklockDeployer
 
 
 @pytest.fixture(scope='module')
 def baseline_deployment(adjudicator_deployer):
-    adjudicator_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    adjudicator_deployer.deploy()
 
 
 @pytest.fixture(scope="module")

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -48,15 +48,6 @@ def click_runner():
 
 
 @pytest.fixture(scope='session')
-def deploy_user_input():
-    account_index = '0\n'
-    yes = 'Y\n'
-    deployment_secret = f'{INSECURE_DEVELOPMENT_PASSWORD}\n'
-    user_input = account_index + yes + (deployment_secret * 8) + 'DEPLOY'
-    return user_input
-
-
-@pytest.fixture(scope='session')
 def nominal_federated_configuration_fields():
     config = UrsulaConfiguration(dev_mode=True, federated_only=True)
     config_fields = config.static_payload()

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -19,7 +19,6 @@ from nucypher.cli.commands.deploy import deploy
 from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,
     INSECURE_DEVELOPMENT_PASSWORD,
-    INSECURE_DEPLOYMENT_SECRET_PLAINTEXT
 )
 
 ALTERNATE_REGISTRY_FILEPATH = '/tmp/nucypher-test-registry-alternate.json'
@@ -199,9 +198,8 @@ def test_manual_proxy_retargeting(testerchain, click_runner, token_economics):
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH,
                '--poa')
 
-    # Reveal the secret and upgrade
-    old_secret = INSECURE_DEPLOYMENT_SECRET_PLAINTEXT.decode()
-    user_input = '0\n' + 'Y\n' + f'{old_secret}\n' + (f'{INSECURE_DEVELOPMENT_PASSWORD}\n' * 2) + 'Y\n'
+    # Upgrade
+    user_input = '0\n' + 'Y\n' + 'Y\n'
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -243,8 +241,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
                '--poa')
 
-    secret = INSECURE_DEPLOYMENT_SECRET_PLAINTEXT.decode()
-    user_input = '0\n' + 'Y\n' + (f'{secret}\n' * 2)
+    user_input = '0\n' + 'Y\n'
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -258,7 +255,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
                '--poa')
 
-    user_input = '0\n' + 'Y\n' + (f'{secret}\n' * 2)
+    user_input = '0\n' + 'Y\n'
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -272,7 +269,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2,
                '--poa')
 
-    user_input = '0\n' + 'Y\n' + (f'{secret}\n' * 2)
+    user_input = '0\n' + 'Y\n'
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 

--- a/tests/cli/test_felix.py
+++ b/tests/cli/test_felix.py
@@ -32,7 +32,7 @@ def test_missing_configuration_file(default_filepath_mock, click_runner):
 
 
 @pytest_twisted.inlineCallbacks
-def test_run_felix(click_runner, testerchain, agency_local_registry, deploy_user_input):
+def test_run_felix(click_runner, testerchain, agency_local_registry):
 
     clock = Clock()
     Felix._CLOCK = clock

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -73,9 +73,6 @@ from nucypher.policy.collections import IndisputableEvidence, WorkOrder
 from nucypher.utilities.logging import GlobalLoggerSettings
 from nucypher.utilities.sandbox.blockchain import token_airdrop, TesterBlockchain
 from nucypher.utilities.sandbox.constants import (
-    BASE_TEMP_PREFIX,
-    BASE_TEMP_DIR,
-    DATETIME_FORMAT,
     DEVELOPMENT_ETH_AIRDROP_AMOUNT,
     DEVELOPMENT_TOKEN_AIRDROP_AMOUNT,
     MIN_STAKE_FOR_TESTS,
@@ -88,7 +85,6 @@ from nucypher.utilities.sandbox.constants import (
     TEST_PROVIDER_URI,
     INSECURE_DEVELOPMENT_PASSWORD,
     TEST_GAS_LIMIT,
-    INSECURE_DEPLOYMENT_SECRET_HASH,
 )
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
 from nucypher.utilities.sandbox.middleware import MockRestMiddlewareForLargeFleetTests
@@ -526,22 +522,22 @@ def _make_agency(testerchain, test_registry, token_economics):
                                                     economics=token_economics,
                                                     registry=test_registry,
                                                     test_mode=True)
-    staking_escrow_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    staking_escrow_deployer.deploy()
 
     policy_manager_deployer = PolicyManagerDeployer(deployer_address=origin,
                                                     economics=token_economics,
                                                     registry=test_registry)
-    policy_manager_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    policy_manager_deployer.deploy()
 
     adjudicator_deployer = AdjudicatorDeployer(deployer_address=origin,
                                                economics=token_economics,
                                                registry=test_registry)
-    adjudicator_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    adjudicator_deployer.deploy()
 
     staking_interface_deployer = StakingInterfaceDeployer(deployer_address=origin,
                                                           economics=token_economics,
                                                           registry=test_registry)
-    staking_interface_deployer.deploy(secret_hash=INSECURE_DEPLOYMENT_SECRET_HASH)
+    staking_interface_deployer.deploy()
 
     worklock_deployer = WorklockDeployer(deployer_address=origin,
                                          economics=token_economics,


### PR DESCRIPTION
Completely removes from contracts and clients any reference to deployment secrets. This never happened.

- Closes #1751
- Closes #1495 

Note: this makes Dispatchers incompatible with all previous testnets