### PR TITLE
Support for missing tests package

### DIFF
--- a/nucypher/blockchain/eth/providers.py
+++ b/nucypher/blockchain/eth/providers.py
@@ -24,6 +24,7 @@ from web3.exceptions import InfuraKeyNotFound
 from web3.providers.eth_tester.main import EthereumTesterProvider
 
 from nucypher.blockchain.eth.clients import NuCypherGethDevProcess
+from nucypher.exceptions import DevelopmentInstallationRequired
 
 
 class ProviderError(Exception):
@@ -90,10 +91,10 @@ def _get_auto_provider(provider_uri):
 
 def _get_pyevm_test_backend() -> PyEVMBackend:
     try:
+        # TODO: Consider packaged support of --dev mode with testerchain
         from tests.constants import PYEVM_GAS_LIMIT, NUMBER_OF_ETH_TEST_ACCOUNTS
     except ImportError:
-        raise ImportError("Nucypher is not installed in development mode.  "
-                          "Please checkout the code locally and reinstall to use the test client.")
+        raise DevelopmentInstallationRequired(importable_name='tests.constants')
 
     # Initialize
     genesis_params = PyEVMBackend._generate_genesis_params(overrides={'gas_limit': PYEVM_GAS_LIMIT})

--- a/nucypher/characters/control/controllers.py
+++ b/nucypher/characters/control/controllers.py
@@ -14,6 +14,7 @@ from nucypher.characters.control.interfaces import CharacterPublicInterface
 from nucypher.characters.control.specifications.exceptions import SpecificationError
 from nucypher.cli.processes import JSONRPCLineReceiver
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
+from nucypher.exceptions import DevelopmentInstallationRequired
 
 
 class CharacterControllerBase(ABC):
@@ -139,8 +140,8 @@ class JSONRPCController(CharacterControlServer):
         try:
             from tests.utils.controllers import JSONRPCTestClient
         except ImportError:
-            raise ImportError("Nucypher is not installed in development mode,  "
-                              "Please checkout the code locally and reinstall to use the test client.")
+            raise DevelopmentInstallationRequired(importable_name='tests.utils.controllers.JSONRPCTestClient')
+
         test_client = JSONRPCTestClient(rpc_controller=self)
         return test_client
 

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -16,6 +16,8 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
+from nucypher.exceptions import DevelopmentInstallationRequired
+
 from copy import copy
 
 from eth_tester.exceptions import ValidationError
@@ -31,7 +33,6 @@ class Vladimir(Ursula):
     """
     from tests.utils.middleware import EvilMiddleWare
 
-    network_middleware = EvilMiddleWare()
     fraud_address = '0xbad022A87Df21E4c787C7B1effD5077014b8CC45'
     fraud_key = 'a75d701cc4199f7646909d15f22e2e0ef6094b3e2aa47a188f35f47e8932a7b9'
     db_filepath = ':memory:'
@@ -47,6 +48,13 @@ class Vladimir(Ursula):
 
         TODO: This is probably a more instructive method if it takes a bytes representation instead of the entire Ursula.
         """
+        try:
+            from tests.utils.middleware import EvilMiddleWare
+        except ImportError:
+            raise DevelopmentInstallationRequired(importable_name='tests.utils.middleware.EvilMiddleWare')
+        else:
+            cls.network_middleware = EvilMiddleWare()
+
         crypto_power = CryptoPower(power_ups=target_ursula._default_crypto_powerups)
 
         if claim_signing_key:
@@ -54,6 +62,7 @@ class Vladimir(Ursula):
 
         if attach_transacting_key:
             cls.attach_transacting_key(blockchain=target_ursula.blockchain)
+
 
         vladimir = cls(is_me=True,
                        crypto_power=crypto_power,

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -31,7 +31,6 @@ class Vladimir(Ursula):
     """
     The power of Ursula, but with a heart forged deep in the mountains of Microsoft or a State Actor or whatever.
     """
-    from tests.utils.middleware import EvilMiddleWare
 
     fraud_address = '0xbad022A87Df21E4c787C7B1effD5077014b8CC45'
     fraud_key = 'a75d701cc4199f7646909d15f22e2e0ef6094b3e2aa47a188f35f47e8932a7b9'
@@ -52,8 +51,7 @@ class Vladimir(Ursula):
             from tests.utils.middleware import EvilMiddleWare
         except ImportError:
             raise DevelopmentInstallationRequired(importable_name='tests.utils.middleware.EvilMiddleWare')
-        else:
-            cls.network_middleware = EvilMiddleWare()
+        cls.network_middleware = EvilMiddleWare()
 
         crypto_power = CryptoPower(power_ups=target_ursula._default_crypto_powerups)
 

--- a/nucypher/cli/options.py
+++ b/nucypher/cli/options.py
@@ -185,10 +185,13 @@ def wrap_option(handler, **options):
 
 
 def process_middleware(mock_networking) -> tuple:
-    """Must not raise"""
+    #################
+    # MUST NOT RAISE!
+    #################
     try:
         from tests.utils.middleware import MockRestMiddleware
     except ImportError:
+        # It's okay to to not crash here despite not having the tests package available.
         logger = Logger("CLI-Middleware-Optional-Handler")
         logger.info('--mock-networking flag is unavailable without dev install.')
     if mock_networking:

--- a/nucypher/exceptions.py
+++ b/nucypher/exceptions.py
@@ -19,15 +19,15 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 # Package Warnings #
 ####################
 
-MESSAGE = '''
-A development installation of nucypher is required to import {module_name}. 
-Please follow the installation instructions published at ' 
-https://docs.nucypher.com/en/latest/guides/installation_guide.html
-'''
-
 
 class DevelopmentInstallationRequired(RuntimeError):
 
+    MESSAGE = '''
+    A development installation of nucypher is required to import {importable_name}. 
+    Please follow the installation instructions published at:
+    https://docs.nucypher.com/en/latest/guides/installation_guide.html
+    '''
+
     def __init__(self, importable_name: str, *args, **kwargs):
-        msg = MESSAGE.format(module_name=importable_name)
+        msg = self.MESSAGE.format(importable_name=importable_name)
         super().__init__(msg, *args, **kwargs)

--- a/nucypher/exceptions.py
+++ b/nucypher/exceptions.py
@@ -1,0 +1,33 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+
+# Package Warnings #
+####################
+
+MESSAGE = '''
+A development installation of nucypher is required to import {module_name}. 
+Please follow the installation instructions published at ' 
+https://docs.nucypher.com/en/latest/guides/installation_guide.html
+'''
+
+
+class DevelopmentInstallationRequired(RuntimeError):
+
+    def __init__(self, importable_name: str, *args, **kwargs):
+        msg = MESSAGE.format(module_name=importable_name)
+        super().__init__(msg, *args, **kwargs)

--- a/scripts/local_fleet/run_single_ursula.py
+++ b/scripts/local_fleet/run_single_ursula.py
@@ -28,7 +28,7 @@ from nucypher.cli.main import nucypher_cli
 from nucypher.exceptions import DevelopmentInstallationRequired
 
 try:
-    from tests.utils.networking import select_test_port
+    from tests.utils.ursula import select_test_port
 except ImportError:
     raise DevelopmentInstallationRequired(importable_name='tests.utils.ursula.select_test_port')
 

--- a/scripts/local_fleet/run_single_ursula.py
+++ b/scripts/local_fleet/run_single_ursula.py
@@ -25,7 +25,12 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 from click.testing import CliRunner
 
 from nucypher.cli.main import nucypher_cli
-from tests.utils.constants import select_test_port
+from nucypher.exceptions import DevelopmentInstallationRequired
+
+try:
+    from tests.utils.networking import select_test_port
+except ImportError:
+    raise DevelopmentInstallationRequired(importable_name='tests.utils.ursula.select_test_port')
 
 click_runner = CliRunner()
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,0 +1,33 @@
+import builtins
+import pytest
+
+from nucypher.exceptions import DevelopmentInstallationRequired
+
+
+def test_development_install_required(capsys, mocker):
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if 'tests' in name:
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    # Test lazy imports for entities that depends on the tests package
+    try:
+        builtins.__import__ = mock_import
+
+        # For example...
+        from nucypher.characters.unlawful import Vladimir     # Import OK
+        with pytest.raises(DevelopmentInstallationRequired):  # Lazy Action
+            Vladimir.from_target_ursula(target_ursula=mocker.Mock())
+
+        from nucypher.blockchain.eth.providers import _get_pyevm_test_backend
+        with pytest.raises(DevelopmentInstallationRequired):
+            _get_pyevm_test_backend()
+
+        from nucypher.characters.control.controllers import JSONRPCController
+        with pytest.raises(DevelopmentInstallationRequired):
+            JSONRPCController.test_client(self=mocker.Mock())
+
+    finally:
+        builtins.__import__ = real_import

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -4,30 +4,77 @@ import pytest
 from nucypher.exceptions import DevelopmentInstallationRequired
 
 
-def test_development_install_required(capsys, mocker):
-    real_import = builtins.__import__
+class TestsImportMocker:
 
-    def mock_import(name, *args, **kwargs):
-        if 'tests' in name:
+    REAL_IMPORT = builtins.__import__
+    __active = False
+
+    def mock_import(self, name, *args, **kwargs):
+        if 'tests' in name and self.__active:
             raise ImportError
-        return real_import(name, *args, **kwargs)
+        return self.REAL_IMPORT(name, *args, **kwargs)
 
-    # Test lazy imports for entities that depends on the tests package
+    def start(self):
+        builtins.__import__ = self.mock_import
+        self.__active = True
+
+    def stop(self):
+        builtins.__import__ = self.REAL_IMPORT
+        self.__active = False
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+
+
+@pytest.fixture(scope='function')
+def import_mocker():
+    mock = TestsImportMocker()
     try:
-        builtins.__import__ = mock_import
+        yield mock
+    finally:
+        mock.stop()
 
-        # For example...
-        from nucypher.characters.unlawful import Vladimir     # Import OK
-        with pytest.raises(DevelopmentInstallationRequired):  # Lazy Action
+
+def test_use_vladimir_without_development_installation(import_mocker, mocker):
+
+    # Expected error message (Related object)
+    from tests.utils.middleware import EvilMiddleWare
+    import_path = f'{EvilMiddleWare.__module__}.{EvilMiddleWare.__name__}'
+    message = DevelopmentInstallationRequired.MESSAGE.format(importable_name=import_path)
+    del EvilMiddleWare
+
+    with import_mocker:
+        from nucypher.characters.unlawful import Vladimir                    # Import OK
+        with pytest.raises(DevelopmentInstallationRequired, match=message):  # Expect lazy failure
             Vladimir.from_target_ursula(target_ursula=mocker.Mock())
 
-        from nucypher.blockchain.eth.providers import _get_pyevm_test_backend
-        with pytest.raises(DevelopmentInstallationRequired):
+
+def test_get_pyevm_backend_without_development_installation(import_mocker):
+
+    # Expected error message (Related object)
+    from tests import constants
+    import_path = f'{constants.__name__}'
+    message = DevelopmentInstallationRequired.MESSAGE.format(importable_name=import_path)
+    del constants
+
+    with import_mocker:
+        from nucypher.blockchain.eth.providers import _get_pyevm_test_backend   # Import OK
+        with pytest.raises(DevelopmentInstallationRequired, match=message):     # Expect lazy failure
             _get_pyevm_test_backend()
 
-        from nucypher.characters.control.controllers import JSONRPCController
-        with pytest.raises(DevelopmentInstallationRequired):
-            JSONRPCController.test_client(self=mocker.Mock())
 
-    finally:
-        builtins.__import__ = real_import
+def test_rpc_test_client_without_development_installation(import_mocker, mocker):
+
+    # Expected error message (Related object)
+    from tests.utils.controllers import JSONRPCTestClient
+    import_path = f'{JSONRPCTestClient.__module__}.{JSONRPCTestClient.__name__}'
+    message = DevelopmentInstallationRequired.MESSAGE.format(importable_name=import_path)
+    del JSONRPCTestClient
+
+    with import_mocker:
+        from nucypher.characters.control.controllers import JSONRPCController  # Import OK
+        with pytest.raises(DevelopmentInstallationRequired, match=message):    # Expect lazy failure
+            JSONRPCController.test_client(self=mocker.Mock())


### PR DESCRIPTION
#### What this does

- Clears blockage for PR #1931 

- Introduces new exception and module: `nucypher.exceptions.DevelopmentInstallationRequired`

- Introduces new tests module `test_package.py` describing lazy imports for tests entities

- Ensures imports to `tests` are lazy as possible and crash with import context if the tests package is missing.  This is especially relevant in 4 distinct situations:
        - Calling `Valdimir.from_target_ursula`
        - Calling `_get_pyevm_test_backend`
        - Calling `JSONRPCController.test_client`
        - Handling the `--mock-networking/-Z` CLI flag for `MockRestMiddleware` in `process_middleware`