### PR TITLE
Updates for staker in StakingEscrow

### DIFF
--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1002,7 +1002,7 @@ class PreallocationEscrowAgent(EthereumContractAgent):
 
     @contract_api(TRANSACTION)
     def lock(self, amount: NuNits, periods: PeriodDelta) -> TxReceipt:
-        contract_function: ContractFunction = self.__interface_contract.functions.lock(amount, periods)
+        contract_function: ContractFunction = self.__interface_contract.functions.lockAndCreate(amount, periods)
         receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=self.__beneficiary)
         return receipt
 

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -361,21 +361,6 @@ contract StakingEscrow is Issuer, IERC900History {
     }
 
     /**
-    * @notice Get the value of locked tokens for a staker in a previous period
-    * @dev Information may be incorrect for rewarded or not committed surpassed period
-    * @param _staker Staker
-    * @param _periods Amount of periods that will be subtracted from the current period
-    */
-    function getLockedTokensInPast(address _staker, uint16 _periods)
-        external view returns (uint256 lockedValue)
-    {
-        StakerInfo storage info = stakerInfo[_staker];
-        uint16 currentPeriod = getCurrentPeriod();
-        uint16 previousPeriod = currentPeriod.sub16(_periods);
-        return getLockedTokens(info, currentPeriod, previousPeriod);
-    }
-
-    /**
     * @notice Get the last committed staker's period
     * @param _staker Staker
     */

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -721,12 +721,14 @@ contract StakingEscrow is Issuer, IERC900History {
     * @param _value Amount of tokens which will be locked
     */
     function depositAndIncrease(uint256 _index, uint256 _value) external onlyStaker {
+        require(_index < MAX_SUB_STAKES);
         deposit(msg.sender, msg.sender, _index, _value, 0);
     }
 
     /**
     * @notice Deposit tokens
-    * @dev Specify either index and zero periods or non-existent index and real value for periods, not both
+    * @dev Specify either index and zero periods (for an existing sub-stake)
+    * or index >= MAX_SUB_STAKES and real value for periods (for a new sub-stake), not both
     * @param _staker Staker
     * @param _payer Owner of tokens
     * @param _index Index of the sub stake
@@ -771,12 +773,14 @@ contract StakingEscrow is Issuer, IERC900History {
     * @param _value Amount of tokens which will be locked
     */
     function lockAndIncrease(uint256 _index, uint256 _value) external onlyStaker {
+        require(_index < MAX_SUB_STAKES);
         lock(msg.sender, _index, _value, 0);
     }
 
     /**
     * @notice Lock some tokens as a stake
-    * @dev Specify either index and zero periods or non-existent index and real value for periods, not both
+    * @dev Specify either index and zero periods (for an existing sub-stake)
+    * or index >= MAX_SUB_STAKES and real value for periods (for a new sub-stake), not both
     * @param _staker Staker
     * @param _index Index of the sub stake
     * @param _value Amount of tokens which will be locked

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -40,7 +40,7 @@ interface WorkLockInterface {
 /**
 * @notice Contract holds and locks stakers tokens.
 * Each staker that locks their tokens will receive some compensation
-* @dev |v5.1.1|
+* @dev |v5.1.2|
 */
 contract StakingEscrow is Issuer, IERC900History {
 
@@ -211,7 +211,8 @@ contract StakingEscrow is Issuer, IERC900History {
     */
     modifier onlyStaker()
     {
-        require(stakerInfo[msg.sender].value > 0);
+        StakerInfo storage info = stakerInfo[msg.sender];
+        require(info.value > 0 || info.nextCommittedPeriod != 0);
         _;
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -82,6 +82,7 @@ contract StakingInterface is BaseStakingInterface {
     event LockedAndCreated(address indexed sender, uint256 value, uint16 periods);
     event LockedAndIncreased(address indexed sender, uint256 index, uint256 value);
     event Divided(address indexed sender, uint256 index, uint256 newValue, uint16 periods);
+    event Merged(address indexed sender, uint256 index1, uint256 index2);
     event Minted(address indexed sender);
     event PolicyFeeWithdrawn(address indexed sender, uint256 value);
     event MinFeeRateSet(address indexed sender, uint256 value);
@@ -199,15 +200,19 @@ contract StakingInterface is BaseStakingInterface {
     * @param _newValue New stake value
     * @param _periods Amount of periods for extending stake
     */
-    function divideStake(
-        uint256 _index,
-        uint256 _newValue,
-        uint16 _periods
-    )
-        public onlyDelegateCall
-    {
+    function divideStake(uint256 _index, uint256 _newValue, uint16 _periods) public onlyDelegateCall {
         escrow.divideStake(_index, _newValue, _periods);
         emit Divided(msg.sender, _index, _newValue, _periods);
+    }
+
+    /**
+    * @notice Merge two sub-stakes into one
+    * @param _index1 Index of the first sub-stake
+    * @param _index2 Index of the second sub-stake
+    */
+    function mergeStake(uint256 _index1, uint256 _index2) public onlyDelegateCall {
+        escrow.mergeStake(_index1, _index2);
+        emit Merged(msg.sender, _index1, _index2);
     }
 
     /**

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -146,7 +146,7 @@ contract StakingInterface is BaseStakingInterface {
     function depositAsStaker(uint256 _value, uint16 _periods) public onlyDelegateCall {
         require(token.balanceOf(address(this)) >= _value);
         token.approve(address(escrow), _value);
-        escrow.deposit(_value, _periods);
+        escrow.deposit(address(this), _value, _periods);
         emit DepositedAsStaker(msg.sender, _value, _periods);
     }
 

--- a/tests/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/contracts/contracts/StakingContractsTestSet.sol
@@ -28,11 +28,7 @@ contract StakingEscrowForStakingContractMock {
         token = _token;
     }
 
-    function deposit(uint256 _value, uint16 _periods) external {
-        deposit(msg.sender, _value, _periods);
-    }
-
-    function deposit(address _node, uint256 _value, uint16 _periods) public {
+    function deposit(address _node, uint256 _value, uint16 _periods) external {
         node = _node;
         value += _value;
         lockedValue += _value;
@@ -40,9 +36,21 @@ contract StakingEscrowForStakingContractMock {
         token.transferFrom(msg.sender, address(this), _value);
     }
 
-    function lock(uint256 _value, uint16 _periods) external {
+    function depositAndIncrease(uint256 _index, uint256 _value) external {
+        index = _index;
+        value += _value;
+        lockedValue += _value;
+        token.transferFrom(msg.sender, address(this), _value);
+    }
+
+    function lockAndCreate(uint256 _value, uint16 _periods) external {
         lockedValue += _value;
         periods += _periods;
+    }
+
+    function lockAndIncrease(uint256 _index, uint256 _value) external {
+        index = _index;
+        lockedValue += _value;
     }
 
     function divideStake(uint256 _index, uint256 _newValue, uint16 _periods) external {

--- a/tests/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/contracts/contracts/StakingContractsTestSet.sol
@@ -89,6 +89,10 @@ contract StakingEscrowForStakingContractMock {
         periods += _periods;
     }
 
+    function mergeStake(uint256 _index1, uint256 _index2) external {
+        index = _index1 + _index2;
+    }
+
     function getAllTokens(address) external view returns (uint256) {
         return value;
     }

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -6,6 +6,62 @@ pragma solidity ^0.6.5;
 import "contracts/StakingEscrow.sol";
 import "contracts/NuCypherToken.sol";
 
+/**
+* @notice Enhanced version of StakingEscrow to use in tests
+*/
+contract EnhancedStakingEscrow is StakingEscrow {
+
+    constructor(
+        NuCypherToken _token,
+        uint32 _hoursPerPeriod,
+        uint256 _issuanceDecayCoefficient,
+        uint256 _lockDurationCoefficient1,
+        uint256 _lockDurationCoefficient2,
+        uint16 _maximumRewardedPeriods,
+        uint256 _firstPhaseTotalSupply,
+        uint256 _firstPhaseMaxIssuance,
+        uint16 _minLockedPeriods,
+        uint256 _minAllowableLockedTokens,
+        uint256 _maxAllowableLockedTokens,
+        uint16 _minWorkerPeriods,
+        bool _isTestContract
+    )
+        public
+        StakingEscrow(
+            _token,
+            _hoursPerPeriod,
+            _issuanceDecayCoefficient,
+            _lockDurationCoefficient1,
+            _lockDurationCoefficient2,
+            _maximumRewardedPeriods,
+            _firstPhaseTotalSupply,
+            _firstPhaseMaxIssuance,
+            _minLockedPeriods,
+            _minAllowableLockedTokens,
+            _maxAllowableLockedTokens,
+            _minWorkerPeriods,
+            _isTestContract
+        )
+    {
+    }
+
+    /**
+    * @notice Get the value of locked tokens for a staker in a previous period
+    * @dev Information may be incorrect for rewarded or not committed surpassed period
+    * @param _staker Staker
+    * @param _periods Amount of periods that will be subtracted from the current period
+    */
+    function getLockedTokensInPast(address _staker, uint16 _periods)
+        external view returns (uint256 lockedValue)
+    {
+        StakerInfo storage info = stakerInfo[_staker];
+        uint16 currentPeriod = getCurrentPeriod();
+        uint16 previousPeriod = currentPeriod.sub16(_periods);
+        return getLockedTokens(info, currentPeriod, previousPeriod);
+    }
+
+}
+
 
 /**
 * @notice Upgrade to this contract must lead to fail

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -244,7 +244,7 @@ contract Intermediary {
 
     function deposit(uint256 _value, uint16 _periods) external {
         token.approve(address(escrow), _value);
-        escrow.deposit(_value, _periods);
+        escrow.deposit(address(this), _value, _periods);
     }
 
     function commitToNextPeriod() external {

--- a/tests/contracts/integration/test_intercontract_integration.py
+++ b/tests/contracts/integration/test_intercontract_integration.py
@@ -584,7 +584,7 @@ def test_staking(testerchain,
 
     # And can't lock because nothing to lock
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.lock(500, 2).transact({'from': staker1})
+        tx = escrow.functions.lockAndCreate(500, 2).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
     # Check that nothing is locked

--- a/tests/contracts/integration/test_intercontract_integration.py
+++ b/tests/contracts/integration/test_intercontract_integration.py
@@ -594,12 +594,12 @@ def test_staking(testerchain,
 
     # Staker can't deposit and lock too low value
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(1, 1).transact({'from': staker1})
+        tx = escrow.functions.deposit(staker1, 1, 1).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
     # And can't deposit and lock too high value
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.deposit(2001, 1).transact({'from': staker1})
+        tx = escrow.functions.deposit(staker1, 2001, 1).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
     # Can't make a commitment before initialization
@@ -629,7 +629,7 @@ def test_staking(testerchain,
     testerchain.wait_for_receipt(tx)
 
     # Staker transfers some tokens to the escrow and lock them
-    tx = escrow.functions.deposit(1000, 10).transact({'from': staker1})
+    tx = escrow.functions.deposit(staker1, 1000, 10).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.bondWorker(staker1).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)

--- a/tests/contracts/integration/test_intercontract_integration.py
+++ b/tests/contracts/integration/test_intercontract_integration.py
@@ -73,7 +73,7 @@ def token(token_economics, deploy_contract):
 def escrow_bare(testerchain, token, token_economics, deploy_contract):
     # Creator deploys the escrow
     contract, _ = deploy_contract(
-        'StakingEscrow', token.address, *token_economics.staking_deployment_parameters, True
+        'EnhancedStakingEscrow', token.address, *token_economics.staking_deployment_parameters, True
     )
     return contract
 

--- a/tests/contracts/main/staking_escrow/conftest.py
+++ b/tests/contracts/main/staking_escrow/conftest.py
@@ -57,7 +57,7 @@ def escrow_contract(testerchain, token, token_economics, request, deploy_contrac
         if disable_reward:
             deploy_parameters[5] = 0
             deploy_parameters[6] = 0
-        contract, _ = deploy_contract('StakingEscrow', token.address, *deploy_parameters)
+        contract, _ = deploy_contract('EnhancedStakingEscrow', token.address, *deploy_parameters)
 
         if request.param:
             dispatcher, _ = deploy_contract('Dispatcher', contract.address)

--- a/tests/contracts/main/staking_escrow/test_staking.py
+++ b/tests/contracts/main/staking_escrow/test_staking.py
@@ -288,7 +288,7 @@ def test_minting(testerchain, token, escrow_contract, token_economics):
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.commitToNextPeriod().transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.lock(500, 2).transact({'from': staker2})
+    tx = escrow.functions.lockAndCreate(500, 2).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
     staker2_stake += 250
 
@@ -675,7 +675,7 @@ def test_slashing(testerchain, token, escrow_contract, token_economics, deploy_c
     assert 260 == escrow.functions.lockedPerPeriod(current_period - 1).call()
     assert 260 == escrow.functions.lockedPerPeriod(current_period).call()
     assert 0 == escrow.functions.lockedPerPeriod(current_period + 1).call()
-    tx = escrow.functions.lock(160, 2).transact({'from': staker})
+    tx = escrow.functions.lockAndCreate(160, 2).transact({'from': staker})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.commitToNextPeriod().transact({'from': staker})
     testerchain.wait_for_receipt(tx)

--- a/tests/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow.py
@@ -66,7 +66,7 @@ def test_staking(testerchain, token, escrow_contract):
 
     # Can't lock because nothing to lock
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.lock(500, 2).transact({'from': staker1})
+        tx = escrow.functions.lockAndCreate(500, 2).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
     # Check that nothing is locked
@@ -330,7 +330,7 @@ def test_staking(testerchain, token, escrow_contract):
     assert current_period + 1 == event_args['period']
     assert 500 == event_args['value']
 
-    tx = escrow.functions.lock(100, 2).transact({'from': staker1})
+    tx = escrow.functions.lockAndCreate(100, 2).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
 
     events = commitments_log.get_all_entries()
@@ -351,7 +351,7 @@ def test_staking(testerchain, token, escrow_contract):
     assert 0 == escrow.functions.getLockedTokens(staker1, 2).call()
 
     # Staker increases lock
-    tx = escrow.functions.lock(500, 2).transact({'from': staker1})
+    tx = escrow.functions.lockAndCreate(500, 2).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.commitToNextPeriod().transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
@@ -414,7 +414,7 @@ def test_staking(testerchain, token, escrow_contract):
         tx = escrow.functions.divideStake(1, 200, 2).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
     # But can lock
-    tx = escrow.functions.lock(200, 2).transact({'from': staker2})
+    tx = escrow.functions.lockAndCreate(200, 2).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
     assert 500 == escrow.functions.getLockedTokens(staker2, 0).call()
     assert 400 == escrow.functions.getLockedTokens(staker2, 1).call()
@@ -541,9 +541,265 @@ def test_staking(testerchain, token, escrow_contract):
     assert 1 == len(withdraw_log.get_all_entries())
 
     # Test max locking duration
-    tx = escrow.functions.lock(200, MAX_UINT16).transact({'from': staker2})
+    tx = escrow.functions.lockAndCreate(200, MAX_UINT16).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
     assert 200 == escrow.functions.getLockedTokens(staker2, MAX_UINT16 - current_period).call()
+
+
+@pytest.mark.slow
+def test_increase_lock(testerchain, token, escrow_contract, token_economics):
+    minimum_allowed_locked = token_economics.minimum_allowed_locked
+    maximum_allowed_locked = 1500
+    minimum_locked_periods = token_economics.minimum_locked_periods
+
+    escrow = escrow_contract(maximum_allowed_locked, disable_reward=True)
+    creator = testerchain.client.accounts[0]
+    staker = testerchain.client.accounts[1]
+    someone_else = testerchain.client.accounts[2]
+    deposit_log = escrow.events.Deposited.createFilter(fromBlock='latest')
+    lock_log = escrow.events.Locked.createFilter(fromBlock='latest')
+    commitments_log = escrow.events.CommitmentMade.createFilter(fromBlock='latest')
+
+    # Initialize Escrow contract
+    tx = escrow.functions.initialize(0).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+
+    # Can't use depositAndIncrease without active sub-stakes
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.depositAndIncrease(0, minimum_allowed_locked).transact({'from': staker})
+        testerchain.wait_for_receipt(tx)
+
+    # Check that nothing is locked
+    assert escrow.functions.getLockedTokens(staker, 0).call() == 0
+    assert escrow.functions.getSubStakesLength(staker).call() == 0
+
+    # Staker transfers some tokens to the escrow and locks them
+    stake = minimum_allowed_locked
+    duration = 2 * minimum_locked_periods
+    current_period = escrow.functions.getCurrentPeriod().call()
+    tx = token.functions.transfer(staker, 2 * maximum_allowed_locked).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+    tx = token.functions.approve(escrow.address, 2 * maximum_allowed_locked).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.deposit(staker, stake, duration).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    assert escrow.functions.getAllTokens(staker).call() == stake
+    assert escrow.functions.getSubStakesLength(staker).call() == 1
+    assert escrow.functions.getLockedTokens(staker, 0).call() == 0
+    assert escrow.functions.getLockedTokens(staker, 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration - 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration + 1).call() == 0
+
+    # Now Staker can deposit to the first sub-stake
+    tx = escrow.functions.depositAndIncrease(0, minimum_allowed_locked // 2).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    stake += minimum_allowed_locked // 2
+    assert escrow.functions.getAllTokens(staker).call() == stake
+    assert escrow.functions.getSubStakesLength(staker).call() == 1
+    assert escrow.functions.getLockedTokens(staker, 0).call() == 0
+    assert escrow.functions.getLockedTokens(staker, 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration - 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration + 1).call() == 0
+
+    events = deposit_log.get_all_entries()
+    assert len(events) == 2
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['value'] == minimum_allowed_locked // 2
+    assert event_args['periods'] == duration
+    events = lock_log.get_all_entries()
+    assert len(events) == 2
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['value'] == minimum_allowed_locked // 2
+    assert event_args['firstPeriod'] == current_period + 1
+    assert event_args['periods'] == duration
+    assert len(commitments_log.get_all_entries()) == 0
+
+    # Can't use depositAndIncrease without active sub-stakes
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.depositAndIncrease(0, minimum_allowed_locked).transact({'from': someone_else})
+        testerchain.wait_for_receipt(tx)
+    # Can't deposit zero amount of tokens
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.depositAndIncrease(0, 0).transact({'from': staker})
+        testerchain.wait_for_receipt(tx)
+
+    # Commit to next period and deposit again to the first sub-stake
+    tx = escrow.functions.bondWorker(staker).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWindDown(True).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+
+    assert escrow.functions.lockedPerPeriod(current_period).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period + 1).call() == 0
+    tx = escrow.functions.commitToNextPeriod().transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    assert escrow.functions.lockedPerPeriod(current_period).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period + 1).call() == stake
+
+    tx = escrow.functions.depositAndIncrease(0, minimum_allowed_locked // 4).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    stake += minimum_allowed_locked // 4
+    assert escrow.functions.getAllTokens(staker).call() == stake
+    assert escrow.functions.getSubStakesLength(staker).call() == 1
+    assert escrow.functions.getLockedTokens(staker, 0).call() == 0
+    assert escrow.functions.getLockedTokens(staker, 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration - 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration + 1).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period + 1).call() == stake
+
+    events = deposit_log.get_all_entries()
+    assert len(events) == 3
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['value'] == minimum_allowed_locked // 4
+    assert event_args['periods'] == duration
+    events = lock_log.get_all_entries()
+    assert len(events) == 3
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['value'] == minimum_allowed_locked // 4
+    assert event_args['firstPeriod'] == current_period + 1
+    assert event_args['periods'] == duration
+    events = commitments_log.get_all_entries()
+    assert len(events) == 2
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['period'] == current_period + 1
+    assert event_args['value'] == minimum_allowed_locked // 4
+
+    # Wait next period and try to increase again to check creation of temporary sub-stake
+    testerchain.time_travel(hours=1)
+    duration -= 1
+    current_period = escrow.functions.getCurrentPeriod().call()
+    assert escrow.functions.getLockedTokens(staker, 0).call() == stake
+    assert escrow.functions.getLockedTokens(staker, 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration - 1).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration).call() == stake
+    assert escrow.functions.getLockedTokens(staker, duration + 1).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period).call() == stake
+    assert escrow.functions.lockedPerPeriod(current_period + 1).call() == 0
+
+    tx = escrow.functions.depositAndIncrease(0, minimum_allowed_locked).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    current_stake = stake
+    next_stake = stake + minimum_allowed_locked
+    assert escrow.functions.getAllTokens(staker).call() == next_stake
+    assert escrow.functions.getSubStakesLength(staker).call() == 2
+    assert escrow.functions.getLockedTokens(staker, 0).call() == current_stake
+    assert escrow.functions.getLockedTokens(staker, 1).call() == next_stake
+    assert escrow.functions.getLockedTokens(staker, duration - 1).call() == next_stake
+    assert escrow.functions.getLockedTokens(staker, duration).call() == next_stake
+    assert escrow.functions.getLockedTokens(staker, duration + 1).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period).call() == current_stake
+    assert escrow.functions.lockedPerPeriod(current_period + 1).call() == 0
+
+    events = deposit_log.get_all_entries()
+    assert len(events) == 4
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['value'] == minimum_allowed_locked
+    assert event_args['periods'] == duration
+    events = lock_log.get_all_entries()
+    assert len(events) == 4
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['value'] == minimum_allowed_locked
+    assert event_args['firstPeriod'] == current_period + 1
+    assert event_args['periods'] == duration
+    events = commitments_log.get_all_entries()
+    assert len(events) == 2
+
+    # Can't use temporary sub-stake because it ends in the current period
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.depositAndIncrease(1, minimum_allowed_locked).transact({'from': staker})
+        testerchain.wait_for_receipt(tx)
+
+    # Wait next period and check that temporary sub-stake is active until minting
+    testerchain.time_travel(hours=1)
+    stake = next_stake
+    assert escrow.functions.getLockedTokens(staker, 0).call() == stake
+    assert escrow.functions.getLockedTokens(staker, 1).call() == stake
+
+    tx = escrow.functions.deposit(staker, minimum_allowed_locked, 3 * minimum_locked_periods).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    assert escrow.functions.getSubStakesLength(staker).call() == 3
+    stake += minimum_allowed_locked
+
+    tx = escrow.functions.mint().transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+
+    tx = escrow.functions.deposit(staker, minimum_allowed_locked, 3 * minimum_locked_periods).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    assert escrow.functions.getSubStakesLength(staker).call() == 3
+    stake += minimum_allowed_locked
+
+    # Unlock some tokens
+    for i in range(duration):
+        tx = escrow.functions.commitToNextPeriod().transact({'from': staker})
+        testerchain.wait_for_receipt(tx)
+        testerchain.time_travel(hours=1)
+    tx = escrow.functions.commitToNextPeriod().transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+
+    current_period = escrow.functions.getCurrentPeriod().call()
+    next_stake = 2 * minimum_allowed_locked
+    duration = 3 * minimum_locked_periods - duration
+    assert escrow.functions.getAllTokens(staker).call() == stake
+    assert escrow.functions.getSubStakesLength(staker).call() == 3
+    assert escrow.functions.getLockedTokens(staker, 0).call() == stake
+    assert escrow.functions.getLockedTokens(staker, 1).call() == next_stake
+    assert escrow.functions.getLockedTokens(staker, duration - 1).call() == next_stake
+    assert escrow.functions.getLockedTokens(staker, duration).call() == next_stake
+    assert escrow.functions.getLockedTokens(staker, duration + 1).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period).call() == stake
+    assert escrow.functions.lockedPerPeriod(current_period + 1).call() == next_stake
+
+    # Can't lock more than staker has
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.lockAndIncrease(1, stake - next_stake + 1).transact({'from': staker})
+        testerchain.wait_for_receipt(tx)
+    # Can't ue zero value
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.lockAndIncrease(1, 0).transact({'from': staker})
+        testerchain.wait_for_receipt(tx)
+
+    # Lock and increase
+    deposits = len(deposit_log.get_all_entries())
+    locks = len(lock_log.get_all_entries())
+    commitments = len(commitments_log.get_all_entries())
+
+    tx = escrow.functions.lockAndIncrease(1, stake - next_stake - 1).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    assert escrow.functions.getAllTokens(staker).call() == stake
+    assert escrow.functions.getSubStakesLength(staker).call() == 4
+    assert escrow.functions.getLockedTokens(staker, 0).call() == stake
+    assert escrow.functions.getLockedTokens(staker, 1).call() == stake - 1
+    assert escrow.functions.getLockedTokens(staker, duration - 1).call() == stake - 1
+    assert escrow.functions.getLockedTokens(staker, duration).call() == stake - 1
+    assert escrow.functions.getLockedTokens(staker, duration + 1).call() == 0
+    assert escrow.functions.lockedPerPeriod(current_period).call() == stake
+    assert escrow.functions.lockedPerPeriod(current_period + 1).call() == stake - 1
+
+    assert len(deposit_log.get_all_entries()) == deposits
+    events = lock_log.get_all_entries()
+    assert len(events) == locks + 1
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['value'] == stake - next_stake - 1
+    assert event_args['firstPeriod'] == current_period + 1
+    assert event_args['periods'] == duration
+    events = commitments_log.get_all_entries()
+    assert len(events) == commitments + 1
+    event_args = events[-1]['args']
+    assert event_args['staker'] == staker
+    assert event_args['period'] == current_period + 1
+    assert event_args['value'] == stake - next_stake - 1
 
 
 @pytest.mark.slow
@@ -615,10 +871,10 @@ def test_max_sub_stakes(testerchain, token, escrow_contract):
 
 @pytest.mark.slow
 def test_allowable_locked_tokens(testerchain, token_economics, token, escrow_contract, deploy_contract):
-    maximum_allowed = 1500
+    maximum_allowed = 2000
     minimum_allowed = token_economics.minimum_allowed_locked
     escrow = escrow_contract(maximum_allowed, disable_reward=True)
-    creator, staker1, staker2, *everyone_else = testerchain.client.accounts
+    creator, staker1, staker2, staker3, *everyone_else = testerchain.client.accounts
 
     # Initialize Escrow contract
     tx = escrow.functions.initialize(0).transact({'from': creator})
@@ -629,6 +885,8 @@ def test_allowable_locked_tokens(testerchain, token_economics, token, escrow_con
     tx = token.functions.transfer(staker1, 2 * maximum_allowed).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     tx = token.functions.transfer(staker2, 2 * maximum_allowed).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+    tx = token.functions.transfer(staker3, 2 * maximum_allowed).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     # Staker can't deposit and lock too low value (less than _minAllowableLockedTokens coefficient)
@@ -663,6 +921,11 @@ def test_allowable_locked_tokens(testerchain, token_economics, token, escrow_con
     testerchain.wait_for_receipt(tx)
     staker1_lock += minimum_allowed
 
+    # Staker can't use depositAndIncrease with zero value
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.depositAndIncrease(0, 0).transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+
     # Preparation for next cases
     tx = token.functions.approveAndCall(escrow.address, minimum_allowed, testerchain.w3.toBytes(duration))\
         .transact({'from': staker1})
@@ -671,8 +934,11 @@ def test_allowable_locked_tokens(testerchain, token_economics, token, escrow_con
     tx = token.functions.approveAndCall(escrow.address, maximum_allowed, testerchain.w3.toBytes(duration))\
         .transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
+    tx = token.functions.approveAndCall(escrow.address, maximum_allowed - 1, testerchain.w3.toBytes(duration))\
+        .transact({'from': staker3})
+    testerchain.wait_for_receipt(tx)
 
-    # Can't deposit or lock too high value (more than _maxAllowableLockedTokens coefficient)
+    # Can't deposit or lock too high value (more than _maxAllowableLockedTokens value)
     with pytest.raises((TransactionFailed, ValueError)):
         tx = token.functions.approveAndCall(escrow.address, minimum_allowed, testerchain.w3.toBytes(2 * duration))\
             .transact({'from': staker2})
@@ -682,8 +948,20 @@ def test_allowable_locked_tokens(testerchain, token_economics, token, escrow_con
     with pytest.raises((TransactionFailed, ValueError)):
         tx = escrow.functions.deposit(staker2, minimum_allowed, 2 * duration).transact({'from': staker2})
         testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.depositAndIncrease(0, 1).transact({'from': staker2})
+        testerchain.wait_for_receipt(tx)
 
-    # Prepare for testing `lock()`: staker makes new sub-staker and unlocks first sub-stake
+    # Can't deposit too high value using depositAndIncrease
+    tx = token.functions.approve(escrow.address, maximum_allowed).transact({'from': staker3})
+    testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.depositAndIncrease(0, 2).transact({'from': staker3})
+        testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.depositAndIncrease(0, 1).transact({'from': staker3})
+    testerchain.wait_for_receipt(tx)
+
+    # Prepare for testing `lock()`: staker makes new sub-stake and unlocks first sub-stake
     tx = token.functions\
         .approveAndCall(escrow.address, maximum_allowed - staker1_lock, testerchain.w3.toBytes(2 * duration)) \
         .transact({'from': staker1})
@@ -702,16 +980,40 @@ def test_allowable_locked_tokens(testerchain, token_economics, token, escrow_con
 
     # Staker can't lock again too low or too high value
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.lock(minimum_allowed - 1, duration).transact({'from': staker1})
+        tx = escrow.functions.lockAndCreate(minimum_allowed - 1, duration).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.lock(maximum_allowed - staker1_lock + 1, duration).transact({'from': staker1})
+        tx = escrow.functions.lockAndCreate(maximum_allowed - staker1_lock + 1, duration).transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+    sub_stake_index = escrow.functions.getSubStakesLength(staker1).call() - 1
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.lockAndIncrease(sub_stake_index, maximum_allowed - staker1_lock + 1).transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.lockAndIncrease(sub_stake_index, 0).transact({'from': staker1})
         testerchain.wait_for_receipt(tx)
 
-    tx = escrow.functions.lock(minimum_allowed, duration).transact({'from': staker1})
+    tx = escrow.functions.lockAndIncrease(sub_stake_index, minimum_allowed // 2).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+    staker1_lock += minimum_allowed // 2
+    tx = escrow.functions.lockAndCreate(minimum_allowed, duration).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
     staker1_lock += minimum_allowed
-    tx = escrow.functions.lock(maximum_allowed - staker1_lock, duration).transact({'from': staker1})
+
+    # Check that still can lock up to maximum
+    tx = escrow.functions.lockAndCreate(maximum_allowed - staker1_lock, duration + 1).transact({'from': staker1})
+    testerchain.wait_for_receipt(tx)
+
+    # Unlock some tokens to check maximum for lockAndIncrease function
+    for _ in range(duration):
+        tx = escrow.functions.commitToNextPeriod().transact({'from': staker1})
+        testerchain.wait_for_receipt(tx)
+        testerchain.time_travel(hours=1)
+    testerchain.time_travel(hours=2)
+    staker1_lock = escrow.functions.getLockedTokens(staker1, 0).call()
+    assert staker1_lock < maximum_allowed
+    sub_stake_index = escrow.functions.getSubStakesLength(staker1).call() - 1
+    tx = escrow.functions.lockAndIncrease(sub_stake_index, maximum_allowed - staker1_lock).transact({'from': staker1})
     testerchain.wait_for_receipt(tx)
 
 

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -185,9 +185,9 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     print(tabulate.tabulate(rows, headers=headers, tablefmt="simple"), end="\n\n")
 
     # Accounts
-    origin, ursula1, ursula2, ursula3, alice1, alice2, *everyone_else = testerchain.client.accounts
+    origin, staker1, staker2, staker3, alice1, alice2, *everyone_else = testerchain.client.accounts
 
-    ursula_with_stamp = mock_ursula(testerchain, ursula1)
+    ursula_with_stamp = mock_ursula(testerchain, staker1)
 
     # Contracts
     token_agent = NucypherTokenAgent(registry=registry)
@@ -219,18 +219,18 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     #
     # Give Ursula and Alice some coins
     #
-    transact_and_log("Transfer tokens", token_functions.transfer(ursula1, MIN_ALLOWED_LOCKED * 10), {'from': origin})
-    transact(token_functions.transfer(ursula2, MIN_ALLOWED_LOCKED * 10), {'from': origin})
-    transact(token_functions.transfer(ursula3, MIN_ALLOWED_LOCKED * 10), {'from': origin})
+    transact_and_log("Transfer tokens", token_functions.transfer(staker1, MIN_ALLOWED_LOCKED * 10), {'from': origin})
+    transact(token_functions.transfer(staker2, MIN_ALLOWED_LOCKED * 10), {'from': origin})
+    transact(token_functions.transfer(staker3, MIN_ALLOWED_LOCKED * 10), {'from': origin})
 
     #
     # Ursula and Alice give Escrow rights to transfer
     #
     transact_and_log("Approving transfer",
                      token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6),
-                     {'from': ursula1})
-    transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6), {'from': ursula2})
-    transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6), {'from': ursula3})
+                     {'from': staker1})
+    transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6), {'from': staker2})
+    transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6), {'from': staker3})
 
     #
     # Batch deposit tokens
@@ -263,46 +263,46 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     # Ursula and Alice transfer some tokens to the escrow and lock them
     #
     transact_and_log("Initial deposit tokens, first",
-                     staker_functions.deposit(MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS),
-                     {'from': ursula1})
+                     staker_functions.deposit(staker1, MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS),
+                     {'from': staker1})
     transact_and_log("Initial deposit tokens, other",
-                     staker_functions.deposit(MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS),
-                     {'from': ursula2})
-    transact(staker_functions.deposit(MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS), {'from': ursula3})
+                     staker_functions.deposit(staker2, MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS),
+                     {'from': staker2})
+    transact(staker_functions.deposit(staker3, MIN_ALLOWED_LOCKED * 3, MIN_LOCKED_PERIODS), {'from': staker3})
 
-    transact(staker_functions.bondWorker(ursula1), {'from': ursula1})
-    transact(staker_functions.bondWorker(ursula2), {'from': ursula2})
-    transact(staker_functions.bondWorker(ursula3), {'from': ursula3})
-    transact(staker_functions.setReStake(False), {'from': ursula1})
-    transact(staker_functions.setReStake(False), {'from': ursula2})
-    transact(staker_functions.setWindDown(True), {'from': ursula1})
-    transact(staker_functions.setWindDown(True), {'from': ursula2})
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula2})
+    transact(staker_functions.bondWorker(staker1), {'from': staker1})
+    transact(staker_functions.bondWorker(staker2), {'from': staker2})
+    transact(staker_functions.bondWorker(staker3), {'from': staker3})
+    transact(staker_functions.setReStake(False), {'from': staker1})
+    transact(staker_functions.setReStake(False), {'from': staker2})
+    transact(staker_functions.setWindDown(True), {'from': staker1})
+    transact(staker_functions.setWindDown(True), {'from': staker2})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker1})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker2})
 
     #
     # Wait 1 period and make a commitment
     #
     testerchain.time_travel(periods=1)
-    transact_and_log("Make a commitment, first", staker_functions.commitToNextPeriod(), {'from': ursula1})
-    transact_and_log("Make a commitment, other", staker_functions.commitToNextPeriod(), {'from': ursula2})
+    transact_and_log("Make a commitment, first", staker_functions.commitToNextPeriod(), {'from': staker1})
+    transact_and_log("Make a commitment, other", staker_functions.commitToNextPeriod(), {'from': staker2})
 
     #
     # Wait 1 period and mint tokens
     #
     testerchain.time_travel(periods=1)
-    transact_and_log("Minting (1 stake), first", staker_functions.mint(), {'from': ursula1})
-    transact_and_log("Minting (1 stake), other", staker_functions.mint(), {'from': ursula2})
-    transact_and_log("Make a commitment again, first", staker_functions.commitToNextPeriod(), {'from': ursula1})
-    transact_and_log("Make a commitment again, other", staker_functions.commitToNextPeriod(), {'from': ursula2})
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula3})
+    transact_and_log("Minting (1 stake), first", staker_functions.mint(), {'from': staker1})
+    transact_and_log("Minting (1 stake), other", staker_functions.mint(), {'from': staker2})
+    transact_and_log("Make a commitment again, first", staker_functions.commitToNextPeriod(), {'from': staker1})
+    transact_and_log("Make a commitment again, other", staker_functions.commitToNextPeriod(), {'from': staker2})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker3})
 
     #
     # Commit again
     #
     testerchain.time_travel(periods=1)
-    transact_and_log("Make a commitment + mint, first", staker_functions.commitToNextPeriod(), {'from': ursula1})
-    transact_and_log("Make a commitment + mint, other", staker_functions.commitToNextPeriod(), {'from': ursula2})
+    transact_and_log("Make a commitment + mint, first", staker_functions.commitToNextPeriod(), {'from': staker1})
+    transact_and_log("Make a commitment + mint, other", staker_functions.commitToNextPeriod(), {'from': staker2})
 
     #
     # Create policy
@@ -316,59 +316,59 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 10 periods, pre-committed), first",
-                     policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [ursula1]),
+                     policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [staker1]),
                      {'from': alice1, 'value': value})
     transact_and_log("Creating policy (1 node, 10 periods, pre-committed), other",
-                     policy_functions.createPolicy(policy_id_2, alice1, end_timestamp, [ursula1]),
+                     policy_functions.createPolicy(policy_id_2, alice1, end_timestamp, [staker1]),
                      {'from': alice1, 'value': value})
 
     #
     # Get locked tokens
     #
-    transact_and_log("Getting locked tokens", staker_functions.getLockedTokens(ursula1, 0), {})
+    transact_and_log("Getting locked tokens", staker_functions.getLockedTokens(staker1, 0), {})
 
     #
     # Wait 1 period and withdraw tokens
     #
     testerchain.time_travel(periods=1)
-    transact_and_log("Withdraw", staker_functions.withdraw(1), {'from': ursula1})
+    transact_and_log("Withdraw", staker_functions.withdraw(1), {'from': staker1})
 
     #
     # Make a commitment with re-stake
     #
-    transact(staker_functions.setReStake(True), {'from': ursula1})
-    transact(staker_functions.setReStake(True), {'from': ursula2})
+    transact(staker_functions.setReStake(True), {'from': staker1})
+    transact(staker_functions.setReStake(True), {'from': staker2})
 
     # Used to remove spending for first call in a day for mint and commitToNextPeriod
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula3})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker3})
 
     transact_and_log("Make a commitment + mint + re-stake",
                      staker_functions.commitToNextPeriod(),
-                     {'from': ursula2})
+                     {'from': staker2})
     transact_and_log("Make a commitment + mint + re-stake + first fee + first fee rate",
                      staker_functions.commitToNextPeriod(),
-                     {'from': ursula1})
+                     {'from': staker1})
 
-    transact(staker_functions.setReStake(False), {'from': ursula1})
-    transact(staker_functions.setReStake(False), {'from': ursula2})
+    transact(staker_functions.setReStake(False), {'from': staker1})
+    transact(staker_functions.setReStake(False), {'from': staker2})
 
     #
     # Wait 2 periods and make a commitment after downtime
     #
     testerchain.time_travel(periods=2)
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula3})
-    transact_and_log("Make a commitment after downtime", staker_functions.commitToNextPeriod(), {'from': ursula2})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker3})
+    transact_and_log("Make a commitment after downtime", staker_functions.commitToNextPeriod(), {'from': staker2})
     transact_and_log("Make a commitment after downtime + updating fee",
                      staker_functions.commitToNextPeriod(),
-                     {'from': ursula1})
+                     {'from': staker1})
 
     #
     # Ursula and Alice deposit some tokens to the escrow again
     #
     transact_and_log("Deposit tokens after making a commitment",
-                     staker_functions.deposit(MIN_ALLOWED_LOCKED * 2, MIN_LOCKED_PERIODS),
-                     {'from': ursula1})
-    transact(staker_functions.deposit(MIN_ALLOWED_LOCKED * 2, MIN_LOCKED_PERIODS), {'from': ursula2})
+                     staker_functions.deposit(staker1, MIN_ALLOWED_LOCKED * 2, MIN_LOCKED_PERIODS),
+                     {'from': staker1})
+    transact(staker_functions.deposit(staker2, MIN_ALLOWED_LOCKED * 2, MIN_LOCKED_PERIODS), {'from': staker2})
 
     #
     # Revoke policy
@@ -391,23 +391,23 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (3 nodes, 100 periods, pre-committed), first",
-                     policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [ursula1, ursula2, ursula3]),
+                     policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [staker1, staker2, staker3]),
                      {'from': alice1, 'value': value})
     transact_and_log("Creating policy (3 nodes, 100 periods, pre-committed), other",
-                     policy_functions.createPolicy(policy_id_2, alice1, end_timestamp, [ursula1, ursula2, ursula3]),
+                     policy_functions.createPolicy(policy_id_2, alice1, end_timestamp, [staker1, staker2, staker3]),
                      {'from': alice1, 'value': value})
     value = 2 * number_of_periods * rate
     transact_and_log("Creating policy (2 nodes, 100 periods, pre-committed), other",
-                     policy_functions.createPolicy(policy_id_3, alice1, end_timestamp, [ursula1, ursula2]),
+                     policy_functions.createPolicy(policy_id_3, alice1, end_timestamp, [staker1, staker2]),
                      {'from': alice1, 'value': value})
 
     #
     # Wait 1 period and mint tokens
     #
     testerchain.time_travel(periods=1)
-    transact(staker_functions.mint(), {'from': ursula3})
-    transact_and_log("Last minting + updating fee + updating fee rate", staker_functions.mint(), {'from': ursula1})
-    transact_and_log("Last minting + first fee + first fee rate", staker_functions.mint(), {'from': ursula2})
+    transact(staker_functions.mint(), {'from': staker3})
+    transact_and_log("Last minting + updating fee + updating fee rate", staker_functions.mint(), {'from': staker1})
+    transact_and_log("Last minting + first fee + first fee rate", staker_functions.mint(), {'from': staker2})
 
     #
     # Create policy again without pre-committed nodes
@@ -420,30 +420,30 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 100 periods)",
-                     policy_functions.createPolicy(policy_id_1, alice2, end_timestamp, [ursula2]),
+                     policy_functions.createPolicy(policy_id_1, alice2, end_timestamp, [staker2]),
                      {'from': alice1, 'value': value})
     testerchain.time_travel(periods=1)
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 100 periods), next period",
-                     policy_functions.createPolicy(policy_id_2, alice2, end_timestamp, [ursula2]),
+                     policy_functions.createPolicy(policy_id_2, alice2, end_timestamp, [staker2]),
                      {'from': alice1, 'value': value})
     transact_and_log("Creating policy (1 node, 100 periods), another node",
-                     policy_functions.createPolicy(policy_id_3, alice2, end_timestamp, [ursula1]),
+                     policy_functions.createPolicy(policy_id_3, alice2, end_timestamp, [staker1]),
                      {'from': alice1, 'value': value})
 
     #
     # Mint and revoke policy
     #
     testerchain.time_travel(periods=10)
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula3})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker1})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker3})
 
     testerchain.time_travel(periods=2)
-    transact(staker_functions.mint(), {'from': ursula3})
+    transact(staker_functions.mint(), {'from': staker3})
     transact_and_log("Last minting after downtime + updating fee",
                      staker_functions.mint(),
-                     {'from': ursula1})
+                     {'from': staker1})
 
     testerchain.time_travel(periods=10)
     transact_and_log("Revoking policy after downtime, 1st policy",
@@ -457,54 +457,54 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
                      {'from': alice2})
 
     for index in range(5):
-        transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
+        transact(staker_functions.commitToNextPeriod(), {'from': staker1})
         testerchain.time_travel(periods=1)
-    transact(staker_functions.mint(), {'from': ursula1})
+    transact(staker_functions.mint(), {'from': staker1})
 
     #
     # Check regular deposit
     #
     transact_and_log("Deposit tokens",
-                     staker_functions.deposit(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS),
-                     {'from': ursula1})
+                     staker_functions.deposit(staker1, MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS),
+                     {'from': staker1})
 
     #
     # ApproveAndCall
     #
     testerchain.time_travel(periods=1)
-    transact(staker_functions.mint(), {'from': ursula1})
+    transact(staker_functions.mint(), {'from': staker1})
 
     transact_and_log("ApproveAndCall",
                      token_functions.approveAndCall(staking_agent.contract_address,
                                                     MIN_ALLOWED_LOCKED * 2,
                                                     web3.toBytes(MIN_LOCKED_PERIODS)),
-                     {'from': ursula1})
+                     {'from': staker1})
 
     #
     # Locking tokens
     #
     testerchain.time_travel(periods=1)
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
-    transact_and_log("Locking tokens", staker_functions.lock(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS), {'from': ursula1})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker1})
+    transact_and_log("Locking tokens", staker_functions.lock(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS), {'from': staker1})
 
     #
     # Divide stake
     #
-    transact_and_log("Divide stake", staker_functions.divideStake(1, MIN_ALLOWED_LOCKED, 2), {'from': ursula1})
-    transact(staker_functions.divideStake(3, MIN_ALLOWED_LOCKED, 2), {'from': ursula1})
+    transact_and_log("Divide stake", staker_functions.divideStake(1, MIN_ALLOWED_LOCKED, 2), {'from': staker1})
+    transact(staker_functions.divideStake(3, MIN_ALLOWED_LOCKED, 2), {'from': staker1})
 
     #
     # Divide almost finished stake
     #
     testerchain.time_travel(periods=1)
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker1})
     testerchain.time_travel(periods=1)
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker1})
 
     #
     # Slashing tests
     #
-    transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
+    transact(staker_functions.commitToNextPeriod(), {'from': staker1})
     testerchain.time_travel(periods=1)
 
     #
@@ -513,50 +513,50 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     slashing_args = generate_args_for_slashing(ursula_with_stamp)
     transact_and_log("Slash just value", adjudicator_functions.evaluateCFrag(*slashing_args), {'from': alice1})
 
-    deposit = staker_functions.stakerInfo(ursula1).call()[0]
-    unlocked = deposit - staker_functions.getLockedTokens(ursula1, 0).call()
-    transact(staker_functions.withdraw(unlocked), {'from': ursula1})
+    deposit = staker_functions.stakerInfo(staker1).call()[0]
+    unlocked = deposit - staker_functions.getLockedTokens(staker1, 0).call()
+    transact(staker_functions.withdraw(unlocked), {'from': staker1})
 
-    sub_stakes_length = str(staker_functions.getSubStakesLength(ursula1).call())
+    sub_stakes_length = str(staker_functions.getSubStakesLength(staker1).call())
     slashing_args = generate_args_for_slashing(ursula_with_stamp)
     transact_and_log("Slashing one sub stake and saving old one (" + sub_stakes_length + " sub stakes), 1st",
                      adjudicator_functions.evaluateCFrag(*slashing_args),
                      {'from': alice1})
 
-    sub_stakes_length = str(staker_functions.getSubStakesLength(ursula1).call())
+    sub_stakes_length = str(staker_functions.getSubStakesLength(staker1).call())
     slashing_args = generate_args_for_slashing(ursula_with_stamp)
     transact_and_log("Slashing one sub stake and saving old one (" + sub_stakes_length + " sub stakes), 2nd",
                      adjudicator_functions.evaluateCFrag(*slashing_args),
                      {'from': alice1})
 
-    sub_stakes_length = str(staker_functions.getSubStakesLength(ursula1).call())
+    sub_stakes_length = str(staker_functions.getSubStakesLength(staker1).call())
     slashing_args = generate_args_for_slashing(ursula_with_stamp)
     transact_and_log("Slashing one sub stake and saving old one (" + sub_stakes_length + " sub stakes), 3rd",
                      adjudicator_functions.evaluateCFrag(*slashing_args),
                      {'from': alice1})
 
-    sub_stakes_length = str(staker_functions.getSubStakesLength(ursula1).call())
+    sub_stakes_length = str(staker_functions.getSubStakesLength(staker1).call())
     slashing_args = generate_args_for_slashing(ursula_with_stamp)
     transact_and_log("Slashing two sub stakes and saving old one (" + sub_stakes_length + " sub stakes)",
                      adjudicator_functions.evaluateCFrag(*slashing_args),
                      {'from': alice1})
 
     for index in range(18):
-        transact(staker_functions.commitToNextPeriod(), {'from': ursula1})
+        transact(staker_functions.commitToNextPeriod(), {'from': staker1})
         testerchain.time_travel(periods=1)
 
-    transact(staker_functions.lock(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS), {'from': ursula1})
-    deposit = staker_functions.stakerInfo(ursula1).call()[0]
-    unlocked = deposit - staker_functions.getLockedTokens(ursula1, 1).call()
-    transact(staker_functions.withdraw(unlocked), {'from': ursula1})
+    transact(staker_functions.lock(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS), {'from': staker1})
+    deposit = staker_functions.stakerInfo(staker1).call()[0]
+    unlocked = deposit - staker_functions.getLockedTokens(staker1, 1).call()
+    transact(staker_functions.withdraw(unlocked), {'from': staker1})
 
-    sub_stakes_length = str(staker_functions.getSubStakesLength(ursula1).call())
+    sub_stakes_length = str(staker_functions.getSubStakesLength(staker1).call())
     slashing_args = generate_args_for_slashing(ursula_with_stamp)
     transact_and_log("Slashing two sub stakes, shortest and new one (" + sub_stakes_length + " sub stakes)",
                      adjudicator_functions.evaluateCFrag(*slashing_args),
                      {'from': alice1})
 
-    sub_stakes_length = str(staker_functions.getSubStakesLength(ursula1).call())
+    sub_stakes_length = str(staker_functions.getSubStakesLength(staker1).call())
     slashing_args = generate_args_for_slashing(ursula_with_stamp)
     transact_and_log("Slashing three sub stakes, two shortest and new one (" + sub_stakes_length + " sub stakes)",
                      adjudicator_functions.evaluateCFrag(*slashing_args),
@@ -565,7 +565,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     slashing_args = generate_args_for_slashing(ursula_with_stamp, corrupt_cfrag=False)
     transact_and_log("Evaluating correct CFrag", adjudicator_functions.evaluateCFrag(*slashing_args), {'from': alice1})
 
-    transact_and_log("Prolong stake", staker_functions.prolongStake(0, 20), {'from': ursula1})
+    transact_and_log("Prolong stake", staker_functions.prolongStake(0, 20), {'from': staker1})
 
     print("********* All Done! *********")
 

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -227,7 +227,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     # Ursula and Alice give Escrow rights to transfer
     #
     transact_and_log("Approving transfer",
-                     token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6),
+                     token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 7),
                      {'from': staker1})
     transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6), {'from': staker2})
     transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 6), {'from': staker3})
@@ -464,8 +464,11 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     #
     # Check regular deposit
     #
-    transact_and_log("Deposit tokens",
+    transact_and_log("Deposit tokens to new sub-stake",
                      staker_functions.deposit(staker1, MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS),
+                     {'from': staker1})
+    transact_and_log("Deposit tokens using existing sub-stake",
+                     staker_functions.depositAndIncrease(0, MIN_ALLOWED_LOCKED),
                      {'from': staker1})
 
     #
@@ -485,7 +488,12 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     #
     testerchain.time_travel(periods=1)
     transact(staker_functions.commitToNextPeriod(), {'from': staker1})
-    transact_and_log("Locking tokens", staker_functions.lock(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS), {'from': staker1})
+    transact_and_log("Locking tokens and creating new sub-stake",
+                     staker_functions.lockAndCreate(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS),
+                     {'from': staker1})
+    transact_and_log("Locking tokens using existing sub-stake",
+                     staker_functions.lockAndIncrease(0, MIN_ALLOWED_LOCKED),
+                     {'from': staker1})
 
     #
     # Divide stake
@@ -545,7 +553,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
         transact(staker_functions.commitToNextPeriod(), {'from': staker1})
         testerchain.time_travel(periods=1)
 
-    transact(staker_functions.lock(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS), {'from': staker1})
+    transact(staker_functions.lockAndCreate(MIN_ALLOWED_LOCKED, MIN_LOCKED_PERIODS), {'from': staker1})
     deposit = staker_functions.stakerInfo(staker1).call()[0]
     unlocked = deposit - staker_functions.getLockedTokens(staker1, 1).call()
     transact(staker_functions.withdraw(unlocked), {'from': staker1})

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -574,6 +574,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     transact_and_log("Evaluating correct CFrag", adjudicator_functions.evaluateCFrag(*slashing_args), {'from': alice1})
 
     transact_and_log("Prolong stake", staker_functions.prolongStake(0, 20), {'from': staker1})
+    transact_and_log("Merge sub-stakes", staker_functions.mergeStake(2, 3), {'from': staker1})
 
     print("********* All Done! *********")
 


### PR DESCRIPTION
Refs #1422 
Fixes #1419
Fixes #1933
Refs #1766
Refs #2015

* `StakingEscrow` code size optimization
* Staker for contract is who has tokens or not rewarded periods
* Auto unbond worker when last portion of NU is withdrawn
* New functions to deposit and lock tokens to existing sub-stake (even if value less than minimum)
* New function to merge two sub-stakes