### PR TITLE
Update WorkLock terminology

### DIFF
--- a/docs/source/architecture/worklock.rst
+++ b/docs/source/architecture/worklock.rst
@@ -33,7 +33,7 @@ Stake-locked NU will be allocated at network launch according to the following p
 
 Finally, if WorkLock participants use that stake-locked NU to run a node and provide threshold cryptography services on the live network for a minimum of six months,
 the NU will subsequently unlock and their temporarily escrowed ETH will be returned in full.
-Participants that fail to successfully run a NuCypher network node for six months of the live network will not receive NU and their ETH will remain escrowed in the
+Participants that fail to successfully run a NuCypher network node for six months of the live network will not receive stake-rewarded NU and their ETH will remain escrowed in the
 WorkLock contract.
 
 

--- a/docs/source/architecture/worklock.rst
+++ b/docs/source/architecture/worklock.rst
@@ -9,7 +9,7 @@ Overview
 
 `WorkLock` is a novel, permissionless network node setup mechanism, developed at NuCypher, which requires participants
 to temporarily stake ETH and operate NuCypher network threshold cryptography nodes in order to be allocated NU, the native
-cryptocurrency of the NuCypher network that enables node operation.
+token of the NuCypher network that enables node operation.
 
 The NuCypher team designed the WorkLock to onboard threshold cryptography nodes to the live NuCypher network using a process that selects participants
 who are most likely to strengthen the network by committing to staking and running nodes.
@@ -23,18 +23,18 @@ At the end of this cancellation period, the allocation period opens and stake-lo
 the limited purpose of running threshold cryptography nodes on the live NuCypher network.
 Stake-locked NU will be allocated at network launch according to the following principles:
 
- - All of the NU held by WorkLock will be allocate to network nodes in non-transferable stakes designed to enable node operation.
+ - All of the NU held by WorkLock will be allocated to network nodes in non-transferable stakes designed to enable node operation.
  - All ETH escrows must be greater than or equal to the minimum allowed escrow.
  - For each escrow, the surplus above the minimum allowed escrow is called the `bonus`; all escrows are composed of a `base` escrow (fixed minimum) and a `bonus` escrow (variable amount).
- - Each participant will receive at least the minimum amount of staked NU needed to operation a network node.
+ - Each participant will receive at least the minimum amount of staked NU needed to operate a network node.
  - Once all participants have been allocated the minimum amount of NU, each participant with a `bonus` will be allocated a portion of the remaining NU,
    allocated pro rata across all participants, taking into consideration only their bonus ETH amounts.
  - If the resulting NU allocated to a participant is above the maximum allowed NU needed to operate a network node, then such a participant has their escrow partially refunded until the corresponding amount of NU is within the allowed limits for node operation.
 
 Finally, if WorkLock participants use that stake-locked NU to run a node and provide threshold cryptography services on the live network for a minimum of six months,
 the NU will subsequently unlock and their temporarily escrowed ETH will be returned in full.
-(Participants that fail to successfully run a NuCypher network node for six months of the live network will not receive NU and their ETH will remain escrowed in the
-WorkLock contract.)
+Participants that fail to successfully run a NuCypher network node for six months of the live network will not receive NU and their ETH will remain escrowed in the
+WorkLock contract.
 
 
 Hypothetical Escrow Scenarios

--- a/docs/source/architecture/worklock.rst
+++ b/docs/source/architecture/worklock.rst
@@ -7,31 +7,37 @@ WorkLock
 Overview
 --------
 
-`WorkLock` is a novel, permissionless token distribution mechanism, developed at NuCypher, which requires participants
-to stake ETH and maintain NuCypher nodes in order to receive NU tokens.
+`WorkLock` is a novel, permissionless network node setup mechanism, developed at NuCypher, which requires participants
+to temporarily stake ETH and operate NuCypher network threshold cryptography nodes in order to be allocated NU, the native
+cryptocurrency of the NuCypher network that enables node operation.
 
-WorkLock offers specific advantages over ICO or airdrop as a distribution mechanism, chiefly: it selects for participants
-who are most likely to strengthen the network because they commit to staking and running nodes.
+The NuCypher team designed the WorkLock to onboard threshold cryptography nodes to the live NuCypher network using a process that selects participants
+who are most likely to strengthen the network by committing to staking and running nodes.
 
-The WorkLock begins with an open bidding or `contribution` period, during which anyone seeking to participate can send
-ETH to the WorkLock contract to be escrowed on-chain.
-At any time during the contribution period, WorkLock participants can cancel their bid to forgo NU and recoup their escrowed ETH immediately.
-Once the contribution period closes, the WorkLock contract does not accept more bids, but it will still accept
-cancellations during an additional time window. At the end of this cancellation period, the claiming window opens and
-stake-locked NU token allocations can be claimed by participants. Stake-locked NU will be distributed according to
-the following principles:
+The WorkLock begins with an escrow period, during which anyone seeking to operate a NuCypher network threshold cryptography node can send
+ETH to the WorkLock contract to be temporarily escrowed on-chain.
+At any time during the escrow period, WorkLock participants can cancel their participation to forgo NU and recoup their escrowed ETH immediately.
+Once the escrow period closes, the WorkLock contract does not accept more ETH, but it will still accept
+cancellations during an additional time window.
+At the end of this cancellation period, the allocation period opens and stake-locked NU are allocated to participants in non-transferable stakes designed for
+the limited purpose of running threshold cryptography nodes on the live NuCypher network.
+Stake-locked NU will be allocated at network launch according to the following principles:
 
- - All of the tokens held by WorkLock will be distributed.
- - All bids must be greater than or equal to the minimum allowed bid.
- - For each bid, the surplus above the minimum allowed bid is called the `bonus`; all bids are composed of a `base` bid (fixed minimum bid) and a `bonus` bid (variable amount).
- - Each bidder will receive at least the minimum amount of NU needed to stake.
- - Once all bidders have been assigned the minimum amount of NU, each bidder with a `bonus` will receive a portion of the remaining NU, distributed pro rata across all participants, taking into consideration only their bonus ETH amounts.
- - If the resulting NU distributed to a bidder is above the maximum allowed NU to stake, then such a bidder has their bid partially refunded until the corresponding amount of NU is within the allowed limits.
+ - All of the NU held by WorkLock will be allocate to network nodes in non-transferable stakes designed to enable node operation.
+ - All ETH escrows must be greater than or equal to the minimum allowed escrow.
+ - For each escrow, the surplus above the minimum allowed escrow is called the `bonus`; all escrows are composed of a `base` escrow (fixed minimum) and a `bonus` escrow (variable amount).
+ - Each participant will receive at least the minimum amount of staked NU needed to operation a network node.
+ - Once all participants have been allocated the minimum amount of NU, each participant with a `bonus` will be allocated a portion of the remaining NU,
+   allocated pro rata across all participants, taking into consideration only their bonus ETH amounts.
+ - If the resulting NU allocated to a participant is above the maximum allowed NU needed to operate a network node, then such a participant has their escrow partially refunded until the corresponding amount of NU is within the allowed limits for node operation.
 
-Finally, if WorkLock participants use that stake-locked NU to run a node, the NU will eventually unlock and their escrowed ETH will be returned in full.
+Finally, if WorkLock participants use that stake-locked NU to run a node and provide threshold cryptography services on the live network for a minimum of six months,
+the NU will subsequently unlock and their temporarily escrowed ETH will be returned in full.
+(Participants that fail to successfully run a NuCypher network node for six months of the live network will not receive NU and their ETH will remain escrowed in the
+WorkLock contract.)
 
 
-Hypothetical Bidding Scenarios
+Hypothetical Escrow Scenarios
 ------------------------------
 
 .. note::
@@ -41,31 +47,31 @@ Hypothetical Bidding Scenarios
 
 For each scenario, assume the following hypothetical WorkLock properties:
 
- #. WorkLock holds 280,000,000 NU tokens and the minimum bid is 15 ETH.
+ #. WorkLock holds 280,000,000 NU and the minimum escrow is 15 ETH.
  #. The minimum amount of NU required to stake is 15,000 NU and the maximum stake size is 4,000,000 NU.
- #. The total number of bidders is 1000 bidders (including you) with a total of 50,000 ETH committed (including your bid).
- #. For our purposes, a `whale` bid is a bid that causes the calculated stake size to be larger than the maximum stake size (4,000,000 NU).
+ #. The total number of participants is 1000 (including you) with a total of 50,000 ETH escrowed (including your escrow).
+ #. For our purposes, a `whale` escrow is an escrow that causes the calculated stake size to be larger than the maximum stake size (4,000,000 NU).
 
 
-Scenario 1: Resulting stake size does not exceed maximum stake size (no whale bids)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Scenario 1: Resulting stake size does not exceed maximum stake size (no whale escrows)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**You submit a bid of 22 ETH i.e. 15 ETH minimum bid + 7 bonus ETH.**
+**You submit an escrow of 22 ETH i.e. 15 ETH minimum + 7 bonus ETH.**
 
-*How many NU tokens would you receive?*
+*How many NU would be allocated to your network node?*
 
- - Each of the 1000 bidders (including you) would receive at least the minimum NU to stake = 15,000 NU
- - Remaining NU in WorkLock after minimum distribution is
-
-        .. math::
-
-            280,000,000 NU - (15,000 NU \times 1000 \,bidders) = 265,000,000 NU
-
- - Bonus ETH supply (i.e. total ETH not including minimum bids) is
+ - Each of the 1000 participants (including you) would be allocated at least the minimum NU to stake = 15,000 NU
+ - Remaining NU in WorkLock after minimum allocation is
 
         .. math::
 
-            50,000 ETH - (15 ETH \times 1000 \,bidders) = 35,000 ETH
+            280,000,000 NU - (15,000 NU \times 1000 \,participants) = 265,000,000 NU
+
+ - Bonus ETH supply (i.e. total ETH not including minimum escrows) is
+
+        .. math::
+
+            50,000 ETH - (15 ETH \times 1000 \,participants) = 35,000 ETH
 
  - Your bonus portion of the bonus ETH supply is
 
@@ -73,67 +79,67 @@ Scenario 1: Resulting stake size does not exceed maximum stake size (no whale bi
 
             \frac{7 ETH}{35,000 ETH} = 0.02\%
 
- - Your portion of the remaining NU is
+ - Your allocation of the remaining NU is
 
         .. math::
 
             0.02\% \times 265,000,000 NU= 53,000 NU
 
 
-**Total NU tokens received = 15,000 NU + 53,000 NU = 68,000 NU**
+**Total NU received = 15,000 NU + 53,000 NU = 68,000 NU**
 
-Scenario 2: Resulting stake size exceeds maximum stake size (1 whale bid)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Scenario 2: Resulting stake size exceeds maximum stake size (1 whale escrow)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**You submit a bid of 715 ETH i.e. 15 ETH minimum bid + 700 bonus ETH.**
+**You submit an escrow of 715 ETH i.e. 15 ETH minimum + 700 bonus ETH.**
 
-*How many NU tokens would you receive?*
+*How many NU would be allocated to your network node?*
 
- - Each of the 1000 bidders (including you) would receive at least the minimum NU to stake = 15,000 NU
- - Remaining NU in WorkLock after minimum distribution is
-
-        .. math::
-
-            280,000,000 NU - (15,000 NU \times 1000 \,bidders) = 265,000,000 NU
-
- - Bonus ETH supply (i.e. total ETH not including minimum bids) is
+ - Each of the 1000 participants (including you) would be allocated at least the minimum NU to stake = 15,000 NU
+ - Remaining NU in WorkLock after minimum allocation is
 
         .. math::
 
-            50,000 ETH - (15 ETH \times 1000 \,bidders) = 35,000 ETH
+            280,000,000 NU - (15,000 NU \times 1000 \,participants) = 265,000,000 NU
 
- - Your bonus portion of the bonus ETH supply is
+ - Bonus ETH supply (i.e. total ETH not including minimum escrows) is
+
+        .. math::
+
+            50,000 ETH - (15 ETH \times 1000 \,participants) = 35,000 ETH
+
+ - Your bonus allocation of the bonus ETH supply is
 
         .. math::
 
             \frac{700 ETH}{35,000 ETH} = 2\%
 
- - Your portion of the remaining NU is
+ - Your allocation of the remaining NU is
 
         .. math::
 
             2\% \times 265,000,000 NU= 5,300,000 NU
 
 
-However, the total amount of NU tokens to receive is 15,000 NU + 5,300,000 NU = 5,315,000 NU which is greater than
-the maximum stake amount (4,000,000 NU). Therefore, the amount of NU tokens distributed to you needs to be reduced,
+However, the total amount of NU to be allocated is 15,000 NU + 5,300,000 NU = 5,315,000 NU which is greater than
+the maximum stake amount (4,000,000 NU). Therefore, the amount of NU allocated to you needs to be reduced,
 and some of your bonus ETH refunded.
 
- - Typically the calculation for the NU received from the bonus portion is
+ - Typically the calculation for the NU allocated from the bonus portion is
 
         .. math::
 
-            \frac{\text{your bonus ETH}}{\text{bonus ETH supply}} \times \text{remaining NU tokens}
+            \frac{\text{your bonus ETH}}{\text{bonus ETH supply}} \times \text{remaining NU bonus supply}
 
  - The additional complication here is that refunding bonus ETH reduces your bonus ETH **AND** the bonus ETH supply since the
-   bonus ETH supply includes the bonus ETH portion of your bid.
+   bonus ETH supply includes the bonus ETH portion of your escrow.
  - A more complicated equation arises for the bonus part of the calculation, where `x` is the refunded ETH:
 
         .. math::
 
-            \text{stake size} = \frac{\text{(your bonus ETH - x)}}{\text{(bonus ETH supply - x)}} \times \text{remaining NU tokens}
+            \text{stake size} = \frac{\text{(your bonus ETH - x)}}{\text{(bonus ETH supply - x)}} \times \text{remaining NU}
 
- - Since you will receive a 15,000 NU minimum, and the maximum stake size is 4,000,000 NU, the most you can receive from the remaining NU is
+ - Since you will be allocated a 15,000 NU minimum, and the maximum stake size is 4,000,000 NU, the most you can be allocated from the remaining NU is
 
         .. math::
 
@@ -152,7 +158,7 @@ and some of your bonus ETH refunded.
             x &= \frac{700 ETH \times 265,000,000 NU - 35,000 ETH \times 3,985,000 NU}{265,000,000 NU - 3,985,000 NU} \\
               &\approx 176.33 ETH
 
- - Therefore, your final bonus bid is
+ - Therefore, your final bonus escrow is
 
         .. math::
 
@@ -164,36 +170,36 @@ and some of your bonus ETH refunded.
 
             \frac{523.67}{(35,000 ETH - 176.33 ETH)} \approx 1.504\%
 
- - Your portion of the remaining NU is
+ - Your allocation of the remaining NU is
 
         .. math::
 
             1.504\% \times 265,000,000 NU \approx 3,985,006.46 NU
 
-**Total NU tokens received ~ 15,000 NU + 3,985,006.46 NU (rounding) ~ 4,000,000 NU, and refunded ETH ~ 176.33 ETH**
+**Total NU allocated ~ 15,000 NU + 3,985,006.46 NU (rounding) ~ 4,000,000 NU, and refunded ETH ~ 176.33 ETH**
 
 
-Scenario 3: Resulting stake size exceeds maximum stake size (2 whale bids)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Scenario 3: Resulting stake size exceeds maximum stake size (2 whale escrows)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Someone else submitted a bid of 715 ETH (15 ETH + 700 bonus ETH); we'll call them `whale_1`.**
+**Someone else submitted an escrow of 715 ETH (15 ETH + 700 bonus ETH); we'll call them `whale_1`.**
 
-**You submit a bid of 785 ETH i.e. 15 ETH minimum bid + 770 bonus ETH; you are `whale_2`.**
+**You submit an escrow of 785 ETH i.e. 15 ETH minimum + 770 bonus ETH; you are `whale_2`.**
 
-*How many NU tokens would you receive?*
+*How many NU would be allocated to your network node?*
 
- - Each of the 1000 bidders (including you) would receive at least the minimum NU to stake = 15,000 NU
- - Remaining NU in WorkLock after minimum distribution is
-
-        .. math::
-
-            280,000,000 NU - (15,000 NU \times 1000 \,bidders) = 265,000,000 NU
-
- - Bonus ETH supply (i.e. total ETH not including minimum bids) is
+ - Each of the 1000 participants (including you) would receive at least the minimum NU to stake = 15,000 NU
+ - Remaining NU in WorkLock after minimum allocation is
 
         .. math::
 
-            50,000 ETH - (15 ETH \times 1000 \,bidders) = 35,000 ETH
+            280,000,000 NU - (15,000 NU \times 1000 \,participants) = 265,000,000 NU
+
+ - Bonus ETH supply (i.e. total ETH not including minimum escrows) is
+
+        .. math::
+
+            50,000 ETH - (15 ETH \times 1000 \,participants) = 35,000 ETH
 
  - Your portion of the bonus ETH supply is
 
@@ -201,27 +207,27 @@ Scenario 3: Resulting stake size exceeds maximum stake size (2 whale bids)
 
             \frac{770 ETH}{35,000 ETH} = 2.2\%
 
- - Your portion of the remaining NU is
+ - Your allocation of the remaining NU is
 
         .. math::
 
             2.2\% \times 265,000,000 NU= 5,830,000 NU
 
-However, the total amount of NU tokens to receive is 15,000 NU + 5,830,000 NU = 5,845,000 NU which is greater than
+However, the total amount of NU to be allocated to receive is 15,000 NU + 5,830,000 NU = 5,845,000 NU which is greater than
 the maximum stake amount (4,000,000 NU).
 
  -  From the previous scenario, the equation for the bonus part of the calculation is as follows, where `x` is the refunded ETH
 
         .. math::
 
-            \text{stake size} = \frac{\text{(your bonus ETH - x)}}{\text{(bonus ETH supply - x)}} \times \text{remaining NU tokens}
+            \text{stake size} = \frac{\text{(your bonus ETH - x)}}{\text{(bonus ETH supply - x)}} \times \text{remaining NU}
 
- - Additionally, there is more than one whale bid, which would also cause the bonus ETH supply to reduce as well
+ - Additionally, there is more than one whale escrow, which would also cause the bonus ETH supply to reduce as well
  - Instead the following `whale resolution` algorithm is employed:
 
-    #. Select the smallest whale bonus ETH bid; in this case 700 ETH from `whale_1` < 770 ETH from `whale_2`
-    #. Equalize the bonus ETH whale bids for all other whales (in this case, just `whale_2` i.e. just you) to be the smallest whale bonus bid i.e. 700 ETH in this case
-    #. Since your bonus ETH bid is > 700 ETH, you will be refunded
+    #. Select the smallest whale bonus ETH escrow; in this case 700 ETH from `whale_1` < 770 ETH from `whale_2`
+    #. Equalize the bonus ETH whale escrows for all other whales (in this case, just `whale_2` i.e. just you) to be the smallest whale bonus escrow i.e. 700 ETH in this case
+    #. Since your bonus ETH escrow is > 700 ETH, you will be refunded
 
         .. math::
 
@@ -234,17 +240,17 @@ the maximum stake amount (4,000,000 NU).
             35,000 ETH - 70 ETH = 34,930 ETH
 
     #. We now need to calculate the bonus ETH refunds based on the updated bonus ETH supply, and the maximum stake size.
-    #. Remember that everyone receives a 15,000 NU minimum, and the maximum stake size is 4,000,000 NU, so the most you can receive from the remaining NU is
+    #. Remember that everyone is allocated a 15,000 NU minimum, and the maximum stake size is 4,000,000 NU, so the most that can be allocated to you from the remaining NU is
 
         .. math::
 
             4,000,000 NU - 15,000 NU = 3,985,000 NU
 
-    #. Since we have multiple bidders, our equation is the following , where `n` is the number of whale bidders
+    #. Since we have multiple participants, our equation is the following , where `n` is the number of whale escrows
 
         .. math::
 
-            x = \frac{\text{(min whale bid} \times \text{token supply - eth_supply} \times \text{max stake)}}{\text{(token supply - n} \times \text{max stake)}}
+            x = \frac{\text{(min whale escrow} \times \text{NU supply - eth_supply} \times \text{max stake)}}{\text{(NU supply - n} \times \text{max stake)}}
 
     #. Plugging in values
 
@@ -262,10 +268,10 @@ the maximum stake amount (4,000,000 NU).
 
     #. Based on the refunds
 
-        - The bonus bids for the whales will now be equalized:
+        - The bonus escrows for the whales will now be equalized:
 
-            - `whale_1` bonus bid = 700 ETH - 180.15 ETH = 519.85 ETH
-            - `whale_2` bonus bid = 770 ETH - 250.15 ETH = 519.85 ETH
+            - `whale_1` bonus = 700 ETH - 180.15 ETH = 519.85 ETH
+            - `whale_2` bonus = 770 ETH - 250.15 ETH = 519.85 ETH
 
         - The updated bonus ETH supply will be
 
@@ -279,20 +285,20 @@ the maximum stake amount (4,000,000 NU).
 
                 \frac{519.85 ETH}{34,569.70 ETH} \approx 1.504\%
 
-    #. And each whale's portion of the remaining NU is
+    #. And each whale's allocation of the remaining NU is
 
             .. math::
 
                 1.504\% \times 265,000,000 NU = 3,985,600 NU
 
-**Total NU tokens received ~ 15,000 NU + 3,985,600 NU (rounding) ~ 4,000,000 NU, and refunded ETH ~ 176.33 ETH**
+**Total NU allocated ~ 15,000 NU + 3,985,600 NU (rounding) ~ 4,000,000 NU, and refunded ETH ~ 176.33 ETH**
 
 
 .. note::
 
     In Scenarios 2 and 3, you will notice that the bonus ETH supply was reduced. This produces a very subtle situation -
-    for previous non-whale bids (bids in the original bonus ETH supply that did not produce a stake larger than the
-    maximum stake) their bids remained unchanged, but the bonus ETH supply was reduced. This means that some bids that
+    for previous non-whale participants (escrows in the original bonus ETH supply that did not produce a stake larger than the
+    maximum stake) their escrows remained unchanged, but the bonus ETH supply was reduced. This means that some participants that
     were not originally whales, may become whales once the bonus ETH supply is reduced since their proportion of the
     bonus pool increased. Therefore, the `whale resolution` algorithm described in Scenario 3 may be repeated for
     multiple rounds until there are no longer any whales. To keep the explanation simple, both Scenarios 2 and 3 ignore

--- a/docs/source/guides/worklock_guide.rst
+++ b/docs/source/guides/worklock_guide.rst
@@ -59,7 +59,7 @@ The following is an example output of the ``status`` command (hypothetical value
 
     Escrow (Closed)
     ------------------------------------------------------
-    Allocations Available ...... Yes
+    Allocations Available . Yes
     Start Date ............ 2020-03-25 00:00:00+00:00
     End Date .............. 2020-03-31 23:59:59+00:00
     Duration .............. 6 days, 23:59:59
@@ -78,7 +78,7 @@ The following is an example output of the ``status`` command (hypothetical value
     Participation
     ------------------------------------------------------
     Lot Size .............. 280000000 NU
-    Min. Allowed Escrow ...... 15 ETH
+    Min. Allowed Escrow ... 15 ETH
     Participants .......... 1000
     ETH Supply ............ 50000 ETH
     ETH Pool .............. 50000 ETH
@@ -138,11 +138,11 @@ The following output is an example of what is included when ``--participant-addr
 
     WorkLock Participant <PARTICIPANT ADDRESS>
     =====================================================
-    NU Claimed? ...... No
-    Total Escrow ............ 22 ETH
+    NU Claimed? .......... No
+    Total Escrow ......... 22 ETH
         Base ETH ......... 15 ETH
         Bonus ETH ........ 7 ETH
-    NU Allocated ..... 68000 NU
+    NU Allocated ......... 68000 NU
 
     Completed Work ....... 0
     Available Refund ..... 0 ETH
@@ -156,7 +156,7 @@ Alternatively, when the NU has been allocated, the following is an example of th
 
     WorkLock Participant <PARTICIPANT ADDRESS>
     =====================================================
-    NU Claimed? ...... Yes
+    NU Claimed? .......... Yes
     Locked ETH ........... 22 ETH
 
     Completed Work ....... 0
@@ -177,7 +177,7 @@ where,
         Allocation of NU
     - Locked ETH
         Remaining ETH to be unlocked via completion of work
-    - NU Allocated
+    - NU Claimed
         Whether the allocation of NU tokens has been allocated or not
     - Completed Work
         Work already completed by the participant

--- a/docs/source/guides/worklock_guide.rst
+++ b/docs/source/guides/worklock_guide.rst
@@ -57,9 +57,9 @@ The following is an example output of the ``status`` command (hypothetical value
     Time
     ══════════════════════════════════════════════════════
 
-    Contribution (Closed)
+    Escrow (Closed)
     ------------------------------------------------------
-    Claims Available ...... Yes
+    Allocations Available ...... Yes
     Start Date ............ 2020-03-25 00:00:00+00:00
     End Date .............. 2020-03-31 23:59:59+00:00
     Duration .............. 6 days, 23:59:59
@@ -78,16 +78,16 @@ The following is an example output of the ``status`` command (hypothetical value
     Participation
     ------------------------------------------------------
     Lot Size .............. 280000000 NU
-    Min. Allowed Bid ...... 15 ETH
+    Min. Allowed Escrow ...... 15 ETH
     Participants .......... 1000
     ETH Supply ............ 50000 ETH
     ETH Pool .............. 50000 ETH
 
-    Base (minimum bid)
+    Base (minimum escrow)
     ------------------------------------------------------
     Base Deposit Rate ..... 1000 NU per base ETH
 
-    Bonus (surplus over minimum bid)
+    Bonus (surplus over minimum escrow)
     ------------------------------------------------------
     Bonus ETH Supply ...... 35000 ETH
     Bonus Lot Size ........ 265000000 NU
@@ -105,44 +105,44 @@ The following is an example output of the ``status`` command (hypothetical value
 For the less obvious values in the output, here are some definitions:
 
     - Lot Size
-        NU tokens to be distributed by WorkLock
+        NU to be allocated by WorkLock
     - ETH Supply
-        Sum of all ETH bids that have been placed
+        Sum of all ETH escrows that have been placed
     - ETH Pool
         Current ETH balance of WorkLock that accounts for refunded ETH for work performed i.e. `ETH Supply` - `Refunds for Work`
     - Refund Rate Multiple
-        Indicates how quickly your ETH is unlocked relative to the deposit rate e.g. a value of ``4`` means that you get your ETH refunded 4x faster than the rate used when you received NU
+        Indicates how quickly your ETH is unlocked relative to the deposit rate e.g. a value of ``4`` means that you get your ETH refunded 4x faster than the rate used when you were allocated NU
     - Base Deposit Rate
-        Amount of NU to be received per base ETH in WorkLock
+        Amount of NU to be allocated per base ETH in WorkLock
     - Bonus ETH Supply
-        Sum of all bonus ETH bids that have been placed i.e. sum of all ETH above minimum bid
+        Sum of all bonus ETH escrows that have been placed i.e. sum of all ETH above minimum escrow
     - Bonus Lot Size
-        Amount of NU tokens tokens that are available to be distributed based on the bonus part of bids
+        Amount of NU that is available to be allocated based on the bonus part of escrows
     - Bonus Deposit Rate
-        Amount of NU to be received per bonus ETH in WorkLock
+        Amount of NU to be allocated per bonus ETH in WorkLock
     - Bonus Refund Rate
         Units of work to unlock 1 bonus ETH
     - Base Refund Rate
         Units of work to unlock 1 base ETH
 
 
-If you want to see specific information about your current bid, you can specify your bidder address with the ``--bidder-address`` flag:
+If you want to see specific information about your current escrow, you can specify your participant address with the ``--participant-address`` flag:
 
 .. code::
 
-    (nucypher)$ nucypher worklock status --bidder-address <YOUR BIDDER ADDRESS> --network <NETWORK> --provider <YOUR PROVIDER URI>
+    (nucypher)$ nucypher worklock status --participant-address <YOUR PARTICIPANT ADDRESS> --network <NETWORK> --provider <YOUR PROVIDER URI>
 
-The following output is an example of what is included when ``--bidder-address`` is used
+The following output is an example of what is included when ``--participant-address`` is used
 
 .. code::
 
-    WorkLock Participant <BIDDER ADDRESS>
+    WorkLock Participant <PARTICIPANT ADDRESS>
     =====================================================
-    Tokens Claimed? ...... No
-    Total Bid ............ 22 ETH
+    NU Claimed? ...... No
+    Total Escrow ............ 22 ETH
         Base ETH ......... 15 ETH
         Bonus ETH ........ 7 ETH
-    Tokens Allocated ..... 68000 NU
+    NU Allocated ..... 68000 NU
 
     Completed Work ....... 0
     Available Refund ..... 0 ETH
@@ -150,13 +150,13 @@ The following output is an example of what is included when ``--bidder-address``
     Refunded Work ........ 0
     Remaining Work ....... <REMAINING WORK>
 
-Alternatively, when the allocated tokens have been claimed, the following is an example of the output
+Alternatively, when the NU has been allocated, the following is an example of the output
 
 .. code::
 
-    WorkLock Participant <BIDDER ADDRESS>
+    WorkLock Participant <PARTICIPANT ADDRESS>
     =====================================================
-    Tokens Claimed? ...... Yes
+    NU Claimed? ...... Yes
     Locked ETH ........... 22 ETH
 
     Completed Work ....... 0
@@ -167,66 +167,66 @@ Alternatively, when the allocated tokens have been claimed, the following is an 
 
 where,
 
-    - Total Bid
-        WorkLock Bid
+    - Total Escrow
+        WorkLock Escrow
     - Base ETH
-        Minimum required bid
+        Minimum required escrow
     - Bonus ETH
-        Surplus over minimum bid
-    - Tokens Allocated
-        Allocation of NU tokens
+        Surplus over minimum escrow
+    - NU Allocated
+        Allocation of NU
     - Locked ETH
         Remaining ETH to be unlocked via completion of work
-    - Tokens Claimed
-        Whether the allocation of NU tokens have been claimed or not
+    - NU Allocated
+        Whether the allocation of NU tokens has been allocated or not
     - Completed Work
-        Work already completed by the bidder
+        Work already completed by the participant
     - Available Refund
         ETH portion available to be refunded due to completed work
     - Refunded Work
         Work that has been completed and already refunded
     - Remaining Work
-        Pending amount of work required before all of the participant's ETH locked will be refunded
+        Pending amount of work required before all of the participant's escrowed ETH will be refunded
 
 
-Place a bid
------------
+Place an escrow
+---------------
 
-You can place a bid to WorkLock by running:
-
-.. code::
-
-    (nucypher)$ nucypher worklock bid --network <NETWORK> --provider <YOUR PROVIDER URI>
-
-
-Recall that there's a minimum bid amount needed to participate in WorkLock.
-
-
-Cancel a bid
-------------
-
-You can cancel a bid to WorkLock by running:
+You can place an escrow to WorkLock by running:
 
 .. code::
 
-    (nucypher)$ nucypher worklock cancel-bid --network <NETWORK> --provider <YOUR PROVIDER URI>
+    (nucypher)$ nucypher worklock escrow --network <NETWORK> --provider <YOUR PROVIDER URI>
+
+
+Recall that there's a minimum escrow amount needed to participate in WorkLock.
+
+
+Cancel an escrow
+----------------
+
+You can cancel an escrow to WorkLock by running:
+
+.. code::
+
+    (nucypher)$ nucypher worklock cancel-escrow --network <NETWORK> --provider <YOUR PROVIDER URI>
 
 
 Claim your stake
 ----------------
 
-Once the claiming window is open, you can claim your tokens as a stake in NuCypher:
+Once the allocation window is open, you can claim your NU as a stake in NuCypher:
 
 .. code::
 
     (nucypher)$ nucypher worklock claim --network <NETWORK> --provider <YOUR PROVIDER URI>
 
 
-Once claimed, you can check that the stake was created successfully by running:
+Once allocated, you can check that the stake was created successfully by running:
 
 .. code::
 
-    (nucypher)$ nucypher status stakers --staking-address <YOUR BIDDER ADDRESS> --network {network} --provider <YOUR PROVIDER URI>
+    (nucypher)$ nucypher status stakers --staking-address <YOUR PARTICIPANT ADDRESS> --network {network} --provider <YOUR PROVIDER URI>
     
 
 Check remaining work
@@ -242,7 +242,7 @@ If you have a stake created from WorkLock, you can check how much work is pendin
 Refund locked ETH
 -----------------
 
-If you've committed some work, you are able to refund proportional part of ETH you've had bid in WorkLock contract:
+If you've committed some work, you are able to refund proportional part of ETH you've escrowed in the WorkLock contract:
 
 .. code::
 

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -207,21 +207,22 @@ def bid(general_config: GroupGeneralConfig,
     if not force:
         if not existing_bid_amount:
             paint_bidding_notice(emitter=emitter, bidder=bidder)
-            click.confirm(f"Place WorkLock bid of {prettify_eth_amount(value)}?", abort=True)
+            click.confirm(f"Place WorkLock escrow of {prettify_eth_amount(value)}?", abort=True)
         else:
-            click.confirm(f"Increase current bid ({prettify_eth_amount(existing_bid_amount)}) "
+            click.confirm(f"Increase current escrow ({prettify_eth_amount(existing_bid_amount)}) "
                           f"by {prettify_eth_amount(value)}?", abort=True)
 
     receipt = bidder.place_bid(value=value)
-    emitter.message("Publishing WorkLock Bid...")
+    emitter.message("Publishing WorkLock Escrow...")
 
     maximum = NU.from_nunits(bidder.economics.maximum_allowed_locked)
     available_claim = NU.from_nunits(bidder.available_claim)
-    message = f'\nCurrent bid: {prettify_eth_amount(bidder.get_deposited_eth)} | Claim: {available_claim}\n'
+    message = f'\nCurrent escrow: {prettify_eth_amount(bidder.get_deposited_eth)} | Allocation: {available_claim}\n'
     if available_claim > maximum:
-        message += f"\nThis claim is currently above the allowed max ({maximum}), " \
-                   f"so the bid may be partially refunded.\n"
-    message += f'Note that available claim value may fluctuate until bidding closes and claims are finalized.\n'
+        message += f"\nThis allocation is currently above the allowed max ({maximum}), " \
+                   f"so the escrow may be partially refunded.\n"
+    message += f'Note that the available allocation value may fluctuate until the escrow period closes and ' \
+               f'allocations are finalized.\n'
     emitter.echo(message, color='yellow')
 
     paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=bidder.staking_agent.blockchain.client.chain_name)
@@ -246,7 +247,7 @@ def cancel_bid(general_config: GroupGeneralConfig, worklock_options: WorkLockOpt
     bidder = worklock_options.create_bidder(registry=registry, hw_wallet=hw_wallet)
     if not force:
         value = bidder.get_deposited_eth
-        click.confirm(f"Confirm bid cancellation of {prettify_eth_amount(value)} for {bidder_address}?", abort=True)
+        click.confirm(f"Confirm escrow cancellation of {prettify_eth_amount(value)} for {bidder_address}?", abort=True)
     receipt = bidder.cancel_bid()
     emitter.echo(SUCCESSFUL_BID_CANCELLATION, color='green')
     paint_receipt_summary(receipt=receipt, emitter=emitter, chain_name=bidder.staking_agent.blockchain.client.chain_name)
@@ -350,12 +351,12 @@ def enable_claiming(general_config: GroupGeneralConfig,
 
     whales = bidder.get_whales()
     if whales:
-        headers = ("Bidders that require correction", "Current bid bonus")
+        headers = ("Participants that require correction", "Current bonus")
         columns = (whales.keys(), map(prettify_eth_amount, whales.values()))
         emitter.echo(tabulate.tabulate(dict(zip(headers, columns)), headers=headers, floatfmt="fancy_grid"))
 
         if not force:
-            click.confirm(f"Confirm force refund to at least {len(whales)} bidders using {bidder_address}?", abort=True)
+            click.confirm(f"Confirm force refund to at least {len(whales)} participants using {bidder_address}?", abort=True)
 
         force_refund_receipt = bidder.force_refund()
         emitter.echo(WHALE_WARNING.format(number=len(whales)), color='green')

--- a/nucypher/cli/commands/worklock.py
+++ b/nucypher/cli/commands/worklock.py
@@ -77,7 +77,7 @@ from nucypher.cli.types import DecimalRange, EIP55_CHECKSUM_ADDRESS
 from nucypher.config.constants import NUCYPHER_ENVVAR_PROVIDER_URI
 
 option_bidder_address = click.option('--participant-address',
-                                     help="Participants's checksum address.",
+                                     help="Participant's checksum address.",
                                      type=EIP55_CHECKSUM_ADDRESS)
 
 

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -452,105 +452,102 @@ MULTISIG_SIGNATURE_RECEIVED = "\nSignature received from {recovered_address}:\n"
 # Worklock
 #
 
-BID_AMOUNT_PROMPT_WITH_MIN_BID = "Enter bid amount in ETH (at least {minimum_bid_in_eth} ETH)"
+BID_AMOUNT_PROMPT_WITH_MIN_BID = "Enter escrow amount in ETH (at least {minimum_bid_in_eth} ETH)"
 
-BID_INCREASE_AMOUNT_PROMPT = "Enter the amount in ETH that you want to increase your bid"
+BID_INCREASE_AMOUNT_PROMPT = "Enter the amount in ETH that you want to increase your escrow"
 
-EXISTING_BID_AMOUNT_NOTICE = "⚠️ You have an existing bid of {eth_amount} ETH"
+EXISTING_BID_AMOUNT_NOTICE = "⚠️ You have an existing escrow of {eth_amount} ETH"
 
 WORKLOCK_AGREEMENT = """
 ⚠️ WorkLock Participant Notice ⚠️
 ---------------------------------
 
 - By participating in NuCypher's WorkLock you are committing to operating a staking
-  NuCypher node after the bidding window closes.
+  NuCypher node once the allocation period opens.
 
-- WorkLock token rewards are claimed in the form of a stake and will be locked for
-  the stake duration.
-
-- WorkLock ETH deposits will be available for refund at a rate of {refund_rate} 
+- WorkLock allocation is provided in the form of a stake and will be locked for
+  the stake duration ({duration} periods). During this time, 
+  you are obligated to maintain a networked and available
+  NuCypher node bonded to the staker address {bidder_address}.
+  
+- ETH in escrow will be available for refund at a rate of {refund_rate} 
   per confirmed period. This rate may vary until {end_date}.
 
-- Once claiming WorkLock tokens, you are obligated to maintain a networked and available
-  Ursula-Worker node bonded to the staker address {bidder_address}
-  for the duration of the stake(s) ({duration} periods).
-
-- Allow NuCypher network users to carry out uninterrupted re-encryption work orders
-  at-will without interference. Failure to keep your node online, or violation of
-  re-encryption work orders will result in the loss of staked tokens as described
+- You agree to allow NuCypher network users to carry out uninterrupted work orders
+  at will without interference. Failure to keep your node online, or violation of
+  work orders will result in the loss of staked tokens as described
   in the NuCypher slashing protocol.
 
-- Keeping your Ursula node online during the staking period and correctly servicing
-  re-encryption work orders will result in rewards paid out in ethers retro-actively
+- Correctly servicing work orders will result in rewards paid out in ethers retro-actively
   and on-demand.
 
 Accept WorkLock terms and node operator obligation?"""  # TODO: Show a special message for first bidder, since there's no refund rate yet?
 
-BIDDING_WINDOW_CLOSED = "❌ You can't bid, the bidding window is closed."
+BIDDING_WINDOW_CLOSED = "❌ You can't escrow, the escrow period is closed."
 
-CANCELLATION_WINDOW_CLOSED = "❌ You can't cancel your bid. The cancellation window is closed."
+CANCELLATION_WINDOW_CLOSED = "❌ You can't cancel your escrow. The cancellation period is closed."
 
-SUCCESSFUL_BID_CANCELLATION = "✅ Bid canceled\n"
+SUCCESSFUL_BID_CANCELLATION = "✅ Escrow canceled\n"
 
 WORKLOCK_ADDITIONAL_COMPENSATION_AVAILABLE = """
-⚠️ Note that WorkLock did not use your entire bid due to a maximum claim limit.
+⚠️ Note that WorkLock did not use your entire escrow due to a maximum allocation limit.
 Therefore, an unspent amount of {amount} is available for refund.
 """
 
 CONFIRM_REQUEST_WORKLOCK_COMPENSATION = """
-Before claiming your NU tokens for {bidder_address},
-you will need to be refunded your unspent bid amount.
+Before requesting the NU allocation for {bidder_address},
+you will need to be refunded your unspent escrow amount.
  
 Would you like to proceed?
 """
 
-REQUESTING_WORKLOCK_COMPENSATION = "Requesting refund of unspent bid amount..."
+REQUESTING_WORKLOCK_COMPENSATION = "Requesting refund of unspent escrow amount..."
 
-CLAIMING_NOT_AVAILABLE = "❌ You can't claim tokens yet. Claiming is not currently available."
+CLAIMING_NOT_AVAILABLE = "❌ You can't request a NU allocation yet. Allocations are not currently available."
 
-CLAIM_ALREADY_PLACED = "⚠️ Claim was already placed for {bidder_address}"
+CLAIM_ALREADY_PLACED = "⚠️ An allocation was already assigned to {bidder_address}"
 
-AVAILABLE_CLAIM_NOTICE = "\nYou have an available claim of {tokens} 🎉 \n"
+AVAILABLE_CLAIM_NOTICE = "\nYou have an available allocation of {tokens} 🎉 \n"
 
 WORKLOCK_CLAIM_ADVISORY = """
-⚠️ Note: Claiming WorkLock NU tokens will initialize a new stake to be locked for {lock_duration} periods.
+⚠️ Note: Allocating WorkLock NU will initialize a new stake to be locked for {lock_duration} periods.
 """
 
-CONFIRM_WORKLOCK_CLAIM = "Continue WorkLock claim for bidder {bidder_address}?"
+CONFIRM_WORKLOCK_CLAIM = "Continue WorkLock allocation for participant {bidder_address}?"
 
-SUBMITTING_WORKLOCK_CLAIM = "Submitting Claim..."
+SUBMITTING_WORKLOCK_CLAIM = "Submitting allocation request..."
 
-CONFIRM_COLLECT_WORKLOCK_REFUND = "Collect ETH refund for bidder {bidder_address}?"
+CONFIRM_COLLECT_WORKLOCK_REFUND = "Collect ETH refund for participant {bidder_address}?"
 
 SUBMITTING_WORKLOCK_REFUND_REQUEST = "Submitting WorkLock refund request..."
 
 PROMPT_BID_VERIFY_GAS_LIMIT = "Enter gas limit per each verification transaction (at least {min_gas})"
 
-COMPLETED_BID_VERIFICATION = "Bidding has been checked\n"
+COMPLETED_BID_VERIFICATION = "Escrow amounts have been checked\n"
 
-BIDS_VALID_NO_FORCE_REFUND_INDICATED = "All bids are correct, force refund is not needed\n"
+BIDS_VALID_NO_FORCE_REFUND_INDICATED = "All escrows are correct, force refund is not needed\n"
 
 CONFIRM_BID_VERIFICATION = """
-Confirm verification of bidding from {bidder_address} using {gas_limit} gas 
-for {bidders_per_transaction} bidders per each transaction?
+Confirm verification of escrow from {bidder_address} using {gas_limit} gas 
+for {bidders_per_transaction} participants per each transaction?
 """
 
-VERIFICATION_ESTIMATES = "Using {gas_limit} gas for {bidders_per_transaction} bidders per each transaction\n"
+VERIFICATION_ESTIMATES = "Using {gas_limit} gas for {bidders_per_transaction} participants per each transaction\n"
 
-WHALE_WARNING = "At least {number} bidders got a force refund\n"
+WHALE_WARNING = "At least {number} participants got a force refund\n"
 
-BIDDERS_ALREADY_VERIFIED = "Bidders have already been checked\n"
+BIDDERS_ALREADY_VERIFIED = "All escrow amounts have already been checked\n"
 
 SUCCESSFUL_WORKLOCK_CLAIM = """
 
-✅ Successfully claimed WorkLock tokens for {bidder_address}.
+✅ Successfully allocated WorkLock NU for {bidder_address}.
 
 You can check that the stake was created correctly by running:
 
   nucypher status stakers --staking-address {bidder_address} --network {network} --provider {provider_uri}
 
-Next Steps for WorkLock Winners
-===============================
+Next Steps for WorkLock Participants
+====================================
 
 Congratulations! 🎉 You're officially a Staker in the NuCypher network.
 

--- a/nucypher/cli/painting/worklock.py
+++ b/nucypher/cli/painting/worklock.py
@@ -71,9 +71,9 @@ def paint_worklock_status(emitter, registry: BaseContractRegistry):
 Time
 ══════════════════════════════════════════════════════
 
-Contribution Period ({'Open' if bidding_open else 'Closed'})
+Escrow Period ({'Open' if bidding_open else 'Closed'})
 ------------------------------------------------------
-Claims Available ...... {'Yes' if worklock_agent.is_claiming_available() else 'No'}
+Allocations Available . {'Yes' if worklock_agent.is_claiming_available() else 'No'}
 Start Date ............ {bidding_start}
 End Date .............. {bidding_end}
 Duration .............. {bidding_duration}
@@ -92,16 +92,16 @@ Economics
 Participation
 ------------------------------------------------------
 Lot Size .............. {NU.from_nunits(worklock_agent.lot_value)} 
-Min. Allowed Bid ...... {prettify_eth_amount(worklock_agent.minimum_allowed_bid)}
+Min. Allowed Escrow ... {prettify_eth_amount(worklock_agent.minimum_allowed_bid)}
 Participants .......... {worklock_agent.get_bidders_population()}
 ETH Supply ............ {prettify_eth_amount(worklock_agent.get_eth_supply())}
 ETH Pool .............. {prettify_eth_amount(blockchain.client.get_balance(worklock_agent.contract_address))}
 
-Base (minimum bid)
+Base (minimum escrow)
 ------------------------------------------------------
 Base Deposit Rate ..... {worklock_agent.get_base_deposit_rate()} NU per base ETH
 
-Bonus (surplus over minimum bid)
+Bonus (surplus over minimum escrow)
 ------------------------------------------------------
 Bonus ETH Supply ...... {prettify_eth_amount(worklock_agent.get_bonus_eth_supply())}
 Bonus Lot Size ........ {NU.from_nunits(worklock_agent.get_bonus_lot_value())}
@@ -121,7 +121,7 @@ Base Refund Rate ...... {worklock_agent.get_base_refund_rate()} units of work to
 def paint_bidder_status(emitter, bidder):
     claim = NU.from_nunits(bidder.available_claim)
     if claim > bidder.economics.maximum_allowed_locked:
-        claim = f"{claim} (Above the allowed max. The bid will be partially refunded)"
+        claim = f"{claim} (Above the allowed max. The escrow will be partially refunded)"
 
     deposited_eth = bidder.get_deposited_eth
     bonus_eth = deposited_eth - bidder.economics.worklock_min_allowed_bid
@@ -132,27 +132,27 @@ WorkLock Participant {bidder.checksum_address}
 
     if bidder.has_claimed:
         message += f"""
-Tokens Claimed? ...... Yes
-Locked ETH ........... {prettify_eth_amount(bidder.get_deposited_eth)}"""
+NU Claimed? ............ Yes
+Locked ETH ............. {prettify_eth_amount(bidder.get_deposited_eth)}"""
     else:
         message += f"""
-Tokens Claimed? ...... No
-Total Bid ............ {prettify_eth_amount(deposited_eth)}
-    Base ETH ......... {prettify_eth_amount(bidder.economics.worklock_min_allowed_bid)}
-    Bonus ETH ........ {prettify_eth_amount(bonus_eth)}
-Tokens Allocated ..... {claim}"""
+NU Claimed? ............ No
+Total Escrow ........... {prettify_eth_amount(deposited_eth)}
+    Base ETH ........... {prettify_eth_amount(bidder.economics.worklock_min_allowed_bid)}
+    Bonus ETH .......... {prettify_eth_amount(bonus_eth)}
+NU Allocated ........... {claim}"""
 
     compensation = bidder.available_compensation
     if compensation:
         message += f"""
-Unspent Bid Amount ... {prettify_eth_amount(compensation)}"""
+Unspent Escrow Amount .. {prettify_eth_amount(compensation)}"""
 
     message += f"""\n
-Completed Work ....... {bidder.completed_work}
-Available Refund ..... {prettify_eth_amount(bidder.available_refund)}
+Completed Work ......... {bidder.completed_work}
+Available Refund ....... {prettify_eth_amount(bidder.available_refund)}
 
-Refunded Work ........ {bidder.refunded_work}
-Remaining Work ....... {bidder.remaining_work}
+Refunded Work .......... {bidder.refunded_work}
+Remaining Work ......... {bidder.remaining_work}
 """
 
     emitter.echo(message)

--- a/tests/acceptance/cli/test_worklock_cli.py
+++ b/tests/acceptance/cli/test_worklock_cli.py
@@ -68,7 +68,7 @@ def test_bid(click_runner, testerchain, agency_local_registry, token_economics, 
     # Wait until biding window starts
     testerchain.time_travel(seconds=90)
 
-    base_command = ('bid',
+    base_command = ('escrow',
                     '--registry-filepath', agency_local_registry.filepath,
                     '--provider', TEST_PROVIDER_URI,
                     '--network', TEMPORARY_DOMAIN,
@@ -81,7 +81,7 @@ def test_bid(click_runner, testerchain, agency_local_registry, token_economics, 
         pre_bid_balance = testerchain.client.get_balance(bidder)
         assert pre_bid_balance > to_wei(bid_eth_value, 'ether')
 
-        command = (*base_command, '--bidder-address', bidder, '--value', bid_eth_value)
+        command = (*base_command, '--participant-address', bidder, '--value', bid_eth_value)
         user_input = f'{INSECURE_DEVELOPMENT_PASSWORD}\n' + 'Y\n'
         result = click_runner.invoke(worklock, command, input=user_input, catch_exceptions=False)
         assert result.exit_code == 0
@@ -101,8 +101,8 @@ def test_cancel_bid(click_runner, testerchain, agency_local_registry, token_econ
     bidder = bidders[-1]
     agent = ContractAgency.get_agent(WorkLockAgent, registry=agency_local_registry)
 
-    command = ('cancel-bid',
-               '--bidder-address', bidder,
+    command = ('cancel-escrow',
+               '--participant-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
@@ -117,8 +117,8 @@ def test_cancel_bid(click_runner, testerchain, agency_local_registry, token_econ
     testerchain.time_travel(seconds=token_economics.bidding_duration + 2)
 
     bidder = bidders[-2]
-    command = ('cancel-bid',
-               '--bidder-address', bidder,
+    command = ('cancel-escrow',
+               '--participant-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
@@ -141,7 +141,7 @@ def test_enable_claiming(click_runner, testerchain, agency_local_registry, token
     assert not agent.bidders_checked()
 
     command = ('enable-claiming',
-               '--bidder-address', bidder,
+               '--participant-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--force',
@@ -160,7 +160,7 @@ def test_claim(click_runner, testerchain, agency_local_registry, token_economics
 
     bidder = testerchain.client.accounts[2]
     command = ('claim',
-               '--bidder-address', bidder,
+               '--participant-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
@@ -173,7 +173,7 @@ def test_claim(click_runner, testerchain, agency_local_registry, token_economics
     whale = testerchain.client.accounts[0]
     assert agent.get_available_compensation(checksum_address=whale) > 0
     command = ('claim',
-               '--bidder-address', whale,
+               '--participant-address', whale,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
@@ -196,7 +196,7 @@ def test_remaining_work(click_runner, testerchain, agency_local_registry, token_
     assert remaining_work > 0
 
     command = ('remaining-work',
-               '--bidder-address', bidder,
+               '--participant-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
@@ -243,7 +243,7 @@ def test_refund(click_runner, testerchain, agency_local_registry, token_economic
         testerchain.time_travel(periods=1)
 
     command = ('refund',
-               '--bidder-address', bidder,
+               '--participant-address', bidder,
                '--registry-filepath', agency_local_registry.filepath,
                '--provider', TEST_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
@@ -263,7 +263,7 @@ def test_participant_status(click_runner, testerchain, agency_local_registry, to
 
     command = ('status',
                '--registry-filepath', agency_local_registry.filepath,
-               '--bidder-address', bidder.checksum_address,
+               '--participant-address', bidder.checksum_address,
                '--provider', TEST_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
 

--- a/tests/integration/cli/test_worklock_cli_functionality.py
+++ b/tests/integration/cli/test_worklock_cli_functionality.py
@@ -78,7 +78,7 @@ def test_account_selection(click_runner, mocker, mock_testerchain, mock_worklock
     # I spy
     mock_select = mocker.spy(worklock_command, 'select_client_account')
 
-    command = ('cancel-bid',
+    command = ('cancel-escrow',
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
 
@@ -99,8 +99,8 @@ def test_account_selection(click_runner, mocker, mock_testerchain, mock_worklock
 def bidding_command(token_economics, surrogate_bidder):
     minimum = token_economics.worklock_min_allowed_bid
     bid_value = random.randint(minimum, minimum*100)
-    command = ('bid',
-               '--bidder-address', surrogate_bidder.checksum_address,
+    command = ('escrow',
+               '--participant-address', surrogate_bidder.checksum_address,
                '--value', bid_value,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
@@ -193,8 +193,8 @@ def test_valid_bid(click_runner,
     )
     mocker.patch.object(Bidder, 'get_deposited_eth', new_callable=PropertyMock, side_effect=deposited_eth_sequence)
 
-    command = ('bid',
-               '--bidder-address', surrogate_bidder.checksum_address,
+    command = ('escrow',
+               '--participant-address', surrogate_bidder.checksum_address,
                '--value', bid_value_in_eth,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
@@ -234,8 +234,8 @@ def test_cancel_bid(click_runner,
     # Spy on the corresponding CLI function we are testing
     mock_cancel = mocker.spy(Bidder, 'cancel_bid')
 
-    command = ('cancel-bid',
-               '--bidder-address', surrogate_bidder.checksum_address,
+    command = ('cancel-escrow',
+               '--participant-address', surrogate_bidder.checksum_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
                '--force')
@@ -301,7 +301,7 @@ def test_enable_claiming(click_runner,
     mock_worklock_agent.estimate_verifying_correctness.side_effect = [3, 6]
 
     command = ('enable-claiming',
-               '--bidder-address', surrogate_bidder.checksum_address,
+               '--participant-address', surrogate_bidder.checksum_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
 
@@ -360,7 +360,7 @@ def test_initial_claim(click_runner,
 
     bidder_address = surrogate_bidder.checksum_address
     command = ('claim',
-               '--bidder-address', bidder_address,
+               '--participant-address', bidder_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
 
@@ -437,7 +437,7 @@ def test_already_claimed(click_runner,
     )
 
     command = ('claim',
-               '--bidder-address', surrogate_bidder.checksum_address,
+               '--participant-address', surrogate_bidder.checksum_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
                '--force')
@@ -468,7 +468,7 @@ def test_remaining_work(click_runner,
                                               return_value=remaining_work)
 
     command = ('remaining-work',
-               '--bidder-address', surrogate_bidder.checksum_address,
+               '--participant-address', surrogate_bidder.checksum_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
 
@@ -494,7 +494,7 @@ def test_refund(click_runner,
 
     bidder_address = surrogate_bidder.checksum_address
     command = ('refund',
-               '--bidder-address', bidder_address,
+               '--participant-address', bidder_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
 
@@ -519,7 +519,7 @@ def test_participant_status(click_runner,
                             mock_worklock_agent,
                             surrogate_bidder):
     command = ('status',
-               '--bidder-address', surrogate_bidder.checksum_address,
+               '--participant-address', surrogate_bidder.checksum_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN)
 
@@ -571,8 +571,8 @@ def test_interactive_new_bid(click_runner,
     )
     mocker.patch.object(Bidder, 'get_deposited_eth', new_callable=PropertyMock, side_effect=deposited_eth_sequence)
 
-    command = ('bid',
-               '--bidder-address', surrogate_bidder.checksum_address,
+    command = ('escrow',
+               '--participant-address', surrogate_bidder.checksum_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,)
 
@@ -621,8 +621,8 @@ def test_interactive_increase_bid(click_runner,
     )
     mocker.patch.object(Bidder, 'get_deposited_eth', new_callable=PropertyMock, side_effect=deposited_eth_sequence)
 
-    command = ('bid',
-               '--bidder-address', surrogate_bidder.checksum_address,
+    command = ('escrow',
+               '--participant-address', surrogate_bidder.checksum_address,
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,)
 


### PR DESCRIPTION
Fix terminology around WorkLock:
* bid -> escrow
* bidder -> participants
* distribution/portion -> allocation
* distribute -> allocate
* token distribution -> network node setup
* remove instances of `tokens`