### PR TITLE
[WIP] Parallel `Bob.retreive()`

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -549,7 +549,7 @@ class Bob(Character):
             raise  # TODO: Maybe do something here?  NRN
 
     def get_treasure_map(self, alice_verifying_key, label):
-        map_id = self.construct_map_id(verifying_key=alice_verifying_key, label=label)
+        map_identifier = self.construct_map_id(verifying_key=alice_verifying_key, label=label)
 
         if not self.known_nodes and not self._learning_task.running:
             # Quick sanity check - if we don't know of *any* Ursulas, and we have no
@@ -561,11 +561,6 @@ class Bob(Character):
             if not self.known_nodes:
                 raise self.NotEnoughTeachers("Can't retrieve without knowing about any nodes at all.  Pass a teacher or seed node.")
 
-        # Ugh stupid federated only mode....
-        if not self.federated_only:
-            map_identifier = _hrac.hex()
-        else:
-            map_identifier = map_id
         treasure_map = self.get_treasure_map_from_known_ursulas(self.network_middleware,
                                                                 map_identifier)
         self._try_orient(treasure_map, alice_verifying_key)
@@ -581,7 +576,13 @@ class Bob(Character):
 
     def construct_map_id(self, verifying_key, label):
         hrac = self.construct_policy_hrac(verifying_key, label)
-        map_id = keccak_digest(bytes(verifying_key) + hrac).hex()
+
+        # Ugh stupid federated only mode....
+        if not self.federated_only:
+            map_id = hrac.hex()
+        else:
+            map_id = keccak_digest(bytes(verifying_key) + hrac).hex()
+
         return map_id
 
     def get_treasure_map_from_known_ursulas(self, network_middleware, map_identifier, timeout=3):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1040,7 +1040,7 @@ class ParallelRunner:
 
         self._deferred_list = []
         for i, worker in enumerate(self._workers):
-            self._deferred_list.append(threads.deferToThread(partial(worker_wrapper2, worker, self, i)))
+            self._deferred_list.append(threads.deferToThread(partial(worker_wrapper, worker, self, i)))
 
         successes, failures = self._queue.get()
         return list(successes.values()), list(failures.values())

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -20,7 +20,7 @@ import maya
 import random
 import time
 from base64 import b64decode, b64encode
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 from datetime import datetime
 from functools import partial
 from json.decoder import JSONDecodeError
@@ -642,7 +642,7 @@ class Bob(Character):
                 raise KeyError(f"Bob doesn't have the TreasureMap {map_id}; can't generate work orders.")
 
         incomplete_work_orders = OrderedDict()
-        complete_work_orders = OrderedDict()
+        complete_work_orders = defaultdict(lambda: [])
 
         if not treasure_map_to_use:
             raise ValueError(f"Bob doesn't have a TreasureMap to match any of these capsules: {capsules}")
@@ -656,7 +656,7 @@ class Bob(Character):
                 try:
                     precedent_work_order = self._completed_work_orders.most_recent_replete(capsule)[node_id]
                     self.log.debug(f"{capsule} already has a saved WorkOrder for this Node:{node_id}.")
-                    complete_work_orders[node_id] = precedent_work_order
+                    complete_work_orders[capsule].append(precedent_work_order)
                 except KeyError:
                     # Don't have a precedent completed WorkOrder for this Ursula for this Capsule.
                     # We need to make a new one.
@@ -678,8 +678,9 @@ class Bob(Character):
                 # TODO: Presently, the order here is haphazard .  Do we want to do the complete or incomplete specifically first? NRN
                 break
 
-        if incomplete_work_orders == OrderedDict():
-            self.log.warn("No new WorkOrders created. Try calling this with different parameters.")  # TODO: Clearer instructions.  NRN
+        if len(incomplete_work_orders) == 0:
+            self.log.warn(
+                "No new WorkOrders created.  Try calling this with different parameters.")  # TODO: Clearer instructions.  NRN
 
         return incomplete_work_orders, complete_work_orders
 
@@ -779,15 +780,15 @@ class Bob(Character):
             alice_verifying_key=alice_verifying_key,
             *capsules_to_activate)
 
-        self.log.info(f"Found {len(complete_work_orders)} for Capsules ({capsules_to_activate}).")
+        # TODO: enabling this causes `builtins.KeyError: 'Capsule'` in logging.
+        #self.log.info(f"Found {len(complete_work_orders)} for Capsules ({capsules_to_activate}).")
 
         if complete_work_orders:
             if use_precedent_work_orders:
-                for capsule in capsules_to_activate:
-                    for work_order in complete_work_orders.values():
-                        if capsule in work_order.tasks:
-                            cfrag_in_question = work_order.tasks[capsule].cfrag
-                            capsule.attach_cfrag(cfrag_in_question)
+                for capsule, work_orders in complete_work_orders.items():
+                    for work_order in work_orders:
+                        cfrag_in_question = work_order.tasks[capsule].cfrag
+                        capsule.attach_cfrag(cfrag_in_question)
             else:
                 self.log.warn(
                     "Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -774,21 +774,23 @@ class Bob(Character):
             capsule.set_correctness_keys(receiving=self.public_keys(DecryptingPower))
             capsule.set_correctness_keys(verifying=alice_verifying_key)
 
-            new_work_orders, complete_work_orders = self.work_orders_for_capsules(
-                treasure_map=treasure_map,
-                alice_verifying_key=alice_verifying_key,
-                *capsules_to_activate)
+        new_work_orders, complete_work_orders = self.work_orders_for_capsules(
+            treasure_map=treasure_map,
+            alice_verifying_key=alice_verifying_key,
+            *capsules_to_activate)
 
-            self.log.debug(f"Found {len(complete_work_orders)} complete WorkOrders for this Capsule ({capsule}).")
+        self.log.info(f"Found {len(complete_work_orders)} for Capsules ({capsules_to_activate}).")
 
-            if complete_work_orders:
-                if use_precedent_work_orders:
+        if complete_work_orders:
+            if use_precedent_work_orders:
+                for capsule in capsules_to_activate:
                     for work_order in complete_work_orders.values():
-                        cfrag_in_question = work_order.tasks[capsule].cfrag
-                        capsule.attach_cfrag(cfrag_in_question)
-                else:
-                    self.log.warn(
-                        "Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")
+                        if capsule in work_order.tasks:
+                            cfrag_in_question = work_order.tasks[capsule].cfrag
+                            capsule.attach_cfrag(cfrag_in_question)
+            else:
+                self.log.warn(
+                    "Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")
 
         # Part II: Getting the cleartexts.
         cleartexts = []

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -478,17 +478,7 @@ class Bob(Character):
         self.log = Logger(self.__class__.__name__)
         self.log.info(self.banner)
 
-    def _pick_treasure_map(self, treasure_map=None, map_id=None):
-        if treasure_map is None:
-            if map_id:
-                treasure_map = self.treasure_maps[map_id]
-            else:
-                raise ValueError("You need to pass either treasure_map or map_id.")
-        elif map_id:
-            raise ValueError("Don't pass both treasure_map and map_id - pick one or the other.")
-        return treasure_map
-
-    def peek_at_treasure_map(self, treasure_map=None, map_id=None):
+    def peek_at_treasure_map(self, treasure_map=None):
         """
         Take a quick gander at the TreasureMap matching map_id to see which
         nodes are already known to us.
@@ -498,7 +488,6 @@ class Bob(Character):
 
         Return two sets: nodes that are unknown to us, nodes that are known to us.
         """
-        treasure_map = self._pick_treasure_map(treasure_map, map_id)
 
         # The intersection of the map and our known nodes will be the known Ursulas...
         known_treasure_ursulas = treasure_map.destinations.keys() & self.known_nodes.addresses()
@@ -510,13 +499,12 @@ class Bob(Character):
 
     def follow_treasure_map(self,
                             treasure_map=None,
-                            map_id=None,
                             block=False,
                             new_thread=False,
                             timeout=10,
                             allow_missing=0):
         """
-        Follows a known TreasureMap, looking it up by map_id.
+        Follows a known TreasureMap.
 
         Determines which Ursulas are known and which are unknown.
 
@@ -530,8 +518,6 @@ class Bob(Character):
 
         # TODO: Check if nodes are up, declare them phantom if not.  567
         """
-        treasure_map = self._pick_treasure_map(treasure_map, map_id)
-
         unknown_ursulas, known_ursulas = self.peek_at_treasure_map(treasure_map=treasure_map)
 
         if unknown_ursulas:
@@ -641,7 +627,6 @@ class Bob(Character):
     def work_orders_for_capsules(self,
                                  *capsules,
                                  alice_verifying_key: UmbralPublicKey,
-                                 map_id: str = None,
                                  treasure_map: 'TreasureMap' = None,
                                  num_ursulas: int = None,
                                  ):
@@ -662,7 +647,7 @@ class Bob(Character):
         if not treasure_map_to_use:
             raise ValueError(f"Bob doesn't have a TreasureMap to match any of these capsules: {capsules}")
 
-        random_walk = list(treasure_map_to_use)
+        random_walk = list(treasure_map)
         shuffle(random_walk)  # Mutates list in-place
         for node_id, arrangement_id in random_walk:
 
@@ -732,8 +717,8 @@ class Bob(Character):
         # Part I: Assembling the WorkOrders.
         capsules_to_activate = set(mk.capsule for mk in message_kits)
 
-        map_id = self.construct_map_id(alice_verifying_key, label)
         if treasure_map is not None:
+
             alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
             compass = self.make_compass_for_alice(alice)
 
@@ -750,9 +735,11 @@ class Bob(Character):
                 tmap_bytes = treasure_map.encode()
                 treasure_map = _MapClass.from_bytes(b64decode(tmap_bytes))
             treasure_map.orient(compass)
-            _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(treasure_map=treasure_map, block=True)
         else:
-            _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(map_id=map_id, block=True)
+            map_id = self.construct_map_id(alice_verifying_key, label)
+            treasure_map = self.treasure_maps[map_id]
+
+        _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(treasure_map=treasure_map, block=True)
 
         for message in message_kits:
 
@@ -788,7 +775,6 @@ class Bob(Character):
             capsule.set_correctness_keys(verifying=alice_verifying_key)
 
             new_work_orders, complete_work_orders = self.work_orders_for_capsules(
-                map_id=map_id,
                 treasure_map=treasure_map,
                 alice_verifying_key=alice_verifying_key,
                 *capsules_to_activate)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -553,7 +553,7 @@ class Bob(Character):
         return unknown_ursulas, known_ursulas, treasure_map.m
 
     def get_treasure_map(self, alice_verifying_key, label):
-        _hrac, map_id = self.construct_hrac_and_map_id(verifying_key=alice_verifying_key, label=label)
+        map_id = self.construct_map_id(verifying_key=alice_verifying_key, label=label)
 
         if not self.known_nodes and not self._learning_task.running:
             # Quick sanity check - if we don't know of *any* Ursulas, and we have no
@@ -591,10 +591,10 @@ class Bob(Character):
         _hrac = keccak_digest(bytes(verifying_key) + self.stamp + label)[:HRAC_LENGTH]
         return _hrac
 
-    def construct_hrac_and_map_id(self, verifying_key, label):
+    def construct_map_id(self, verifying_key, label):
         hrac = self.construct_policy_hrac(verifying_key, label)
         map_id = keccak_digest(bytes(verifying_key) + hrac).hex()
-        return hrac, map_id
+        return map_id
 
     def get_treasure_map_from_known_ursulas(self, network_middleware, map_identifier, timeout=3):
         """
@@ -732,7 +732,7 @@ class Bob(Character):
         # Part I: Assembling the WorkOrders.
         capsules_to_activate = set(mk.capsule for mk in message_kits)
 
-        hrac, map_id = self.construct_hrac_and_map_id(alice_verifying_key, label)
+        map_id = self.construct_map_id(alice_verifying_key, label)
         if treasure_map is not None:
             alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
             compass = self.make_compass_for_alice(alice)

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -187,6 +187,20 @@ class TreasureMap:
         return self._id
 
     @classmethod
+    def from_obj_or_bytes(cls, obj):
+
+        if isinstance(obj, cls):
+            return obj
+
+        # TODO: This LBYL is ugly and fraught with danger.  NRN
+        elif isinstance(obj, bytes):
+            return cls.from_bytes(obj)
+
+        elif isinstance(obj, str):
+            tmap_bytes = obj.encode()
+            return cls.from_bytes(b64decode(tmap_bytes))
+
+    @classmethod
     def from_bytes(cls, bytes_representation, verify=True):
         splitter = cls.splitter()
         treasure_map = splitter(bytes_representation)

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from base64 import b64decode
 import json
 from collections import OrderedDict
 from typing import Optional, Tuple

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -172,7 +172,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     assert work_order.completed is False
 
     # **** RE-ENCRYPTION HAPPENS HERE! ****
-    cfrags = federated_bob.get_reencrypted_cfrags(work_order, retain_cfrags=True)
+    _success, cfrags = federated_bob._reencrypt(work_order, retain_cfrags=True)
 
     # We only gave one Capsule, so we only got one cFrag.
     assert len(cfrags) == 1
@@ -243,7 +243,7 @@ def test_bob_can_use_cfrag_attached_to_completed_workorder(enacted_federated_pol
 
     # As such, we will get TypeError if we try to get CFrags again.
     with pytest.raises(TypeError):
-        federated_bob.get_reencrypted_cfrags(new_work_order)
+        federated_bob._reencrypt(new_work_order)
 
 
 def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_federated_policy, federated_alice,
@@ -292,7 +292,7 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_feder
     assert new_work_order != saved_work_order
 
     # This WorkOrder has never been completed
-    cfrags = federated_bob.get_reencrypted_cfrags(new_work_order, retain_cfrags=True)
+    _success, cfrags = federated_bob._reencrypt(new_work_order, retain_cfrags=True)
 
     # Again: one Capsule, one cFrag.
     assert len(cfrags) == 1
@@ -332,7 +332,7 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
         num_ursulas=number_left_to_collect)
     _id_of_yet_another_ursula, new_work_order = list(new_incomplete_work_orders.items())[0]
 
-    cfrags = federated_bob.get_reencrypted_cfrags(new_work_order)
+    _success, cfrags = federated_bob._reencrypt(new_work_order)
     cfrag = cfrags[0]
     assert cfrag not in the_message_kit.capsule._attached_cfrags
 

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -32,13 +32,12 @@ from tests.utils.middleware import MockRestMiddleware, NodeIsDownMiddleware
 def test_bob_cannot_follow_the_treasure_map_in_isolation(enacted_federated_policy, federated_bob):
     # Assume for the moment that Bob has already received a TreasureMap, perhaps via a side channel.
     hrac, treasure_map = enacted_federated_policy.hrac(), enacted_federated_policy.treasure_map
-    federated_bob.treasure_maps[treasure_map.public_id()] = treasure_map
 
     # Bob knows of no Ursulas.
     assert len(federated_bob.known_nodes) == 0
 
     # He can't successfully follow the TreasureMap until he learns of a node to ask.
-    unknown, known = federated_bob.peek_at_treasure_map(map_id=treasure_map.public_id())
+    unknown, known = federated_bob.peek_at_treasure_map(treasure_map=treasure_map)
     assert len(known) == 0
 
     # TODO: Show that even with learning loop going, nothing happens here.
@@ -88,8 +87,6 @@ def test_bob_can_follow_treasure_map_even_if_he_only_knows_of_one_node(enacted_f
 
     # Again, let's assume that he received the TreasureMap via a side channel.
     hrac, treasure_map = enacted_federated_policy.hrac(), enacted_federated_policy.treasure_map
-    map_id = treasure_map.public_id()
-    bob.treasure_maps[map_id] = treasure_map
 
     # Now, let's create a scenario in which Bob knows of only one node.
     assert len(bob.known_nodes) == 0
@@ -98,13 +95,13 @@ def test_bob_can_follow_treasure_map_even_if_he_only_knows_of_one_node(enacted_f
     assert len(bob.known_nodes) == 1
 
     # This time, when he follows the TreasureMap...
-    unknown_nodes, known_nodes = bob.peek_at_treasure_map(map_id=map_id)
+    unknown_nodes, known_nodes = bob.peek_at_treasure_map(treasure_map=treasure_map)
 
     # Bob already knew about one node; the rest are unknown.
     assert len(unknown_nodes) == len(treasure_map) - 1
 
     # He needs to actually follow the treasure map to get the rest.
-    bob.follow_treasure_map(map_id=map_id)
+    bob.follow_treasure_map(treasure_map=treasure_map)
 
     # The nodes in the learning loop are now his top target, but he's not learning yet.
     assert not bob._learning_task.running
@@ -136,11 +133,9 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
 
     # We pick up our story with Bob already having followed the treasure map above, ie:
     hrac, treasure_map = enacted_federated_policy.hrac(), enacted_federated_policy.treasure_map
-    map_id = treasure_map.public_id()
-    federated_bob.treasure_maps[map_id] = treasure_map
     federated_bob.start_learning_loop()
 
-    federated_bob.follow_treasure_map(map_id=map_id, block=True, timeout=1)
+    federated_bob.follow_treasure_map(treasure_map=treasure_map, block=True, timeout=1)
 
     assert len(federated_bob.known_nodes) == len(federated_ursulas)
 
@@ -155,7 +150,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
                                  verifying=federated_alice.stamp.as_umbral_pubkey())
     work_orders, _ = federated_bob.work_orders_for_capsules(
         capsule,
-        map_id=map_id,
+        treasure_map=treasure_map,
         alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=1)
 
@@ -168,7 +163,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     # This time, we'll tell Bob to cache it.
     retained_work_orders, _ = federated_bob.work_orders_for_capsules(
         capsule,
-        map_id=map_id,
+        treasure_map=treasure_map,
         alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=1)
 
@@ -233,7 +228,7 @@ def test_bob_can_use_cfrag_attached_to_completed_workorder(enacted_federated_pol
 
     incomplete_work_orders, complete_work_orders = federated_bob.work_orders_for_capsules(
         last_capsule_on_side_channel,
-        map_id=enacted_federated_policy.treasure_map.public_id(),
+        treasure_map=enacted_federated_policy.treasure_map,
         alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=1,
     )
@@ -280,7 +275,7 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_feder
     # The rest of this test will show that if Bob generates another WorkOrder, it's for a *different* Ursula.
     incomplete_work_orders, complete_work_orders = federated_bob.work_orders_for_capsules(
         last_capsule_on_side_channel,
-        map_id=enacted_federated_policy.treasure_map.public_id(),
+        treasure_map=enacted_federated_policy.treasure_map,
         alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=1)
     id_of_this_new_ursula, new_work_order = list(incomplete_work_orders.items())[0]
@@ -332,7 +327,7 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
 
     new_incomplete_work_orders, _ = federated_bob.work_orders_for_capsules(
         the_message_kit.capsule,
-        map_id=enacted_federated_policy.treasure_map.public_id(),
+        treasure_map=enacted_federated_policy.treasure_map,
         alice_verifying_key=federated_alice.stamp.as_umbral_pubkey(),
         num_ursulas=number_left_to_collect)
     _id_of_yet_another_ursula, new_work_order = list(new_incomplete_work_orders.items())[0]

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -172,7 +172,8 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     assert work_order.completed is False
 
     # **** RE-ENCRYPTION HAPPENS HERE! ****
-    _success, cfrags = federated_bob._reencrypt(work_order, retain_cfrags=True)
+    federated_bob._reencrypt(work_order, retain_cfrags=True)
+    cfrags = [task.cfrag for task in work_order.tasks.values()]
 
     # We only gave one Capsule, so we only got one cFrag.
     assert len(cfrags) == 1
@@ -292,7 +293,8 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_feder
     assert new_work_order != saved_work_order
 
     # This WorkOrder has never been completed
-    _success, cfrags = federated_bob._reencrypt(new_work_order, retain_cfrags=True)
+    federated_bob._reencrypt(new_work_order, retain_cfrags=True)
+    cfrags = [task.cfrag for task in new_work_order.tasks.values()]
 
     # Again: one Capsule, one cFrag.
     assert len(cfrags) == 1
@@ -332,7 +334,9 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
         num_ursulas=number_left_to_collect)
     _id_of_yet_another_ursula, new_work_order = list(new_incomplete_work_orders.items())[0]
 
-    _success, cfrags = federated_bob._reencrypt(new_work_order)
+    federated_bob._reencrypt(new_work_order)
+    cfrags = [task.cfrag for task in new_work_order.tasks.values()]
+
     cfrag = cfrags[0]
     assert cfrag not in the_message_kit.capsule._attached_cfrags
 

--- a/tests/integration/network/test_treasure_map_integration.py
+++ b/tests/integration/network/test_treasure_map_integration.py
@@ -64,7 +64,7 @@ def test_treasure_map_stored_by_ursula_is_the_correct_one_for_bob(federated_alic
     hrac_by_bob = federated_bob.construct_policy_hrac(federated_alice.stamp, enacted_federated_policy.label)
     assert enacted_federated_policy.hrac() == hrac_by_bob
 
-    hrac, map_id_by_bob = federated_bob.construct_hrac_and_map_id(federated_alice.stamp, enacted_federated_policy.label)
+    map_id_by_bob = federated_bob.construct_map_id(federated_alice.stamp, enacted_federated_policy.label)
     assert map_id_by_bob == treasure_map_on_network.public_id()
 
 


### PR DESCRIPTION
Attempting to fix issue #1176 (also the working changes should fix #1359)

This is a proof of concept, I tried to simplify `retreive()` and isolate the parallelizable parts.  The non-parallel version works, but when futures are added (the last commit), there's some strange SQL error...
```
    def do_execute(self, cursor, statement, parameters, context=None):
>       cursor.execute(statement, parameters)
E       sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: policyarrangements
E       [SQL: SELECT policyarrangements.id AS policyarrangements_id, policyarrangements.expiration AS policyarrangements_expiration, policyarrangements.kfrag AS policyarrangements_kfrag, policyarrangements.alice_verifying_key_id AS policyarrangements_alice_verifying_key_id, policyarrangements.alice_signature AS policyarrangements_alice_signature, policyarrangements.created_at AS policyarrangements_created_at, keys_1.id AS keys_1_id, keys_1.fingerprint AS keys_1_fingerprint, keys_1.key_data AS keys_1_key_data, keys_1.is_signing AS keys_1_is_signing, keys_1.created_at AS keys_1_created_at 
E       FROM policyarrangements LEFT OUTER JOIN keys AS keys_1 ON keys_1.id = policyarrangements.alice_verifying_key_id 
E       WHERE policyarrangements.id = ?
E        LIMIT ? OFFSET ?]
E       [parameters: (<memory at 0x107f37340>, 1, 0)]
E       (Background on this error at: http://sqlalche.me/e/e3q8)

../../../.local/share/virtualenvs/nucypher-3pdGgPxB/lib/python3.8/site-packages/sqlalchemy/engine/default.py:590: OperationalError
```
Some race condition?