### PR TITLE
Bump version: 2.1.0-beta.8 → 2.1.0-beta.9

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.0-beta.8
+current_version = 2.1.0-beta.9
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -45,7 +45,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '2.1.0-beta.8'
+release = '2.1.0-beta.9'
 
 
 # -- General configuration ---------------------------------------------------

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -28,7 +28,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "2.1.0-beta.8"
+__version__ = "2.1.0-beta.9"
 
 __author__ = "NuCypher"
 

--- a/tests/integration/cli/test_worklock_cli_functionality.py
+++ b/tests/integration/cli/test_worklock_cli_functionality.py
@@ -353,7 +353,7 @@ def test_already_claimed(click_runner,
                '--force')
 
     result = click_runner.invoke(worklock, command, input=YES, env=CLI_TEST_ENV, catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 1  # TODO: Decide if this case should error (like now) or simply do nothing
 
     # Bidder
     mock_withdraw_compensation.assert_called_once()


### PR DESCRIPTION
The TODO in the included fix is associated with https://github.com/nucypher/nucypher/issues/1984#issuecomment-635024691