### PR TITLE
Correct usage of TxReceipt.data during grant

### DIFF
--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -237,7 +237,7 @@ class StakingEscrowAgent(EthereumContractAgent):
     def get_staker_population(self) -> int:
         """Returns the number of stakers on the blockchain"""
         return self.contract.functions.getStakersLength().call()
-    
+
     @contract_api(CONTRACT_CALL)
     def get_current_period(self) -> Period:
         """Returns the current period"""
@@ -321,7 +321,7 @@ class StakingEscrowAgent(EthereumContractAgent):
     #
     # StakingEscrow Contract API
     #
-    
+
     @contract_api(CONTRACT_CALL)
     def get_global_locked_tokens(self, at_period: Optional[Period] = None) -> NuNits:
         """
@@ -435,7 +435,7 @@ class StakingEscrowAgent(EthereumContractAgent):
                       dry_run: bool = False,
                       gas_limit: Optional[Wei] = None
                       ) -> Union[TxReceipt, Wei]:
-        
+
         min_gas_batch_deposit: Wei = Wei(250_000)  # TODO: move elsewhere?
         if gas_limit and gas_limit < min_gas_batch_deposit:
             raise ValueError(f"{gas_limit} is not enough gas for any batch deposit")
@@ -618,7 +618,7 @@ class StakingEscrowAgent(EthereumContractAgent):
     @contract_api(CONTRACT_CALL)
     def staking_parameters(self) -> StakingEscrowParameters:
         parameter_signatures = (
-            
+
             # Period
             'secondsPerPeriod',  # Seconds in single period
 
@@ -806,7 +806,10 @@ class PolicyManagerAgent(EthereumContractAgent):
         # TODO: Won't it be great when this is impossible?  #1274
         _receipt = self.blockchain.client.wait_for_receipt(txhash, timeout=timeout)
         transaction = self.blockchain.client.w3.eth.getTransaction(txhash)
-        _signature, parameters = self.contract.decode_function_input(transaction.data)
+        try:
+            _signature, parameters = self.contract.decode_function_input(self.blockchain.client.parse_transaction_data(transaction))
+        except AttributeError:
+            raise RuntimeError(f"Eth Client incompatibility issue: {self.blockchain.client} could not extract data from {transaction}")
         return parameters['_nodes']
 
     @contract_api(TRANSACTION)
@@ -1229,7 +1232,7 @@ class WorkLockAgent(EthereumContractAgent):
     def check_claim(self, checksum_address: ChecksumAddress) -> bool:
         has_claimed: bool = bool(self.contract.functions.workInfo(checksum_address).call()[2])
         return has_claimed
-    
+
     #
     # Internal
     #

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -807,7 +807,8 @@ class PolicyManagerAgent(EthereumContractAgent):
         _receipt = self.blockchain.client.wait_for_receipt(txhash, timeout=timeout)
         transaction = self.blockchain.client.w3.eth.getTransaction(txhash)
         try:
-            _signature, parameters = self.contract.decode_function_input(self.blockchain.client.parse_transaction_data(transaction))
+            _signature, parameters = self.contract.decode_function_input(
+                self.blockchain.client.parse_transaction_data(transaction))
         except AttributeError:
             raise RuntimeError(f"Eth Client incompatibility issue: {self.blockchain.client} could not extract data from {transaction}")
         return parameters['_nodes']

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -428,6 +428,9 @@ class EthereumClient:
 
         return True
 
+    def parse_transaction_data(self, transaction):
+        return transaction.data
+
 
 class GethClient(EthereumClient):
 
@@ -528,6 +531,9 @@ class InfuraClient(EthereumClient):
 
     def sync(self, *args, **kwargs) -> bool:
         return True
+
+    def parse_transaction_data(self, transaction):
+        return transaction.input
 
 
 class EthereumTesterClient(EthereumClient):

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -589,7 +589,7 @@ class EthereumTesterClient(EthereumClient):
         return signature_and_stuff['signature']
 
     def parse_transaction_data(self, transaction):
-        return transaction.data
+        return transaction.data  # TODO: See https://github.com/ethereum/eth-tester/issues/173
 
 
 class NuCypherGethProcess(LoggingMixin, BaseGethProcess):

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -429,7 +429,7 @@ class EthereumClient:
         return True
 
     def parse_transaction_data(self, transaction):
-        return transaction.data
+        return transaction.input
 
 
 class GethClient(EthereumClient):
@@ -532,9 +532,6 @@ class InfuraClient(EthereumClient):
     def sync(self, *args, **kwargs) -> bool:
         return True
 
-    def parse_transaction_data(self, transaction):
-        return transaction.input
-
 
 class EthereumTesterClient(EthereumClient):
     is_local = True
@@ -590,6 +587,9 @@ class EthereumTesterClient(EthereumClient):
         signable_message = encode_defunct(primitive=message)
         signature_and_stuff = Account.sign_message(signable_message=signable_message, private_key=signing_key)
         return signature_and_stuff['signature']
+
+    def parse_transaction_data(self, transaction):
+        return transaction.data
 
 
 class NuCypherGethProcess(LoggingMixin, BaseGethProcess):

--- a/nucypher/blockchain/eth/multisig.py
+++ b/nucypher/blockchain/eth/multisig.py
@@ -43,7 +43,7 @@ class Proposal:
         proposal_elements = dict(trustee_address=trustee_address,
                                  target_address=transaction['to'],
                                  value=transaction['value'],
-                                 data=Web3.toBytes(hexstr=transaction['data']),
+                                 data=Web3.toBytes(hexstr=transaction['data']), # TODO: should use a blockchain client to get correct data
                                  nonce=multisig_agent.nonce)
 
         digest = multisig_agent.get_unsigned_transaction_hash(**proposal_elements)

--- a/tests/acceptance/blockchain/deployers/test_staking_escrow_deployer.py
+++ b/tests/acceptance/blockchain/deployers/test_staking_escrow_deployer.py
@@ -172,7 +172,7 @@ def test_manual_proxy_retargeting(testerchain, test_registry, token_economics):
                                     just_build_transaction=True)
 
     assert transaction['to'] == proxy_deployer.contract.address
-    upgrade_function, _params = proxy_deployer.contract.decode_function_input(transaction['data'])
+    upgrade_function, _params = proxy_deployer.contract.decode_function_input(transaction['data']) # TODO: this only tests for ethtester
     assert upgrade_function.fn_name == proxy_deployer.contract.functions.upgrade.fn_name
 
     # Retarget, for real


### PR DESCRIPTION
Some upstream library/protocol change changed the structure of the transaction AttributeDict and broke our  `fetch_arrangement_addresses_from_policy_txid` method.

This commit fixes that.