### PR TITLE
SPDX license identifier in contracts

### DIFF
--- a/nucypher/blockchain/eth/sol/__conf__.py
+++ b/nucypher/blockchain/eth/sol/__conf__.py
@@ -15,4 +15,4 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-SOLIDITY_COMPILER_VERSION = 'v0.6.7'
+SOLIDITY_COMPILER_VERSION = 'v0.6.9'

--- a/nucypher/blockchain/eth/sol/source/aragon/interfaces/IERC900History.sol
+++ b/nucypher/blockchain/eth/sol/source/aragon/interfaces/IERC900History.sol
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 pragma solidity ^0.6.5;
+
 
 // Minimum interface to interact with Aragon's Aggregator
 interface IERC900History {

--- a/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 import "contracts/lib/ReEncryptionValidator.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
@@ -30,9 +30,7 @@ contract MultiSig {
         _;
     }
 
-    // TODO #1809
-//    receive() external payable {}
-    fallback() external payable {}
+    receive() external payable {}
 
     /**
     * @param _required Number of required signings

--- a/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/NuCypherToken.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/NuCypherToken.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/PolicyManager.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
+
 
 import "aragon/interfaces/IERC900History.sol";
 import "contracts/Issuer.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/AdditionalMath.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/AdditionalMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/Bits.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/Bits.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 /**

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 import "contracts/lib/UmbralDeserializer.sol";
@@ -11,9 +13,9 @@ library ReEncryptionValidator {
     using UmbralDeserializer for bytes;
 
 
-    //////////////////////////////////
+    //------------------------------//
     //   Umbral-specific constants  //
-    //////////////////////////////////
+    //------------------------------//
 
     // See parameter `u` of `UmbralParameters` class in pyUmbral
     // https://github.com/nucypher/pyUmbral/blob/master/umbral/params.py
@@ -22,9 +24,9 @@ library ReEncryptionValidator {
     uint256 public constant UMBRAL_PARAMETER_U_YCOORD = 0x7880ed56962d7c0ae44d6f14bb53b5fe64b31ea44a41d0316f3a598778f0f936;
 
 
-    //////////////////////////////////
+    //------------------------------//
     // SECP256K1-specific constants //
-    //////////////////////////////////
+    //------------------------------//
 
     // Base field order
     uint256 constant FIELD_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F;

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/Snapshot.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/Snapshot.sol
@@ -1,4 +1,7 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
+
 
 /**
  * @title Snapshot

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
@@ -131,7 +131,19 @@ contract Dispatcher is Upgradeable, ERCProxy {
     function finishUpgrade(address) public override {}
 
     /**
-    * @dev Fallback function send all requests to the target contract
+    * @dev Receive function sends empty request to the target contract
+    */
+    receive() external payable {
+        assert(target.isContract());
+        // execute receive function from target contract using storage of the dispatcher
+        (bool callSuccess,) = target.delegatecall("");
+        if (!callSuccess) {
+            revert();
+        }
+    }
+
+    /**
+    * @dev Fallback function sends all requests to the target contract
     */
     fallback() external payable {
         assert(target.isContract());

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 
@@ -37,7 +39,9 @@ abstract contract Upgradeable is Ownable {
     */
     uint256 stubSlot;
 
-    /** Constants for `isUpgrade` field **/
+    /**
+    * @dev Constants for `isUpgrade` field
+    */
     uint8 constant UPGRADE_FALSE = 1;
     uint8 constant UPGRADE_TRUE = 2;
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
@@ -71,15 +71,12 @@ abstract contract AbstractStakingContract {
     */
     function withdrawETH() public virtual;
 
+    receive() external payable {}
+
     /**
     * @dev Function sends all requests to the target contract
     */
-    // TODO #1809
     fallback() external payable {
-        if (msg.data.length == 0) {
-            return;
-        }
-
         require(isFallbackAllowed());
         address target = address(router.target());
         require(target.isContract());

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/math/Math.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/math/Math.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/math/SafeMath.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/math/SafeMath.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/ownership/Ownable.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/ownership/Ownable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20Detailed.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20Detailed.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/IERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/IERC20.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/SafeERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/SafeERC20.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MIT
+
 pragma solidity ^0.6.1;
 
 /**

--- a/tests/acceptance/blockchain/interfaces/contracts/multiversion/v1/VersionTest.sol
+++ b/tests/acceptance/blockchain/interfaces/contracts/multiversion/v1/VersionTest.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/acceptance/blockchain/interfaces/contracts/multiversion/v2/VersionTest.sol
+++ b/tests/acceptance/blockchain/interfaces/contracts/multiversion/v2/VersionTest.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/AdjudicatorTestSet.sol
+++ b/tests/contracts/contracts/AdjudicatorTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/tests/contracts/contracts/IssuerTestSet.sol
+++ b/tests/contracts/contracts/IssuerTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/tests/contracts/contracts/LibTestSet.sol
+++ b/tests/contracts/contracts/LibTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/contracts/contracts/PolicyManagerTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/tests/contracts/contracts/ReceiveApprovalMethodMock.sol
+++ b/tests/contracts/contracts/ReceiveApprovalMethodMock.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/ReentrancyTest.sol
+++ b/tests/contracts/contracts/ReentrancyTest.sol
@@ -19,9 +19,7 @@ contract ReentrancyTest {
         data = _data;
     }
 
-    // TODO #1809
-//    receive() external payable {
-    fallback() external payable {
+    receive() external payable {
         // call no more than maxDepth times
         if (lockCounter >= maxDepth) {
             return;

--- a/tests/contracts/contracts/ReentrancyTest.sol
+++ b/tests/contracts/contracts/ReentrancyTest.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/contracts/contracts/StakingContractsTestSet.sol
@@ -112,9 +112,7 @@ contract PolicyManagerForStakingContractMock {
         minFeeRate = _minFeeRate;
     }
 
-    // TODO #1809
-//    receive() external payable {}
-    fallback() external payable {}
+    receive() external payable {}
 }
 
 
@@ -193,12 +191,7 @@ contract StakingInterfaceMockV2 {
     address public immutable token = address(1);
     address public immutable escrow = address(1);
 
-    // TODO #1809
-//    receive() external payable {}
-    fallback() external payable {
-        // can only use with ETH
-        require(msg.value > 0);
-    }
+    receive() external payable {}
 
     function firstMethod(uint256) public pure {}
 

--- a/tests/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/contracts/contracts/StakingContractsTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/tests/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/contracts/contracts/WorkLockTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.5;
 
 

--- a/tests/contracts/contracts/proxy/BadContracts.sol
+++ b/tests/contracts/contracts/proxy/BadContracts.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/proxy/ContractV1.sol
+++ b/tests/contracts/contracts/proxy/ContractV1.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/proxy/ContractV2.sol
+++ b/tests/contracts/contracts/proxy/ContractV2.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/proxy/ContractV3.sol
+++ b/tests/contracts/contracts/proxy/ContractV3.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/proxy/ContractV4.sol
+++ b/tests/contracts/contracts/proxy/ContractV4.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 
@@ -14,22 +16,22 @@ import "contracts/proxy/Upgradeable.sol";
 contract ContractV4 is Upgradeable {
 
     // slot allocation costs nothing
-    /// uint256 public storageValue;
+    // uint256 public storageValue;
     uint256 reservedSlot4;
-    /// string public dynamicallySizedValue;
+    // string public dynamicallySizedValue;
     uint256 reservedSlot5;
-    /// uint256[] public arrayValues;
+    // uint256[] public arrayValues;
     uint256 reservedSlot6;
-    /// mapping (uint256 => uint256) public mappingValues;
+    // mapping (uint256 => uint256) public mappingValues;
     uint256 reservedSlot7;
-    /// uint256[] public mappingIndices;
+    // uint256[] public mappingIndices;
     uint256 reservedSlot8;
 
     struct Structure1 {
         uint256 value;
         uint256[] arrayValues;
     }
-    /// Structure1[] public arrayStructures;
+    // Structure1[] public arrayStructures;
     uint256 reservedSlot9;
 
     struct Structure2 {
@@ -37,12 +39,12 @@ contract ContractV4 is Upgradeable {
         uint256[] arrayValues;
         uint256 valueToCheck;
     }
-    /// mapping (uint256 => Structure2) public mappingStructures;
+    // mapping (uint256 => Structure2) public mappingStructures;
     uint256 reservedSlot10;
-    /// uint256 public mappingStructuresLength;
+    // uint256 public mappingStructuresLength;
     uint256 reservedSlot11;
 
-    /// uint256 public storageValueToCheck;
+    // uint256 public storageValueToCheck;
     uint256 reservedSlot12;
     uint256 public anotherStorageValue;
 

--- a/tests/contracts/contracts/proxy/Destroyable.sol
+++ b/tests/contracts/contracts/proxy/Destroyable.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
+++ b/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 pragma solidity ^0.6.1;
 
 

--- a/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
+++ b/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.6.1;
+
+
+import "contracts/proxy/Upgradeable.sol";
+
+
+/**
+* @dev Contract can't handle 'receive' and 'fallback' requests
+*/
+contract NoFallback is Upgradeable {}
+
+
+/**
+* @dev Contract can handle only 'receive' requests
+*/
+contract OnlyReceive is NoFallback {
+
+    uint256 public receiveRequests;
+    uint256 public value;
+
+    receive() external payable {
+        receiveRequests += 1;
+        value += msg.value;
+    }
+
+}
+
+
+/**
+* @dev Contract can handle 'receive' and 'fallback' requests
+*/
+contract ReceiveFallback is OnlyReceive {
+
+    uint256 public fallbackRequests;
+
+    fallback() external payable {
+        fallbackRequests += 1;
+        value += msg.value;
+    }
+
+}


### PR DESCRIPTION
Based on #2075

https://spdx.org/licenses/
NuCypher contracts: AGPL-3.0-or-later
OpenZeppelin: MIT
Aragon (IERC900History): GPL-3.0-or-later

Also updates version of solidity to `0.6.9`, and fixes some warnings for comments in contract
