### PR TITLE
Versioning and "Futureproofing" of bytes serialized Nucypher products

### DIFF
--- a/nucypher/characters/control/specifications/fields/treasuremap.py
+++ b/nucypher/characters/control/specifications/fields/treasuremap.py
@@ -1,11 +1,7 @@
 from marshmallow import fields
 from base64 import b64decode, b64encode
-from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from nucypher.characters.control.specifications.fields.base import BaseField
 from nucypher.characters.control.specifications.exceptions import InvalidInputData, InvalidNativeDataTypes
-from nucypher.crypto.signing import Signature
-from nucypher.crypto.constants import KECCAK_DIGEST_LENGTH
-from nucypher.crypto.kits import UmbralMessageKit
 
 
 class TreasureMap(BaseField, fields.Field):
@@ -20,13 +16,9 @@ class TreasureMap(BaseField, fields.Field):
             raise InvalidInputData(f"Could not parse {self.name}: {e}")
 
     def _validate(self, value):
-
-        splitter = BytestringSplitter(Signature,
-                                  (bytes, KECCAK_DIGEST_LENGTH),  # hrac
-                                  (UmbralMessageKit, VariableLengthBytestring)
-                                  )  # TODO: USe the one from TMap
+        from nucypher.policy.collections import TreasureMap
         try:
-            signature, hrac, tmap_message_kit = splitter(value)
+            TreasureMap.from_bytes(value)
             return True
         except InvalidNativeDataTypes as e:
             raise InvalidInputData(f"Could not parse {self.name}: {e}")

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -67,7 +67,7 @@ class MessageKit(CryptoKit):
             as_bytes += bytes(self.sender_verifying_key)
 
         as_bytes += VariableLengthBytestring(self.ciphertext)
-        return super().add_version(as_bytes)
+        return super().prepend_version(as_bytes)
 
     @classmethod
     def splitter(cls, *args, **kwargs):
@@ -81,7 +81,7 @@ class MessageKit(CryptoKit):
         return self._signature
 
     def __bytes__(self):
-        return super().add_version(bytes(self.capsule) + VariableLengthBytestring(self.ciphertext))
+        return super().prepend_version(bytes(self.capsule) + VariableLengthBytestring(self.ciphertext))
 
 
 class MessageKitV1(MessageKit):

--- a/nucypher/crypto/kits.py
+++ b/nucypher/crypto/kits.py
@@ -17,10 +17,10 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 from constant_sorrow.constants import UNKNOWN_SENDER, NOT_SIGNED
 from bytestring_splitter import BytestringKwargifier, VariableLengthBytestring
 from nucypher.crypto.splitters import key_splitter, capsule_splitter
-from nucypher.primitives import VersionedBytes
+from nucypher.utilities.versioning import ByteVersioningMixin
 
 
-class CryptoKit(VersionedBytes):
+class CryptoKit(ByteVersioningMixin):
     """
     A package of discrete items, meant to be sent over the wire or saved to disk (in either case, as bytes),
     capable of performing a distinct cryptological function.

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -299,7 +299,7 @@ class PolicyCredential:
                 (self.policy_pubkey == other.policy_pubkey))
 
 
-class WorkOrder(VersionedBytes):
+class WorkOrder:
 
     class PRETask:
         def __init__(self, capsule, signature, cfrag=None, cfrag_signature=None):
@@ -320,11 +320,10 @@ class WorkOrder(VersionedBytes):
             data = bytes(self.capsule) + bytes(self.signature)
             if self.cfrag and self.cfrag_signature:
                 data += bytes(self.cfrag) + bytes(self.cfrag_signature)
-            return super().add_version(data)
+            return data
 
         @classmethod
         def from_bytes(cls, data: bytes):
-            cls, data = super().parse_version(data)
             item_splitter = capsule_splitter + signature_splitter
             capsule, signature, remainder = item_splitter(data, return_remainder=True)
             if remainder:
@@ -476,10 +475,6 @@ class WorkOrder(VersionedBytes):
     def sanitize(self):
         for task in self.tasks.values():
             task.cfrag = CFRAG_NOT_RETAINED
-
-
-class WorkOrderV1(WorkOrder):
-    version = 1
 
 
 class WorkOrderHistory:

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -45,10 +45,10 @@ from nucypher.crypto.utils import (canonical_address_from_umbral_key,
                                    get_coordinates_as_bytes,
                                    get_signature_recovery_value)
 from nucypher.network.middleware import RestMiddleware
-from nucypher.primitives import VersionedBytes
+from nucypher.utilities.versioning import ByteVersioningMixin
 
 
-class TreasureMap(VersionedBytes):
+class TreasureMap(ByteVersioningMixin):
     from nucypher.policy.policies import Arrangement
     ID_LENGTH = Arrangement.ID_LENGTH  # TODO: Unify with Policy / Arrangement - or is this ok?
 

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -131,7 +131,7 @@ class TreasureMap(ByteVersioningMixin):
         if self._payload is None:
             self._set_payload()
 
-        return super().add_version(self._payload)
+        return super().prepend_version(self._payload)
 
     @property
     def _verifying_key(self):

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -85,7 +85,7 @@ class Arrangement(ByteVersioningMixin):
 
     def __bytes__(self):
 
-        return super().add_version(
+        return super().prepend_version(
             bytes(self.alice.stamp) + self.id + bytes(VariableLengthBytestring(self.expiration.iso8601().encode())))
 
     @classmethod

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -37,11 +37,11 @@ from nucypher.crypto.powers import DecryptingPower, SigningPower
 from nucypher.crypto.utils import construct_policy_id
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
-from nucypher.primitives import VersionedBytes
+from nucypher.utilities.versioning import ByteVersioningMixin
 
 
 
-class Arrangement(VersionedBytes):
+class Arrangement(ByteVersioningMixin):
     """
     A Policy must be implemented by arrangements with n Ursulas.  This class tracks the status of that implementation.
     """

--- a/nucypher/primitives.py
+++ b/nucypher/primitives.py
@@ -21,13 +21,17 @@ class VersionedBytes:
 
     @classmethod
     def __get_class(cls, klass, version):
-        v = int.from_bytes(version, 'little')
+        v = int.from_bytes(version, 'big')
 
         if getattr(klass, 'version', None) == v:
             return klass
 
         versioned_subclasses = VersionedBytes.__get_versioned_subclasses(klass)
-        outclass = next(iter([c for c in versioned_subclasses if c.version == v]))
+        try:
+            outclass = next(iter([c for c in versioned_subclasses if c.version == v]))
+        except StopIteration:
+            # if we can't find the right version, just return the base class.
+            return klass
         return outclass
 
     @classmethod
@@ -36,4 +40,4 @@ class VersionedBytes:
         return VersionedBytes.__get_class(cls, version_bytes), some_bytes[2:]
 
     def add_version(self, some_bytes):
-        return (self.version).to_bytes(2, 'little') + some_bytes
+        return (self.version).to_bytes(2, 'big') + some_bytes

--- a/nucypher/primitives.py
+++ b/nucypher/primitives.py
@@ -1,5 +1,8 @@
 class VersionedBytes:
 
+    class NucypherNeedsUpdateException(BaseException):
+        """This node cannot instantiate a class from data created by a newer version of NuCypher."""
+
     def __new__(cls, *args, **kwargs):
         """
         When instantiating a specific version of a versioned Bytestring,
@@ -30,8 +33,20 @@ class VersionedBytes:
         try:
             outclass = next(iter([c for c in versioned_subclasses if c.version == v]))
         except StopIteration:
-            # if we can't find the right version, just return the base class.
+
+            if len(versioned_subclasses) and v > 1:
+                # We have received data that was clearly created by a newer version of Nucypher,
+                # TODO:  I don't know exactly what to do here.
+                # would a bob be receiving this?  Or an Alice?
+                # Who needs to know about this?
+                # can we notify the staker of a node that their Worker needs an update?
+
+                raise VersionedBytes.NucypherNeedsUpdateException("This node is running outdated NuCypher code")
+
+            # if we don't have versioned subclasses or the version == 1, it's just really soon.
+            # lets not get ahead of ourselves, we can probably move on with life.
             return klass
+
         return outclass
 
     @classmethod

--- a/nucypher/primitives.py
+++ b/nucypher/primitives.py
@@ -1,0 +1,39 @@
+class VersionedBytes:
+
+    def __new__(cls, *args, **kwargs):
+        """
+        When instantiating a specific version of a versioned Bytestring,
+        we want to automatically instantiate the latest version without
+        requiring implementers to have to deal with any of this.
+
+        If we are instantiating a specificly versioned class, allow for that also
+        """
+
+        if not hasattr(cls, 'version'):
+            versioned_subclasses = VersionedBytes.__get_versioned_subclasses(cls)
+            # take the highest
+            cls = sorted(versioned_subclasses, key=lambda x: x.version)[-1]
+        return super(VersionedBytes, cls).__new__(cls)
+
+    @classmethod
+    def __get_versioned_subclasses(cls, klass):
+        return [cls for cls in klass.__subclasses__() if hasattr(cls, 'version')]
+
+    @classmethod
+    def __get_class(cls, klass, version):
+        v = int.from_bytes(version, 'little')
+
+        if getattr(klass, 'version', None) == v:
+            return klass
+
+        versioned_subclasses = VersionedBytes.__get_versioned_subclasses(klass)
+        outclass = next(iter([c for c in versioned_subclasses if c.version == v]))
+        return outclass
+
+    @classmethod
+    def parse_version(cls, some_bytes):
+        version_bytes = some_bytes[:2]
+        return VersionedBytes.__get_class(cls, version_bytes), some_bytes[2:]
+
+    def add_version(self, some_bytes):
+        return (self.version).to_bytes(2, 'little') + some_bytes

--- a/nucypher/primitives.py
+++ b/nucypher/primitives.py
@@ -4,9 +4,9 @@ class VersionedBytes:
         """
         When instantiating a specific version of a versioned Bytestring,
         we want to automatically instantiate the latest version without
-        requiring implementers to have to deal with any of this.
+        requiring implementors to have to deal with any of this.
 
-        If we are instantiating a specificly versioned class, allow for that also
+        If we are instantiating a specifically versioned class, allow for that also
         """
 
         if not hasattr(cls, 'version'):
@@ -20,8 +20,8 @@ class VersionedBytes:
         return [cls for cls in klass.__subclasses__() if hasattr(cls, 'version')]
 
     @classmethod
-    def __get_class(cls, klass, version):
-        v = int.from_bytes(version, 'big')
+    def __get_class(cls, klass, version_bytes):
+        v = int.from_bytes(version_bytes, 'big')
 
         if getattr(klass, 'version', None) == v:
             return klass

--- a/nucypher/utilities/versioning.py
+++ b/nucypher/utilities/versioning.py
@@ -62,5 +62,5 @@ class ByteVersioningMixin:
 
         return output_class, output_bytes
 
-    def add_version(self, some_bytes):
+    def prepend_version(self, some_bytes):
         return (self.version).to_bytes(2, 'big') + some_bytes

--- a/nucypher/utilities/versioning.py
+++ b/nucypher/utilities/versioning.py
@@ -1,6 +1,6 @@
 class ByteVersioningMixin:
 
-    class NucypherNeedsUpdateException(BaseException):
+    class UnknownVersionException(BaseException):
         """This node cannot instantiate a class from data created by a newer version of NuCypher."""
 
     def __new__(cls, *args, **kwargs):
@@ -40,12 +40,13 @@ class ByteVersioningMixin:
                 # would a bob be receiving this?  Or an Alice?
                 # Who needs to know about this?
                 # can we notify the staker of a node that their Worker needs an update?
-
-                raise ByteVersioningMixin.NucypherNeedsUpdateException("This node is running outdated NuCypher code")
+                versions = [c.version for c in versioned_subclasses]
+                raise ByteVersioningMixin.UnknownVersionException(
+                    f"Unable to instantiate version: "
+                    f"{v} of {klass}. Available versions: {versions}")
 
             # if the 1st two bytes aren't between 1 and 99, or if we have some weird broken data,
-            # lets not get ahead of ourselves, we can probably move on with life.
-            # return the base class and let it fail or succeed...
+            # return the base class and let it fail or succeed in its own Bytesplitter.
             return klass
 
         return outclass

--- a/tests/crypto/test_bytestring_types.py
+++ b/tests/crypto/test_bytestring_types.py
@@ -25,7 +25,7 @@ from nucypher.crypto.api import secure_random
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.signing import Signature
 
-from nucypher.primitives import VersionedBytes
+from nucypher.utilities.versioning import ByteVersioningMixin
 
 
 def test_split_two_signatures():
@@ -176,6 +176,6 @@ def test_newer_version_than_installed_code_can_accomodate(enacted_federated_poli
     V99_mkit_bytes = (
         v99 + bytes(mkit.capsule) + bytes(mkit.sender_verifying_key) + VariableLengthBytestring(mkit.ciphertext))
 
-    with pytest.raises(VersionedBytes.NucypherNeedsUpdateException):
+    with pytest.raises(ByteVersioningMixin.NucypherNeedsUpdateException):
         # we should catch this NucypherNeedsUpdateException here
         UmbralMessageKit.from_bytes(V99_mkit_bytes)

--- a/tests/crypto/test_bytestring_types.py
+++ b/tests/crypto/test_bytestring_types.py
@@ -108,7 +108,7 @@ def test_message_kit_versions(enacted_federated_policy, federated_alice):
             self._signature = signature
 
         def __bytes__(self):
-            return super().add_version(
+            return super().prepend_version(
                 bytes(self.capsule) + bytes(
                     self.sender_verifying_key
                 ) + bytes(

--- a/tests/crypto/test_bytestring_types.py
+++ b/tests/crypto/test_bytestring_types.py
@@ -143,6 +143,7 @@ def test_message_kit_versions(enacted_federated_policy, federated_alice):
 
     # when instantiating from bytes we get an instance of MessageKitVersion19
     mkit19 = UmbralMessageKit.from_bytes(v19_mkit_bytes)
+    assert mkit19.version == 19
     assert mkit19.pandemic == b'covid-19'
 
     v1 = (1).to_bytes(2, 'big')
@@ -154,11 +155,6 @@ def test_message_kit_versions(enacted_federated_policy, federated_alice):
     # lets just throw them into our base class
     v1_mkit = UmbralMessageKit.from_bytes(V1_mkit_bytes)
 
-    # we have a good old fashioned version one UmbralMessageKit
+    # we have a good old fashioned version one UmbralMessageKit with no weird attributes from the future
     assert v1_mkit.version == 1
     assert hasattr(v1_mkit, 'pandemic') is False
-
-    # and just to make sure we're not crazy...
-    new_mkit19 = UmbralMessageKit.from_bytes(v19_mkit_bytes)
-    assert new_mkit19.version == 19
-    assert mkit19.pandemic == b'covid-19'

--- a/tests/crypto/test_bytestring_types.py
+++ b/tests/crypto/test_bytestring_types.py
@@ -176,6 +176,9 @@ def test_newer_version_than_installed_code_can_accomodate(enacted_federated_poli
     V99_mkit_bytes = (
         v99 + bytes(mkit.capsule) + bytes(mkit.sender_verifying_key) + VariableLengthBytestring(mkit.ciphertext))
 
-    with pytest.raises(ByteVersioningMixin.NucypherNeedsUpdateException):
-        # we should catch this NucypherNeedsUpdateException here
+    with pytest.raises(ByteVersioningMixin.UnknownVersionException) as excinfo:
+        # we should catch this UnknownVersionException here
         UmbralMessageKit.from_bytes(V99_mkit_bytes)
+
+    assert "version: 99" in str(excinfo.value)
+    print(str(excinfo.value))

--- a/tests/crypto/test_bytestring_types.py
+++ b/tests/crypto/test_bytestring_types.py
@@ -145,8 +145,7 @@ def test_message_kit_versions(enacted_federated_policy, federated_alice):
     mkit19 = UmbralMessageKit.from_bytes(v19_mkit_bytes)
     assert mkit19.pandemic == b'covid-19'
 
-
-    v1 = (1).to_bytes(2, 'little')
+    v1 = (1).to_bytes(2, 'big')
 
     # along come some bytes representing an old message kit created during a more innocent time
     V1_mkit_bytes = (


### PR DESCRIPTION
When we go to mainnet and people start making Treasuremaps, Arrangements and MessageKits and storing them in side channels, one day we may make a change that breaks compatibility with some of those existing bytestrings in the wild.  This is supposed to solve that.

Goals:
* nobody has to change anything
* everything will 'just' work
* adds seamless hooks to accommodate any future unforeseen changes 
closes #343 and #281 

- [x] figure out how to do this
- [x] implement it for message kits
- [x] exception handling
- [ ] do these versions factor into learning loop/availability/sampling/network? (discussion needed)
- [x] implementation and tests for treasure maps 
- [x] implementation and tests for whatever else