### PR TITLE
Some fixes for `stake` commands

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1663,7 +1663,7 @@ class StakeHolder(Staker):
         else:
             new_form = self.checksum_address
 
-        self.log.info(f"Resistance is futile - Assimilating Staker {original_form} -> {new_form}.")
+        self.log.info(f"Setting Staker from {original_form} to {new_form}.")
 
     @validate_checksum_address
     def assimilate(self, checksum_address: str = None, password: str = None) -> None:

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -270,6 +270,15 @@ class Stake:
     #
 
     def status(self, staker_info: StakerInfo = None, current_period: Period = None) -> Status:
+        """
+        Returns status of sub-stake:
+        UNLOCKED - final period in the past
+        INACTIVE - UNLOCKED and sub-stake will not be included in any future calculations
+        LOCKED - sub-stake is still locked and final period is current period
+        EDITABLE - LOCKED and final period greater than current
+        DIVISIBLE - EDITABLE and locked value is greater than two times the minimum allowed locked
+        """
+
         if self._status:
             return self._status
 
@@ -527,7 +536,7 @@ class Stake:
         self.sync()
         status = self.status()
         if not status.is_child(Stake.Status.EDITABLE):
-            raise self.StakingError(f'Cannot divide a not editable stake. '
+            raise self.StakingError(f'Cannot prolong a non-editable stake. '
                                     f'Selected stake expired {self.unlock_datetime}.')
         receipt = self.staking_agent.prolong_stake(staker_address=self.staker_address,
                                                    stake_index=self.index,

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -17,6 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 from _pydecimal import Decimal
 from collections import UserList
+from enum import Enum
 
 import maya
 from constant_sorrow.constants import (EMPTY_STAKING_SLOT, NEW_STAKE, NOT_STAKING, NO_STAKING_RECEIPT,
@@ -30,6 +31,7 @@ from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.utils import datetime_at_period
+from nucypher.types import SubStakeInfo, NuNits, StakerInfo, Period
 
 
 class NU:
@@ -93,9 +95,9 @@ class NU:
         """Returns a decimal value of NU"""
         return currency.from_wei(self.__value, unit='ether')
 
-    def to_nunits(self) -> int:
+    def to_nunits(self) -> NuNits:
         """Returns an int value in NuNit"""
-        return int(self.__value)
+        return NuNits(self.__value)
 
     def __eq__(self, other) -> bool:
         return int(self) == int(other)
@@ -159,6 +161,24 @@ class Stake:
     class StakingError(Exception):
         """Raised when a staking operation cannot be executed due to failure."""
 
+    class Status(Enum):
+        """
+        Sub-stake status.
+        """
+        INACTIVE = 1   # Unlocked inactive
+        UNLOCKED = 2   # Unlocked active
+        LOCKED = 3     # Locked but not editable
+        EDITABLE = 4   # Editable
+        DIVISIBLE = 5  # Editable and divisible
+
+        def is_child(self, other: 'Status') -> bool:
+            if other == self.INACTIVE:
+                return self == self.INACTIVE
+            elif other == self.UNLOCKED:
+                return self.value <= self.UNLOCKED.value
+            else:
+                return self.value >= other.value
+
     @validate_checksum_address
     def __init__(self,
                  staking_agent: StakingEscrowAgent,
@@ -174,7 +194,6 @@ class Stake:
 
         # Ownership
         self.staker_address = checksum_address
-        self.worker_address = UNKNOWN_WORKER_STATUS
 
         # Stake Metadata
         self.index = index
@@ -210,6 +229,7 @@ class Stake:
             self.validate()
 
         self.receipt = NO_STAKING_RECEIPT
+        self._status = None
 
     def __repr__(self) -> str:
         r = f'Stake(' \
@@ -249,43 +269,56 @@ class Stake:
     # Metadata
     #
 
-    @property
-    def is_expired(self) -> bool:
-        current_period = self.staking_agent.get_current_period()  # TODO #1514 this is online only.
-        return bool(current_period > self.final_locked_period)
+    def status(self, staker_info: StakerInfo = None, current_period: Period = None) -> Status:
+        if self._status:
+            return self._status
 
-    @property
-    def is_active(self) -> bool:
-        return not self.is_expired
+        staker_info = staker_info or self.staking_agent.get_staker_info(self.staker_address) # TODO related to #1514
+        current_period = current_period or self.staking_agent.get_current_period()  # TODO #1514 this is online only.
+
+        if self.final_locked_period < current_period:
+            if (staker_info.current_committed_period == 0 or
+                staker_info.current_committed_period > self.final_locked_period) and \
+                (staker_info.next_committed_period == 0 or
+                 staker_info.next_committed_period > self.final_locked_period):
+                self._status = Stake.Status.INACTIVE
+            else:
+                self._status = Stake.Status.UNLOCKED
+        elif self.final_locked_period == current_period:
+            self._status = Stake.Status.LOCKED
+        elif self.value < 2 * self.economics.minimum_allowed_locked:
+            self._status = Stake.Status.EDITABLE
+        else:
+            self._status = Stake.Status.DIVISIBLE
+
+        return self._status
 
     @classmethod
     @validate_checksum_address
     def from_stake_info(cls,
                         checksum_address: str,
                         index: int,
-                        stake_info: Tuple[int, int, int],
+                        stake_info: SubStakeInfo,
                         economics,
                         *args, **kwargs
                         ) -> 'Stake':
 
         """Reads staking values as they exist on the blockchain"""
-        first_locked_period, final_locked_period, value = stake_info
 
         instance = cls(checksum_address=checksum_address,
                        index=index,
-                       first_locked_period=first_locked_period,
-                       final_locked_period=final_locked_period,
-                       value=NU(value, 'NuNit'),
+                       first_locked_period=stake_info.first_period,
+                       final_locked_period=stake_info.last_period,
+                       value=NU(stake_info.locked_value, 'NuNit'),
                        economics=economics,
                        validate_now=False,
                        *args, **kwargs)
 
-        instance.worker_address = instance.staking_agent.get_worker_from_staker(staker_address=checksum_address)
         return instance
 
-    def to_stake_info(self) -> Tuple[int, int, int]:
+    def to_stake_info(self) -> SubStakeInfo:
         """Returns a tuple representing the blockchain record of a stake"""
-        return self.first_locked_period, self.final_locked_period, int(self.value)
+        return SubStakeInfo(self.first_locked_period, self.final_locked_period, self.value.to_nunits())
 
     #
     # Duration
@@ -383,14 +416,13 @@ class Stake:
         stake_info = self.staking_agent.get_substake_info(staker_address=self.staker_address,
                                                           stake_index=self.index)  # < -- Read from blockchain
 
-        first_period, last_period, locked_value = stake_info
-        if not self.first_locked_period == first_period:
+        if not self.first_locked_period == stake_info.first_period:
             raise self.StakingError("Inconsistent staking cache.  Make sure your node is synced and try again.")
 
         # Mutate the instance with the on-chain values
-        self.final_locked_period = last_period
-        self.value = NU.from_nunits(locked_value)
-        self.worker_address = self.staking_agent.get_worker_from_staker(staker_address=self.staker_address)
+        self.final_locked_period = stake_info.last_period
+        self.value = NU.from_nunits(stake_info.locked_value)
+        self._status = None
 
     def divide(self, target_value: NU, additional_periods: int = None) -> Tuple['Stake', 'Stake']:
         """
@@ -404,8 +436,10 @@ class Stake:
         self.sync()
 
         # Ensure selected stake is active
-        if self.is_expired:
-            raise self.StakingError(f'Cannot divide an expired stake. Selected stake expired {self.unlock_datetime}.')
+        status = self.status()
+        if not status.is_child(Stake.Status.DIVISIBLE):
+            raise self.StakingError(f'Cannot divide an non-divisible stake. '
+                                    f'Selected stake expired {self.unlock_datetime} and has value {self.value}.')
 
         if target_value >= self.value:
             raise self.StakingError(f"Cannot divide stake; Target value ({target_value}) must be less "
@@ -491,8 +525,10 @@ class Stake:
 
     def prolong(self, additional_periods: int):
         self.sync()
-        if self.is_expired:
-            raise self.StakingError(f'Cannot divide an expired stake. Selected stake expired {self.unlock_datetime}.')
+        status = self.status()
+        if not status.is_child(Stake.Status.EDITABLE):
+            raise self.StakingError(f'Cannot divide a not editable stake. '
+                                    f'Selected stake expired {self.unlock_datetime}.')
         receipt = self.staking_agent.prolong_stake(staker_address=self.staker_address,
                                                    stake_index=self.index,
                                                    periods=additional_periods)

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -59,6 +59,7 @@ def select_stake(stakeholder: StakeHolder,
 
     # Precondition: Active Stakes
     if staker_address:
+        # FIXME: get_staker does not mutate stakeholder so stakeholder.get_staker().stakes may differ from stakeholder.sorted_stakes
         staker = stakeholder.get_staker(checksum_address=staker_address)
         stakes = staker.stakes
     else:
@@ -153,7 +154,7 @@ def select_client_account(emitter,
         row = [account]
         if show_staking:
             staker = Staker(is_me=True, checksum_address=account, registry=registry)
-            staker.stakes.refresh()
+            staker.refresh_stakes()
             is_staking = 'Yes' if bool(staker.stakes) else 'No'
             row.append(is_staking)
         if show_eth_balance:
@@ -207,6 +208,7 @@ def select_client_account_for_staking(emitter: StdoutEmitter,
                                                    network=stakeholder.network,
                                                    wallet=stakeholder.wallet)
             staking_address = client_account
+    stakeholder.set_staker(client_account)
 
     return client_account, staking_address
 

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -35,7 +35,6 @@ from nucypher.cli.literature import (
     GENERIC_SELECT_ACCOUNT,
     IS_THIS_CORRECT,
     NO_CONFIGURATIONS_ON_DISK,
-    NO_DIVISIBLE_STAKES,
     NO_ETH_ACCOUNTS,
     NO_STAKES_FOUND,
     ONLY_DISPLAYING_DIVISIBLE_STAKES_NOTE,
@@ -50,38 +49,27 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT, NUCYPHER_ENVVAR_WORKE
 from nucypher.config.node import CharacterConfiguration
 
 
-def select_stake(stakeholder: StakeHolder,
+def select_stake(staker: Staker,
                  emitter: StdoutEmitter,
-                 divisible: bool = False,
-                 staker_address: str = None
+                 stakes_status: Stake.Status = Stake.Status.EDITABLE
                  ) -> Stake:
     """Interactively select a stake or abort if there are no eligible stakes."""
 
-    # Precondition: Active Stakes
-    if staker_address:
-        # FIXME: get_staker does not mutate stakeholder so stakeholder.get_staker().stakes may differ from stakeholder.sorted_stakes
-        staker = stakeholder.get_staker(checksum_address=staker_address)
-        stakes = staker.stakes
-    else:
-        stakes = stakeholder.all_stakes
+    if stakes_status.is_child(Stake.Status.DIVISIBLE):
+        emitter.echo(ONLY_DISPLAYING_DIVISIBLE_STAKES_NOTE, color='yellow')
+
+    # Filter stakes by status
+    stakes = staker.sorted_stakes(parent_status=stakes_status)
     if not stakes:
         emitter.echo(NO_STAKES_FOUND, color='red')
         raise click.Abort
 
-    # Precondition: Divisible Stakes
-    stakes = stakeholder.sorted_stakes
-    if divisible:
-        emitter.echo(ONLY_DISPLAYING_DIVISIBLE_STAKES_NOTE, color='yellow')
-        stakes = stakeholder.divisible_stakes
-        if not stakes:
-            emitter.echo(NO_DIVISIBLE_STAKES, color='red')
-            raise click.Abort
-
     # Interactive Selection
-    enumerated_stakes = dict(enumerate(stakes))
-    paint_stakes(stakeholder=stakeholder, emitter=emitter, staker_address=staker_address)
-    choice = click.prompt(SELECT_STAKE, type=click.IntRange(min=0, max=len(enumerated_stakes)-1))
-    chosen_stake = enumerated_stakes[choice]
+    paint_stakes(staker=staker, emitter=emitter, stakes=stakes)
+    indexed_stakes = {stake.index: stake for stake in stakes}
+    indices = [str(index) for index in indexed_stakes.keys()]
+    choice = click.prompt(SELECT_STAKE, type=click.Choice(indices))
+    chosen_stake = indexed_stakes[int(choice)]
     return chosen_stake
 
 

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -216,8 +216,6 @@ SUCCESSFUL_SET_MIN_POLICY_RATE = "\nMinimum fee rate {min_rate} successfully set
 
 ONLY_DISPLAYING_DIVISIBLE_STAKES_NOTE = "NOTE: Showing divisible stakes only"
 
-NO_DIVISIBLE_STAKES = "No divisible stakes found."
-
 CONFIRM_BROADCAST_STAKE_DIVIDE = "Publish stake division to the blockchain?"
 
 PROMPT_STAKE_EXTEND_VALUE = "Enter number of periods to extend"

--- a/nucypher/cli/painting/staking.py
+++ b/nucypher/cli/painting/staking.py
@@ -192,7 +192,7 @@ def paint_staking_accounts(emitter, wallet, registry):
         nu = str(NU.from_nunits(wallet.token_balance(account, registry)))
 
         staker = Staker(is_me=True, checksum_address=account, registry=registry)
-        staker.stakes.refresh()
+        staker.refresh_stakes()
         is_staking = 'Yes' if bool(staker.stakes) else 'No'
         rows.append((is_staking, account, eth, nu))
     headers = ('Staking', 'Account', 'ETH', 'NU')

--- a/tests/acceptance/blockchain/interfaces/test_token_and_stake.py
+++ b/tests/acceptance/blockchain/interfaces/test_token_and_stake.py
@@ -113,3 +113,4 @@ def test_stake_integration(stakers):
     published_stake_info = list(blockchain_stakes)[0]
     assert stake_info == published_stake_info
     assert stake_info == stake.to_stake_info()
+    assert stake.status() == Stake.Status.DIVISIBLE

--- a/tests/acceptance/characters/test_stakeholder.py
+++ b/tests/acceptance/characters/test_stakeholder.py
@@ -63,7 +63,7 @@ def test_initialize_stake_with_existing_account(testerchain,
                                                 token_economics,
                                                 test_registry):
 
-    assert len(software_stakeholder.all_stakes) == 0
+    assert len(software_stakeholder.stakes) == 0
 
     # No Stakes
     with pytest.raises(IndexError):
@@ -83,7 +83,7 @@ def test_initialize_stake_with_existing_account(testerchain,
     testerchain.time_travel(periods=1)
 
     # Ensure the stakeholder is tracking the new staker and stake.
-    assert len(software_stakeholder.all_stakes) == 1
+    assert len(software_stakeholder.stakes) == 1
 
     # Ensure common stake perspective between stakeholder and stake
     assert stake.value == stake_value

--- a/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
@@ -182,7 +182,7 @@ def test_stake_prolong(click_runner,
                     '--force')
 
     staker = Staker(is_me=True, checksum_address=manual_staker, registry=agency_local_registry)
-    staker.stakes.refresh()
+    staker.refresh_stakes()
     stake = staker.stakes[0]
     old_termination = stake.final_locked_period
 
@@ -423,7 +423,7 @@ def test_collect_rewards_integration(click_runner,
     worker_address = manual_worker
 
     staker = Staker(is_me=True, checksum_address=staker_address, registry=agency_local_registry)
-    staker.stakes.refresh()
+    staker.refresh_stakes()
 
     # The staker is staking.
     assert staker.is_staking

--- a/tests/integration/blockchain/test_token_and_stake.py
+++ b/tests/integration/blockchain/test_token_and_stake.py
@@ -1,0 +1,176 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+import pytest
+
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.blockchain.eth.token import NU, Stake
+from nucypher.types import StakerInfo
+
+
+def test_child_status():
+    for status in Stake.Status:
+        assert status.is_child(status)
+
+    # Check relations for inactive status
+    assert Stake.Status.INACTIVE.is_child(Stake.Status.UNLOCKED)
+    assert not Stake.Status.INACTIVE.is_child(Stake.Status.LOCKED)
+    assert not Stake.Status.INACTIVE.is_child(Stake.Status.EDITABLE)
+    assert not Stake.Status.INACTIVE.is_child(Stake.Status.DIVISIBLE)
+
+    # Check relations for unlocked status
+    assert not Stake.Status.UNLOCKED.is_child(Stake.Status.INACTIVE)
+    assert not Stake.Status.UNLOCKED.is_child(Stake.Status.LOCKED)
+    assert not Stake.Status.UNLOCKED.is_child(Stake.Status.EDITABLE)
+    assert not Stake.Status.UNLOCKED.is_child(Stake.Status.DIVISIBLE)
+
+    # Check relations for locked status
+    assert not Stake.Status.LOCKED.is_child(Stake.Status.INACTIVE)
+    assert not Stake.Status.LOCKED.is_child(Stake.Status.UNLOCKED)
+    assert not Stake.Status.LOCKED.is_child(Stake.Status.EDITABLE)
+    assert not Stake.Status.LOCKED.is_child(Stake.Status.DIVISIBLE)
+
+    # Check relations for editable status
+    assert not Stake.Status.EDITABLE.is_child(Stake.Status.INACTIVE)
+    assert not Stake.Status.EDITABLE.is_child(Stake.Status.UNLOCKED)
+    assert Stake.Status.EDITABLE.is_child(Stake.Status.LOCKED)
+    assert not Stake.Status.EDITABLE.is_child(Stake.Status.DIVISIBLE)
+
+    # Check relations for divisible status
+    assert not Stake.Status.DIVISIBLE.is_child(Stake.Status.INACTIVE)
+    assert not Stake.Status.DIVISIBLE.is_child(Stake.Status.UNLOCKED)
+    assert Stake.Status.DIVISIBLE.is_child(Stake.Status.LOCKED)
+    assert Stake.Status.DIVISIBLE.is_child(Stake.Status.EDITABLE)
+
+
+def test_stake_status(mock_testerchain, token_economics, mock_staking_agent):
+
+    address = mock_testerchain.etherbase_account
+    current_period = 3
+    staker_info = StakerInfo(current_committed_period=current_period-1,
+                             next_committed_period=current_period,
+                             value=0,
+                             last_committed_period=0,
+                             lock_restake_until_period=False,
+                             completed_work=0,
+                             worker_start_period=0,
+                             worker=NULL_ADDRESS,
+                             flags=bytes())
+
+    mock_staking_agent.get_current_period.return_value = current_period
+    mock_staking_agent.get_staker_info.return_value = staker_info
+
+    def make_sub_stake(value, first_locked_period, final_locked_period):
+        return Stake(checksum_address=address,
+                     first_locked_period=first_locked_period,
+                     final_locked_period=final_locked_period,
+                     value=value,
+                     index=0,
+                     staking_agent=mock_staking_agent,
+                     economics=token_economics,
+                     validate_now=False)
+
+    # Prepare unlocked sub-stake
+    nu = NU.from_nunits(2 * token_economics.minimum_allowed_locked - 1)
+    stake = make_sub_stake(nu, current_period - 2, current_period - 1)
+    assert stake.status() == Stake.Status.UNLOCKED
+
+    # Prepare inactive sub-stake
+    # Update staker info and create new state
+    stake = make_sub_stake(nu, current_period - 2, current_period - 1)
+
+    staker_info = staker_info._replace(current_committed_period=current_period,
+                                       next_committed_period=current_period + 1)
+    mock_staking_agent.get_staker_info.return_value = staker_info
+
+    assert stake.status() == Stake.Status.INACTIVE
+
+    # Prepare locked sub-stake
+    stake = make_sub_stake(nu, current_period - 2, current_period)
+    assert stake.status() == Stake.Status.LOCKED
+
+    # Prepare editable sub-stake
+    stake = make_sub_stake(nu, current_period - 2, current_period + 1)
+    assert stake.status() == Stake.Status.EDITABLE
+
+    # Prepare divisible sub-stake
+    nu = NU.from_nunits(2 * token_economics.minimum_allowed_locked)
+    stake = make_sub_stake(nu, current_period - 2, current_period + 1)
+    assert stake.status() == Stake.Status.DIVISIBLE
+
+
+def test_stake_sync(mock_testerchain, token_economics, mock_staking_agent):
+
+    address = mock_testerchain.etherbase_account
+    current_period = 3
+    staker_info = StakerInfo(current_committed_period=current_period-1,
+                             next_committed_period=current_period,
+                             value=0,
+                             last_committed_period=0,
+                             lock_restake_until_period=False,
+                             completed_work=0,
+                             worker_start_period=0,
+                             worker=NULL_ADDRESS,
+                             flags=bytes())
+
+    mock_staking_agent.get_current_period.return_value = current_period
+    mock_staking_agent.get_staker_info.return_value = staker_info
+
+    # Prepare sub-stake
+    nu = NU.from_nunits(2 * token_economics.minimum_allowed_locked - 1)
+    stake = Stake(checksum_address=address,
+                  first_locked_period=current_period - 2,
+                  final_locked_period=current_period + 1,
+                  value=nu,
+                  index=0,
+                  staking_agent=mock_staking_agent,
+                  economics=token_economics,
+                  validate_now=False)
+    assert stake.status() == Stake.Status.EDITABLE
+
+    # Update locked value and sync
+    sub_stake_info = stake.to_stake_info()
+    nunits = 2 * token_economics.minimum_allowed_locked
+    sub_stake_info = sub_stake_info._replace(locked_value=nunits)
+    mock_staking_agent.get_substake_info.return_value = sub_stake_info
+
+    stake.sync()
+    assert stake.status() == Stake.Status.DIVISIBLE
+    assert stake.value == NU.from_nunits(nunits)
+
+    # Update current period and sync
+    mock_staking_agent.get_current_period.return_value = current_period + 1
+    sub_stake_info = sub_stake_info._replace(locked_value=nunits)
+    mock_staking_agent.get_substake_info.return_value = sub_stake_info
+
+    stake.sync()
+    assert stake.status() == Stake.Status.LOCKED
+    assert stake.final_locked_period == current_period + 1
+
+    # Update final period and sync
+    sub_stake_info = sub_stake_info._replace(last_period=current_period)
+    mock_staking_agent.get_substake_info.return_value = sub_stake_info
+
+    stake.sync()
+    assert stake.status() == Stake.Status.UNLOCKED
+    assert stake.final_locked_period == current_period
+
+    # Update first period and sync
+    sub_stake_info = sub_stake_info._replace(first_period=current_period)
+    mock_staking_agent.get_substake_info.return_value = sub_stake_info
+
+    with pytest.raises(Stake.StakingError):
+        stake.sync()

--- a/tests/integration/cli/actions/test_select_client_account.py
+++ b/tests/integration/cli/actions/test_select_client_account.py
@@ -32,6 +32,7 @@ from nucypher.cli.literature import (
     GENERIC_SELECT_ACCOUNT,
     )
 from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.types import SubStakeInfo
 from tests.constants import MOCK_PROVIDER_URI, MOCK_SIGNER_URI, NUMBER_OF_ETH_TEST_ACCOUNTS
 
 
@@ -156,8 +157,8 @@ def test_select_client_account_valid_sources(mocker,
         (1, True, True, True, []),
         (5, True, True, True, []),
         (NUMBER_OF_ETH_TEST_ACCOUNTS-1, True, True, True, []),
-        (4, True, True, True, [(1, 2, 3)]),
-        (7, True, True, True, [(1, 2, 3), (1, 2, 3)]),
+        (4, True, True, True, [SubStakeInfo(1, 2, 3)]),
+        (7, True, True, True, [SubStakeInfo(1, 2, 3), SubStakeInfo(1, 2, 3)]),
         (0, False, True, True, []),
         (0, False, False, True, []),
         (0, False, False, False, []),

--- a/tests/integration/cli/actions/test_select_client_account_for_staking.py
+++ b/tests/integration/cli/actions/test_select_client_account_for_staking.py
@@ -28,9 +28,11 @@ def test_select_client_account_for_staking_cli_action(test_emitter,
                                                       mock_stdin,
                                                       mock_testerchain,
                                                       capsys,
-                                                      mocker):
+                                                      mocker,
+                                                      mock_staking_agent):
     """Fine-grained assertions about the return value of interactive client account selection"""
     force = False
+    mock_staking_agent.get_all_stakes.return_value = []
 
     selected_index = 0
     selected_account = mock_testerchain.client.accounts[selected_index]

--- a/tests/integration/cli/test_stake_cli_functionality.py
+++ b/tests/integration/cli/test_stake_cli_functionality.py
@@ -30,6 +30,7 @@ from nucypher.cli.literature import (
     PROMPT_STAKE_EXTEND_VALUE, CONFIRM_BROADCAST_STAKE_DIVIDE, SUCCESSFUL_STAKE_DIVIDE
 )
 from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.types import SubStakeInfo
 from tests.constants import MOCK_PROVIDER_URI, YES, INSECURE_DEVELOPMENT_PASSWORD
 
 
@@ -49,7 +50,8 @@ def surrogate_stakes(mock_staking_agent, token_economics, surrogate_staker):
     duration = token_economics.minimum_locked_periods + 1
     final_period = current_period + duration
     # TODO: Add non divisible, non editable and inactive sub-stakes
-    stakes = [(current_period - 1, final_period - 1, nu), (current_period + 1, final_period, nu)]
+    stakes = [SubStakeInfo(current_period - 1, final_period - 1, nu),
+              SubStakeInfo(current_period + 1, final_period, nu)]
 
     mock_staking_agent.get_current_period.return_value = current_period
 
@@ -74,7 +76,7 @@ def test_stakeholder_configuration(test_emitter, test_registry, mock_testerchain
                                                           network=TEMPORARY_DOMAIN,
                                                           signer_uri=None)
 
-    mock_staking_agent.get_all_stakes.return_value = [(1, 2, 3)]
+    mock_staking_agent.get_all_stakes.return_value = [SubStakeInfo(1, 2, 3)]
     force = False
     selected_index = 0
     selected_account = mock_testerchain.client.accounts[selected_index]
@@ -449,7 +451,7 @@ def test_divide_interactive(click_runner,
     mock_refresh_stakes = mocker.spy(Staker, 'refresh_stakes')
 
     selected_index = 0
-    sub_stake_index = 1
+    sub_stake_index = len(surrogate_stakes) - 1
     lock_periods = 10
     min_allowed_locked = token_economics.minimum_allowed_locked
     target_value = min_allowed_locked
@@ -496,7 +498,7 @@ def test_divide_non_interactive(click_runner,
                                 mock_testerchain):
     mock_refresh_stakes = mocker.spy(Staker, 'refresh_stakes')
 
-    sub_stake_index = 1
+    sub_stake_index = len(surrogate_stakes) - 1
     lock_periods = 10
     min_allowed_locked = token_economics.minimum_allowed_locked
     target_value = min_allowed_locked

--- a/tests/integration/cli/test_stake_cli_functionality.py
+++ b/tests/integration/cli/test_stake_cli_functionality.py
@@ -15,41 +15,22 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
-import random
-from unittest.mock import call, patch, PropertyMock
-
-import maya
 import pytest
-from eth_utils import to_wei
 from web3 import Web3
 
-from nucypher.blockchain.eth.actors import Bidder, Staker
-from nucypher.blockchain.eth.interfaces import BlockchainInterface
-from nucypher.blockchain.eth.token import NU
-from nucypher.blockchain.eth.utils import prettify_eth_amount
-from nucypher.cli.commands import worklock as worklock_command
-from nucypher.cli.commands.stake import stake
-from nucypher.cli.commands.worklock import worklock
+from nucypher.blockchain.eth.actors import Staker, StakeHolder
+from nucypher.blockchain.eth.constants import MAX_UINT16
+from nucypher.blockchain.eth.token import NU, StakeList
+from nucypher.cli.actions.select import select_client_account_for_staking
+from nucypher.cli.commands.stake import stake, StakeHolderConfigOptions, StakerOptions, TransactingStakerOptions
 from nucypher.cli.literature import (
-    BID_AMOUNT_PROMPT_WITH_MIN_BID,
-    BID_INCREASE_AMOUNT_PROMPT,
-    BIDDING_WINDOW_CLOSED,
-    CLAIMING_NOT_AVAILABLE,
-    COLLECT_ETH_PASSWORD,
-    CONFIRM_BID_VERIFICATION,
-    CONFIRM_COLLECT_WORKLOCK_REFUND,
-    CONFIRM_REQUEST_WORKLOCK_COMPENSATION,
-    CONFIRM_WORKLOCK_CLAIM,
-    GENERIC_SELECT_ACCOUNT,
-    SELECTED_ACCOUNT,
-    WORKLOCK_CLAIM_ADVISORY, NO_TOKENS_TO_WITHDRAW, COLLECTING_TOKEN_REWARD, CONFIRM_COLLECTING_WITHOUT_MINTING,
-    NO_FEE_TO_WITHDRAW, COLLECTING_ETH_FEE, NO_MINTABLE_PERIODS, STILL_LOCKED_TOKENS, CONFIRM_MINTING
+    NO_TOKENS_TO_WITHDRAW, COLLECTING_TOKEN_REWARD, CONFIRM_COLLECTING_WITHOUT_MINTING,
+    NO_FEE_TO_WITHDRAW, COLLECTING_ETH_FEE, NO_MINTABLE_PERIODS, STILL_LOCKED_TOKENS, CONFIRM_MINTING,
+    PROMPT_PROLONG_VALUE, CONFIRM_PROLONG, SUCCESSFUL_STAKE_PROLONG, PERIOD_ADVANCED_WARNING, PROMPT_STAKE_DIVIDE_VALUE,
+    PROMPT_STAKE_EXTEND_VALUE, CONFIRM_BROADCAST_STAKE_DIVIDE, SUCCESSFUL_STAKE_DIVIDE
 )
 from nucypher.config.constants import TEMPORARY_DOMAIN
-from nucypher.types import NuNits
-from tests.constants import MOCK_PROVIDER_URI, YES, NO, INSECURE_DEVELOPMENT_PASSWORD
-from tests.mock.agents import MockContractAgent
+from tests.constants import MOCK_PROVIDER_URI, YES, INSECURE_DEVELOPMENT_PASSWORD
 
 
 @pytest.fixture()
@@ -57,7 +38,80 @@ def surrogate_staker(mock_testerchain, test_registry, mock_staking_agent):
     address = mock_testerchain.etherbase_account
     staker = Staker(is_me=True, checksum_address=address, registry=test_registry)
     mock_staking_agent.get_all_stakes.return_value = []
+
     return staker
+
+
+@pytest.fixture()
+def surrogate_stakes(mock_staking_agent, token_economics, surrogate_staker):
+    nu = 2 * token_economics.minimum_allowed_locked + 1
+    current_period = 10
+    duration = token_economics.minimum_locked_periods + 1
+    final_period = current_period + duration
+    # TODO: Add non divisible, non editable and inactive sub-stakes
+    stakes = [(current_period - 1, final_period - 1, nu), (current_period + 1, final_period, nu)]
+
+    mock_staking_agent.get_current_period.return_value = current_period
+
+    def get_all_stakes(staker_address):
+        return stakes if staker_address == surrogate_staker.checksum_address else []
+    mock_staking_agent.get_all_stakes.side_effect = get_all_stakes
+
+    def get_substake_info(staker_address, stake_index):
+        return stakes[stake_index] if staker_address == surrogate_staker.checksum_address else []
+    mock_staking_agent.get_substake_info.side_effect = get_substake_info
+
+    return stakes
+
+
+@pytest.mark.usefixtures("test_registry_source_manager", "patch_stakeholder_configuration")
+def test_stakeholder_configuration(test_emitter, test_registry, mock_testerchain, mock_staking_agent):
+
+    stakeholder_config_options = StakeHolderConfigOptions(provider_uri=MOCK_PROVIDER_URI,
+                                                          poa=None,
+                                                          light=None,
+                                                          registry_filepath=None,
+                                                          network=TEMPORARY_DOMAIN,
+                                                          signer_uri=None)
+
+    mock_staking_agent.get_all_stakes.return_value = [(1, 2, 3)]
+    force = False
+    selected_index = 0
+    selected_account = mock_testerchain.client.accounts[selected_index]
+    expected_stakeholder = StakeHolder(registry=test_registry,
+                                       domains={TEMPORARY_DOMAIN},
+                                       initial_address=selected_account)
+    expected_stakeholder.refresh_stakes()
+
+    staker_options = StakerOptions(config_options=stakeholder_config_options, staking_address=selected_account)
+    transacting_staker_options = TransactingStakerOptions(staker_options=staker_options,
+                                                          hw_wallet=None,
+                                                          beneficiary_address=None,
+                                                          allocation_filepath=None)
+    stakeholder_from_configuration = transacting_staker_options.create_character(emitter=test_emitter, config_file=None)
+    client_account, staking_address = select_client_account_for_staking(emitter=test_emitter,
+                                                                        stakeholder=stakeholder_from_configuration,
+                                                                        staking_address=selected_account,
+                                                                        individual_allocation=None,
+                                                                        force=force)
+    assert client_account == staking_address == selected_account
+    assert stakeholder_from_configuration.stakes == expected_stakeholder.stakes
+    assert stakeholder_from_configuration.checksum_address == client_account
+
+    staker_options = StakerOptions(config_options=stakeholder_config_options, staking_address=None)
+    transacting_staker_options = TransactingStakerOptions(staker_options=staker_options,
+                                                          hw_wallet=None,
+                                                          beneficiary_address=None,
+                                                          allocation_filepath=None)
+    stakeholder_from_configuration = transacting_staker_options.create_character(emitter=None, config_file=None)
+    client_account, staking_address = select_client_account_for_staking(emitter=test_emitter,
+                                                                        stakeholder=stakeholder_from_configuration,
+                                                                        staking_address=selected_account,
+                                                                        individual_allocation=None,
+                                                                        force=force)
+    assert client_account == staking_address == selected_account
+    assert stakeholder_from_configuration.stakes == expected_stakeholder.stakes
+    assert stakeholder_from_configuration.checksum_address == client_account
 
 
 @pytest.mark.usefixtures("test_registry_source_manager", "patch_stakeholder_configuration")
@@ -299,3 +353,181 @@ def test_mint_without_warning(click_runner, surrogate_staker, mock_staking_agent
     mock_staking_agent.get_next_committed_period.assert_called_once_with(staker_address=surrogate_staker.checksum_address)
     mock_mintable_periods.assert_called_once()
     mock_staking_agent.assert_only_transactions([mock_staking_agent.mint])
+
+
+@pytest.mark.usefixtures("test_registry_source_manager", "patch_stakeholder_configuration")
+def test_prolong_interactive(click_runner,
+                             mocker,
+                             surrogate_staker,
+                             surrogate_stakes,
+                             mock_staking_agent,
+                             token_economics,
+                             mock_testerchain):
+    mock_refresh_stakes = mocker.spy(Staker, 'refresh_stakes')
+
+    selected_index = 0
+    sub_stake_index = 1
+    lock_periods = 10
+    final_period = surrogate_stakes[sub_stake_index][1]
+
+    command = ('prolong',
+                '--provider', MOCK_PROVIDER_URI,
+                '--network', TEMPORARY_DOMAIN)
+
+    user_input = '\n'.join((str(selected_index),
+                            str(sub_stake_index),
+                            str(lock_periods),
+                            YES,
+                            INSECURE_DEVELOPMENT_PASSWORD))
+    result = click_runner.invoke(stake, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PROMPT_PROLONG_VALUE.format(minimum=1, maximum=MAX_UINT16 - final_period) in result.output
+    assert CONFIRM_PROLONG.format(lock_periods=lock_periods) in result.output
+    assert SUCCESSFUL_STAKE_PROLONG in result.output
+    assert PERIOD_ADVANCED_WARNING not in result.output
+
+    mock_staking_agent.get_all_stakes.assert_called()
+    mock_staking_agent.get_current_period.assert_called()
+    mock_refresh_stakes.assert_called()
+    mock_staking_agent.prolong_stake.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                             stake_index=sub_stake_index,
+                                                             periods=lock_periods)
+    mock_staking_agent.assert_only_transactions([mock_staking_agent.prolong_stake])
+    mock_staking_agent.get_substake_info.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                                 stake_index=sub_stake_index)
+
+
+@pytest.mark.usefixtures("test_registry_source_manager", "patch_stakeholder_configuration")
+def test_prolong_non_interactive(click_runner,
+                                 mocker,
+                                 surrogate_staker,
+                                 surrogate_stakes,
+                                 mock_staking_agent,
+                                 token_economics,
+                                 mock_testerchain):
+    mock_refresh_stakes = mocker.spy(Staker, 'refresh_stakes')
+
+    sub_stake_index = 1
+    lock_periods = 10
+    final_period = surrogate_stakes[sub_stake_index][1]
+
+    command = ('prolong',
+                '--provider', MOCK_PROVIDER_URI,
+                '--network', TEMPORARY_DOMAIN,
+                '--staking-address', surrogate_staker.checksum_address,
+                '--index', sub_stake_index,
+                '--lock-periods', lock_periods,
+                '--force')
+
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
+    result = click_runner.invoke(stake, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PROMPT_PROLONG_VALUE.format(minimum=1, maximum=MAX_UINT16 - final_period) not in result.output
+    assert CONFIRM_PROLONG.format(lock_periods=lock_periods) not in result.output
+    assert SUCCESSFUL_STAKE_PROLONG in result.output
+    assert PERIOD_ADVANCED_WARNING not in result.output
+
+    mock_staking_agent.get_all_stakes.assert_called()
+    mock_staking_agent.get_current_period.assert_called()
+    mock_refresh_stakes.assert_called()
+    mock_staking_agent.prolong_stake.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                             stake_index=sub_stake_index,
+                                                             periods=lock_periods)
+    mock_staking_agent.assert_only_transactions([mock_staking_agent.prolong_stake])
+    mock_staking_agent.get_substake_info.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                                 stake_index=sub_stake_index)
+
+
+@pytest.mark.usefixtures("test_registry_source_manager", "patch_stakeholder_configuration")
+def test_divide_interactive(click_runner,
+                            mocker,
+                            surrogate_staker,
+                            surrogate_stakes,
+                            mock_staking_agent,
+                            token_economics,
+                            mock_testerchain):
+    mock_refresh_stakes = mocker.spy(Staker, 'refresh_stakes')
+
+    selected_index = 0
+    sub_stake_index = 1
+    lock_periods = 10
+    min_allowed_locked = token_economics.minimum_allowed_locked
+    target_value = min_allowed_locked
+
+    mock_staking_agent.get_worker_from_staker.return_value = surrogate_staker.checksum_address
+
+    command = ('divide',
+               '--provider', MOCK_PROVIDER_URI,
+               '--network', TEMPORARY_DOMAIN)
+
+    user_input = '\n'.join((str(selected_index),
+                            str(sub_stake_index),
+                            str(NU.from_nunits(target_value).to_tokens()),
+                            str(lock_periods),
+                            YES,
+                            INSECURE_DEVELOPMENT_PASSWORD))
+    result = click_runner.invoke(stake, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PROMPT_STAKE_DIVIDE_VALUE.format(minimum=NU.from_nunits(min_allowed_locked),
+                                            maximum=NU.from_nunits(min_allowed_locked + 1)) in result.output
+    assert PROMPT_STAKE_EXTEND_VALUE in result.output
+    assert CONFIRM_BROADCAST_STAKE_DIVIDE in result.output
+    assert SUCCESSFUL_STAKE_DIVIDE in result.output
+
+    mock_staking_agent.get_all_stakes.assert_called()
+    mock_staking_agent.get_current_period.assert_called()
+    mock_refresh_stakes.assert_called()
+    mock_staking_agent.divide_stake.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                            stake_index=sub_stake_index,
+                                                            target_value=target_value,
+                                                            periods=lock_periods)
+    mock_staking_agent.assert_only_transactions([mock_staking_agent.divide_stake])
+    mock_staking_agent.get_substake_info.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                                 stake_index=sub_stake_index)
+
+
+@pytest.mark.usefixtures("test_registry_source_manager", "patch_stakeholder_configuration")
+def test_divide_non_interactive(click_runner,
+                                mocker,
+                                surrogate_staker,
+                                surrogate_stakes,
+                                mock_staking_agent,
+                                token_economics,
+                                mock_testerchain):
+    mock_refresh_stakes = mocker.spy(Staker, 'refresh_stakes')
+
+    sub_stake_index = 1
+    lock_periods = 10
+    min_allowed_locked = token_economics.minimum_allowed_locked
+    target_value = min_allowed_locked
+
+    mock_staking_agent.get_worker_from_staker.return_value = surrogate_staker.checksum_address
+
+    command = ('divide',
+               '--provider', MOCK_PROVIDER_URI,
+               '--network', TEMPORARY_DOMAIN,
+                '--staking-address', surrogate_staker.checksum_address,
+                '--index', sub_stake_index,
+                '--lock-periods', lock_periods,
+                '--value', NU.from_nunits(target_value).to_tokens(),
+                '--force')
+
+    user_input = INSECURE_DEVELOPMENT_PASSWORD
+    result = click_runner.invoke(stake, command, input=user_input, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PROMPT_STAKE_DIVIDE_VALUE.format(minimum=NU.from_nunits(min_allowed_locked),
+                                            maximum=NU.from_nunits(min_allowed_locked + 1)) not in result.output
+    assert PROMPT_STAKE_EXTEND_VALUE not in result.output
+    assert CONFIRM_BROADCAST_STAKE_DIVIDE not in result.output
+    assert SUCCESSFUL_STAKE_DIVIDE in result.output
+
+    mock_staking_agent.get_all_stakes.assert_called()
+    mock_staking_agent.get_current_period.assert_called()
+    mock_refresh_stakes.assert_called()
+    mock_staking_agent.divide_stake.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                            stake_index=sub_stake_index,
+                                                            target_value=target_value,
+                                                            periods=lock_periods)
+    mock_staking_agent.assert_only_transactions([mock_staking_agent.divide_stake])
+    mock_staking_agent.get_substake_info.assert_called_once_with(staker_address=surrogate_staker.checksum_address,
+                                                                 stake_index=sub_stake_index)


### PR DESCRIPTION
Fixes #2113
Fixes #2116
Fixes #1657 
Fixes #1696 

* Adds status for sub-stake
* Simplifies sub-stake selection
* Splitted `StakeHolder.assimilate()` into two methods 
* More tests