### PR TITLE
fix doctor.retrieve param in heartbeat_demo example

### DIFF
--- a/examples/heartbeat_demo/doctor.py
+++ b/examples/heartbeat_demo/doctor.py
@@ -97,8 +97,8 @@ for message_kit in message_kits:
     try:
         start = timer()
         retrieved_plaintexts = doctor.retrieve(
+            message_kit,
             label=label,
-            message_kit=message_kit,
             enrico=data_source,
             alice_verifying_key=alices_sig_pubkey
         )


### PR DESCRIPTION
When running *doctor.py* from the _heartbeat_demo_ example, I've got an error

```
Traceback (most recent call last):
  File "doctor.py", line 103, in <module>
    alice_verifying_key=alices_sig_pubkey
TypeError: retrieve() got an unexpected keyword argument 'message_kit'
```

Since I'm using **2.1.0b2**, I've decided to had a look at the function definition [here](https://github.com/nucypher/nucypher/blob/2da817ae1a958a6c53e8738b31c48bfbaad0c94f/nucypher/characters/lawful.py#L680). From that, I did a little change and it worked.