### PR TITLE
Variety of cleanup work related to docs/cli output for setting up staker and worker

### DIFF
--- a/docs/source/guides/network_node/staking_guide.rst
+++ b/docs/source/guides/network_node/staking_guide.rst
@@ -202,8 +202,8 @@ the commitment period.
     ══════════════════════════════ STAGED STAKE ══════════════════════════════
 
     Staking address: 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
-    ~ Chain  	-> ID # <CHAIN_ID>
-    ~ Value  	-> 30000 NU (30000000000000000000000 NuNits)
+    ~ Chain      -> ID # <CHAIN_ID>
+    ~ Value      -> 30000 NU (30000000000000000000000 NuNits)
     ~ Duration   -> 30 Days (30 Periods)
     ~ Enactment  -> Jun 19 20:00 EDT (period #18433)
     ~ Expiration -> Jul 19 20:00 EDT (period #18463)
@@ -247,23 +247,21 @@ Once you have created one or more stakes, you can view all active stake for conn
 
     (nucypher)$ nucypher stake list
 
-    Network <NETWORK> ═════════════════════════════════════════
+    Network <NETWORK_NAME> ═══════════════════════════════
     Staker 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f ════
     Worker NO_WORKER_BONDED ════
     --------------  -----------------------------------
-    Status      	Never Made a Commitment (New Stake)
-    Restaking   	Yes (Unlocked)
-    Winding Down	No
+    Status          Never Made a Commitment (New Stake)
+    Restaking       Yes (Unlocked)
+    Winding Down    No
     Unclaimed Fees  0 ETH
-    Min fee rate	0 ETH
+    Min fee rate    0 ETH
     --------------  -----------------------------------
     ╒═══════╤══════════╤═════════════╤═════════════╤═══════════════╕
     │   Idx │ Value    │   Remaining │ Enactment   │ Termination   │
     ╞═══════╪══════════╪═════════════╪═════════════╪═══════════════╡
     │ 	0   │ 30000 NU │      	  31 │ Jun 19 2020 │ Jul 19 2020   │
     ╘═══════╧══════════╧═════════════╧═════════════╧═══════════════╛
-
-
 
 If the Worker in the list is shown as ``NO_WORKER_BONDED``, it means that you haven't yet
 bonded a Worker node to your Staker, so you still have to do it!
@@ -394,42 +392,54 @@ To divide an existing stake:
 
     (nucypher)$ nucypher stake divide --hw-wallet
 
-    Select Stake: 2
-    Enter target value (must be less than or equal to 30000 NU): 15000
-    Enter number of periods to extend: 1
+    Select Stake: 0
+    Enter target value (15000 NU - 16437.841006996376688377 NU): 15000
+    Enter number of periods to extend: 20
 
-    ============================== ORIGINAL STAKE ============================
+    ══════════════════════════════ ORIGINAL STAKE ════════════════════════════
 
-    Staking address: 0xbb0300106378096883ca067B198d9d98112760e7
-    ~ Original Stake: | - | 0xbb03 | 0xbb04 | 0 | 30000 NU | 39 periods . | Aug 09 12:29:44 CEST - Sep 16 12:29:44 CEST
+    Staking address: 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
+    ~ Original Stake: | - | 0x270b | 0x45D3 | 0 | 31437.841006996376688377 NU | 33 periods . | Jun 19 20:00 EDT - Jul 22 20:00 EDT
 
 
-    ============================== STAGED STAKE ==============================
+    ══════════════════════════════ STAGED STAKE ══════════════════════════════
 
-    Staking address: 0xbb0300106378096883ca067B198d9d98112760e7
-    ~ Chain      -> ID # <CHAIN ID>
-    ~ Value      -> 15000 NU (1.50E+22 NuNits)
-    ~ Duration   -> 39 Days (39 Periods)
-    ~ Enactment  -> 2019-08-09 10:29:49.844348+00:00 (period #18117)
-    ~ Expiration -> 2019-09-17 10:29:49.844612+00:00 (period #18156)
+    Staking address: 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
+    ~ Chain      -> ID # 4 | Rinkeby
+    ~ Value      -> 15000 NU (15000000000000000000000 NuNits)
+    ~ Duration   -> 53 Days (53 Periods)
+    ~ Enactment  -> Jun 19 20:00 EDT (period #18433)
+    ~ Expiration -> Aug 11 20:00 EDT (period #18486)
 
-    =========================================================================
-    Is this correct? [y/N]: y
-    Enter password to unlock account 0xbb0300106378096883ca067B198d9d98112760e7:
-
+    ═════════════════════════════════════════════════════════════════════════
+    Publish stake division to the blockchain? [y/N]: y
+    Enter password to unlock account 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f:
+    Confirm transaction DIVIDESTAKE on hardware wallet... (76058 gwei @ 1000000000)
+    Broadcasting DIVIDESTAKE Transaction (76058 gwei @ 1000000000)...
     Successfully divided stake
-    OK | 0xfa30927f05967b9a752402db9faecf146c46eda0740bd3d67b9e86dd908b6572 (85128 gas)
-    Block #1146153 | 0x2f87bccff86bf48d18f8ab0f54e30236bce6ca5ea9f85f3165c7389f2ea44e45
-    See https://etherscan.io/tx/0xfa30927f05967b9a752402db9faecf146c46eda0740bd3d67b9e86dd908b6572
+    OK | 0x74ddd647de6eaca7ef0c485706ef526001d959a3c2eaa98699e087a7d259d08b (75349 gas)
+    Block #6711982 | 0xd1c6d6df257ecd05632550565edb709ae577066a60ca433bc4d23de5fb332009
+     See https://rinkeby.etherscan.io/tx/0x74ddd647de6eaca7ef0c485706ef526001d959a3c2eaa98699e087a7d259d08b
 
-    ======================================= Active Stakes =========================================
 
-    | ~ | Staker | Worker | # | Value    | Duration     | Enactment
-    |   | ------ | ------ | - | -------- | ------------ | -----------------------------------------
-    | 0 | 0xbb01 | 0xbb02 | 0 | 15000 NU | 41 periods . | Aug 04 12:29:44 CEST - Sep 13 12:29:44 CEST
-    | 1 | 0xbb01 | 0xbb02 | 1 | 15000 NU | 30 periods . | Aug 20 12:29:44 CEST - Sep 18 12:29:44 CEST
-    | 2 | 0xbb03 | 0xbb04 | 0 | 15000 NU | 39 periods . | Aug 09 12:30:38 CEST - Sep 16 12:30:38 CEST
-    | 3 | 0xbb03 | 0xbb04 | 1 | 15000 NU | 40 periods . | Aug 09 12:30:38 CEST - Sep 17 12:30:38 CEST
+    Network <NETWORK_NAME> ═══════════════════════════════
+    Staker 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f ════
+    Worker 0x45D33d1Ff0A7E696556f36DE697E5C92C2CCcFaE ════
+    --------------  ----------------
+    Status          Committed #18436
+    Restaking       Yes (Unlocked)
+    Winding Down    No
+    Unclaimed Fees  0 ETH
+    Min fee rate    0 ETH
+    --------------  ----------------
+    ╒═══════╤═════════════════════════════╤═════════════╤═════════════╤═══════════════╕
+    │   Idx │ Value                   	  │   Remaining │ Enactment   │ Termination   │
+    ╞═══════╪═════════════════════════════╪═════════════╪═════════════╪═══════════════╡
+    │ 	0   │ 16437.841006996376688377 NU │         31  │ Jun 19 2020 │ Jul 22 2020   │
+    ├───────┼─────────────────────────────┼─────────────┼─────────────┼───────────────┤
+    │ 	1   │ 15000 NU                	  │         51  │ Jun 19 2020 │ Aug 11 2020   │
+    ╘═══════╧═════════════════════════════╧═════════════╧═════════════╧═══════════════╛
+
 
 
 Collect rewards earned by the staker

--- a/docs/source/guides/network_node/staking_guide.rst
+++ b/docs/source/guides/network_node/staking_guide.rst
@@ -186,32 +186,39 @@ the commitment period.
 
 .. code:: bash
 
+
     (nucypher)$ nucypher stake create --hw-wallet
 
-    Select staking account [0]: 0
-    Enter stake value in NU [15000]: 15000
-    Enter stake duration (30 periods minimum): 30
+        Account
+    --  ------------------------------------------
+     0  0x63e478bc474eBb6c31568ff131cCd95C24bfD552
+     1  0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
+     2  0x45D33d1Ff0A7E696556f36DE697E5C92C2CCcFaE
+    Select index of staking account [0]: 1
+    Selected 1: 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
+    Enter stake value in NU (15000 NU - 30000 NU) [30000]: 30000
+    Enter stake duration (30 - 47103) [365]: 30
 
-    ============================== STAGED STAKE ==============================
+    ══════════════════════════════ STAGED STAKE ══════════════════════════════
 
-    Staking address: 0xbb01c4fE50f91eF73c5dD6eD89f38D55A6b1EdCA
-    ~ Chain      -> ID # <CHAIN ID>
-    ~ Value      -> 15000 NU (1.50E+22 NuNits)
+    Staking address: 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
+    ~ Chain  	-> ID # <CHAIN_ID>
+    ~ Value  	-> 30000 NU (30000000000000000000000 NuNits)
     ~ Duration   -> 30 Days (30 Periods)
-    ~ Enactment  -> 2019-08-19 09:51:16.704875+00:00 (period #18127)
-    ~ Expiration -> 2019-09-18 09:51:16.705113+00:00 (period #18157)
+    ~ Enactment  -> Jun 19 20:00 EDT (period #18433)
+    ~ Expiration -> Jul 19 20:00 EDT (period #18463)
 
-    =========================================================================
+    ═════════════════════════════════════════════════════════════════════════
 
     * Ursula Node Operator Notice *
     -------------------------------
 
-    By agreeing to stake 15000 NU (15000000000000000000000 NuNits):
+    By agreeing to stake 30000 NU (30000000000000000000000 NuNits):
 
     - Staked tokens will be locked for the stake duration.
 
     - You are obligated to maintain a networked and available Ursula-Worker node
-      bonded to the staker address 0xbb01c4fE50f91eF73c5dD6eD89f38D55A6b1EdCA for the duration
+      bonded to the staker address 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f for the duration
       of the stake(s) (30 periods).
 
     - Agree to allow NuCypher network users to carry out uninterrupted re-encryption
@@ -221,19 +228,12 @@ the commitment period.
     will result in the loss of staked tokens as described in the NuCypher slashing protocol.
 
     Keeping your Ursula node online during the staking period and successfully
-    producing correct re-encryption work orders will earn fees
-    paid out in ETH on-demand and retroactively.
+    producing correct re-encryption work orders will result in rewards
+    paid out in ethers retro-actively and on-demand.
 
     Accept ursula node operator obligation? [y/N]: y
     Publish staged stake to the blockchain? [y/N]: y
 
-    Stake initialization transaction was successful.
-
-    Transaction details:
-    OK | deposit stake | 0xe05babab52d00157d0c6e95b7c5165a95adc0ee7ff64ca4d89807805f0ef0fcf (229181 gas)
-    Block #16 | 0xbf8252bc84831c26fc91a2272047e394ec0356af515d785d4a179596e722d836
-
-    StakingEscrow address: 0xDe09E74d4888Bc4e65F589e8c13Bce9F71DdF4c7
 
 If you used a hardware wallet, you will need to confirm two transactions here.
 
@@ -247,15 +247,25 @@ Once you have created one or more stakes, you can view all active stake for conn
 
     (nucypher)$ nucypher stake list
 
-    ======================================= Active Stakes =========================================
+    Network <NETWORK> ═════════════════════════════════════════
+    Staker 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f ════
+    Worker NO_WORKER_BONDED ════
+    --------------  -----------------------------------
+    Status      	Never Made a Commitment (New Stake)
+    Restaking   	Yes (Unlocked)
+    Winding Down	No
+    Unclaimed Fees  0 ETH
+    Min fee rate	0 ETH
+    --------------  -----------------------------------
+    ╒═══════╤══════════╤═════════════╤═════════════╤═══════════════╕
+    │   Idx │ Value    │   Remaining │ Enactment   │ Termination   │
+    ╞═══════╪══════════╪═════════════╪═════════════╪═══════════════╡
+    │ 	0   │ 30000 NU │      	  31 │ Jun 19 2020 │ Jul 19 2020   │
+    ╘═══════╧══════════╧═════════════╧═════════════╧═══════════════╛
 
-    | ~ | Staker | Worker | # | Value    | Duration     | Enactment
-    |   | ------ | ------ | - | -------- | ------------ | -----------------------------------------
-    | 0 | 0xbb01 | 0xdead | 0 | 15000 NU | 41 periods . | Aug 04 12:15:16 CEST - Sep 13 12:15:16 CEST
-    | 1 | 0xbb02 | 0xbeef | 1 | 15000 NU | 30 periods . | Aug 20 12:15:16 CEST - Sep 18 12:15:16 CEST
-    | 2 | 0xbb03 | 0x0000 | 0 | 30000 NU | 30 periods . | Aug 09 12:15:16 CEST - Sep 9 12:15:16 CEST
 
-If the Worker in the list is shown as ``0x0000``, it means that you haven't yet
+
+If the Worker in the list is shown as ``NO_WORKER_BONDED``, it means that you haven't yet
 bonded a Worker node to your Staker, so you still have to do it!
 
 .. _bond-worker:
@@ -268,25 +278,22 @@ There is a 1:1 relationship between the roles: A Staker may have multiple Stakes
 
 .. note:: The Worker cannot be changed for a minimum of 2 periods once bonded.
 
-.. note:: Stakers without a worker bonded will be highlighted in yellow (sometimes called "Unbonded" or "Headless").
+.. note:: Stakers without a worker bonded will be highlighted in red.
 
 .. code:: bash
 
     (nucypher)$ nucypher stake bond-worker --hw-wallet
 
-    ======================================= Active Stakes =========================================
+            Account
+    --  ------------------------------------------
+     0  0x63e478bc474eBb6c31568ff131cCd95C24bfD552
+     1  0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
+     2  0x45D33d1Ff0A7E696556f36DE697E5C92C2CCcFaE
+    Select index of staking account [0]: 1
+    Selected 1: 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f
+    Enter worker address: 0x45D33d1Ff0A7E696556f36DE697E5C92C2CCcFaE
+    Commit to bonding worker 0x45D33d1Ff0A7E696556f36DE697E5C92C2CCcFaE to staker 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f for a minimum of 2 periods? [y/N]: y
 
-    | ~ | Staker | Worker | # | Value    | Duration     | Enactment
-    |   | ------ | ------ | - | -------- | ------------ | -----------------------------------------
-    | 0 | 0xbb01 | 0xdead | 0 | 15000 NU | 41 periods . | Aug 04 12:15:16 CEST - Sep 13 12:15:16 CEST
-    | 1 | 0xbb02 | 0xbeef | 1 | 15000 NU | 30 periods . | Aug 20 12:15:16 CEST - Sep 18 12:15:16 CEST
-    | 2 | 0xbb03 | 0x0000 | 0 | 30000 NU | 30 periods . | Aug 09 12:15:16 CEST - Sep 9 12:15:16 CEST
-
-    Select Stake: 2
-    Enter Worker Address: 0xbeefc4fE50f91eF73c5dD6eD89f38D55A6b1EdCA
-    Worker 0xbb04c4fE50f91eF73c5dD6eD89f38D55A6b1EdCA successfully bonded to staker 0xbb03...
-
-    OK!
 
 .. note:: The worker's address must be EIP-55 checksum valid, however, geth shows addresses in the normalized format.
           You can convert the normalized address to checksum format in geth console:
@@ -295,9 +302,10 @@ There is a 1:1 relationship between the roles: A Staker may have multiple Stakes
 
     $ geth attach ~/.ethereum/geth.ipc
     > eth.accounts
-    ["0x287a817426dd1ae78ea23e9918e2273b6733a43d", "0xc080708026a3a280894365efd51bb64521c45147"]
-    > web3.toChecksumAddress(eth.accounts[0])
-    "0x287A817426DD1AE78ea23e9918e2273b6733a43D"
+    ["0x63e478bc474ebb6c31568ff131ccd95c24bfd552", "0x270b3f8af5ba2b79ea3bd6a6efc7ecab056d3e3f", "0x45d33d1ff0a7e696556f36de697e5c92c2cccfae"]
+    > web3.toChecksumAddress(eth.accounts[2])
+    "0x45D33d1Ff0A7E696556f36DE697E5C92C2CCcFaE"
+
 
 After this step, you're finished with the Staker, and you can proceed to :ref:`ursula-config-guide`.
 

--- a/docs/source/guides/network_node/staking_guide.rst
+++ b/docs/source/guides/network_node/staking_guide.rst
@@ -454,29 +454,20 @@ policy fees using the ``--withdraw-address <ETH_ADDRESS>`` flag.
 
 .. code:: bash
 
-    (nucypher)$ nucypher stake collect-reward --staking-reward --policy-fee --staking-address 0x287A817426DD1AE78ea23e9918e2273b6733a43D --hw-wallet
+    (nucypher)$ nucypher stake collect-reward --staking-reward --policy-fee --staking-address 0x270b3f8af5ba2B79ea3Bd6a6Efc7ecAB056d3E3f --hw-wallet
+    Collecting 228.340621510864128225 NU from staking rewards...
+    Confirm transaction WITHDRAW on hardware wallet... (500000 gwei @ 1000000000)
+    Broadcasting WITHDRAW Transaction (500000 gwei @ 1000000000)...
+    OK | 0x1c59af9353b016080fef9e93ddd03fde4260b6c282880db7b15fc0d4f28b2d34 (124491 gas)
+    Block #6728952 | 0xdadfef1767eb5bdc4bb4ad469a5f7aded44a87799dd2ee0edd6b6147951dbd3f
+     See https://rinkeby.etherscan.io/tx/0x1c59af9353b016080fef9e93ddd03fde4260b6c282880db7b15fc0d4f28b2d34
 
-     ____    __            __
-    /\  _`\ /\ \__        /\ \
-    \ \,\L\_\ \ ,_\    __ \ \ \/'\      __   _ __
-     \/_\__ \\ \ \/  /'__`\\ \ , <    /'__`\/\`'__\
-       /\ \L\ \ \ \_/\ \L\.\\ \ \\`\ /\  __/\ \ \/
-       \ `\____\ \__\ \__/.\_\ \_\ \_\ \____\\ \_\
-        \/_____/\/__/\/__/\/_/\/_/\/_/\/____/ \/_/
-
-    The Holder of Stakes.
-
-    Collecting 12.345 NU from staking rewards...
-
-    OK | 0xb0625030224e228198faa3ed65d43f93247cf6067aeb62264db6f31b5bf411fa (55062 gas)
-    Block #1245170 | 0x63e4da39056873adaf869674db4002e016c80466f38256a4c251516a0e25e547
-     See https://etherscan.io/tx/0xb0625030224e228198faa3ed65d43f93247cf6067aeb62264db6f31b5bf411fa
-
-    Collecting 0.978 ETH from policy fees...
-
-    OK | 0xe6d555be43263702b74727ce29dc4bcd6e32019159ccb15120791dfda0975372 (25070 gas)
-    Block #1245171 | 0x0d8180a69213c240e2bf2045179976d5f18de56a82f17a9d59db54756b6604e4
-     See https://etherscan.io/tx/0xe6d555be43263702b74727ce29dc4bcd6e32019159ccb15120791dfda0975372
+    Collecting 1.0004E-13 ETH from policy fees...
+    Confirm transaction WITHDRAW on hardware wallet... (42070 gwei @ 1000000000)
+    Broadcasting WITHDRAW Transaction (42070 gwei @ 1000000000)...
+    OK | 0xba2afb864c24d783c5185429706c77a39e9053570de892a351dd86f7719fe58b (41656 gas)
+    Block #6728953 | 0x1238f61e8adf8bf42e022f5182b692aca5ec5bf45c70871156ca540055daaa94
+     See https://rinkeby.etherscan.io/tx/0xba2afb864c24d783c5185429706c77a39e9053570de892a351dd86f7719fe58b
 
 You can run ``nucypher stake accounts`` to verify that your staking compensation
 is indeed in your wallet. Use your favorite Ethereum wallet (MyCrypto or Metamask

--- a/docs/source/guides/network_node/ursula_configuration_guide.rst
+++ b/docs/source/guides/network_node/ursula_configuration_guide.rst
@@ -186,10 +186,16 @@ parameters to the ``nucypher ursula run`` command:
 * ``--prometheus`` - a boolean flag to enable the prometheus endpoint
 * ``--metrics-port <PORT>`` - the HTTP port to run the prometheus endpoint on
 
-The corresponding endpoint, ``http://<node_ip>:<METRICS PORT>``, can be used as a Prometheus data source for
+The corresponding endpoint, ``http://<node_ip>:<METRICS PORT>/metrics``, can be used as a Prometheus data source for
 monitoring including the creation of alert criteria.
+
+Prometheus is **not** installed by default and must be explicitly installed:
+
+.. code:: bash
+
+     (nucypher)$ pip install nucypher[ursula]
 
 
 .. note::
 
-    The Ursula Status Page and Prometheus Endpoint are areas of active development.
+    Both the Ursula Status Page and Prometheus Endpoint are areas of active development.

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -661,7 +661,7 @@ def divide(general_config, transacting_staker_options, config_file, force, value
     if not value:
         min_allowed_locked = NU.from_nunits(STAKEHOLDER.economics.minimum_allowed_locked)
         max_divide_value = max(min_allowed_locked, current_stake.value - min_allowed_locked)
-        prompt = PROMPT_STAKE_DIVIDE_VALUE.format(minimm=min_allowed_locked, maximum=str(max_divide_value))
+        prompt = PROMPT_STAKE_DIVIDE_VALUE.format(minimum=min_allowed_locked, maximum=str(max_divide_value))
         value = click.prompt(prompt, type=stake_value_range)
     value = NU(value, 'NU')
 

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -41,7 +41,7 @@ from nucypher.cli.config import group_general_config
 from nucypher.cli.literature import (
     BONDING_DETAILS,
     BONDING_RELEASE_INFO,
-    COLLECTING_ETH_REWARD,
+    COLLECTING_ETH_FEE,
     COLLECTING_PREALLOCATION_REWARD,
     COLLECTING_TOKEN_REWARD,
     CONFIRM_BROADCAST_CREATE_STAKE,
@@ -819,7 +819,7 @@ def collect_reward(general_config,
 
     if policy_fee:
         fee_amount = Web3.fromWei(STAKEHOLDER.calculate_policy_fee(), 'ether')
-        emitter.echo(message=COLLECTING_ETH_REWARD.format(reward_amount=fee_amount))
+        emitter.echo(message=COLLECTING_ETH_FEE.format(fee_amount=fee_amount))
         policy_receipt = STAKEHOLDER.collect_policy_fee(collector_address=withdraw_address)
         paint_receipt_summary(receipt=policy_receipt,
                               chain_name=STAKEHOLDER.wallet.blockchain.client.chain_name,

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -97,7 +97,7 @@ NO_STAKES_FOUND = "No stakes found."
 
 POST_STAKING_ADVICE = """
 View your stakes by running 'nucypher stake list'
-or set your Ursula worker node address by running 'nucypher stake set-worker'.
+or set your Ursula worker node address by running 'nucypher stake bond-worker'.
 
 See https://docs.nucypher.com/en/latest/guides/staking_guide.html
 """
@@ -532,7 +532,7 @@ See the official NuCypher documentation for a comprehensive guide on next steps!
 
 As a first step, you need to bond a worker to your stake by running:
 
-  nucypher stake set-worker --worker-address <WORKER ADDRESS>
+  nucypher stake bond-worker --worker-address <WORKER ADDRESS>
 
 """
 

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -222,7 +222,7 @@ SUCCESSFUL_STAKE_PROLONG = 'Successfully Prolonged Stake'
 
 COLLECTING_TOKEN_REWARD = 'Collecting {reward_amount} from staking rewards...'
 
-COLLECTING_ETH_REWARD = 'Collecting {reward_amount} ETH from policy rewards...'
+COLLECTING_ETH_FEE = 'Collecting {fee_amount} ETH from policy fees...'
 
 COLLECTING_PREALLOCATION_REWARD = 'Collecting {unlocked_tokens} from PreallocationEscrow contract {staking_address}...'
 

--- a/nucypher/cli/painting/worklock.py
+++ b/nucypher/cli/painting/worklock.py
@@ -128,7 +128,7 @@ def paint_bidder_status(emitter, bidder):
 
     message = f"""
 WorkLock Participant {bidder.checksum_address}
-====================================================="""
+══════════════════════════════════════════════════════"""
 
     if bidder.has_claimed:
         message += f"""


### PR DESCRIPTION
- [x] `set-worker` -> `bond-worker`
- [x] Updated output for command execution
- [x] Documentation of prometheus optional installation (Related to #2100 )
- [x] Update documentation text output for `nucypher stake divide`
- [x] Update documentation text output for `nucypher stake collect-reward`