### PR TITLE
Solidity -> 0.7.0

### DIFF
--- a/nucypher/blockchain/eth/sol/__conf__.py
+++ b/nucypher/blockchain/eth/sol/__conf__.py
@@ -15,4 +15,4 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-SOLIDITY_COMPILER_VERSION = 'v0.6.9'
+SOLIDITY_COMPILER_VERSION = 'v0.7.0'

--- a/nucypher/blockchain/eth/sol/source/aragon/interfaces/IERC900History.sol
+++ b/nucypher/blockchain/eth/sol/source/aragon/interfaces/IERC900History.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 // Minimum interface to interact with Aragon's Aggregator

--- a/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Adjudicator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 import "contracts/lib/ReEncryptionValidator.sol";
 import "contracts/lib/SignatureVerifier.sol";
@@ -59,9 +59,7 @@ contract Adjudicator is Upgradeable {
         uint256 _penaltyHistoryCoefficient,
         uint256 _percentagePenaltyCoefficient,
         uint256 _rewardCoefficient
-    )
-        public
-    {
+    ) {
         // Sanity checks.
         require(_escrow.secondsPerPeriod() > 0 &&  // This contract has an escrow, and it's not the null address.
             // The reward and penalty coefficients are set.

--- a/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/Issuer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/NuCypherToken.sol";
@@ -87,9 +87,7 @@ abstract contract Issuer is Upgradeable {
         uint16 _maximumRewardedPeriods,
         uint256 _firstPhaseTotalSupply,
         uint256 _firstPhaseMaxIssuance
-    )
-        public
-    {
+    ) {
         uint256 localTotalSupply = _token.totalSupply();
         require(localTotalSupply > 0 &&
             _issuanceDecayCoefficient != 0 &&

--- a/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/MultiSig.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "zeppelin/math/SafeMath.sol";
@@ -38,7 +38,7 @@ contract MultiSig {
     * @param _required Number of required signings
     * @param _owners List of initial owners.
     */
-    constructor (uint8 _required, address[] memory _owners) public {
+    constructor (uint8 _required, address[] memory _owners) {
         require(_owners.length <= MAX_OWNER_COUNT &&
             _required <= _owners.length &&
             _required > 0);

--- a/nucypher/blockchain/eth/sol/source/contracts/NuCypherToken.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/NuCypherToken.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "zeppelin/token/ERC20/ERC20.sol";
@@ -18,7 +18,7 @@ contract NuCypherToken is ERC20, ERC20Detailed('NuCypher', 'NU', 18) {
     * @notice Set amount of tokens
     * @param _totalSupplyOfTokens Total number of tokens
     */
-    constructor (uint256 _totalSupplyOfTokens) public {
+    constructor (uint256 _totalSupplyOfTokens) {
         _mint(msg.sender, _totalSupplyOfTokens);
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "aragon/interfaces/IERC900History.sol";
@@ -8,6 +8,7 @@ import "contracts/Issuer.sol";
 import "contracts/lib/Bits.sol";
 import "contracts/lib/Snapshot.sol";
 import "zeppelin/math/SafeMath.sol";
+import "zeppelin/token/ERC20/SafeERC20.sol";
 
 
 /**
@@ -49,6 +50,7 @@ contract StakingEscrow is Issuer, IERC900History {
     using Bits for uint256;
     using SafeMath for uint256;
     using Snapshot for uint128[];
+    using SafeERC20 for NuCypherToken;
 
     event Deposited(address indexed staker, uint256 value, uint16 periods);
     event Locked(address indexed staker, uint256 value, uint16 firstPeriod, uint16 periods);
@@ -186,7 +188,6 @@ contract StakingEscrow is Issuer, IERC900History {
         uint16 _minWorkerPeriods,
         bool _isTestContract
     )
-        public
         Issuer(
             _token,
             _hoursPerPeriod,

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "zeppelin/math/SafeMath.sol";
@@ -103,9 +103,7 @@ contract WorkLock is Ownable {
         uint256 _boostingRefund,
         uint16 _stakingPeriods,
         uint256 _minAllowedBid
-    )
-        public
-    {
+    ) {
         uint256 totalSupply = _token.totalSupply();
         require(totalSupply > 0 &&                              // token contract is deployed and accessible
             _escrow.secondsPerPeriod() > 0 &&                   // escrow contract is deployed and accessible

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/AdditionalMath.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/AdditionalMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "zeppelin/math/SafeMath.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/Bits.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/Bits.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 /**
 * @dev Taken from https://github.com/ethereum/solidity-examples/blob/master/src/bits/Bits.sol

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/ReEncryptionValidator.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 import "contracts/lib/UmbralDeserializer.sol";
 import "contracts/lib/SignatureVerifier.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/SignatureVerifier.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/Snapshot.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/Snapshot.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/lib/UmbralDeserializer.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Dispatcher.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "./Upgradeable.sol";
@@ -39,7 +39,7 @@ contract Dispatcher is Upgradeable, ERCProxy {
     /**
     * @param _target Target contract address
     */
-    constructor(address _target) public upgrading {
+    constructor(address _target) upgrading {
         require(_target.isContract());
         // Checks that target contract inherits Dispatcher state
         verifyState(_target);

--- a/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/proxy/Upgradeable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "zeppelin/ownership/Ownable.sol";

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/AbstractStakingContract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "zeppelin/ownership/Ownable.sol";
@@ -18,7 +18,7 @@ contract StakingInterfaceRouter is Ownable {
     /**
     * @param _target Address of the interface contract
     */
-    constructor(BaseStakingInterface _target) public {
+    constructor(BaseStakingInterface _target) {
         require(address(_target.token()) != address(0));
         target = _target;
     }
@@ -51,7 +51,7 @@ abstract contract AbstractStakingContract {
     /**
     * @param _router Interface router contract address
     */
-    constructor(StakingInterfaceRouter _router) public {
+    constructor(StakingInterfaceRouter _router) {
         router = _router;
         NuCypherToken localToken = _router.target().token();
         require(address(localToken) != address(0));

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/PreallocationEscrow.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "zeppelin/ownership/Ownable.sol";
@@ -14,6 +14,8 @@ import "contracts/staking_contracts/AbstractStakingContract.sol";
 */
 contract PreallocationEscrow is AbstractStakingContract, Ownable {
     using SafeMath for uint256;
+    using SafeERC20 for NuCypherToken;
+    using Address for address payable;
 
     event TokensDeposited(address indexed sender, uint256 value, uint256 duration);
     event TokensWithdrawn(address indexed owner, uint256 value);
@@ -27,7 +29,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     /**
     * @param _router Address of the StakingInterfaceRouter contract
     */
-    constructor(StakingInterfaceRouter _router) public AbstractStakingContract(_router) {
+    constructor(StakingInterfaceRouter _router) AbstractStakingContract(_router) {
         stakingEscrow = _router.target().escrow();
     }
 
@@ -131,7 +133,7 @@ contract PreallocationEscrow is AbstractStakingContract, Ownable {
     /**
     * @notice Calling fallback function is allowed only for the owner
     */
-    function isFallbackAllowed() public override returns (bool) {
+    function isFallbackAllowed() public view override returns (bool) {
         return msg.sender == owner();
     }
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/staking_contracts/AbstractStakingContract.sol";
@@ -33,9 +33,7 @@ contract BaseStakingInterface {
         StakingEscrow _escrow,
         PolicyManager _policyManager,
         WorkLock _workLock
-    )
-        public
-    {
+    ) {
         require(_token.totalSupply() > 0 &&
             _escrow.secondsPerPeriod() > 0 &&
             _policyManager.secondsPerPeriod() > 0 &&
@@ -110,7 +108,7 @@ contract StakingInterface is BaseStakingInterface {
         PolicyManager _policyManager,
         WorkLock _workLock
     )
-        public BaseStakingInterface(_token, _escrow, _policyManager, _workLock)
+        BaseStakingInterface(_token, _escrow, _policyManager, _workLock)
     {
     }
 

--- a/nucypher/blockchain/eth/sol/source/zeppelin/math/Math.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/math/Math.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/zeppelin/math/SafeMath.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/math/SafeMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/zeppelin/ownership/Ownable.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/ownership/Ownable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**
@@ -8,7 +8,7 @@ pragma solidity ^0.6.1;
  * @dev The Ownable contract has an owner address, and provides basic authorization control
  * functions, this simplifies the implementation of "user permissions".
  */
-contract Ownable {
+abstract contract Ownable {
     address private _owner;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
@@ -17,7 +17,7 @@ contract Ownable {
      * @dev The Ownable constructor sets the original `owner` of the contract to the sender
      * account.
      */
-    constructor () internal {
+    constructor () {
         _owner = msg.sender;
         emit OwnershipTransferred(address(0), _owner);
     }

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "./IERC20.sol";

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20Detailed.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/ERC20Detailed.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "./IERC20.sol";
@@ -17,7 +17,7 @@ abstract contract ERC20Detailed is IERC20 {
     string private _symbol;
     uint8 private _decimals;
 
-    constructor (string memory name, string memory symbol, uint8 decimals) public {
+    constructor (string memory name, string memory symbol, uint8 decimals) {
         _name = name;
         _symbol = symbol;
         _decimals = decimals;

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/IERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/SafeERC20.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/token/ERC20/SafeERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "./IERC20.sol";

--- a/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
+++ b/nucypher/blockchain/eth/sol/source/zeppelin/utils/Address.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 /**
  * @dev Collection of functions related to the address type

--- a/tests/acceptance/blockchain/interfaces/contracts/multiversion/v1/VersionTest.sol
+++ b/tests/acceptance/blockchain/interfaces/contracts/multiversion/v1/VersionTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/tests/acceptance/blockchain/interfaces/contracts/multiversion/v2/VersionTest.sol
+++ b/tests/acceptance/blockchain/interfaces/contracts/multiversion/v2/VersionTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/tests/contracts/contracts/AdjudicatorTestSet.sol
+++ b/tests/contracts/contracts/AdjudicatorTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/Adjudicator.sol";
@@ -72,7 +72,6 @@ contract AdjudicatorV2Mock is Adjudicator {
         uint256 _penaltyHistoryCoefficient,
         uint256 _rewardCoefficient
     )
-        public
         Adjudicator(
             _escrow,
             _hashAlgorithm,

--- a/tests/contracts/contracts/IssuerTestSet.sol
+++ b/tests/contracts/contracts/IssuerTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/Issuer.sol";
@@ -23,7 +23,6 @@ contract IssuerMock is Issuer {
         uint256 _firstPhaseTotalSupply,
         uint256 _firstPhaseMaxIssuance
     )
-        public
         Issuer(
             _token,
             _hoursPerPeriod,
@@ -85,7 +84,6 @@ contract IssuerV2Mock is Issuer {
         uint256 _firstPhaseTotalSupply,
         uint256 _firstPhaseMaxIssuance
     )
-        public
         Issuer(
             _token,
             _hoursPerPeriod,

--- a/tests/contracts/contracts/LibTestSet.sol
+++ b/tests/contracts/contracts/LibTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "contracts/lib/SignatureVerifier.sol";

--- a/tests/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/contracts/contracts/PolicyManagerTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/PolicyManager.sol";
@@ -12,7 +12,7 @@ import "contracts/StakingEscrow.sol";
 */
 contract PolicyManagerBad is PolicyManager {
 
-    constructor(StakingEscrow _escrow) public PolicyManager(_escrow) {
+    constructor(StakingEscrow _escrow) PolicyManager(_escrow) {
     }
 
     function getNodeFeeDelta(address, uint16) public view override returns (int256) {}
@@ -27,7 +27,7 @@ contract PolicyManagerV2Mock is PolicyManager {
 
     uint256 public valueToCheck;
 
-    constructor(StakingEscrow _escrow) public PolicyManager(_escrow) {
+    constructor(StakingEscrow _escrow) PolicyManager(_escrow) {
     }
 
     function setValueToCheck(uint256 _valueToCheck) public {
@@ -60,7 +60,7 @@ contract StakingEscrowForPolicyMock {
     /**
     * @param _hoursPerPeriod Size of period in hours
     */
-    constructor(uint16 _hoursPerPeriod) public {
+    constructor(uint16 _hoursPerPeriod) {
         secondsPerPeriod = uint32(_hoursPerPeriod * 1 hours);
     }
 
@@ -159,7 +159,7 @@ contract StakingEscrowForPolicyMock {
 */
 contract ExtendedPolicyManager is PolicyManager {
 
-    constructor(StakingEscrow _escrow) public PolicyManager(_escrow) {
+    constructor(StakingEscrow _escrow) PolicyManager(_escrow) {
     }
 
     function setNodeFeeDelta(address _node, uint16 _period, int256 _value) external {

--- a/tests/contracts/contracts/ReceiveApprovalMethodMock.sol
+++ b/tests/contracts/contracts/ReceiveApprovalMethodMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/tests/contracts/contracts/ReentrancyTest.sol
+++ b/tests/contracts/contracts/ReentrancyTest.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 /**

--- a/tests/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/contracts/contracts/StakingContractsTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/NuCypherToken.sol";
@@ -24,7 +24,7 @@ contract StakingEscrowForStakingContractMock {
     address public worker;
     bool public windDown;
 
-    constructor(NuCypherToken _token) public {
+    constructor(NuCypherToken _token) {
         token = _token;
     }
 
@@ -241,11 +241,13 @@ contract DestroyableStakingInterface {
 * @notice Simple implementation of AbstractStakingContract
 */
 contract SimpleStakingContract is AbstractStakingContract, Ownable {
+    using SafeERC20 for NuCypherToken;
+    using Address for address payable;
 
     /**
     * @param _router Address of the StakingInterfaceRouter contract
     */
-    constructor(StakingInterfaceRouter _router) public AbstractStakingContract(_router) {}
+    constructor(StakingInterfaceRouter _router) AbstractStakingContract(_router) {}
 
     /**
     * @notice Withdraw available amount of tokens to owner
@@ -267,7 +269,7 @@ contract SimpleStakingContract is AbstractStakingContract, Ownable {
     /**
     * @notice Calling fallback function is allowed only for the owner
     */
-    function isFallbackAllowed() public override returns (bool) {
+    function isFallbackAllowed() public view override returns (bool) {
         return msg.sender == owner();
     }
 

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/StakingEscrow.sol";
@@ -10,6 +10,7 @@ import "contracts/NuCypherToken.sol";
 * @notice Enhanced version of StakingEscrow to use in tests
 */
 contract EnhancedStakingEscrow is StakingEscrow {
+    using AdditionalMath for uint16;
 
     constructor(
         NuCypherToken _token,
@@ -26,7 +27,6 @@ contract EnhancedStakingEscrow is StakingEscrow {
         uint16 _minWorkerPeriods,
         bool _isTestContract
     )
-        public
         StakingEscrow(
             _token,
             _hoursPerPeriod,
@@ -83,7 +83,6 @@ contract StakingEscrowBad is StakingEscrow {
         uint16 _minWorkerPeriods,
         bool _isTestContract
     )
-        public
         StakingEscrow(
             _token,
             _hoursPerPeriod,
@@ -130,7 +129,6 @@ contract StakingEscrowV2Mock is StakingEscrow {
         bool _isTestContract,
         uint256 _valueToCheck
     )
-        public
         StakingEscrow(
             _token,
             _hoursPerPeriod,
@@ -175,7 +173,7 @@ contract PolicyManagerForStakingEscrowMock {
     StakingEscrow public immutable escrow;
     mapping (address => uint16[]) public nodes;
 
-    constructor(address, StakingEscrow _escrow) public {
+    constructor(address, StakingEscrow _escrow) {
         escrow = _escrow;
     }
 
@@ -209,7 +207,7 @@ contract AdjudicatorForStakingEscrowMock {
 
     StakingEscrow public immutable escrow;
 
-    constructor(StakingEscrow _escrow) public {
+    constructor(StakingEscrow _escrow) {
         escrow = _escrow;
     }
 
@@ -233,7 +231,7 @@ contract Intermediary {
     NuCypherToken immutable token;
     StakingEscrow immutable escrow;
 
-    constructor(NuCypherToken _token, StakingEscrow _escrow) public {
+    constructor(NuCypherToken _token, StakingEscrow _escrow) {
         token = _token;
         escrow = _escrow;
     }
@@ -261,7 +259,7 @@ contract WorkLockForStakingEscrowMock {
 
     StakingEscrow public immutable escrow;
 
-    constructor(StakingEscrow _escrow) public {
+    constructor(StakingEscrow _escrow) {
         escrow = _escrow;
     }
 

--- a/tests/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/contracts/contracts/WorkLockTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.5;
+pragma solidity ^0.7.0;
 
 
 import "contracts/NuCypherToken.sol";
@@ -31,9 +31,7 @@ contract StakingEscrowForWorkLockMock {
         uint256 _minAllowableLockedTokens,
         uint256 _maxAllowableLockedTokens,
         uint16 _minLockedPeriods
-    )
-        public
-    {
+    ) {
         token = _token;
         minAllowableLockedTokens = _minAllowableLockedTokens;
         maxAllowableLockedTokens = _maxAllowableLockedTokens;

--- a/tests/contracts/contracts/proxy/BadContracts.sol
+++ b/tests/contracts/contracts/proxy/BadContracts.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "./ContractV1.sol";
@@ -63,7 +63,7 @@ contract ContractV2BadStorage is Upgradeable {
 */
 contract ContractV2BadVerifyState is ContractV1(1) {
 
-    function verifyState(address) public override {
+    function verifyState(address) public pure override {
         revert();
     }
 

--- a/tests/contracts/contracts/proxy/ContractV1.sol
+++ b/tests/contracts/contracts/proxy/ContractV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -40,7 +40,7 @@ contract ContractV1 is Upgradeable {
     mapping (uint256 => Structure2) public mappingStructures;
     uint256 public mappingStructuresLength;
 
-    constructor(uint256 _storageValue) public {
+    constructor(uint256 _storageValue) {
         storageValue = _storageValue;
     }
 

--- a/tests/contracts/contracts/proxy/ContractV2.sol
+++ b/tests/contracts/contracts/proxy/ContractV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -35,7 +35,7 @@ contract ContractV2 is Upgradeable {
 
     uint256 public storageValueToCheck;
 
-    constructor(uint256 _storageValueToCheck) public {
+    constructor(uint256 _storageValueToCheck) {
         storageValueToCheck = _storageValueToCheck;
     }
 

--- a/tests/contracts/contracts/proxy/ContractV3.sol
+++ b/tests/contracts/contracts/proxy/ContractV3.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "./ContractV2.sol";
@@ -11,7 +11,6 @@ contract ContractV3 is ContractV2 {
     uint256 public anotherStorageValue;
 
     constructor(uint256 _storageValueToCheck)
-        public
         ContractV2(_storageValueToCheck)
     {
     }

--- a/tests/contracts/contracts/proxy/ContractV4.sol
+++ b/tests/contracts/contracts/proxy/ContractV4.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -48,7 +48,7 @@ contract ContractV4 is Upgradeable {
     uint256 reservedSlot12;
     uint256 public anotherStorageValue;
 
-    constructor(uint256 _storageValueToCheck) public {
+    constructor(uint256 _storageValueToCheck) {
         setStorageValueToCheck(_storageValueToCheck);
     }
 

--- a/tests/contracts/contracts/proxy/Destroyable.sol
+++ b/tests/contracts/contracts/proxy/Destroyable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "contracts/proxy/Upgradeable.sol";
@@ -14,7 +14,7 @@ contract Destroyable is Upgradeable {
     uint256 public constructorValue;
     uint256 public functionValue;
 
-    constructor(uint256 _constructorValue) public {
+    constructor(uint256 _constructorValue) {
         constructorValue = _constructorValue;
     }
 

--- a/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
+++ b/tests/contracts/contracts/proxy/ReceiveFallbackTestSet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-pragma solidity ^0.6.1;
+pragma solidity ^0.7.0;
 
 
 import "contracts/proxy/Upgradeable.sol";


### PR DESCRIPTION
Test for upgrading contracts is failing because we compile two sets of contracts with the same compiler version