### PR TITLE
Multi-account management for local keystore signers

### DIFF
--- a/nucypher/blockchain/eth/__init__.py
+++ b/nucypher/blockchain/eth/__init__.py
@@ -14,3 +14,12 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+from nucypher.blockchain.eth.signers import Signer, ClefSigner, KeystoreSigner
+
+SIGNERS = {
+    ClefSigner.URI_SCHEME: ClefSigner,
+    KeystoreSigner.URI_SCHEME: KeystoreSigner,
+}
+
+Signer.SIGNERS = SIGNERS

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1535,7 +1535,7 @@ class Wallet:
                          signer: Optional[Signer] = None,
                          password: Optional[str] = None
                          ) -> None:
-        
+
         if checksum_address not in self:
             self.__signer = signer or Web3Signer(client=self.blockchain.client)
             if isinstance(self.__signer, KeystoreSigner):

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -15,28 +15,25 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import click
 import csv
 import json
+import maya
 import os
 import time
 from decimal import Decimal
+from eth_tester.exceptions import TransactionFailed
+from eth_utils import is_checksum_address, to_checksum_address, to_canonical_address
 from pathlib import Path
-from typing import Tuple, List, Dict, Union
+from twisted.logger import Logger
+from typing import Tuple, List, Dict, Union, Optional
+from web3 import Web3
 
-import click
-import maya
 from constant_sorrow.constants import (
     WORKER_NOT_RUNNING,
     NO_WORKER_ASSIGNED,
-    BARE,
-    IDLE,
     FULL
 )
-from eth_tester.exceptions import TransactionFailed
-from eth_utils import keccak, is_checksum_address, to_checksum_address, to_canonical_address
-from twisted.logger import Logger
-from web3 import Web3
-
 from nucypher.blockchain.economics import StandardTokenEconomics, EconomicsFactory, BaseEconomics
 from nucypher.blockchain.eth.agents import (
     NucypherTokenAgent,
@@ -68,7 +65,7 @@ from nucypher.blockchain.eth.registry import (
     BaseContractRegistry,
     IndividualAllocationRegistry
 )
-from nucypher.blockchain.eth.signers import ClefSigner, Web3Signer, Signer
+from nucypher.blockchain.eth.signers import Web3Signer, Signer, KeystoreSigner
 from nucypher.blockchain.eth.token import NU, Stake, StakeList, WorkTracker
 from nucypher.blockchain.eth.utils import datetime_to_period, calculate_period_duration, datetime_at_period, \
     prettify_eth_amount
@@ -137,8 +134,7 @@ class NucypherTokenActor(BaseActor):
 
     def __init__(self, registry: BaseContractRegistry, **kwargs):
         super().__init__(registry, **kwargs)
-        self.token_agent = ContractAgency.get_agent(NucypherTokenAgent,
-                                                    registry=self.registry)  # type: NucypherTokenAgent
+        self.token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=self.registry)
 
     @property
     def token_balance(self) -> NU:
@@ -678,7 +674,7 @@ class MultiSigActor(BaseActor):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.multisig_agent = ContractAgency.get_agent(MultiSigAgent, registry=self.registry)  # type: MultiSigAgent
+        self.multisig_agent = ContractAgency.get_agent(MultiSigAgent, registry=self.registry)
 
 
 class Trustee(MultiSigActor):
@@ -697,8 +693,8 @@ class Trustee(MultiSigActor):
                  *args, **kwargs):
         super().__init__(checksum_address=checksum_address, *args, **kwargs)
         self.authorizations = dict()
-        self.executive_addresses = tuple(self.multisig_agent.owners)
-        if client_password:  # TODO: Consider a is_transacting parameter
+        self.executive_addresses = tuple(self.multisig_agent.owners)  # TODO: Investigate unresolved reference to .owners (linter)
+        if client_password:  # TODO: Consider an is_transacting parameter
             self.transacting_power = TransactingPower(password=client_password,
                                                       account=checksum_address)
             self.transacting_power.activate()
@@ -742,7 +738,7 @@ class Trustee(MultiSigActor):
         # TODO: check for inconsistencies (nonce, etc.)
 
         r, s, v = self._combine_authorizations()
-        receipt = self.multisig_agent.execute(sender_address=self.checksum_address,
+        receipt = self.multisig_agent.execute(sender_address=self.checksum_address,   # TODO: Investigate unresolved reference to .execute
                                               v=v, r=r, s=s,
                                               destination=proposal.target_address,
                                               value=proposal.value,
@@ -828,10 +824,8 @@ class Staker(NucypherTokenActor):
         self.__worker_address = None
 
         # Blockchain
-        self.policy_agent = ContractAgency.get_agent(PolicyManagerAgent,
-                                                     registry=self.registry)  # type: PolicyManagerAgent
-        self.staking_agent = ContractAgency.get_agent(StakingEscrowAgent,
-                                                      registry=self.registry)  # type: StakingEscrowAgent
+        self.policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=self.registry)
+        self.staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=self.registry)
         self.economics = EconomicsFactory.get_economics(registry=self.registry)
 
         # Staking via contract
@@ -1536,8 +1530,16 @@ class Wallet:
         return tuple(self.__client_accounts)
 
     @validate_checksum_address
-    def activate_account(self, checksum_address: str, password: str = None) -> None:
+    def activate_account(self,
+                         checksum_address: str,
+                         signer: Optional[Signer] = None,
+                         password: Optional[str] = None
+                         ) -> None:
+        
         if checksum_address not in self:
+            self.__signer = signer or Web3Signer(client=self.blockchain.client)
+            if isinstance(self.__signer, KeystoreSigner):
+                raise BaseActor.ActorError(f"Staking operations are not permitted while using a local keystore signer.")
             self.__get_accounts()
             if checksum_address not in self:
                 raise self.UnknownAccount

--- a/nucypher/blockchain/eth/signers.py
+++ b/nucypher/blockchain/eth/signers.py
@@ -40,6 +40,8 @@ from nucypher.blockchain.eth.decorators import validate_checksum_address
 
 class Signer(ABC):
 
+    URI_SCHEME = NotImplemented
+
     log = Logger(__qualname__)
 
     class SignerError(Exception):
@@ -104,6 +106,8 @@ class Signer(ABC):
 
 class Web3Signer(Signer):
 
+    URI_SCHEME = 'web3://'
+
     def __init__(self, client):
         super().__init__()
         self.__client = client
@@ -166,6 +170,8 @@ class Web3Signer(Signer):
 
 
 class ClefSigner(Signer):
+
+    URI_SCHEME = 'keystore://'
 
     DEFAULT_IPC_PATH = '~/Library/Signer/clef.ipc' if sys.platform == 'darwin' else '~/.clef/clef.ipc'  #TODO: #1808
 
@@ -277,6 +283,7 @@ class ClefSigner(Signer):
 class KeystoreSigner(Signer):
     """Local Web3 signer implementation supporting a single account/keystore file"""
 
+    URI_SCHEME = 'keystore://'
     __keys: Dict[str, dict]
     __signers: Dict[str, LocalAccount]
 
@@ -390,6 +397,8 @@ class KeystoreSigner(Signer):
             except KeyError:
                 raise self.UnknownAccount(account=account)
             else:
+                # TODO: It is possible that password is None here passed form the above leayer,
+                #       causing Account.decrypt to crash, expecting a value for password.
                 signing_key = Account.from_key(Account.decrypt(key_metadata, password))
                 self.__signers[account] = signing_key
 

--- a/nucypher/blockchain/eth/signers.py
+++ b/nucypher/blockchain/eth/signers.py
@@ -67,11 +67,11 @@ class Signer(ABC):
             raise cls.InvalidSignerURI('Blank signer URI - No keystore path provided')
         scheme = parsed.scheme
 
-        singer_classes = {
+        signer_classes = {
             'clef': ClefSigner,
             'keystore': KeystoreSigner,
         }
-        signer_class = singer_classes.get(scheme, Web3Signer)  # Fallback through to web3 provider URI parsing
+        signer_class = signer_classes.get(scheme, Web3Signer)  # Fallback through to web3 provider URI parsing
 
         signer = signer_class.from_signer_uri(uri=uri)
         return signer

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -925,6 +925,7 @@ class Ursula(Teacher, Character, Worker):
                  decentralized_identity_evidence: bytes = constants.NOT_SIGNED,
                  checksum_address: str = None,
                  worker_address: str = None,  # TODO: deprecate, and rename to "checksum_address"
+                 block_until_ready: bool = None,
                  work_tracker: WorkTracker = None,
                  start_working_now: bool = True,
                  client_password: str = None,
@@ -1009,7 +1010,8 @@ class Ursula(Teacher, Character, Worker):
                             checksum_address=checksum_address,
                             worker_address=worker_address,
                             work_tracker=work_tracker,
-                            start_working_now=start_working_now)
+                            start_working_now=start_working_now,
+                            block_until_ready=block_until_ready)
 
         if not crypto_power or (TLSHostingPower not in crypto_power):
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -925,7 +925,7 @@ class Ursula(Teacher, Character, Worker):
                  decentralized_identity_evidence: bytes = constants.NOT_SIGNED,
                  checksum_address: str = None,
                  worker_address: str = None,  # TODO: deprecate, and rename to "checksum_address"
-                 block_until_ready: bool = None,
+                 block_until_ready: bool = True,  # TODO: Must be true in order to set staker address - Allow for manual staker addr to be passed too!
                  work_tracker: WorkTracker = None,
                  start_working_now: bool = True,
                  client_password: str = None,

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -62,7 +62,6 @@ class CharacterConfiguration(BaseConfiguration):
 
     # Gas
     DEFAULT_GAS_STRATEGY = 'fast'
-    LOCAL_SIGNERS_ALLOWED = False
 
     def __init__(self,
 
@@ -394,8 +393,7 @@ class CharacterConfiguration(BaseConfiguration):
         payload = dict()
         if not self.federated_only:
             payload.update(dict(registry=self.registry,
-                                signer=Signer.from_signer_uri(self.signer_uri,
-                                                              local_signers_allowed=self.LOCAL_SIGNERS_ALLOWED)))
+                                signer=Signer.from_signer_uri(self.signer_uri)))
 
         payload.update(dict(network_middleware=self.network_middleware or self.DEFAULT_NETWORK_MIDDLEWARE(),
                             known_nodes=self.known_nodes,

--- a/tests/blockchain/eth/clients/test_keystore_signer.py
+++ b/tests/blockchain/eth/clients/test_keystore_signer.py
@@ -1,0 +1,163 @@
+import os
+
+import pytest
+from cytoolz.dicttoolz import assoc
+from eth_account import Account
+from eth_account._utils.transactions import Transaction
+from eth_utils import to_checksum_address
+from hexbytes import HexBytes
+
+from nucypher.blockchain.eth.signers import KeystoreSigner, Signer
+from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
+
+# Example keystore filename
+MOCK_KEYFILE_NAME = 'UTC--2019-12-04T05-39-04.006429310Z--0xdeadbeef'
+MOCK_KEYSTORE_PATH = '/mock-keystore'
+MOCK_KEYSTORE_URI = f'keystore://{MOCK_KEYSTORE_PATH}'
+
+TRANSACTION_DICT = {
+    "chainId": None,
+    "nonce": 0,
+    "gasPrice": 1000000000000,
+    "gas": 10000,
+    "to": "0x13978aee95f38490e9769C39B2773Ed763d9cd5F",
+    "value": 10000000000000000,
+    "data": ""
+}
+
+
+@pytest.fixture(scope='module', autouse=True)
+def mock_listdir(module_mocker):
+    mock_listdir = module_mocker.patch.object(os, 'listdir', autospec=True)
+    mock_listdir.return_value = [MOCK_KEYFILE_NAME]
+    return mock_listdir
+
+
+@pytest.fixture(scope='module')
+def mock_key():
+    test_key = Account.create(extra_entropy='M*A*S*H* DIWOKNECNECENOE#@!')
+    return test_key
+
+
+@pytest.fixture(scope='module')
+def mock_account(mock_key):
+    account = Account.from_key(private_key=mock_key.privateKey)
+    return account
+
+
+@pytest.fixture(scope='function')
+def good_signer(mocker, mock_account, mock_key):
+    # Return a "real" account address from the keyfile
+    mock_keyfile_reader = mocker.patch.object(KeystoreSigner, '_KeystoreSigner__read_keyfile', autospec=True)
+    mock_keyfile_reader.return_value = mock_account.address, dict(address=mock_account.address)
+
+    signer = Signer.from_signer_uri(uri=MOCK_KEYSTORE_URI)  # type: KeystoreSigner
+
+    # unlock
+    mock_decrypt = mocker.patch.object(Account, 'decrypt', autospec=True)
+    mock_decrypt.return_value = mock_key.privateKey
+    signer.unlock_account(account=mock_account.address, password=INSECURE_DEVELOPMENT_PASSWORD)
+
+    return signer
+
+
+@pytest.fixture(scope='module')
+def unknown_address():
+    address = Account.create().address
+    return address
+
+
+def test_blank_keystore_uri():
+    with pytest.raises(Signer.InvalidSignerURI) as error:
+        Signer.from_signer_uri(uri='keystore://')  # it's blank!
+    assert 'Blank signer URI - No keystore path provided' in str(error)
+
+
+def test_invalid_keystore(mocker, mock_listdir):
+    
+    # mock Keystoresigner.__read_keyfile
+    # Invalid keystore values and exception handling
+    mock_keyfile_reader = mocker.patch.object(KeystoreSigner, '_KeystoreSigner__read_keyfile', autospec=True)
+    mock_keyfile_reader.return_value = '0xdeadbeef', dict()
+
+    #
+    # 1 - Create
+    #
+
+    with pytest.raises(KeystoreSigner.InvalidKeyfile) as e:
+        Signer.from_signer_uri(uri=MOCK_KEYSTORE_URI)
+    assert "does not contain a valid ethereum address" in str(e.value)
+
+    # Invalid keyfiles
+    for exception in (FileNotFoundError, KeyError):
+        with pytest.raises(KeystoreSigner.InvalidKeyfile):
+            mock_keyfile_reader.side_effect = exception
+            Signer.from_signer_uri(uri=MOCK_KEYSTORE_URI)
+    mock_keyfile_reader.side_effect = None  # clean up this mess
+
+
+def test_create_signer(mocker, mock_listdir, mock_account, mock_key):
+
+    # Return a "real" account address from the keyfile
+    mock_keyfile_reader = mocker.patch.object(KeystoreSigner, '_KeystoreSigner__read_keyfile', autospec=True)
+    mock_keyfile_reader.return_value = mock_account.address, dict(address=mock_account.address)
+
+    signer = Signer.from_signer_uri(uri=MOCK_KEYSTORE_URI)  # type: KeystoreSigner
+    assert signer.path == MOCK_KEYSTORE_PATH
+    assert len(signer.accounts) == 1
+    assert mock_account.address in signer.accounts
+
+
+def test_keystore_locking(mocker, mock_account, mock_key, good_signer, unknown_address):
+    mock_from_key = mocker.patch.object(Account, 'from_key')
+    mock_from_key.return_value = mock_account
+
+    #
+    # Unlock
+    #
+
+    with pytest.raises(Signer.UnknownAccount):
+        good_signer.unlock_account(account=unknown_address, password=INSECURE_DEVELOPMENT_PASSWORD)
+
+    successful_unlock = good_signer.unlock_account(account=mock_account.address, password=INSECURE_DEVELOPMENT_PASSWORD)
+    assert successful_unlock
+
+    #
+    # Lock
+    #
+
+    with pytest.raises(Signer.UnknownAccount):
+        good_signer.lock_account(account=unknown_address)
+
+    successful_lock = good_signer.lock_account(account=mock_account.address)
+    assert successful_lock
+
+
+def test_list_keystore_accounts(good_signer, mock_account):
+    tracked_accounts = good_signer.accounts
+    assert mock_account.address in tracked_accounts
+    assert len(tracked_accounts) == 1
+
+
+def test_sign_message(mocker, good_signer, mock_account, mock_key):
+
+    # unlock
+    mock_decrypt = mocker.patch.object(Account, 'decrypt', autospec=True)
+    mock_decrypt.return_value = mock_key.privateKey
+    successful_unlock = good_signer.unlock_account(account=mock_account.address, password=INSECURE_DEVELOPMENT_PASSWORD)
+    assert successful_unlock
+
+    # sign message
+    message = b'A million tiny bubbles exploding'
+    signature = good_signer.sign_message(account=mock_account.address, message=message)
+    assert len(signature) == 65
+
+
+def test_sign_transaction(good_signer, mock_account):
+    transaction_dict = assoc(TRANSACTION_DICT, 'from', value=mock_account.address)
+    signed_transaction = good_signer.sign_transaction(transaction_dict=transaction_dict)
+    assert isinstance(signed_transaction, HexBytes)
+
+    # assert valid transaction
+    transaction = Transaction.from_bytes(signed_transaction)
+    assert to_checksum_address(transaction.to) == transaction_dict['to']

--- a/tests/cli/ursula/test_ursula_local_keystore_cli_integration.py
+++ b/tests/cli/ursula/test_ursula_local_keystore_cli_integration.py
@@ -1,0 +1,188 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import json
+import os
+import pytest
+from eth_account import Account
+from web3 import Web3
+
+from nucypher.blockchain.eth.signers import KeystoreSigner, Signer
+from nucypher.blockchain.eth.token import StakeList
+from nucypher.characters.lawful import Ursula
+from nucypher.cli.main import nucypher_cli
+from nucypher.config.characters import UrsulaConfiguration
+from nucypher.config.constants import NUCYPHER_ENVVAR_KEYRING_PASSWORD, NUCYPHER_ENVVAR_WORKER_ETH_PASSWORD
+from nucypher.utilities.sandbox.constants import (
+    MOCK_IP_ADDRESS,
+    TEST_PROVIDER_URI,
+    MOCK_URSULA_STARTING_PORT,
+    INSECURE_DEVELOPMENT_PASSWORD,
+    TEMPORARY_DOMAIN,
+)
+
+CLI_ENV = {NUCYPHER_ENVVAR_KEYRING_PASSWORD: INSECURE_DEVELOPMENT_PASSWORD,
+           NUCYPHER_ENVVAR_WORKER_ETH_PASSWORD: INSECURE_DEVELOPMENT_PASSWORD}
+
+KEYFILE_NAME_TEMPLATE = 'UTC--2020-{month}-21T03-42-07.869432648Z--{address}'
+MOCK_KEYSTORE_PATH = '/home/fakeMcfakeson/.ethereum/llamanet/keystore/'
+MOCK_SIGNER_URI = f'keystore://{MOCK_KEYSTORE_PATH}'
+NUMBER_OF_MOCK_ACCOUNTS = 3
+
+
+@pytest.fixture(scope='module')
+def mock_accounts():
+    accounts = dict()
+    for i in range(NUMBER_OF_MOCK_ACCOUNTS):
+        account = Account.create()
+        filename = KEYFILE_NAME_TEMPLATE.format(month=i+1, address=account.address)
+        accounts[filename] = account
+    return accounts
+
+
+@pytest.fixture(scope='module')
+def worker_account(mock_accounts, testerchain):
+    account = list(mock_accounts.values())[0]
+    tx = {'to': account.address,
+          'from': testerchain.etherbase_account,
+          'value': Web3.toWei('1', 'ether')}
+    txhash = testerchain.client.w3.eth.sendTransaction(tx)
+    _receipt = testerchain.wait_for_receipt(txhash)
+    return account
+
+
+@pytest.fixture(scope='module')
+def worker_address(worker_account):
+    address = worker_account.address
+    return address
+
+
+@pytest.fixture(scope='module')
+def custom_config_filepath(custom_filepath):
+    filepath = os.path.join(custom_filepath, UrsulaConfiguration.generate_filename())
+    return filepath
+
+
+@pytest.fixture(scope='function', autouse=True)
+def mock_keystore(mock_accounts, monkeypatch, mocker):
+
+    def mock_keyfile_reader(_keystore, path):
+        try:
+            account = mock_accounts[path]
+        except KeyError:
+            pytest.fail()
+        else:
+            return account.address, dict(version=3, address=account.address)
+
+    mocker.patch('os.listdir', return_value=list(mock_accounts.keys()))
+    monkeypatch.setattr(KeystoreSigner, '_KeystoreSigner__read_keyfile', mock_keyfile_reader)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def stakeholder(click_runner,
+                stakeholder_configuration_file_location,
+                stake_value,
+                token_economics,
+                agency_local_registry,
+                manual_staker,
+                custom_filepath,
+                worker_address):
+
+    init_args = ('stake', 'init-stakeholder',
+                 '--config-root', custom_filepath,
+                 '--provider', TEST_PROVIDER_URI,
+                 '--network', TEMPORARY_DOMAIN,
+                 '--registry-filepath', agency_local_registry.filepath)
+    click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False)
+
+    stake_args = ('stake', 'create',
+                  '--config-file', stakeholder_configuration_file_location,
+                  '--staking-address', manual_staker,
+                  '--value', stake_value.to_tokens(),
+                  '--lock-periods', token_economics.minimum_locked_periods,
+                  '--force')
+    # TODO: Is This test is writing to the default system directory and ignoring updates to the passed filepath?
+    user_input = f'0\n' + f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + f'Y\n'
+    click_runner.invoke(nucypher_cli, stake_args, input=user_input, catch_exceptions=False)
+
+    init_args = ('stake', 'set-worker',
+                 '--config-file', stakeholder_configuration_file_location,
+                 '--staking-address', manual_staker,
+                 '--worker-address', worker_address,
+                 '--force')
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
+    click_runner.invoke(nucypher_cli, init_args, input=user_input, catch_exceptions=False)
+
+
+def test_ursula_init_with_local_keystore_signer(click_runner,
+                                                custom_filepath,
+                                                custom_config_filepath,
+                                                agency_local_registry,
+                                                worker_account,
+                                                mocker,
+                                                testerchain):
+
+    # Good signer...
+    pre_config_signer = KeystoreSigner.from_signer_uri(uri=MOCK_SIGNER_URI)
+    assert worker_account.address in pre_config_signer.accounts
+
+    init_args = ('ursula', 'init',
+                 '--network', TEMPORARY_DOMAIN,
+                 '--worker-address', worker_account.address,
+                 '--config-root', custom_filepath,
+                 '--provider', TEST_PROVIDER_URI,
+                 '--registry-filepath', agency_local_registry.filepath,
+                 '--rest-host', MOCK_IP_ADDRESS,
+                 '--rest-port', MOCK_URSULA_STARTING_PORT,
+
+                 # The bit were' testing here
+                 '--signer', MOCK_SIGNER_URI)
+
+    result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False, env=CLI_ENV)
+    assert result.exit_code == 0, result.stdout
+
+    # Inspect the configuration file for the signer URI
+    with open(custom_config_filepath, 'r') as config_file:
+        raw_config_data = config_file.read()
+        config_data = json.loads(raw_config_data)
+        assert config_data['signer_uri'] == MOCK_SIGNER_URI,\
+            "Keystore URI was not correctly included in configuration file"
+
+    # Recreate a configuration with the signer URI preserved
+    ursula_config = UrsulaConfiguration.from_configuration_file(custom_config_filepath)
+    assert ursula_config.signer_uri == MOCK_SIGNER_URI
+
+    # Mock decryption of web3 client keyring
+    mocker.patch.object(Account, 'decrypt', return_value=worker_account.privateKey)
+    ursula_config.attach_keyring(checksum_address=worker_account.address)
+    ursula_config.keyring.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
+
+    # Produce an ursula with a Keystore signer correctly derived from the signer URI, and dont do anything else!
+    mocker.patch.object(StakeList, 'refresh', autospec=True)
+    ursula = ursula_config.produce(client_password=INSECURE_DEVELOPMENT_PASSWORD, block_until_ready=False)
+
+    # Verify the keystore path is still preserved
+    assert isinstance(ursula.signer, KeystoreSigner)
+    assert ursula.signer.path == MOCK_KEYSTORE_PATH
+
+    # Show that we can produce the exact same signer as pre-config...
+    assert pre_config_signer.path == ursula.signer.path
+
+    # ...and that transactions are signed by the keytore signer
+    receipt = ursula.confirm_activity()
+    transaction_data = testerchain.client.w3.eth.getTransaction(receipt['transactionHash'])
+    assert transaction_data['from'] == worker_account.address

--- a/tests/cli/ursula/test_ursula_local_keystore_cli_integration.py
+++ b/tests/cli/ursula/test_ursula_local_keystore_cli_integration.py
@@ -90,6 +90,8 @@ def mock_keystore(mock_accounts, monkeypatch, mocker):
 
     mocker.patch('os.listdir', return_value=list(mock_accounts.keys()))
     monkeypatch.setattr(KeystoreSigner, '_KeystoreSigner__read_keyfile', mock_keyfile_reader)
+    yield
+    monkeypatch.delattr(KeystoreSigner, '_KeystoreSigner__read_keyfile')
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -173,7 +175,8 @@ def test_ursula_init_with_local_keystore_signer(click_runner,
 
     # Produce an ursula with a Keystore signer correctly derived from the signer URI, and dont do anything else!
     mocker.patch.object(StakeList, 'refresh', autospec=True)
-    ursula = ursula_config.produce(client_password=INSECURE_DEVELOPMENT_PASSWORD, block_until_ready=False)
+    ursula = ursula_config.produce(client_password=INSECURE_DEVELOPMENT_PASSWORD,
+                                   block_until_ready=False)
 
     # Verify the keystore path is still preserved
     assert isinstance(ursula.signer, KeystoreSigner)


### PR DESCRIPTION
Fixes #1921 Based on #1858 

- Support Ursula operation with a local private key provided by the user.
- Unit testing for `KeystoreSigner`

Try it out: `nucypher ursula config --signer keystore://<PATH TO GETH KEYSTORE>`

Needs manual CLI testing.
