### PR TITLE
Restore default return values in mock agents

### DIFF
--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -156,7 +156,8 @@ class NucypherTokenAgent(EthereumContractAgent):
     def get_balance(self, address: Optional[ChecksumAddress] = None) -> NuNits:
         """Get the NU balance (in NuNits) of a token holder address, or of this contract address"""
         address = address if address is not None else self.contract_address
-        return self.contract.functions.balanceOf(address).call()
+        balance: int = self.contract.functions.balanceOf(address).call()
+        return NuNits(balance)
 
     @contract_api(CONTRACT_CALL)
     def get_allowance(self, owner: ChecksumAddress, spender: ChecksumAddress) -> NuNits:

--- a/tests/mock/agents.py
+++ b/tests/mock/agents.py
@@ -160,11 +160,12 @@ class MockContractAgent:
         unexpected_transactions = self.get_unexpected_transactions(allowed=None)
         assert not bool(unexpected_transactions)
 
-    def reset(self, clear_side_effects: bool = True) -> None:
+    def reset(self, clear_side_effects: bool = True, clear_return_values: bool = True) -> None:
         for mock in self._MOCK_METHODS:
-            mock.reset_mock()
-            if clear_side_effects:
-                mock.side_effect = None
+            mock.reset_mock(return_value=clear_return_values, side_effect=clear_side_effects)
+            interface = getattr(mock, self.__COLLECTION_MARKER)
+            default_return = self.__DEFAULTS.get(interface)
+            mock.return_value = default_return
 
 
 class MockContractAgency(ContractAgency):

--- a/tests/mock/agents.py
+++ b/tests/mock/agents.py
@@ -163,9 +163,10 @@ class MockContractAgent:
     def reset(self, clear_side_effects: bool = True, clear_return_values: bool = True) -> None:
         for mock in self._MOCK_METHODS:
             mock.reset_mock(return_value=clear_return_values, side_effect=clear_side_effects)
-            interface = getattr(mock, self.__COLLECTION_MARKER)
-            default_return = self.__DEFAULTS.get(interface)
-            mock.return_value = default_return
+            if clear_return_values:
+                interface = getattr(mock, self.__COLLECTION_MARKER)
+                default_return = self.__DEFAULTS.get(interface)
+                mock.return_value = default_return
 
 
 class MockContractAgency(ContractAgency):


### PR DESCRIPTION
Mock.reset_mock() doesn't do that by default so return values remained between test modules