### PR TITLE
Small test fixes

### DIFF
--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -174,7 +174,7 @@ class CharacterConfiguration(BaseConfiguration):
                                'provider_uri': provider_uri,
                                'gas_strategy': gas_strategy}
             if any(blockchain_args.values()):
-                bad_args = (f"{arg}={val}" for arg, val in blockchain_args.items() if val)
+                bad_args = ", ".join(f"{arg}={val}" for arg, val in blockchain_args.items() if val)
                 self.log.warn(f"Arguments {bad_args} are incompatible with federated_only. "
                               f"Overridden with a sane default.")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 addopts = -s -v --runslow --junitxml=./reports/pytest-results.xml --strict-markers --durations=0 --cov=nucypher --cov-report xml:reports/coverage.xml
 markers =
     slow: marks tests as slow (skipped by default, use '--runslow' to include these tests)
+junit_family = xunit1

--- a/tests/cli/test_deploy_commands.py
+++ b/tests/cli/test_deploy_commands.py
@@ -232,7 +232,6 @@ def test_batch_deposits(click_runner,
                                  deploy_command,
                                  input=user_input,
                                  catch_exceptions=False)
-    print(result.output)
     assert result.exit_code == 0
     for allocation_address in testerchain.unassigned_accounts:
         assert allocation_address in result.output

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -578,15 +578,6 @@ def agency_local_registry(testerchain, agency, test_registry):
         os.remove(MOCK_REGISTRY_FILEPATH)
 
 
-@pytest.fixture(scope='module')
-def agency_local_registry(testerchain, agency, test_registry):
-    registry = LocalContractRegistry(filepath=MOCK_REGISTRY_FILEPATH)
-    registry.write(test_registry.read())
-    yield registry
-    if os.path.exists(MOCK_REGISTRY_FILEPATH):
-        os.remove(MOCK_REGISTRY_FILEPATH)
-
-
 @pytest.fixture(scope="module")
 def stakers(testerchain, agency, token_economics, test_registry):
     token_agent, _staking_agent, _policy_agent = agency

--- a/tests/utils/blockchain.py
+++ b/tests/utils/blockchain.py
@@ -65,6 +65,8 @@ class TesterBlockchain(BlockchainDeployerInterface):
     Blockchain subclass with additional test utility methods and options.
     """
 
+    __test__ = False # prohibit Pytest from picking it up
+
     _instance = None
 
     GAS_STRATEGIES = {**BlockchainDeployerInterface.GAS_STRATEGIES,


### PR DESCRIPTION
* Remove a `print()` seemingly left from debugging.
* Remove a duplicate `agency_local_registry()` fixture
* Add `junit_family=xunit1` to `pytest.ini` to avoid deprecation warnings
* Mark `TesterBlockchain` as a non-test class to avoid pytest warnings
* Fix a warning message in `CharacterConfiguration` constructor 