### PR TITLE
Simplify staker sampling

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -44,7 +44,8 @@ from nucypher.blockchain.eth.agents import (
     PolicyManagerAgent,
     PreallocationEscrowAgent,
     StakingEscrowAgent,
-    WorkLockAgent
+    WorkLockAgent,
+    StakersReservoir,
 )
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.decorators import (
@@ -1545,16 +1546,11 @@ class BlockchainPolicyAuthor(NucypherTokenActor):
         payload = {**blockchain_payload, **policy_end_time}
         return payload
 
-    def recruit(self, quantity: int, **options) -> List[str]:
+    def get_stakers_reservoir(self, **options) -> StakersReservoir:
         """
-        Uses sampling logic to gather stakers from the blockchain and
-        caches the resulting node ethereum addresses.
-
-        :param quantity: Number of ursulas to sample from the blockchain.
-
+        Get a sampler object containing the currently registered stakers.
         """
-        staker_addresses = self.staking_agent.sample(quantity=quantity, **options)
-        return staker_addresses
+        return self.staking_agent.get_stakers_reservoir(**options)
 
     def create_policy(self, *args, **kwargs):
         """

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -34,7 +34,7 @@ from eth_utils import to_checksum_address
 from requests.exceptions import SSLError
 from twisted.internet import defer, reactor, task
 from twisted.internet.threads import deferToThread
-from typing import Set, Tuple, Union
+from typing import Set, Tuple, Union, Iterable
 from umbral.signing import Signature
 
 import nucypher
@@ -603,9 +603,10 @@ class Learner:
         # TODO: Allow the user to set eagerness?  1712
         self.learn_from_teacher_node(eager=False)
 
-    def learn_about_specific_nodes(self, addresses: Set):
-        self._node_ids_to_learn_about_immediately.update(addresses)  # hmmmm
-        self.learn_about_nodes_now()
+    def learn_about_specific_nodes(self, addresses: Iterable):
+        if len(addresses) > 0:
+            self._node_ids_to_learn_about_immediately.update(addresses)  # hmmmm
+            self.learn_about_nodes_now()
 
     # TODO: Dehydrate these next two methods.  NRN
 

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -205,9 +205,6 @@ class Policy(ABC):
         self.treasure_map = TreasureMap(m=m)
         self.expiration = expiration
 
-        # Keep track of this stuff
-        self.selection_buffer = 1
-
         self._accepted_arrangements = set()    # type: Set[Arrangement]
         self._rejected_arrangements = set()    # type: Set[Arrangement]
         self._spare_candidates = set()         # type: Set[Ursula]
@@ -532,7 +529,6 @@ class BlockchainPolicy(Policy):
 
         super().__init__(alice=alice, expiration=expiration, *args, **kwargs)
 
-        self.selection_buffer = 1.5
         self.validate_fee_value()
 
     def validate_fee_value(self) -> None:
@@ -618,8 +614,7 @@ class BlockchainPolicy(Policy):
         selected_addresses = set()
         try:
             sampled_addresses = self.alice.recruit(quantity=quantity,
-                                                   duration=self.duration_periods,
-                                                   additional_ursulas=self.selection_buffer)
+                                                   duration=self.duration_periods)
         except StakingEscrowAgent.NotEnoughStakers as e:
             error = f"Cannot create policy with {quantity} arrangements: {e}"
             raise self.NotEnoughBlockchainUrsulas(error)

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -413,8 +413,7 @@ class Policy(ABC):
         raise NotImplementedError
 
     def sample(self, handpicked_ursulas: Optional[Set[Ursula]] = None) -> Set[Ursula]:
-        handpicked_ursulas = handpicked_ursulas or set()
-        selected_ursulas = set(handpicked_ursulas)
+        selected_ursulas = set(handpicked_ursulas) if handpicked_ursulas else set()
 
         # Calculate the target sample quantity
         target_sample_quantity = self.n - len(selected_ursulas)

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -419,7 +419,7 @@ class Policy(ABC):
         target_sample_quantity = self.n - len(selected_ursulas)
         if target_sample_quantity > 0:
             sampled_ursulas = self.sample_essential(quantity=target_sample_quantity,
-                                                    handpicked_ursulas=handpicked_ursulas)
+                                                    handpicked_ursulas=selected_ursulas)
             selected_ursulas.update(sampled_ursulas)
 
         return selected_ursulas

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import time
 import random
 from collections import OrderedDict, deque
 
@@ -22,7 +23,7 @@ import maya
 from abc import ABC, abstractmethod
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import NOT_SIGNED, UNKNOWN_KFRAG
-from typing import Generator, List, Set
+from typing import Generator, List, Set, Optional
 from umbral.keys import UmbralPublicKey
 from umbral.kfrags import KFrag
 
@@ -381,7 +382,7 @@ class Policy(ABC):
 
     def make_arrangements(self,
                           network_middleware: RestMiddleware,
-                          handpicked_ursulas: Set[Ursula] = None,
+                          handpicked_ursulas: Optional[Set[Ursula]] = None,
                           *args, **kwargs,
                           ) -> None:
 
@@ -408,11 +409,12 @@ class Policy(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def sample_essential(self, quantity: int, handpicked_ursulas: Set[Ursula] = None) -> Set[Ursula]:
+    def sample_essential(self, quantity: int, handpicked_ursulas: Set[Ursula]) -> Set[Ursula]:
         raise NotImplementedError
 
-    def sample(self, handpicked_ursulas: Set[Ursula] = None) -> Set[Ursula]:
-        selected_ursulas = set(handpicked_ursulas) if handpicked_ursulas else set()
+    def sample(self, handpicked_ursulas: Optional[Set[Ursula]] = None) -> Set[Ursula]:
+        handpicked_ursulas = handpicked_ursulas if handpicked_ursulas else set()
+        selected_ursulas = set(handpicked_ursulas)
 
         # Calculate the target sample quantity
         target_sample_quantity = self.n - len(selected_ursulas)
@@ -475,11 +477,11 @@ class FederatedPolicy(Policy):
                     "Pass them here as handpicked_ursulas.".format(self.n)
             raise self.MoreKFragsThanArrangements(error)  # TODO: NotEnoughUrsulas where in the exception tree is this?
 
-    def sample_essential(self, quantity: int, handpicked_ursulas: Set[Ursula] = None) -> Set[Ursula]:
+    def sample_essential(self, quantity: int, handpicked_ursulas: Set[Ursula]) -> Set[Ursula]:
         known_nodes = self.alice.known_nodes
         if handpicked_ursulas:
             # Prevent re-sampling of handpicked ursulas.
-            known_nodes = set(known_nodes) - set(handpicked_ursulas)
+            known_nodes = set(known_nodes) - handpicked_ursulas
         sampled_ursulas = set(random.sample(k=quantity, population=list(known_nodes)))
         return sampled_ursulas
 
@@ -572,57 +574,69 @@ class BlockchainPolicy(Policy):
         params = dict(rate=rate, value=value)
         return params
 
-    def __find_ursulas(self,
-                       ether_addresses: List[str],
-                       target_quantity: int,
-                       timeout: int = 10) -> set:  # TODO #843: Make timeout configurable
+    def sample_essential(self,
+                         quantity: int,
+                         handpicked_ursulas: Set[Ursula],
+                         learner_timeout: int = 1,
+                         timeout: int = 10) -> Set[Ursula]:
 
-        start_time = maya.now()                            # marker for timeout calculation
+        selected_ursulas = set(handpicked_ursulas)
+        quantity_remaining = quantity
 
-        found_ursulas, unknown_addresses = set(), deque()
-        while len(found_ursulas) < target_quantity:        # until there are enough Ursulas
+        # Need to sample some stakers
 
-            delta = maya.now() - start_time                # check for a timeout
-            if delta.total_seconds() >= timeout:
-                missing_nodes = ', '.join(a for a in unknown_addresses)
-                raise RuntimeError("Timed out after {} seconds; Cannot find {}.".format(timeout, missing_nodes))
-
-            # Select an ether_address: Prefer the selection pool, then unknowns queue
-            if ether_addresses:
-                ether_address = ether_addresses.pop()
-            else:
-                ether_address = unknown_addresses.popleft()
-
-            try:
-                # Check if this is a known node.
-                selected_ursula = self.alice.known_nodes[ether_address]
-
-            except KeyError:
-                # Unknown Node
-                self.alice.learn_about_specific_nodes({ether_address})  # enter address in learning loop
-                unknown_addresses.append(ether_address)
-                continue
-
-            else:
-                # Known Node
-                found_ursulas.add(selected_ursula)  # We already knew, or just learned about this ursula
-
-        return found_ursulas
-
-    def sample_essential(self, quantity: int, handpicked_ursulas: Set[Ursula] = None) -> Set[Ursula]:
-        # TODO: Prevent re-sampling of handpicked ursulas.
-        selected_addresses = set()
-        try:
-            sampled_addresses = self.alice.recruit(quantity=quantity,
-                                                   duration=self.duration_periods)
-        except StakingEscrowAgent.NotEnoughStakers as e:
-            error = f"Cannot create policy with {quantity} arrangements: {e}"
+        handpicked_addresses = [ursula.checksum_address for ursula in handpicked_ursulas]
+        reservoir = self.alice.get_stakers_reservoir(duration=self.duration_periods,
+                                                     without=handpicked_addresses)
+        if len(reservoir) < quantity_remaining:
+            error = f"Cannot create policy with {quantity} arrangements"
             raise self.NotEnoughBlockchainUrsulas(error)
 
-        # Capture the selection and search the network for those Ursulas
-        selected_addresses.update(sampled_addresses)
-        found_ursulas = self.__find_ursulas(sampled_addresses, quantity)
-        return found_ursulas
+        to_check = reservoir.draw(quantity_remaining)
+
+        # Sample stakers in a loop and feed them to the learner to check
+        # until we have enough in selected_ursulas`.
+
+        start_time = maya.now()
+        new_to_check = to_check
+
+        while True:
+
+            # Check if the sampled addresses are already known.
+            # If we're lucky, we won't have to wait for the learner iteration to finish.
+            known = list(filter(lambda x: x in self.alice.known_nodes, to_check))
+            to_check = list(filter(lambda x: x not in self.alice.known_nodes, to_check))
+
+            known = known[:min(len(known), quantity_remaining)] # we only need so many
+            selected_ursulas.update([self.alice.known_nodes[address] for address in known])
+            quantity_remaining -= len(known)
+
+            if quantity_remaining == 0:
+                break
+            else:
+                new_to_check = reservoir.draw_at_most(quantity_remaining)
+                to_check.extend(new_to_check)
+
+            # Feed newly sampled stakers to the learner
+            self.alice.learn_about_specific_nodes(new_to_check)
+
+            # TODO: would be nice to wait for the learner to finish an iteration here,
+            # because if it hasn't, we really have nothing to do.
+            time.sleep(learner_timeout)
+
+            delta = maya.now() - start_time
+            if delta.total_seconds() >= timeout:
+                still_checking = ', '.join(to_check)
+                raise RuntimeError(f"Timed out after {timeout} seconds; "
+                                   f"need {quantity} more, still checking {still_checking}.")
+
+        found_ursulas = list(selected_ursulas)
+
+        # Randomize the output to avoid the largest stakers always being the first in the list
+        system_random = random.SystemRandom()
+        system_random.shuffle(found_ursulas) # inplace
+
+        return set(found_ursulas)
 
     def publish_to_blockchain(self) -> dict:
 

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -628,7 +628,7 @@ class BlockchainPolicy(Policy):
             if delta.total_seconds() >= timeout:
                 still_checking = ', '.join(to_check)
                 raise RuntimeError(f"Timed out after {timeout} seconds; "
-                                   f"need {quantity} more, still checking {still_checking}.")
+                                   f"need {quantity_remaining} more, still checking {still_checking}.")
 
         found_ursulas = list(selected_ursulas)
 

--- a/tests/acceptance/blockchain/agents/test_policy_manager_agent.py
+++ b/tests/acceptance/blockchain/agents/test_policy_manager_agent.py
@@ -35,7 +35,7 @@ def policy_meta(testerchain, agency, token_economics, blockchain_ursulas):
     agent = policy_agent
 
     _policy_id = os.urandom(16)
-    staker_addresses = list(staking_agent.sample(quantity=3, duration=1))
+    staker_addresses = list(staking_agent.get_stakers_reservoir(duration=1).draw(3))
     number_of_periods = 10
     now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     _txhash = agent.create_policy(policy_id=_policy_id,
@@ -56,7 +56,7 @@ def test_create_policy(testerchain, agency, token_economics, mock_transacting_po
     mock_transacting_power_activation(account=testerchain.alice_account, password=INSECURE_DEVELOPMENT_PASSWORD)
 
     policy_id = os.urandom(16)
-    node_addresses = list(staking_agent.sample(quantity=3, duration=1))
+    node_addresses = list(staking_agent.get_stakers_reservoir(duration=1).draw(3))
     now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
     receipt = agent.create_policy(policy_id=policy_id,
                                   author_address=testerchain.alice_account,

--- a/tests/acceptance/blockchain/agents/test_sampling_distribution.py
+++ b/tests/acceptance/blockchain/agents/test_sampling_distribution.py
@@ -156,13 +156,14 @@ def probability_reference_no_replacement(weights, idxs):
 @pytest.mark.parametrize('sample_size', [1, 2, 3])
 def test_weighted_sampler(sample_size):
     weights = [1, 9, 100, 2, 18, 70]
+    elements = list(range(len(weights)))
     rng = random.SystemRandom()
     counter = Counter()
 
-    elements = list(range(len(weights)))
+    weighted_elements = {element: weight for element, weight in zip(elements, weights)}
 
     samples = 100000
-    sampler = WeightedSampler(elements, weights)
+    sampler = WeightedSampler(weighted_elements)
     for i in range(samples):
         sample_set = sampler.sample_no_replacement(rng, sample_size)
         counter.update({tuple(sample_set): 1})

--- a/tests/acceptance/blockchain/agents/test_sampling_distribution.py
+++ b/tests/acceptance/blockchain/agents/test_sampling_distribution.py
@@ -117,7 +117,8 @@ def test_sampling_distribution(testerchain, token, deploy_contract, token_econom
     sampled, failed = 0, 0
     while sampled < SAMPLES:
         try:
-            addresses = set(staking_agent.sample(quantity=quantity, duration=1))
+            reservoir = staking_agent.get_stakers_reservoir(duration=1)
+            addresses = set(reservoir.draw(quantity))
             addresses.discard(NULL_ADDRESS)
         except staking_agent.NotEnoughStakers:
             failed += 1

--- a/tests/acceptance/blockchain/agents/test_sampling_distribution.py
+++ b/tests/acceptance/blockchain/agents/test_sampling_distribution.py
@@ -16,11 +16,13 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 from collections import Counter
+from itertools import permutations
+import random
 
 import pytest
 
 from nucypher.blockchain.economics import BaseEconomics
-from nucypher.blockchain.eth.agents import StakingEscrowAgent
+from nucypher.blockchain.eth.agents import StakingEscrowAgent, WeightedSampler
 from nucypher.blockchain.eth.constants import NULL_ADDRESS, STAKING_ESCROW_CONTRACT_NAME
 
 
@@ -115,7 +117,7 @@ def test_sampling_distribution(testerchain, token, deploy_contract, token_econom
     sampled, failed = 0, 0
     while sampled < SAMPLES:
         try:
-            addresses = set(staking_agent.sample(quantity=quantity, additional_ursulas=1, duration=1))
+            addresses = set(staking_agent.sample(quantity=quantity, duration=1))
             addresses.discard(NULL_ADDRESS)
         except staking_agent.NotEnoughStakers:
             failed += 1
@@ -134,3 +136,41 @@ def test_sampling_distribution(testerchain, token, deploy_contract, token_econom
         assert abs_error < ERROR_TOLERANCE
 
     # TODO: Test something wrt to % of failed
+
+
+def probability_reference_no_replacement(weights, idxs):
+    """
+    The probability of drawing elements with (distinct) indices ``idxs`` (in given order),
+    given ``weights``. No replacement.
+    """
+    assert len(set(idxs)) == len(idxs)
+    all_weights = sum(weights)
+    p = 1
+    for idx in idxs:
+        p *= weights[idx] / all_weights
+        all_weights -= weights[idx]
+    return p
+
+
+@pytest.mark.parametrize('sample_size', [1, 2, 3])
+def test_weighted_sampler(sample_size):
+    weights = [1, 9, 100, 2, 18, 70]
+    rng = random.SystemRandom()
+    counter = Counter()
+
+    elements = list(range(len(weights)))
+
+    samples = 100000
+    sampler = WeightedSampler(elements, weights)
+    for i in range(samples):
+        sample_set = sampler.sample_no_replacement(rng, sample_size)
+        counter.update({tuple(sample_set): 1})
+
+    for idxs in permutations(elements, sample_size):
+        test_prob = counter[idxs] / samples
+        ref_prob = probability_reference_no_replacement(weights, idxs)
+
+        # A rough estimate to check probabilities.
+        # A little too forgiving for samples with smaller probabilities,
+        # but can go up to 0.5 on occasion.
+        assert abs(test_prob - ref_prob) * samples**0.5 < 1

--- a/tests/acceptance/blockchain/agents/test_staking_escrow_agent.py
+++ b/tests/acceptance/blockchain/agents/test_staking_escrow_agent.py
@@ -152,19 +152,19 @@ def test_sample_stakers(agency):
     stakers_population = staking_agent.get_staker_population()
 
     with pytest.raises(StakingEscrowAgent.NotEnoughStakers):
-        staking_agent.sample(quantity=stakers_population + 1, duration=1)  # One more than we have deployed
+        staking_agent.get_stakers_reservoir(duration=1).draw(stakers_population + 1)  # One more than we have deployed
 
-    stakers = staking_agent.sample(quantity=3, duration=5)
+    stakers = staking_agent.get_stakers_reservoir(duration=5).draw(3)
     assert len(stakers) == 3       # Three...
     assert len(set(stakers)) == 3  # ...unique addresses
 
     # Same but with pagination
-    stakers = staking_agent.sample(quantity=3, duration=5, pagination_size=1)
+    stakers = staking_agent.get_stakers_reservoir(duration=5, pagination_size=1).draw(3)
     assert len(stakers) == 3
     assert len(set(stakers)) == 3
     light = staking_agent.blockchain.is_light
     staking_agent.blockchain.is_light = not light
-    stakers = staking_agent.sample(quantity=3, duration=5)
+    stakers = staking_agent.get_stakers_reservoir(duration=5).draw(3)
     assert len(stakers) == 3
     assert len(set(stakers)) == 3
     staking_agent.blockchain.is_light = light

--- a/tests/acceptance/blockchain/agents/test_staking_escrow_agent.py
+++ b/tests/acceptance/blockchain/agents/test_staking_escrow_agent.py
@@ -292,13 +292,13 @@ def test_lock_restaking(agency, testerchain, test_registry):
     staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
     current_period = staking_agent.get_current_period()
     terminal_period = current_period + 2
-    
+
     assert staking_agent.is_restaking(staker_account)
     assert not staking_agent.is_restaking_locked(staker_account)
     receipt = staking_agent.lock_restaking(staker_account, release_period=terminal_period)
     assert receipt['status'] == 1, "Transaction Rejected"
     assert staking_agent.is_restaking_locked(staker_account)
-    
+
     testerchain.time_travel(periods=2)  # Wait for re-staking lock to be released.
     assert not staking_agent.is_restaking_locked(staker_account)
 


### PR DESCRIPTION
More logical weighted sampling for stakers, with the sampler extracted to a separate class for the ease of unit testing. `additional_ursulas` and `attempts` parameters removed from `sample()`.

The second commit makes exposes the staker sampler as an iterator-like object. `BlockchainPolicy.sample_essential()` now works as follows:

- `quantity` stakers is needed
- Get the stakers reservoir based on the list of stakers returned by the contract (excluding `handpicked_ursulas` right away)
- Draw `quantity` of stakers, see which ones are already known, and send the rest to the learner
- Wait a little, check for newly known nodes. If it's still not enough (some nodes are being checked), draw more stakers from the reservoir and send them to the learner.
- Loop until time is expired or we have enough nodes

The nodes that were drawn first have the priority. The returned result is shuffled (or should it be shuffled in `sample()` instead, that is shuffle the known stakers as well?)

Advantages over the previous sampling method:
- no need to "pre-sample" 1.5x of Ursulas; we draw samples as we need them. 
- simpler algorithm structure
- we give addresses to the learner in a batch instead of one by one
- do not run the loop again and again; `sleep()` and let the learner do its thing

There are more advanced sampling methods, e.g. ["Weighted random sampling with a reservoir" by Efraimidis and Spirakis](https://www.sciencedirect.com/science/article/abs/pii/S002001900500298X), but they require floats. I'll stick to integers for now, in case we ever want it back in a contract.