### PR TITLE
`receive()` function in contracts

### DIFF
--- a/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
@@ -30,9 +30,7 @@ contract MultiSig {
         _;
     }
 
-    // TODO #1809
-//    receive() external payable {}
-    fallback() external payable {}
+    receive() external payable {}
 
     /**
     * @param _required Number of required signings

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
@@ -131,7 +131,19 @@ contract Dispatcher is Upgradeable, ERCProxy {
     function finishUpgrade(address) public override {}
 
     /**
-    * @dev Fallback function send all requests to the target contract
+    * @dev Receive function sends empty request to the target contract
+    */
+    receive() external payable {
+        assert(target.isContract());
+        // execute receive function from target contract using storage of the dispatcher
+        (bool callSuccess,) = target.delegatecall("");
+        if (!callSuccess) {
+            revert();
+        }
+    }
+
+    /**
+    * @dev Fallback function sends all requests to the target contract
     */
     fallback() external payable {
         assert(target.isContract());

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
@@ -71,15 +71,12 @@ abstract contract AbstractStakingContract {
     */
     function withdrawETH() public virtual;
 
+    receive() external payable {}
+
     /**
     * @dev Function sends all requests to the target contract
     */
-    // TODO #1809
     fallback() external payable {
-        if (msg.data.length == 0) {
-            return;
-        }
-
         require(isFallbackAllowed());
         address target = address(router.target());
         require(target.isContract());

--- a/tests/contracts/contracts/ReentrancyTest.sol
+++ b/tests/contracts/contracts/ReentrancyTest.sol
@@ -19,9 +19,7 @@ contract ReentrancyTest {
         data = _data;
     }
 
-    // TODO #1809
-//    receive() external payable {
-    fallback() external payable {
+    receive() external payable {
         // call no more than maxDepth times
         if (lockCounter >= maxDepth) {
             return;

--- a/tests/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/contracts/contracts/StakingContractsTestSet.sol
@@ -112,9 +112,7 @@ contract PolicyManagerForStakingContractMock {
         minFeeRate = _minFeeRate;
     }
 
-    // TODO #1809
-//    receive() external payable {}
-    fallback() external payable {}
+    receive() external payable {}
 }
 
 
@@ -193,12 +191,7 @@ contract StakingInterfaceMockV2 {
     address public immutable token = address(1);
     address public immutable escrow = address(1);
 
-    // TODO #1809
-//    receive() external payable {}
-    fallback() external payable {
-        // can only use with ETH
-        require(msg.value > 0);
-    }
+    receive() external payable {}
 
     function firstMethod(uint256) public pure {}
 

--- a/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
+++ b/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.6.1;
+
+
+import "contracts/proxy/Upgradeable.sol";
+
+
+/**
+* @dev Contract can't handle 'receive' and 'fallback' requests
+*/
+contract NoFallback is Upgradeable {}
+
+
+/**
+* @dev Contract can handle only 'receive' requests
+*/
+contract OnlyReceive is NoFallback {
+
+    uint256 public receiveRequests;
+    uint256 public value;
+
+    receive() external payable {
+        receiveRequests += 1;
+        value += msg.value;
+    }
+
+}
+
+
+/**
+* @dev Contract can handle 'receive' and 'fallback' requests
+*/
+contract ReceiveFallback is OnlyReceive {
+
+    uint256 public fallbackRequests;
+
+    fallback() external payable {
+        fallbackRequests += 1;
+        value += msg.value;
+    }
+
+}


### PR DESCRIPTION
Fixes #1809

Now `Dispatcher` has two functions to handle requests: `receive` and `fallback`, but behaviour remains unchanged. Separate `receive` makes ETH transfer cheaper because less logic inside, also this solves warning from compiler.
This PR does not require to hard fork of any current deployments