### PR TITLE
`nucypher` module must be present to build APIs docs section

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -15,6 +15,10 @@ formats: all
 python:
   version: 3.7
   install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
     - requirements: docs/requirements.txt
 
 build:


### PR DESCRIPTION
Ensure that `nucypher` module is installed when building docs on RTD.

Follow-up to #1953 .