### PR TITLE
Fix Codecov / CircleCI Integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -448,12 +448,6 @@ commands:
           when: always
       - store_artifacts:
           path: ~/test-logs/
-      - run:
-          name: If $ENABLE_CODECOV, exit job without failing now to avoid uploading codecov results
-          command: |
-            if [ -z "$ENABLE_CODECOV"]; then
-                circleci-agent step halt
-            fi
       - codecov
 
   build_and_save_test_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -432,6 +432,7 @@ commands:
     description: "Upload Coverage Report To codecov.io"
     steps:
       - codecov/upload:
+          flags: all
           file: reports/coverage.xml
 
   capture_test_results:


### PR DESCRIPTION
#### What this does

Makes codecov accurate. Use codecov CI orb flag for coverage report aggregation and upload.

#### Example report 

From this PR.

<https://codecov.io/gh/nucypher/nucypher/tree/f87194ebca285a299227f1b5ff6c3f5f93850eca>

#### But... how?

Multiple uploads (one per workflow step) via circleci orb parameters
<https://codecov.io/gh/nucypher/nucypher/commit/f87194ebca285a299227f1b5ff6c3f5f93850eca/build>

#### Resources

Under the Hood:
<https://docs.codecov.io/docs/flags>

CircleCI setting the example:

> We then upload the coverage data from all three test runs using the flags macos, windows, and linux. Codecov is then able to combine the three reports into a single report to give us an overall code coverage metric for the build.

<https://circleci.com/blog/circleci-config-teardown-how-we-write-our-circleci-config-at-circleci/>