### PR TITLE
Removal of 'min' from fee range & more informative/consistent comments 

### DIFF
--- a/docs/source/guides/network_node/staking_guide.rst
+++ b/docs/source/guides/network_node/staking_guide.rst
@@ -371,8 +371,8 @@ the commitment period.
     will result in the loss of staked tokens as described in the NuCypher slashing protocol.
 
     Keeping your Ursula node online during the staking period and successfully
-    producing correct re-encryption work orders will result in fees
-    paid out in ethers retro-actively and on-demand.
+    producing correct re-encryption work orders will earn fees
+    paid out in ETH on-demand and retroactively.
 
     Accept ursula node operator obligation? [y/N]: y
     Publish staged stake to the blockchain? [y/N]: y

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1203,7 +1203,7 @@ class Staker(NucypherTokenActor):
 
     @property
     def min_fee_rate(self) -> int:
-        """Minimum fee rate that staker earns"""
+        """Minimum fee rate that staker accepts"""
         staker_address = self.checksum_address
         min_fee = self.policy_agent.get_min_fee_rate(staker_address)
         return min_fee

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -511,9 +511,9 @@ class ContractAdministrator(NucypherTokenActor):
                                                         deployer_address=self.deployer_address,
                                                         economics=self.economics)
         receipt = policy_manager_deployer.set_fee_rate_range(minimum=minimum,
-                                                                 default=default,
-                                                                 maximum=maximum,
-                                                                 gas_limit=transaction_gas_limit)
+                                                             default=default,
+                                                             maximum=maximum,
+                                                             gas_limit=transaction_gas_limit)
         return receipt
 
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -502,10 +502,10 @@ class ContractAdministrator(NucypherTokenActor):
         return filepath
 
     def set_fee_rate_range(self,
-                               minimum: int,
-                               default: int,
-                               maximum: int,
-                               transaction_gas_limit: int = None) -> dict:
+                           minimum: int,
+                           default: int,
+                           maximum: int,
+                           transaction_gas_limit: int = None) -> dict:
 
         policy_manager_deployer = PolicyManagerDeployer(registry=self.registry,
                                                         deployer_address=self.deployer_address,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1191,7 +1191,7 @@ class Staker(NucypherTokenActor):
     @only_me
     @save_receipt
     def set_min_fee_rate(self, min_rate: int) -> Tuple[str, str]:
-        """Public facing method for staker to set their minimum acceptable fee rate"""
+        """Public facing method for staker to set the minimum acceptable fee rate for their associated worker"""
         minimum, _default, maximum = self.policy_agent.get_fee_rate_range()
         if min_rate < minimum or min_rate > maximum:
             raise ValueError(f"Minimum fee rate {min_rate} must fall within global fee range of [{minimum}, {maximum}]")
@@ -1210,7 +1210,7 @@ class Staker(NucypherTokenActor):
 
     @property
     def raw_min_fee_rate(self) -> int:
-        """Minimum acceptable fee rate set by staker.
+        """Minimum acceptable fee rate set by staker for their associated worker.
         This fee rate is only used if it falls within the global fee range.
         If it doesn't a default fee rate is used instead of the raw value (see `min_fee_rate`)"""
         staker_address = self.checksum_address

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -501,7 +501,7 @@ class ContractAdministrator(NucypherTokenActor):
             file.write(data)
         return filepath
 
-    def set_min_fee_rate_range(self,
+    def set_fee_rate_range(self,
                                minimum: int,
                                default: int,
                                maximum: int,
@@ -510,7 +510,7 @@ class ContractAdministrator(NucypherTokenActor):
         policy_manager_deployer = PolicyManagerDeployer(registry=self.registry,
                                                         deployer_address=self.deployer_address,
                                                         economics=self.economics)
-        receipt = policy_manager_deployer.set_min_fee_rate_range(minimum=minimum,
+        receipt = policy_manager_deployer.set_fee_rate_range(minimum=minimum,
                                                                  default=default,
                                                                  maximum=maximum,
                                                                  gas_limit=transaction_gas_limit)
@@ -1125,7 +1125,7 @@ class Staker(NucypherTokenActor):
     @save_receipt
     @validate_checksum_address
     def collect_policy_fee(self, collector_address=None) -> dict:
-        """Collect fee ETH."""
+        """Collect fees (ETH) earned since last withdrawal"""
         if self.is_contract:
             if collector_address and collector_address != self.beneficiary_address:
                 raise ValueError("Policy fees must be withdrawn to the beneficiary address")
@@ -1140,7 +1140,7 @@ class Staker(NucypherTokenActor):
     @only_me
     @save_receipt
     def collect_staking_reward(self) -> dict:
-        """Withdraw tokens rewarded for staking."""
+        """Withdraw tokens rewarded for staking"""
         if self.is_contract:
             reward_amount = self.calculate_staking_reward()
             self.log.debug(f"Withdrawing staking reward ({NU.from_nunits(reward_amount)}) to {self.checksum_address}")
@@ -1191,10 +1191,10 @@ class Staker(NucypherTokenActor):
     @only_me
     @save_receipt
     def set_min_fee_rate(self, min_rate: int) -> Tuple[str, str]:
-        """Public facing method for setting min fee rate."""
-        minimum, _default, maximum = self.policy_agent.get_min_fee_rate_range()
+        """Public facing method for staker to set their minimum fee rate"""
+        minimum, _default, maximum = self.policy_agent.get_fee_rate_range()
         if min_rate < minimum or min_rate > maximum:
-            raise ValueError(f"Min fee rate  {min_rate} must be within range [{minimum}, {maximum}]")
+            raise ValueError(f"Min fee rate {min_rate} must fall within universal fee range of [{minimum}, {maximum}]")
         if self.is_contract:
             receipt = self.preallocation_escrow_agent.set_min_fee_rate(min_rate=min_rate)
         else:
@@ -1203,16 +1203,16 @@ class Staker(NucypherTokenActor):
 
     @property
     def min_fee_rate(self) -> int:
-        """Minimum acceptable fee rate"""
+        """Minimum fee rate that staker earns"""
         staker_address = self.checksum_address
         min_fee = self.policy_agent.get_min_fee_rate(staker_address)
         return min_fee
 
     @property
     def raw_min_fee_rate(self) -> int:
-        """Minimum acceptable fee rate set by staker.
-        This's not applicable if this rate out of global range.
-        In that case default value will be used instead of raw value (see `min_fee_rate`)"""
+        """Minimum fee rate set by staker.
+        This fee rate is only used if it falls within the universal fee range.
+        If not, a default fee rate is used instead of the raw value (see `min_fee_rate`)"""
 
         staker_address = self.checksum_address
         min_fee = self.policy_agent.get_raw_min_fee_rate(staker_address)
@@ -1385,7 +1385,7 @@ class BlockchainPolicyAuthor(NucypherTokenActor):
 
     @property
     def default_rate(self):
-        _minimum, default, _maximum = self.policy_agent.get_min_fee_rate_range()
+        _minimum, default, _maximum = self.policy_agent.get_fee_rate_range()
         return default
 
     def generate_policy_parameters(self,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1191,10 +1191,10 @@ class Staker(NucypherTokenActor):
     @only_me
     @save_receipt
     def set_min_fee_rate(self, min_rate: int) -> Tuple[str, str]:
-        """Public facing method for staker to set their minimum fee rate"""
+        """Public facing method for staker to set their minimum acceptable fee rate"""
         minimum, _default, maximum = self.policy_agent.get_fee_rate_range()
         if min_rate < minimum or min_rate > maximum:
-            raise ValueError(f"Min fee rate {min_rate} must fall within universal fee range of [{minimum}, {maximum}]")
+            raise ValueError(f"Minimum fee rate {min_rate} must fall within global fee range of [{minimum}, {maximum}]")
         if self.is_contract:
             receipt = self.preallocation_escrow_agent.set_min_fee_rate(min_rate=min_rate)
         else:
@@ -1210,10 +1210,9 @@ class Staker(NucypherTokenActor):
 
     @property
     def raw_min_fee_rate(self) -> int:
-        """Minimum fee rate set by staker.
-        This fee rate is only used if it falls within the universal fee range.
-        If not, a default fee rate is used instead of the raw value (see `min_fee_rate`)"""
-
+        """Minimum acceptable fee rate set by staker.
+        This fee rate is only used if it falls within the global fee range.
+        If it doesn't a default fee rate is used instead of the raw value (see `min_fee_rate`)"""
         staker_address = self.checksum_address
         min_fee = self.policy_agent.get_raw_min_fee_rate(staker_address)
         return min_fee

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -821,7 +821,7 @@ class PolicyManagerAgent(EthereumContractAgent):
         return fee_amount
 
     def get_fee_rate_range(self) -> Tuple[int, int, int]:
-        """Check maximum, minimum & default fee rate for all stakers and all policies ('global fee range')"""
+        """Check minimum, default & maximum fee rate for all stakers and all policies ('global fee range')"""
         minimum, default, maximum = self.contract.functions.feeRateRange().call()
         return minimum, default, maximum
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -822,7 +822,7 @@ class PolicyManagerAgent(EthereumContractAgent):
 
     def get_fee_rate_range(self) -> Tuple[int, int, int]:
         """Check maximum, minimum & default fee rate for all stakers and all policies ('global fee range')"""
-        minimum, default, maximum = self.contract.functions.FeeRateRange().call()
+        minimum, default, maximum = self.contract.functions.feeRateRange().call()
         return minimum, default, maximum
 
     @validate_checksum_address

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -821,18 +821,19 @@ class PolicyManagerAgent(EthereumContractAgent):
         return fee_amount
 
     def get_fee_rate_range(self) -> Tuple[int, int, int]:
-        """Check max, min & default fee rate for all stakers and all policies (universal fee range)"""
+        """Check maximum, minimum & default fee rate for all stakers and all policies ('global fee range')"""
         minimum, default, maximum = self.contract.functions.FeeRateRange().call()
         return minimum, default, maximum
 
     @validate_checksum_address
-    """Check min fee rate acceptable to staker"""
     def get_min_fee_rate(self, staker_address: str) -> int:
+        """Check minimum fee rate that staker earns"""
         min_rate = self.contract.functions.getMinFeeRate(staker_address).call()
         return min_rate
 
     @validate_checksum_address
     def get_raw_min_fee_rate(self, staker_address: str) -> int:
+        """Check minimum acceptable fee rate set by staker"""
         min_rate = self.contract.functions.nodes(staker_address).call()[3]
         return min_rate
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -821,19 +821,19 @@ class PolicyManagerAgent(EthereumContractAgent):
         return fee_amount
 
     def get_fee_rate_range(self) -> Tuple[int, int, int]:
-        """Check minimum, default & maximum fee rate for all stakers and all policies ('global fee range')"""
+        """Check minimum, default & maximum fee rate for all policies ('global fee range')"""
         minimum, default, maximum = self.contract.functions.feeRateRange().call()
         return minimum, default, maximum
 
     @validate_checksum_address
     def get_min_fee_rate(self, staker_address: str) -> int:
-        """Check minimum fee rate that staker earns"""
+        """Check minimum fee rate that staker accepts"""
         min_rate = self.contract.functions.getMinFeeRate(staker_address).call()
         return min_rate
 
     @validate_checksum_address
     def get_raw_min_fee_rate(self, staker_address: str) -> int:
-        """Check minimum acceptable fee rate set by staker"""
+        """Check minimum acceptable fee rate set by staker for their associated worker"""
         min_rate = self.contract.functions.nodes(staker_address).call()[3]
         return min_rate
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -786,7 +786,7 @@ class PolicyManagerAgent(EthereumContractAgent):
 
     @validate_checksum_address
     def collect_policy_fee(self, collector_address: str, staker_address: str):
-        """Collect fee ETH"""
+        """Collect fees (ETH) earned since last withdrawal"""
         contract_function = self.contract.functions.withdraw(collector_address)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
         return receipt
@@ -820,11 +820,13 @@ class PolicyManagerAgent(EthereumContractAgent):
         fee_amount = self.contract.functions.nodes(staker_address).call()[0]
         return fee_amount
 
-    def get_min_fee_rate_range(self) -> Tuple[int, int, int]:
-        minimum, default, maximum = self.contract.functions.minFeeRateRange().call()
+    def get_fee_rate_range(self) -> Tuple[int, int, int]:
+        """Check max, min & default fee rate for all stakers and all policies (universal fee range)"""
+        minimum, default, maximum = self.contract.functions.FeeRateRange().call()
         return minimum, default, maximum
 
     @validate_checksum_address
+    """Check min fee rate acceptable to staker"""
     def get_min_fee_rate(self, staker_address: str) -> int:
         min_rate = self.contract.functions.getMinFeeRate(staker_address).call()
         return min_rate

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -813,7 +813,7 @@ class PolicyManagerDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
                                confirmations: int = 0) -> dict:
 
         if minimum > default or default > maximum:
-            raise ValueError(f"Default fee rate ({default}) must fall within the universal fee range by satisfying the condition: "
+            raise ValueError(f"Default fee rate ({default}) must fall within the global fee range by satisfying the condition: "
                              f"minimum ({minimum}) <= default ({default}) <= maximum ({maximum})")
 
         policy_manager = self.blockchain.get_contract_by_name(registry=self.registry,

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -806,11 +806,11 @@ class PolicyManagerDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
         return deployment_receipts
 
     def set_fee_rate_range(self,
-                               minimum: int,
-                               default: int,
-                               maximum: int,
-                               gas_limit: int = None,
-                               confirmations: int = 0) -> dict:
+                           minimum: int,
+                           default: int,
+                           maximum: int,
+                           gas_limit: int = None,
+                           confirmations: int = 0) -> dict:
 
         if minimum > default or default > maximum:
             raise ValueError(f"Default fee rate ({default}) must fall within the global fee range by satisfying the condition: "

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -805,7 +805,7 @@ class PolicyManagerDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
         self._contract = wrapped_contract
         return deployment_receipts
 
-    def set_min_fee_rate_range(self,
+    def set_fee_rate_range(self,
                                minimum: int,
                                default: int,
                                maximum: int,
@@ -813,7 +813,7 @@ class PolicyManagerDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
                                confirmations: int = 0) -> dict:
 
         if minimum > default or default > maximum:
-            raise ValueError(f"Default rate ({default}) must satisfy the condition: "
+            raise ValueError(f"Default fee rate ({default}) must fall within the universal fee range by satisfying the condition: "
                              f"minimum ({minimum}) <= default ({default}) <= maximum ({maximum})")
 
         policy_manager = self.blockchain.get_contract_by_name(registry=self.registry,
@@ -823,7 +823,7 @@ class PolicyManagerDeployer(BaseContractDeployer, UpgradeableContractMixin, Owna
         tx_args = {}
         if gas_limit:
             tx_args.update({'gas': gas_limit})  # TODO: Gas management - 842
-        set_range_function = policy_manager.functions.setMinFeeRateRange(minimum, default, maximum)
+        set_range_function = policy_manager.functions.setFeeRateRange(minimum, default, maximum)
         set_range_receipt = self.blockchain.send_transaction(contract_function=set_range_function,
                                                              sender_address=self.deployer_address,
                                                              payload=tx_args,

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -14,7 +14,7 @@ import "contracts/proxy/Upgradeable.sol";
 
 /**
 * @notice Contract holds policy data and locks accrued policy fees until collection
-* @dev |v5.1.1|
+* @dev |v6.1.1|
 */
 contract PolicyManager is Upgradeable {
     using SafeERC20 for NuCypherToken;
@@ -51,7 +51,7 @@ contract PolicyManager is Upgradeable {
     event MinFeeRateSet(address indexed node, uint256 value);
     // TODO #1501
     // Range range
-    event FeeRateRangeSet(address indexed sender, uint256 min, uint256 defaultValue, uint256 max);
+    event feeRateRangeSet(address indexed sender, uint256 min, uint256 defaultValue, uint256 max);
     event Withdrawn(address indexed node, address indexed recipient, uint256 value);
 
     struct ArrangementInfo {
@@ -103,7 +103,7 @@ contract PolicyManager is Upgradeable {
 
     mapping (bytes16 => Policy) public policies;
     mapping (address => NodeInfo) public nodes;
-    Range public FeeRateRange;
+    Range public feeRateRange;
 
     /**
     * @notice Constructor sets address of the escrow contract
@@ -145,23 +145,23 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Set maximum, minimum and and default fee rate for all stakers and all policies ('global fee range')
+    * @notice Set maximum, minimum and default fee rate for all stakers and all policies ('global fee range')
     */
     // TODO # 1501
     // function setFeeRateRange(Range calldata _range) external onlyOwner {
     function setFeeRateRange(uint128 _min, uint128 _default, uint128 _max) external onlyOwner {
         require(_min <= _default && _default <= _max);
-        FeeRateRange = Range(_min, _default, _max);
-        emit FeeRateRangeSet(msg.sender, _min, _default, _max);
+        feeRateRange = Range(_min, _default, _max);
+        emit feeRateRangeSet(msg.sender, _min, _default, _max);
     }
 
     /**
     * @notice Set the minimum acceptable fee rate (set by staker)
-    * @dev Input value must fall within `FeeRateRange` (global fee range)
+    * @dev Input value must fall within `feeRateRange` (global fee range)
     */
     function setMinFeeRate(uint256 _minFeeRate) external {
-        require(_minFeeRate >= FeeRateRange.min &&
-            _minFeeRate <= FeeRateRange.max,
+        require(_minFeeRate >= feeRateRange.min &&
+            _minFeeRate <= feeRateRange.max,
             "The staker's min fee rate must fall within the global fee range");
         NodeInfo storage nodeInfo = nodes[msg.sender];
         if (nodeInfo.minFeeRate == _minFeeRate) {
@@ -178,9 +178,9 @@ contract PolicyManager is Upgradeable {
         // if minFeeRate has not been set or chosen value falls outside the global fee range
         // a default value is returned instead
         if (_nodeInfo.minFeeRate == 0 ||
-            _nodeInfo.minFeeRate < FeeRateRange.min ||
-            _nodeInfo.minFeeRate > FeeRateRange.max) {
-            return FeeRateRange.defaultValue;
+            _nodeInfo.minFeeRate < feeRateRange.min ||
+            _nodeInfo.minFeeRate > feeRateRange.max) {
+            return feeRateRange.defaultValue;
         } else {
             return _nodeInfo.minFeeRate;
         }
@@ -690,10 +690,10 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @dev Get FeeRateRange structure by delegatecall
+    * @dev Get feeRateRange structure by delegatecall
     */
     function delegateGetFeeRateRange(address _target) internal returns (Range memory result) {
-        bytes32 memoryAddress = delegateGetData(_target, this.FeeRateRange.selector, 0, 0, 0);
+        bytes32 memoryAddress = delegateGetData(_target, this.feeRateRange.selector, 0, 0, 0);
         assembly {
             result := memoryAddress
         }
@@ -703,9 +703,9 @@ contract PolicyManager is Upgradeable {
     function verifyState(address _testTarget) public override virtual {
         super.verifyState(_testTarget);
         Range memory rangeToCheck = delegateGetFeeRateRange(_testTarget);
-        require(FeeRateRange.min == rangeToCheck.min &&
-            FeeRateRange.defaultValue == rangeToCheck.defaultValue &&
-            FeeRateRange.max == rangeToCheck.max);
+        require(feeRateRange.min == rangeToCheck.min &&
+            feeRateRange.defaultValue == rangeToCheck.defaultValue &&
+            feeRateRange.max == rangeToCheck.max);
         Policy storage policy = policies[RESERVED_POLICY_ID];
         Policy memory policyToCheck = delegateGetPolicy(_testTarget, RESERVED_POLICY_ID);
         require(policyToCheck.sponsor == policy.sponsor &&

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -13,7 +13,7 @@ import "contracts/proxy/Upgradeable.sol";
 
 
 /**
-* @notice Contract holds policy data and locks accrued policy fees until collection
+* @notice Contract holds policy data and locks accrued policy fees
 * @dev |v6.1.1|
 */
 contract PolicyManager is Upgradeable {
@@ -51,7 +51,7 @@ contract PolicyManager is Upgradeable {
     event MinFeeRateSet(address indexed node, uint256 value);
     // TODO #1501
     // Range range
-    event feeRateRangeSet(address indexed sender, uint256 min, uint256 defaultValue, uint256 max);
+    event FeeRateRangeSet(address indexed sender, uint256 min, uint256 defaultValue, uint256 max);
     event Withdrawn(address indexed node, address indexed recipient, uint256 value);
 
     struct ArrangementInfo {
@@ -152,7 +152,7 @@ contract PolicyManager is Upgradeable {
     function setFeeRateRange(uint128 _min, uint128 _default, uint128 _max) external onlyOwner {
         require(_min <= _default && _default <= _max);
         feeRateRange = Range(_min, _default, _max);
-        emit feeRateRangeSet(msg.sender, _min, _default, _max);
+        emit FeeRateRangeSet(msg.sender, _min, _default, _max);
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -13,7 +13,7 @@ import "contracts/proxy/Upgradeable.sol";
 
 
 /**
-* @notice Contract holds policy data and locks fees
+* @notice Contract holds policy data and locks accrued policy fees until collection
 * @dev |v5.1.1|
 */
 contract PolicyManager is Upgradeable {
@@ -145,7 +145,7 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Set maximum, minimum and and default fee rate for all stakers and all transactions (universal fee range)
+    * @notice Set maximum, minimum and and default fee rate for all stakers and all policies ('global fee range')
     */
     // TODO # 1501
     // function setFeeRateRange(Range calldata _range) external onlyOwner {
@@ -156,13 +156,13 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Set the minimum fee rate acceptable to staker
-    * @dev Input value must fall within `FeeRateRange` (universal fee range)
+    * @notice Set the minimum acceptable fee rate (set by staker)
+    * @dev Input value must fall within `FeeRateRange` (global fee range)
     */
     function setMinFeeRate(uint256 _minFeeRate) external {
         require(_minFeeRate >= FeeRateRange.min &&
             _minFeeRate <= FeeRateRange.max,
-            "The staker's min fee rate must fall within the universal fee range");
+            "The staker's min fee rate must fall within the global fee range");
         NodeInfo storage nodeInfo = nodes[msg.sender];
         if (nodeInfo.minFeeRate == _minFeeRate) {
             return;
@@ -172,11 +172,11 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Get the minimum fee rate acceptable to staker
+    * @notice Get the minimum acceptable fee rate (set by staker)
     */
     function getMinFeeRate(NodeInfo storage _nodeInfo) internal view returns (uint256) {
-        // if minFeeRate has not been set or chosen value falls outside the universal fee range
-        // default
+        // if minFeeRate has not been set or chosen value falls outside the global fee range
+        // a default value is returned instead
         if (_nodeInfo.minFeeRate == 0 ||
             _nodeInfo.minFeeRate < FeeRateRange.min ||
             _nodeInfo.minFeeRate > FeeRateRange.max) {
@@ -187,7 +187,7 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Get the minimum fee rate acceptable to staker
+    * @notice Get the minimum acceptable fee rate (set by staker)
     */
     function getMinFeeRate(address _node) public view returns (uint256) {
         NodeInfo storage nodeInfo = nodes[_node];
@@ -626,8 +626,8 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Get information about node fee
-    * @param _node Address of node
+    * @notice Get information about staker fee
+    * @param _node Address of staker
     * @param _period Period to get fee delta
     */
     function getNodeFeeDelta(address _node, uint16 _period)

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -145,7 +145,7 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Set maximum, minimum and default fee rate for all stakers and all policies ('global fee range')
+    * @notice Set minimum, default & maximum fee rate for all stakers and all policies ('global fee range')
     */
     // TODO # 1501
     // function setFeeRateRange(Range calldata _range) external onlyOwner {
@@ -156,7 +156,7 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Set the minimum acceptable fee rate (set by staker)
+    * @notice Set the minimum acceptable fee rate (set by staker for their associated worker)
     * @dev Input value must fall within `feeRateRange` (global fee range)
     */
     function setMinFeeRate(uint256 _minFeeRate) external {
@@ -172,7 +172,7 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Get the minimum acceptable fee rate (set by staker)
+    * @notice Get the minimum acceptable fee rate (set by staker for their associated worker)
     */
     function getMinFeeRate(NodeInfo storage _nodeInfo) internal view returns (uint256) {
         // if minFeeRate has not been set or chosen value falls outside the global fee range
@@ -187,7 +187,7 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Get the minimum acceptable fee rate (set by staker)
+    * @notice Get the minimum acceptable fee rate (set by staker for their associated worker)
     */
     function getMinFeeRate(address _node) public view returns (uint256) {
         NodeInfo storage nodeInfo = nodes[_node];
@@ -626,7 +626,7 @@ contract PolicyManager is Upgradeable {
     }
 
     /**
-    * @notice Get information about staker fee
+    * @notice Get information about staker's fee rate
     * @param _node Address of staker
     * @param _period Period to get fee delta
     */

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -193,7 +193,7 @@ contract StakingInterface is BaseStakingInterface {
     }
 
     /**
-    * @notice Withdraw available fee from the policy manager to the staking contract
+    * @notice Withdraw available policy fees from the policy manager to the staking contract
     */
     function withdrawPolicyFee() public onlyDelegateCall {
         uint256 value = policyManager.withdraw();
@@ -201,7 +201,7 @@ contract StakingInterface is BaseStakingInterface {
     }
 
     /**
-    * @notice Set the minimum fee that the staker will take in the policy manager
+    * @notice Set the minimum fee that the staker will accept in the policy manager contract
     */
     function setMinFeeRate(uint256 _minFeeRate) public onlyDelegateCall {
         policyManager.setMinFeeRate(_minFeeRate);
@@ -253,7 +253,7 @@ contract StakingInterface is BaseStakingInterface {
     }
 
     /**
-    * @notice Claimed tokens will be deposited and locked as stake in the StakingEscrow contract.
+    * @notice Claimed tokens will be deposited and locked as stake in the StakingEscrow contract
     */
     function claim() public onlyDelegateCall workLockSet {
         uint256 claimedTokens = workLock.claim();

--- a/nucypher/cli/actions.py
+++ b/nucypher/cli/actions.py
@@ -296,7 +296,7 @@ will result in the loss of staked tokens as described in the NuCypher slashing p
 
 Keeping your Ursula node online during the staking period and successfully
 producing correct re-encryption work orders will earn fees
-paid out in ethers retroactively and on-demand.
+paid out in ETH on-demand and retroactively.
 
 Accept ursula node operator obligation?""", abort=True)
 

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -594,7 +594,8 @@ def transfer_ownership(general_config, actor_options, target_address, gas):
 @click.option('--maximum', help="Maximum value for range (in wei)", type=WEI)
 def set_range(general_config, actor_options, minimum, default, maximum):
     """
-    Set the allowed range for the minimum fee rate in the policy manager contract.
+    Set the maximum, minimum & default fee rate for all stakers and all policies ('global fee range') in the policy manager contract.
+    The minimum acceptable fee rate (set by stakers) must fall within the global fee range.
     """
     emitter = general_config.emitter
     ADMINISTRATOR, _, _, _ = actor_options.create_actor(emitter)

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -606,6 +606,6 @@ def set_range(general_config, actor_options, minimum, default, maximum):
     if not maximum:
         maximum = click.prompt("Enter new maximum value for range", type=click.IntRange(min=default))
 
-    ADMINISTRATOR.set_min_fee_rate_range(minimum=minimum, default=default, maximum=maximum)
-    emitter.echo(f"The minimum fee rate was limited to the range [{minimum}, {maximum}] "
-                 f"with the default value {default}")
+    ADMINISTRATOR.set_fee_rate_range(minimum=minimum, default=default, maximum=maximum)
+    emitter.echo(f"The staker fee rate was set to the default value {default} such that it falls "
+                 f"within the range [{minimum}, {maximum}]")

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -594,7 +594,7 @@ def transfer_ownership(general_config, actor_options, target_address, gas):
 @click.option('--maximum', help="Maximum value for range (in wei)", type=WEI)
 def set_range(general_config, actor_options, minimum, default, maximum):
     """
-    Set the maximum, minimum & default fee rate for all stakers and all policies ('global fee range') in the policy manager contract.
+    Set the minimum, default & maximum fee rate for all policies ('global fee range') in the policy manager contract.
     The minimum acceptable fee rate (set by stakers) must fall within the global fee range.
     """
     emitter = general_config.emitter
@@ -608,5 +608,5 @@ def set_range(general_config, actor_options, minimum, default, maximum):
         maximum = click.prompt("Enter new maximum value for range", type=click.IntRange(min=default))
 
     ADMINISTRATOR.set_fee_rate_range(minimum=minimum, default=default, maximum=maximum)
-    emitter.echo(f"The staker fee rate was set to the default value {default} such that it falls "
+    emitter.echo(f"The staker's fee rate was set to the default value {default} such that it falls "
                  f"within the range [{minimum}, {maximum}]")

--- a/nucypher/cli/commands/multisig.py
+++ b/nucypher/cli/commands/multisig.py
@@ -234,7 +234,7 @@ def propose(general_config, blockchain_options, multisig_options):
     #  - Transfer ownership of contract
     #  - Send ETH from MultiSig
     #  - Send tokens from MultiSig
-    #  - Change min fee rate range in PolicyManager
+    #  - Change global fee range in PolicyManager
     #  - Send raw transaction
 
     # Init

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -919,7 +919,7 @@ def events(general_config, staker_options, config_file, event_name):
 @click.option('--min-rate', help="Minimum acceptable fee rate, set by staker", type=WEI)
 def set_min_rate(general_config, transacting_staker_options, config_file, force, min_rate):
     """
-    Staker sets the minimum fee rate they will accept.
+    Staker sets the minimum acceptable fee rate for their associated worker.
     """
     emitter = _setup_emitter(general_config)
 

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -916,10 +916,10 @@ def events(general_config, staker_options, config_file, event_name):
 @option_config_file
 @option_force
 @group_general_config
-@click.option('--min-rate', help="Minimum acceptable fee rate", type=WEI)
+@click.option('--min-rate', help="Minimum acceptable fee rate, set by staker", type=WEI)
 def set_min_rate(general_config, transacting_staker_options, config_file, force, min_rate):
     """
-    Set minimum acceptable value for the fee rate.
+    Staker sets the minimum fee rate they will accept.
     """
     emitter = _setup_emitter(general_config)
 
@@ -936,13 +936,13 @@ def set_min_rate(general_config, transacting_staker_options, config_file, force,
     if not min_rate:
         painting.paint_min_rate(emitter, STAKEHOLDER.registry, STAKEHOLDER.policy_agent, staking_address)
         # TODO check range
-        min_rate = click.prompt("Enter new value for min fee rate within range", type=WEI)
+        min_rate = click.prompt("Enter new value so the minimum fee rate falls within global fee range", type=WEI)
 
     password = transacting_staker_options.get_password(blockchain, client_account)
 
     if not force:
         click.confirm(f"Commit new value {min_rate} for "
-                      f"minimum acceptable fee rate?", abort=True)
+                      f"minimum fee rate?", abort=True)
 
     STAKEHOLDER.assimilate(checksum_address=client_account, password=password)
     receipt = STAKEHOLDER.set_min_fee_rate(min_rate=min_rate)

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -47,7 +47,7 @@ from nucypher.cli.painting import (
     paint_contract_status,
     paint_stakers,
     paint_locked_tokens_status,
-    paint_min_fee_range
+    paint_fee_rate_range
 )
 from nucypher.config.constants import NUCYPHER_ENVVAR_PROVIDER_URI
 
@@ -185,4 +185,4 @@ def fee_range(general_config, registry_options):
     """Show information about the allowed range for min fee rate."""
     emitter, registry, blockchain = registry_options.setup(general_config=general_config)
     policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=registry)
-    paint_min_fee_range(emitter=emitter, policy_agent=policy_agent)
+    paint_fee_rate_range(emitter=emitter, policy_agent=policy_agent)

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -182,7 +182,7 @@ def events(general_config, registry_options, contract_name, from_block, to_block
 @group_registry_options
 @group_general_config
 def fee_range(general_config, registry_options):
-    """Show information about the allowed range for min fee rate."""
+    """Provide information on the global fee range – the range into which the minimum fee rate must fall."""
     emitter, registry, blockchain = registry_options.setup(general_config=general_config)
     policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=registry)
     paint_fee_rate_range(emitter=emitter, policy_agent=policy_agent)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -348,7 +348,7 @@ Registry  ................ {registry.filepath}
     try:
 
         policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=registry)
-        paint_min_fee_range(emitter, policy_agent)
+        paint_fee_rate_range(emitter, policy_agent)
         emitter.echo(sep, nl=False)
 
     except BaseContractRegistry.UnknownContract:
@@ -357,8 +357,8 @@ Registry  ................ {registry.filepath}
         emitter.echo(sep, nl=False)
 
 
-def paint_min_fee_range(emitter, policy_agent):
-    minimum, default, maximum = policy_agent.get_min_fee_rate_range()
+def paint_fee_rate_range(emitter, policy_agent):
+    minimum, default, maximum = policy_agent.get_fee_rate_range()
 
     range_payload = f"""
 Range of the minimum fee rate:
@@ -369,7 +369,7 @@ Range of the minimum fee rate:
 
 
 def paint_min_rate(emitter, registry, policy_agent, staker_address):
-    paint_min_fee_range(emitter, policy_agent)
+    paint_fee_rate_range(emitter, policy_agent)
     minimum = policy_agent.min_fee_rate(staker_address)
     raw_minimum = policy_agent.raw_min_fee_rate(staker_address)
 

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -374,7 +374,7 @@ def paint_min_rate(emitter, registry, policy_agent, staker_address):
     raw_minimum = policy_agent.raw_min_fee_rate(staker_address)
 
     rate_payload = f"""
-Minimum acceptable fee rate (set by staker):
+Minimum acceptable fee rate (set by staker for their associated worker):
     ~ Previously set ....... {prettify_eth_amount(raw_minimum)}
     ~ Effective ............ {prettify_eth_amount(minimum)}"""
     emitter.echo(rate_payload)

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -361,7 +361,7 @@ def paint_fee_rate_range(emitter, policy_agent):
     minimum, default, maximum = policy_agent.get_fee_rate_range()
 
     range_payload = f"""
-Global fee range:
+Global fee Range:
     ~ Minimum ............ {prettify_eth_amount(minimum)}
     ~ Default ............ {prettify_eth_amount(default)}
     ~ Maximum ............ {prettify_eth_amount(maximum)}"""

--- a/nucypher/cli/painting.py
+++ b/nucypher/cli/painting.py
@@ -361,7 +361,7 @@ def paint_fee_rate_range(emitter, policy_agent):
     minimum, default, maximum = policy_agent.get_fee_rate_range()
 
     range_payload = f"""
-Range of the minimum fee rate:
+Global fee range:
     ~ Minimum ............ {prettify_eth_amount(minimum)}
     ~ Default ............ {prettify_eth_amount(default)}
     ~ Maximum ............ {prettify_eth_amount(maximum)}"""
@@ -374,7 +374,7 @@ def paint_min_rate(emitter, registry, policy_agent, staker_address):
     raw_minimum = policy_agent.raw_min_fee_rate(staker_address)
 
     rate_payload = f"""
-Minimum fee rate:
+Minimum acceptable fee rate (set by staker):
     ~ Previously set ....... {prettify_eth_amount(raw_minimum)}
     ~ Effective ............ {prettify_eth_amount(minimum)}"""
     emitter.echo(rate_payload)
@@ -978,8 +978,7 @@ def paint_bidding_notice(emitter, bidder):
   in the NuCypher slashing protocol.
 
 - Keeping your Ursula node online during the staking period and correctly servicing
-  re-encryption work orders will earn fees paid out in ethers retroactively
-  and on-demand.
+  re-encryption work orders will earn fees paid out in ETH on-demand and retroactively.
 
 Accept WorkLock terms and node operator obligation?"""  # TODO: Show a special message for first bidder, since there's no refund rate yet?
 

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
@@ -58,7 +58,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
     warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
     min_fee_log = policy_manager.events.MinFeeRateSet.createFilter(fromBlock='latest')
-    fee_range_log = policy_manager.events.feeRateRangeSet.createFilter(fromBlock='latest')
+    fee_range_log = policy_manager.events.FeeRateRangeSet.createFilter(fromBlock='latest')
 
     # Only past periods is allowed in register method
     current_period = policy_manager.functions.getCurrentPeriod().call()

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
@@ -58,7 +58,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
     warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
     min_fee_log = policy_manager.events.MinFeeRateSet.createFilter(fromBlock='latest')
-    fee_range_log = policy_manager.events.FeeRateRangeSet.createFilter(fromBlock='latest')
+    fee_range_log = policy_manager.events.feeRateRangeSet.createFilter(fromBlock='latest')
 
     # Only past periods is allowed in register method
     current_period = policy_manager.functions.getCurrentPeriod().call()
@@ -311,7 +311,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.setFeeRateRange(10, 20, 30).transact({'from': node1})
         testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.FeeRateRange().call() == [0, 0, 0]
+    assert policy_manager.functions.feeRateRange().call() == [0, 0, 0]
 
     tx = policy_manager.functions.setMinFeeRate(0).transact({'from': node1})
     testerchain.wait_for_receipt(tx)
@@ -320,7 +320,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     tx = policy_manager.functions.setFeeRateRange(0, 0, 0).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.FeeRateRange().call() == [0, 0, 0]
+    assert policy_manager.functions.feeRateRange().call() == [0, 0, 0]
 
     events = fee_range_log.get_all_entries()
     assert len(events) == 1
@@ -341,7 +341,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     min_rate, default_rate, max_rate = 10, 20, 30
     tx = policy_manager.functions.setFeeRateRange(min_rate, default_rate, max_rate).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.FeeRateRange().call() == [min_rate, default_rate, max_rate]
+    assert policy_manager.functions.feeRateRange().call() == [min_rate, default_rate, max_rate]
     assert policy_manager.functions.nodes(node1).call()[MIN_FEE_RATE_FIELD] == 0
     assert policy_manager.functions.nodes(node2).call()[MIN_FEE_RATE_FIELD] == 0
     assert policy_manager.functions.getMinFeeRate(node1).call() == default_rate
@@ -485,7 +485,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     min_rate, default_rate, max_rate = 11, 15, 19
     tx = policy_manager.functions.setFeeRateRange(min_rate, default_rate, max_rate).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.FeeRateRange().call() == [min_rate, default_rate, max_rate]
+    assert policy_manager.functions.feeRateRange().call() == [min_rate, default_rate, max_rate]
     assert policy_manager.functions.nodes(node1).call()[MIN_FEE_RATE_FIELD] == 10
     assert policy_manager.functions.nodes(node2).call()[MIN_FEE_RATE_FIELD] == 20
     assert policy_manager.functions.getMinFeeRate(node1).call() == default_rate

--- a/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/blockchain/eth/contracts/main/policy_manager/test_policy_manager.py
@@ -58,7 +58,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
     warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
     min_fee_log = policy_manager.events.MinFeeRateSet.createFilter(fromBlock='latest')
-    fee_range_log = policy_manager.events.MinFeeRateRangeSet.createFilter(fromBlock='latest')
+    fee_range_log = policy_manager.events.FeeRateRangeSet.createFilter(fromBlock='latest')
 
     # Only past periods is allowed in register method
     current_period = policy_manager.functions.getCurrentPeriod().call()
@@ -309,18 +309,18 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     # Only owner can change range
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.setMinFeeRateRange(10, 20, 30).transact({'from': node1})
+        tx = policy_manager.functions.setFeeRateRange(10, 20, 30).transact({'from': node1})
         testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.minFeeRateRange().call() == [0, 0, 0]
+    assert policy_manager.functions.FeeRateRange().call() == [0, 0, 0]
 
     tx = policy_manager.functions.setMinFeeRate(0).transact({'from': node1})
     testerchain.wait_for_receipt(tx)
     assert policy_manager.functions.getMinFeeRate(node1).call() == 0
     assert len(min_fee_log.get_all_entries()) == 0
 
-    tx = policy_manager.functions.setMinFeeRateRange(0, 0, 0).transact({'from': creator})
+    tx = policy_manager.functions.setFeeRateRange(0, 0, 0).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.minFeeRateRange().call() == [0, 0, 0]
+    assert policy_manager.functions.FeeRateRange().call() == [0, 0, 0]
 
     events = fee_range_log.get_all_entries()
     assert len(events) == 1
@@ -332,16 +332,16 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     # Can't set range with inconsistent values
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.setMinFeeRateRange(10, 5, 11).transact({'from': creator})
+        tx = policy_manager.functions.setFeeRateRange(10, 5, 11).transact({'from': creator})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = policy_manager.functions.setMinFeeRateRange(10, 15, 11).transact({'from': creator})
+        tx = policy_manager.functions.setFeeRateRange(10, 15, 11).transact({'from': creator})
         testerchain.wait_for_receipt(tx)
 
     min_rate, default_rate, max_rate = 10, 20, 30
-    tx = policy_manager.functions.setMinFeeRateRange(min_rate, default_rate, max_rate).transact({'from': creator})
+    tx = policy_manager.functions.setFeeRateRange(min_rate, default_rate, max_rate).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.minFeeRateRange().call() == [min_rate, default_rate, max_rate]
+    assert policy_manager.functions.FeeRateRange().call() == [min_rate, default_rate, max_rate]
     assert policy_manager.functions.nodes(node1).call()[MIN_FEE_RATE_FIELD] == 0
     assert policy_manager.functions.nodes(node2).call()[MIN_FEE_RATE_FIELD] == 0
     assert policy_manager.functions.getMinFeeRate(node1).call() == default_rate
@@ -483,9 +483,9 @@ def test_create_revoke(testerchain, escrow, policy_manager):
 
     # If min fee rate is outside of the range after changing it - then default value must be returned
     min_rate, default_rate, max_rate = 11, 15, 19
-    tx = policy_manager.functions.setMinFeeRateRange(min_rate, default_rate, max_rate).transact({'from': creator})
+    tx = policy_manager.functions.setFeeRateRange(min_rate, default_rate, max_rate).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
-    assert policy_manager.functions.minFeeRateRange().call() == [min_rate, default_rate, max_rate]
+    assert policy_manager.functions.FeeRateRange().call() == [min_rate, default_rate, max_rate]
     assert policy_manager.functions.nodes(node1).call()[MIN_FEE_RATE_FIELD] == 10
     assert policy_manager.functions.nodes(node2).call()[MIN_FEE_RATE_FIELD] == 20
     assert policy_manager.functions.getMinFeeRate(node1).call() == default_rate
@@ -542,7 +542,7 @@ def test_upgrading(testerchain, deploy_contract):
         abi=contract_library_v2.abi,
         address=dispatcher.address,
         ContractFactoryClass=Contract)
-    tx = contract.functions.setMinFeeRateRange(10, 15, 20).transact({'from': creator})
+    tx = contract.functions.setFeeRateRange(10, 15, 20).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Can't call `finishUpgrade` and `verifyState` methods outside upgrade lifecycle

--- a/tests/blockchain/eth/entities/actors/test_deployer.py
+++ b/tests/blockchain/eth/entities/actors/test_deployer.py
@@ -80,4 +80,4 @@ def test_rapid_deployment(token_economics, test_registry, tmpdir, get_random_che
     administrator.batch_deposits(allocation_data_filepath=str(filepath), interactive=False)
 
     minimum, default, maximum = 10, 20, 30
-    administrator.set_min_fee_rate_range(minimum, default, maximum)
+    administrator.set_fee_rate_range(minimum, default, maximum)

--- a/tests/blockchain/eth/entities/actors/test_staker.py
+++ b/tests/blockchain/eth/entities/actors/test_staker.py
@@ -26,7 +26,7 @@ from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.blockchain import token_airdrop
 from nucypher.utilities.sandbox.constants import DEVELOPMENT_TOKEN_AIRDROP_AMOUNT, INSECURE_DEVELOPMENT_PASSWORD
 from nucypher.utilities.sandbox.ursula import make_decentralized_ursulas
-from tests.fixtures import MIN_FEE_RATE_RANGE
+from tests.fixtures import FEE_RATE_RANGE
 
 
 @pytest.mark.slow()
@@ -202,7 +202,7 @@ def test_staker_manages_winding_down(testerchain,
 def test_set_min_fee_rate(testerchain, test_registry, staker):
 
     # Check before set
-    _minimum, default, maximum = MIN_FEE_RATE_RANGE
+    _minimum, default, maximum = FEE_RATE_RANGE
     assert staker.min_fee_rate == default
 
     # New value must be within range

--- a/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
+++ b/tests/blockchain/eth/entities/agents/test_policy_manager_agent.py
@@ -25,7 +25,7 @@ from eth_utils import is_checksum_address, to_wei
 from nucypher.blockchain.eth.agents import PolicyManagerAgent, ContractAgency
 from nucypher.crypto.powers import TransactingPower
 from nucypher.utilities.sandbox.constants import INSECURE_DEVELOPMENT_PASSWORD
-from tests.fixtures import MIN_FEE_RATE_RANGE
+from tests.fixtures import FEE_RATE_RANGE
 
 MockPolicyMetadata = collections.namedtuple('MockPolicyMetadata', 'policy_id author addresses')
 
@@ -139,7 +139,7 @@ def test_collect_refund(testerchain, agency, policy_meta):
 @pytest.mark.slow()
 def test_set_min_fee_rate(testerchain, test_registry, agency, policy_meta):
     policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=test_registry)  # type: PolicyManagerAgent
-    minimum, default, maximum = MIN_FEE_RATE_RANGE
+    minimum, default, maximum = FEE_RATE_RANGE
     staker = policy_meta.addresses[-1]
 
     assert policy_agent.get_min_fee_rate(staker) == default

--- a/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
+++ b/tests/blockchain/eth/entities/deployers/test_policy_manager_deployer.py
@@ -140,9 +140,9 @@ def test_rollback(testerchain, test_registry):
 
 def test_set_fee_range(policy_manager_deployer, test_registry):
     policy_agent = ContractAgency.get_agent(PolicyManagerAgent, registry=test_registry)  # type: PolicyManagerAgent
-    assert policy_agent.get_min_fee_rate_range() == (0, 0, 0)
+    assert policy_agent.get_fee_rate_range() == (0, 0, 0)
 
     minimum, default, maximum = 10, 20, 30
-    receipt = policy_manager_deployer.set_min_fee_rate_range(minimum, default, maximum)
+    receipt = policy_manager_deployer.set_fee_rate_range(minimum, default, maximum)
     assert receipt['status'] == 1
-    assert policy_agent.get_min_fee_rate_range() == (minimum, default, maximum)
+    assert policy_agent.get_fee_rate_range() == (minimum, default, maximum)

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -28,7 +28,7 @@ from nucypher.blockchain.eth.agents import (
 from nucypher.blockchain.eth.token import NU
 from nucypher.cli.commands.status import status
 from nucypher.utilities.sandbox.constants import TEST_PROVIDER_URI, TEMPORARY_DOMAIN
-from tests.fixtures import MIN_FEE_RATE_RANGE
+from tests.fixtures import FEE_RATE_RANGE
 
 
 def test_nucypher_status_network(click_runner, testerchain, agency_local_registry):
@@ -91,7 +91,7 @@ def test_nucypher_status_stakers(click_runner, agency_local_registry, stakers):
     assert re.search(r"Worker:\s+" + some_dude.worker_address, result.output, re.MULTILINE)
     assert re.search(r"Owned:\s+" + str(round(owned_tokens, 2)), result.output, re.MULTILINE)
     assert re.search(r"Staked: " + str(round(locked_tokens, 2)), result.output, re.MULTILINE)
-    _minimum, default, _maximum = MIN_FEE_RATE_RANGE
+    _minimum, default, _maximum = FEE_RATE_RANGE
     assert f"Min fee rate: {default} wei" in result.output
 
 
@@ -105,7 +105,7 @@ def test_nucypher_status_fee_range(click_runner, agency_local_registry, stakers)
 
     result = click_runner.invoke(status, stakers_command, catch_exceptions=False)
     assert result.exit_code == 0
-    minimum, default, maximum = MIN_FEE_RATE_RANGE
+    minimum, default, maximum = FEE_RATE_RANGE
     assert f"{minimum} wei" in result.output
     assert f"{default} wei" in result.output
     assert f"{maximum} wei" in result.output

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -97,7 +97,7 @@ def test_nucypher_status_stakers(click_runner, agency_local_registry, stakers):
 
 def test_nucypher_status_fee_range(click_runner, agency_local_registry, stakers):
 
-    # Get info about fee range
+    # Get information about global fee range (maximum rate, minimum rate, default rate)
     stakers_command = ('fee-range',
                        '--registry-filepath', agency_local_registry.filepath,
                        '--provider', TEST_PROVIDER_URI,

--- a/tests/cli/test_status.py
+++ b/tests/cli/test_status.py
@@ -97,7 +97,7 @@ def test_nucypher_status_stakers(click_runner, agency_local_registry, stakers):
 
 def test_nucypher_status_fee_range(click_runner, agency_local_registry, stakers):
 
-    # Get information about global fee range (maximum rate, minimum rate, default rate)
+    # Get information about global fee range (minimum rate, default rate, maximum rate)
     stakers_command = ('fee-range',
                        '--registry-filepath', agency_local_registry.filepath,
                        '--provider', TEST_PROVIDER_URI,

--- a/tests/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/cli/ursula/test_stakeholder_and_ursula.py
@@ -39,7 +39,7 @@ from nucypher.utilities.sandbox.constants import (
     select_test_port,
 )
 from nucypher.utilities.sandbox.middleware import MockRestMiddleware
-from tests.fixtures import MIN_FEE_RATE_RANGE
+from tests.fixtures import FEE_RATE_RANGE
 
 
 @mock.patch('nucypher.config.characters.StakeHolderConfiguration.default_filepath', return_value='/non/existent/file')
@@ -139,7 +139,7 @@ def test_stake_list(click_runner,
     result = click_runner.invoke(nucypher_cli, stake_args, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
     assert str(stake_value) in result.output
-    _minimum, default, _maximum = MIN_FEE_RATE_RANGE
+    _minimum, default, _maximum = FEE_RATE_RANGE
     assert f"{default} wei" in result.output
 
 
@@ -610,7 +610,7 @@ def test_set_min_rate(click_runner,
                       agency_local_registry,
                       stakeholder_configuration_file_location):
 
-    _minimum, _default, maximum = MIN_FEE_RATE_RANGE
+    _minimum, _default, maximum = FEE_RATE_RANGE
     min_rate = maximum - 1
     staker = Staker(is_me=True, checksum_address=manual_staker, registry=agency_local_registry)
     assert staker.raw_min_fee_rate == 0

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -100,7 +100,7 @@ from tests.performance_mocks import (
 )
 
 test_logger = Logger("test-logger")
-MIN_FEE_RATE_RANGE = (5, 10, 15)
+FEE_RATE_RANGE = (5, 10, 15)
 
 
 #
@@ -564,8 +564,8 @@ def _make_agency(testerchain,
     _worklock_agent = worklock_deployer.make_agent()                    # 5 Worklock
 
     # Set additional parameters
-    minimum, default, maximum = MIN_FEE_RATE_RANGE
-    txhash = policy_agent.contract.functions.setMinFeeRateRange(minimum, default, maximum).transact()
+    minimum, default, maximum = FEE_RATE_RANGE
+    txhash = policy_agent.contract.functions.setFeeRateRange(minimum, default, maximum).transact()
     _receipt = testerchain.wait_for_receipt(txhash)
 
     # TODO: Get rid of returning these agents here.


### PR DESCRIPTION
Follow on from #1959 

`MinFeeRateRange` -> `FeeRateRange`
`min_fee_rate_range` -> `fee_rate_range`
etc 

Use of _min_ is a bit misleading when the variable comprises a fixed, universal maximum, minimum and default rate (also referred to as the "global fee range"). Furthermore, stakers must choose their own _minimum_ acceptable fee rate, which must fall within the global fee range, and so unnecessary name similarities may cause unnecessary confusion.