### PR TITLE
Correct path handling in keystore signer / support individual files

### DIFF
--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -179,7 +179,7 @@ class UrsulaConfigOptions:
         if (not worker_address) and not self.federated_only:
             if not worker_address:
                 prompt = "Select worker account"
-                worker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=self.provider_uri)
+                worker_address = select_client_account(emitter=emitter, prompt=prompt, provider_uri=self.provider_uri, signer_uri=self.signer_uri)
 
         rest_host = self.rest_host
         if not rest_host:

--- a/tests/blockchain/eth/clients/test_keystore_signer.py
+++ b/tests/blockchain/eth/clients/test_keystore_signer.py
@@ -43,11 +43,12 @@ def mock_account(mock_key):
 
 @pytest.fixture(scope='module')
 def mock_keystore(mock_account, tmp_path_factory):
-    keystore = tmp_path_factory.mktemp('keystore', numbered=True)
-    for filename, account in ((MOCK_KEYFILE_NAME, mock_account),):
-        json.dump(account.encrypt(INSECURE_DEVELOPMENT_PASSWORD),
-                  open(keystore / filename, 'x+t'))
-        return keystore
+    keystore = tmp_path_factory.mktemp('keystore')
+    json.dump(
+        mock_account.encrypt(INSECURE_DEVELOPMENT_PASSWORD),
+        open(keystore / MOCK_KEYFILE_NAME, 'x+t')
+    )
+    return keystore
 
 
 @pytest.fixture(scope='function')

--- a/tests/blockchain/eth/clients/test_keystore_signer.py
+++ b/tests/blockchain/eth/clients/test_keystore_signer.py
@@ -1,6 +1,7 @@
 import json
 
 import os
+import collections
 import pytest
 import shutil
 from cytoolz.dicttoolz import assoc
@@ -30,11 +31,17 @@ TRANSACTION_DICT = {
 }
 
 
-@pytest.fixture(scope='module', autouse=True)
-def mock_listdir(module_mocker):
-    mock_listdir = module_mocker.patch.object(os, 'listdir', autospec=True)
-    mock_listdir.return_value = [MOCK_KEYFILE_NAME]
-    return mock_listdir
+def mock_stat_scandir(mocker):
+    mock_stat = mocker.patch.object(os, 'stat', autospec=True)
+    mock_stat.return_value = os.stat_result((0o40755,) + (None,)*9)
+
+    mock_scandir = mocker.patch.object(os, 'scandir', autospec=True)
+    mock_scandir.return_value = (
+        collections.namedtuple('DirEntry', 'path is_file')(
+            path=os.path.join(MOCK_KEYSTORE_PATH, MOCK_KEYFILE_NAME),
+            is_file=lambda: True,
+        ),
+    )
 
 
 @pytest.fixture(scope='module')
@@ -51,6 +58,8 @@ def mock_account(mock_key):
 
 @pytest.fixture(scope='function')
 def good_signer(mocker, mock_account, mock_key):
+    mock_stat_scandir(mocker)
+
     # Return a "real" account address from the keyfile
     mock_keyfile_reader = mocker.patch.object(KeystoreSigner, '_KeystoreSigner__read_keyfile', autospec=True)
     mock_keyfile_reader.return_value = mock_account.address, dict(address=mock_account.address)
@@ -77,8 +86,9 @@ def test_blank_keystore_uri():
     assert 'Blank signer URI - No keystore path provided' in str(error)
 
 
-def test_invalid_keystore(mocker, mock_listdir):
-    
+def test_invalid_keystore(mocker):
+    mock_stat_scandir(mocker)
+
     # mock Keystoresigner.__read_keyfile
     # Invalid keystore values and exception handling
     mock_keyfile_reader = mocker.patch.object(KeystoreSigner, '_KeystoreSigner__read_keyfile', autospec=True)
@@ -100,7 +110,7 @@ def test_invalid_keystore(mocker, mock_listdir):
     mock_keyfile_reader.side_effect = None  # clean up this mess
 
 
-def test_signer_reads_keystore_from_disk(mock_listdir, mock_account, mock_key, tmpdir):
+def test_signer_reads_keystore_from_disk(mock_account, mock_key, tmpdir):
 
     # Test reading a keyfile from the disk via KeystoreSigner since
     # it is mocked for the rest of this test module
@@ -120,7 +130,7 @@ def test_signer_reads_keystore_from_disk(mock_listdir, mock_account, mock_key, t
         mock_keystore_uri = f'keystore://{tmp_keystore}'
         signer = Signer.from_signer_uri(uri=mock_keystore_uri)
 
-        assert signer.path == tmp_keystore
+        assert signer.path == str(tmp_keystore)
         assert len(signer.accounts) == 1
         assert MOCK_KEYFILE['address'] in signer.accounts
 
@@ -129,14 +139,15 @@ def test_signer_reads_keystore_from_disk(mock_listdir, mock_account, mock_key, t
             shutil.rmtree(fake_ethereum, ignore_errors=True)
 
 
-def test_create_signer(mocker, mock_listdir, mock_account, mock_key):
+def test_create_signer(mocker, mock_account, mock_key):
+    mock_stat_scandir(mocker)
 
     # Return a "real" account address from the keyfile
     mock_keyfile_reader = mocker.patch.object(KeystoreSigner, '_KeystoreSigner__read_keyfile', autospec=True)
     mock_keyfile_reader.return_value = mock_account.address, dict(address=mock_account.address)
 
     signer = Signer.from_signer_uri(uri=MOCK_KEYSTORE_URI)  # type: KeystoreSigner
-    assert signer.path == Path(MOCK_KEYSTORE_PATH)
+    assert signer.path == MOCK_KEYSTORE_PATH
     assert len(signer.accounts) == 1
     assert mock_account.address in signer.accounts
 

--- a/tests/cli/functional/conftest.py
+++ b/tests/cli/functional/conftest.py
@@ -25,8 +25,6 @@ from nucypher.blockchain.eth.agents import ContractAgency
 from nucypher.blockchain.eth.interfaces import BlockchainInterface, BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import InMemoryContractRegistry
 from nucypher.config.characters import UrsulaConfiguration
-from tests.cli.functional.test_ursula_local_keystore_cli_functionality import KEYFILE_NAME_TEMPLATE, \
-    NUMBER_OF_MOCK_ACCOUNTS
 from tests.fixtures import _make_testerchain, make_token_economics
 from tests.mock.agents import FAKE_RECEIPT, MockContractAgency
 from tests.mock.interfaces import MockBlockchain, make_mock_registry_source_manager
@@ -83,28 +81,6 @@ def mock_contract_agency(module_mocker, token_economics):
     # Restore the monkey patching
     ContractAgency.get_agent = get_agent
     ContractAgency.get_agent_by_contract_name = get_agent_by_name
-
-
-@pytest.fixture(scope='module')
-def mock_accounts():
-    accounts = dict()
-    for i in range(NUMBER_OF_MOCK_ACCOUNTS):
-        account = Account.create()
-        filename = KEYFILE_NAME_TEMPLATE.format(month=i+1, address=account.address)
-        accounts[filename] = account
-    return accounts
-
-
-@pytest.fixture(scope='module')
-def worker_account(mock_accounts, mock_testerchain):
-    account = list(mock_accounts.values())[0]
-    return account
-
-
-@pytest.fixture(scope='module')
-def worker_address(worker_account):
-    address = worker_account.address
-    return address
 
 
 @pytest.fixture(scope='module')

--- a/tests/cli/ursula/test_local_keystore_integration.py
+++ b/tests/cli/ursula/test_local_keystore_integration.py
@@ -27,7 +27,6 @@ from nucypher.blockchain.eth.token import StakeList
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
 from tests.cli.functional.test_ursula_local_keystore_cli_functionality import (CLI_ENV, KEYFILE_NAME_TEMPLATE,
-                                                                               MOCK_KEYSTORE_PATH, MOCK_SIGNER_URI,
                                                                                NUMBER_OF_MOCK_ACCOUNTS)
 from tests.constants import (INSECURE_DEVELOPMENT_PASSWORD, MOCK_IP_ADDRESS, TEST_PROVIDER_URI)
 from tests.utils.ursula import MOCK_URSULA_STARTING_PORT
@@ -135,7 +134,7 @@ def test_ursula_and_local_keystore_signer_integration(click_runner,
                  '--rest-port', MOCK_URSULA_STARTING_PORT,
 
                  # The bit we are testing for here
-                 '--signer', MOCK_SIGNER_URI)
+                 '--signer', mock_signer_uri)
 
     result = click_runner.invoke(nucypher_cli, init_args, catch_exceptions=False, env=CLI_ENV)
     assert result.exit_code == 0, result.stdout
@@ -163,15 +162,8 @@ def test_ursula_and_local_keystore_signer_integration(click_runner,
 
     # Verify the keystore path is still preserved
     assert isinstance(ursula.signer, KeystoreSigner)
-<<<<<<< HEAD:tests/cli/ursula/test_local_keystore_integration.py
-    assert ursula.signer.path == Path(MOCK_KEYSTORE_PATH)
-||||||| merged common ancestors
-    assert isinstance(ursula.signer.path, Path), "Use Pathlib"
-    assert ursula.signer.path == Path(MOCK_KEYSTORE_PATH)  # confirm Pathlib is used internally despite string input
-=======
     assert isinstance(ursula.signer.path, str), "Use str"
-    assert ursula.signer.path == str(mock_keystore_path)  # confirm Pathlib is used internally despite string input
->>>>>>> Updated ci cli tests for KeyStoreSigner.:tests/cli/ursula/test_ursula_local_keystore_cli_integration.py
+    assert ursula.signer.path == str(mock_keystore_path)
 
     # Show that we can produce the exact same signer as pre-config...
     assert pre_config_signer.path == ursula.signer.path


### PR DESCRIPTION
Simple bugfix / feature enhancement to keystore signer (related to issue #1962).

Path given to keystore signer is stat'd and:
- if it is a directory, it is scanned and regular directory entries are processed
- if it is a regular file, it is processed
- if something else (i.e. device node, etc.), an exception is raised

Additionally during directory scanning, OSError exceptions (such as permission error, etc.) are appended to InvalidSignerURI exception text and raised.