### PR TITLE
New Logger with automatic escaping of curly braces 

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -31,7 +31,6 @@ from constant_sorrow.constants import FULL, NO_WORKER_BONDED, WORKER_NOT_RUNNING
 from decimal import Decimal
 from eth_tester.exceptions import TransactionFailed as TestTransactionFailed
 from eth_utils import to_canonical_address, to_checksum_address
-from twisted.logger import Logger
 from typing import Dict, Iterable, List, Optional, Tuple
 from web3 import Web3
 from web3.exceptions import ValidationError
@@ -84,6 +83,7 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nicknames import nickname_from_seed
 from nucypher.types import NuNits, Period
+from nucypher.utilities.logging import Logger
 
 
 class BaseActor:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -29,7 +29,6 @@ from eth_typing.encoding import HexStr
 from eth_typing.evm import ChecksumAddress
 from eth_utils.address import to_checksum_address
 from hexbytes.main import HexBytes
-from twisted.logger import Logger  # type: ignore
 from typing import Dict, Iterable, List, Tuple, Type, Union, Any, Optional, cast
 from web3.contract import Contract, ContractFunction
 from web3.types import Wei, Timestamp, TxReceipt, TxParams, Nonce
@@ -67,6 +66,7 @@ from nucypher.types import (
     StakingEscrowParameters,
     Evidence
 )
+from nucypher.utilities.logging import Logger  # type: ignore
 
 
 class EthereumContractAgent:

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -25,7 +25,6 @@ from constant_sorrow.constants import NOT_RUNNING, UNKNOWN_DEVELOPMENT_CHAIN_ID
 from cytoolz.dicttoolz import dissoc
 from eth_account import Account
 from eth_account.messages import encode_defunct
-from eth_typing import HexStr
 from eth_typing.evm import BlockNumber, ChecksumAddress
 from eth_utils import to_canonical_address, to_checksum_address
 from geth import LoggingMixin
@@ -37,7 +36,6 @@ from geth.chain import (
     is_ropsten_chain
 )
 from geth.process import BaseGethProcess
-from twisted.logger import Logger
 from typing import Union
 from web3 import Web3
 from web3.contract import Contract
@@ -47,6 +45,7 @@ from web3.exceptions import TimeExhausted, TransactionNotFound
 
 from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, DEPLOY_DIR, USER_LOG_DIR
+from nucypher.utilities.logging import Logger
 
 UNKNOWN_DEVELOPMENT_CHAIN_ID.bool_value(True)
 

--- a/nucypher/blockchain/eth/decorators.py
+++ b/nucypher/blockchain/eth/decorators.py
@@ -25,10 +25,10 @@ from constant_sorrow.constants import (
     UNKNOWN_CONTRACT_INTERFACE
 )
 from datetime import datetime
-from twisted.logger import Logger
 from typing import Callable, Optional, Union
 
 from nucypher.types import ContractReturnValue
+from nucypher.utilities.logging import Logger
 
 ContractInterfaces = Union[
     CONTRACT_CALL,

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -770,7 +770,6 @@ class BlockchainDeployerInterface(BlockchainInterface):
             deploy_transaction.update({'gas': gas_limit})
 
         pprint_args = ', '.join(list(map(str, constructor_args)) + list(f"{k}={v}" for k, v in constructor_kwargs.items()))
-        pprint_args = pprint_args.replace("{", "{{").replace("}", "}}")  # TODO: See #724
 
         contract_factory = self.get_contract_factory(contract_name=contract_name, version=contract_version)
         self.log.info(f"Deploying contract {contract_name}:{contract_factory.version} with "

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -16,8 +16,6 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-import collections
-
 import click
 import os
 import pprint
@@ -34,8 +32,7 @@ from constant_sorrow.constants import (
 from eth_tester import EthereumTester
 from eth_tester.exceptions import TransactionFailed as TestTransactionFailed
 from eth_utils import to_checksum_address
-from twisted.logger import Logger
-from typing import Callable, List, NamedTuple, Tuple, Union
+from typing import Callable, NamedTuple, Tuple, Union
 from urllib.parse import urlparse
 from web3 import HTTPProvider, IPCProvider, Web3, WebsocketProvider, middleware
 from web3.contract import Contract, ContractConstructor, ContractFunction
@@ -59,7 +56,7 @@ from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.blockchain.eth.utils import get_transaction_name, prettify_eth_amount
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter, StdoutEmitter
-from nucypher.utilities.logging import GlobalLoggerSettings
+from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 
 Web3Providers = Union[IPCProvider, WebsocketProvider, HTTPProvider, EthereumTester]
 

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -25,12 +25,12 @@ import shutil
 import tempfile
 from abc import ABC, abstractmethod
 from constant_sorrow.constants import NO_REGISTRY_SOURCE, REGISTRY_COMMITTED
-from twisted.logger import Logger
 from typing import Dict, Iterator, List, Tuple, Type, Union
 
 from nucypher.blockchain.eth.constants import PREALLOCATION_ESCROW_CONTRACT_NAME
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
+from nucypher.utilities.logging import Logger
 
 
 class CanonicalRegistrySource(ABC):

--- a/nucypher/blockchain/eth/signers.py
+++ b/nucypher/blockchain/eth/signers.py
@@ -27,14 +27,13 @@ from eth_account.messages import encode_defunct
 from eth_account.signers.local import LocalAccount
 from eth_utils import apply_formatters_to_dict, is_address, to_checksum_address
 from hexbytes import HexBytes
-from pathlib import Path
-from twisted.logger import Logger
 from typing import Dict, List, Tuple
 from urllib.parse import urlparse
 from web3 import IPCProvider, Web3
 
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.decorators import validate_checksum_address
+from nucypher.utilities.logging import Logger
 
 
 class Signer(ABC):

--- a/nucypher/blockchain/eth/sol/compile.py
+++ b/nucypher/blockchain/eth/sol/compile.py
@@ -16,16 +16,15 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-import collections
 from os.path import abspath, dirname
 
 import itertools
 import os
 import re
-from twisted.logger import Logger
 from typing import List, NamedTuple, Optional, Set
 
 from nucypher.blockchain.eth.sol import SOLIDITY_COMPILER_VERSION
+from nucypher.utilities.logging import Logger
 
 
 class SourceDirs(NamedTuple):

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -24,14 +24,14 @@ from constant_sorrow.constants import (EMPTY_STAKING_SLOT, NEW_STAKE, NOT_STAKIN
                                        UNKNOWN_WORKER_STATUS)
 from eth_utils import currency, is_checksum_address
 from twisted.internet import reactor, task
-from twisted.logger import Logger
-from typing import Callable, Dict, Tuple, Union
+from typing import Callable, Dict, Union
 
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.utils import datetime_at_period
 from nucypher.types import SubStakeInfo, NuNits, StakerInfo, Period
+from nucypher.utilities.logging import Logger
 
 
 class NU:

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -31,7 +31,6 @@ from nacl.hash import sha256
 from sqlalchemy import create_engine, or_
 from twisted.internet import reactor, threads
 from twisted.internet.task import LoopingCall
-from twisted.logger import Logger
 
 from nucypher.blockchain.economics import EconomicsFactory
 from nucypher.blockchain.eth.actors import NucypherTokenActor
@@ -44,6 +43,7 @@ from nucypher.characters.base import Character
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH, TEMPLATES_DIR
 from nucypher.crypto.powers import SigningPower, TransactingPower
 from nucypher.datastore.threading import ThreadedSession
+from nucypher.utilities.logging import Logger
 
 
 class Felix(Character, NucypherTokenActor):

--- a/nucypher/characters/control/controllers.py
+++ b/nucypher/characters/control/controllers.py
@@ -24,7 +24,6 @@ from abc import ABC, abstractmethod
 from flask import Flask, Response
 from hendrix.deploy.base import HendrixDeploy
 from twisted.internet import reactor, stdio
-from twisted.logger import Logger
 
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter, StdoutEmitter, WebEmitter
 from nucypher.characters.control.interfaces import CharacterPublicInterface
@@ -32,6 +31,7 @@ from nucypher.characters.control.specifications.exceptions import SpecificationE
 from nucypher.cli.processes import JSONRPCLineReceiver
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
 from nucypher.exceptions import DevelopmentInstallationRequired
+from nucypher.utilities.logging import Logger
 
 
 class CharacterControllerBase(ABC):

--- a/nucypher/characters/control/emitters.py
+++ b/nucypher/characters/control/emitters.py
@@ -21,10 +21,10 @@ import click
 import os
 from flask import Response
 from functools import partial
-from twisted.logger import Logger
 from typing import Callable, Union
 
 import nucypher
+from nucypher.utilities.logging import Logger
 
 
 def null_stream():

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -38,7 +38,6 @@ from json.decoder import JSONDecodeError
 from sqlalchemy.exc import OperationalError
 from twisted.internet import reactor, stdio, threads
 from twisted.internet.task import LoopingCall
-from twisted.logger import Logger
 from typing import Dict, Iterable, List, Set, Tuple, Union
 from umbral import pre
 from umbral.keys import UmbralPublicKey
@@ -76,6 +75,7 @@ from nucypher.network.nodes import NodeSprout, Teacher
 from nucypher.network.protocols import InterfaceInfo, parse_node_uri
 from nucypher.network.server import ProxyRESTServer, TLSHostingPower, make_rest_app
 from nucypher.network.trackers import AvailabilityTracker
+from nucypher.utilities.logging import Logger
 
 
 class Alice(Character, BlockchainPolicyAuthor):

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -18,13 +18,12 @@
 
 import click
 import os
-from twisted.logger import Logger
 
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter, StdoutEmitter
 from nucypher.cli.utils import get_env_bool
 from nucypher.cli.options import group_options
 from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT
-from nucypher.utilities.logging import GlobalLoggerSettings
+from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 
 
 class GroupGeneralConfig:

--- a/nucypher/cli/options.py
+++ b/nucypher/cli/options.py
@@ -20,7 +20,6 @@ from collections import namedtuple
 import click
 import functools
 import os
-from twisted.python.log import Logger
 
 from nucypher.blockchain.eth.constants import NUCYPHER_CONTRACT_NAMES
 from nucypher.cli.types import (
@@ -29,6 +28,7 @@ from nucypher.cli.types import (
     NETWORK_PORT,
     WEI
 )
+from nucypher.utilities.logging import Logger
 
 # Alphabetical
 
@@ -51,6 +51,7 @@ option_min_stake = click.option('--min-stake', help="The minimum stake the teach
 option_n = click.option('--n', help="N-Total KFrags", type=click.INT)
 option_poa = click.option('--poa/--disable-poa', help="Inject POA middleware", is_flag=True, default=None)
 option_registry_filepath = click.option('--registry-filepath', help="Custom contract registry filepath", type=EXISTING_READABLE_FILE)
+option_signer_uri = click.option('--signer', 'signer_uri', '-S', default=None, type=str)
 option_staking_address = click.option('--staking-address', help="Address of a NuCypher staker", type=EIP55_CHECKSUM_ADDRESS)
 option_teacher_uri = click.option('--teacher', 'teacher_uri', help="An Ursula URI to start learning from (seednode)", type=click.STRING)
 _option_middleware = click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True)
@@ -191,7 +192,7 @@ def process_middleware(mock_networking) -> tuple:
     try:
         from tests.utils.middleware import MockRestMiddleware
     except ImportError:
-        # It's okay to to not crash here despite not having the tests package available.
+        # It's okay to not crash here despite not having the tests package available.
         logger = Logger("CLI-Middleware-Optional-Handler")
         logger.info('--mock-networking flag is unavailable without dev install.')
     if mock_networking:
@@ -204,6 +205,5 @@ def process_middleware(mock_networking) -> tuple:
 
 option_middleware = wrap_option(
     process_middleware,
-    mock_networking=click.option('-Z', '--mock-networking', help="Use in-memory transport instead of networking", count=True),
-    )
-option_signer_uri = click.option('--signer', 'signer_uri', '-S', default=None, type=str)
+    mock_networking=_option_middleware,
+)

--- a/nucypher/cli/processes.py
+++ b/nucypher/cli/processes.py
@@ -24,10 +24,10 @@ import os
 from twisted.internet import reactor
 from twisted.internet.protocol import connectionDone
 from twisted.internet.stdio import StandardIO
-from twisted.logger import Logger
 from twisted.protocols.basic import LineReceiver
 
 from nucypher.blockchain.eth.clients import NuCypherGethGoerliProcess
+from nucypher.utilities.logging import Logger
 
 
 class UrsulaCommandProtocol(LineReceiver):

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -46,6 +46,8 @@ CONTRACT_ROOT = SOL_PACKAGE / 'source' / 'contracts'
 APP_DIR = AppDirs(nucypher.__title__, nucypher.__author__)
 DEFAULT_CONFIG_ROOT = os.getenv('NUCYPHER_CONFIG_ROOT', default=APP_DIR.user_data_dir)
 USER_LOG_DIR = os.getenv('NUCYPHER_USER_LOG_DIR', default=APP_DIR.user_log_dir)
+DEFAULT_LOG_FILENAME = "nucypher.log"
+DEFAULT_JSON_LOG_FILENAME = "nucypher.json"
 
 
 # Static Seednodes

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -23,7 +23,6 @@ from appdirs import AppDirs
 from pathlib import Path
 
 import nucypher
-from nucypher.blockchain.eth import sol
 
 # Environment variables
 NUCYPHER_ENVVAR_KEYRING_PASSWORD = "NUCYPHER_KEYRING_PASSWORD"
@@ -38,8 +37,6 @@ NUCYPHER_ENVVAR_WORKER_IP_ADDRESS = 'NUCYPHER_WORKER_IP_ADDRESS'
 NUCYPHER_PACKAGE = Path(nucypher.__file__).parent.resolve()
 BASE_DIR = NUCYPHER_PACKAGE.parent.resolve()
 DEPLOY_DIR = BASE_DIR / 'deploy'
-SOL_PACKAGE = Path(sol.__file__).parent.resolve()
-CONTRACT_ROOT = SOL_PACKAGE / 'source' / 'contracts'
 
 
 # User Application Filepaths

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -37,7 +37,6 @@ from eth_keys import KeyAPI as EthKeyAPI
 from eth_utils import to_checksum_address
 from nacl.exceptions import CryptoError
 from nacl.secret import SecretBox
-from twisted.logger import Logger
 from typing import Callable, ClassVar, Dict, List, Tuple, Union
 from umbral.keys import UmbralKeyingMaterial, UmbralPrivateKey, UmbralPublicKey, derive_key_from_password
 
@@ -46,6 +45,7 @@ from nucypher.crypto.api import generate_teacher_certificate
 from nucypher.crypto.constants import BLAKE2B
 from nucypher.crypto.powers import (DecryptingPower, DerivedKeyBasedPower, KeyPairBasedPower, SigningPower)
 from nucypher.network.server import TLSHostingPower
+from nucypher.utilities.logging import Logger
 
 FILE_ENCODING = 'utf-8'
 

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -28,7 +28,6 @@ from constant_sorrow.constants import (
 )
 from eth_utils.address import is_checksum_address
 from tempfile import TemporaryDirectory
-from twisted.logger import Logger
 from typing import Callable, List, Set, Union
 from umbral.signing import Signature
 
@@ -45,6 +44,7 @@ from nucypher.config.keyring import NucypherKeyring
 from nucypher.config.storages import ForgetfulNodeStorage, LocalFileBasedNodeStorage, NodeStorage
 from nucypher.crypto.powers import CryptoPower, CryptoPowerUp
 from nucypher.network.middleware import RestMiddleware
+from nucypher.utilities.logging import Logger
 
 
 # TODO: Relocate - #1575

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -27,13 +27,13 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate, NameOID
 from eth_utils import is_checksum_address
-from twisted.logger import Logger
 from typing import Any, Callable, Set, Tuple, Union
 
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.api import read_certificate_pseudonym
+from nucypher.utilities.logging import Logger
 
 
 class NodeStorage(ABC):

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -24,9 +24,10 @@ from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import CERTIFICATE_NOT_SAVED, EXEMPT_FROM_VERIFICATION
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from twisted.logger import Logger
 from umbral.cfrags import CapsuleFrag
 from umbral.signing import Signature
+
+from nucypher.utilities.logging import Logger
 
 EXEMPT_FROM_VERIFICATION.bool_value(False)
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -34,7 +34,6 @@ from eth_utils import to_checksum_address
 from requests.exceptions import SSLError
 from twisted.internet import defer, reactor, task
 from twisted.internet.threads import deferToThread
-from twisted.logger import Logger
 from typing import Set, Tuple, Union
 from umbral.signing import Signature
 
@@ -55,6 +54,7 @@ from nucypher.network.middleware import RestMiddleware
 from nucypher.network.nicknames import nickname_from_seed
 from nucypher.network.protocols import SuspiciousActivity
 from nucypher.network.server import TLSHostingPower
+from nucypher.utilities.logging import Logger
 
 
 def icon_from_checksum(checksum,

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -536,8 +536,7 @@ class Learner:
             self.log.critical("Unhandled error during node learning.  Attempting graceful crash.")
             reactor.callFromThread(self._crash_gracefully, failure=failure)
         else:
-            cleaned_traceback = failure.getTraceback().replace('{', '').replace('}', '')  # FIXME: Amazing.  724
-            self.log.warn("Unhandled error during node learning: {}".format(cleaned_traceback))
+            self.log.warn(f"Unhandled error during node learning: {failure.getTraceback()}")
             if not self._learning_task.running:
                 self.start_learning_loop()  # TODO: Consider a single entry point for this with more elegant pause and unpause.  NRN
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -23,7 +23,6 @@ from constant_sorrow.constants import FLEET_STATES_MATCH, NO_BLOCKCHAIN_CONNECTI
 from flask import Flask, Response, jsonify, request
 from hendrix.experience import crosstown_traffic
 from jinja2 import Template, TemplateError
-from twisted.logger import Logger
 from typing import Tuple
 from umbral.keys import UmbralPublicKey
 from umbral.kfrags import KFrag
@@ -42,6 +41,7 @@ from nucypher.datastore.threading import ThreadedSession
 from nucypher.network import LEARNING_LOOP_VERSION
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.protocols import InterfaceInfo
+from nucypher.utilities.logging import Logger
 
 HERE = BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 TEMPLATES_DIR = os.path.join(HERE, "templates")

--- a/nucypher/network/trackers.py
+++ b/nucypher/network/trackers.py
@@ -20,12 +20,12 @@ import random
 import maya
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
-from twisted.logger import Logger
 from typing import Union
 
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
 from nucypher.network.nodes import NodeSprout
+from nucypher.utilities.logging import Logger
 
 
 class AvailabilityTracker:

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -22,7 +22,6 @@ import maya
 from abc import ABC, abstractmethod
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import NOT_SIGNED, UNKNOWN_KFRAG
-from twisted.logger import Logger
 from typing import Generator, List, Set
 from umbral.keys import UmbralPublicKey
 from umbral.kfrags import KFrag
@@ -37,6 +36,7 @@ from nucypher.crypto.powers import DecryptingPower, SigningPower
 from nucypher.crypto.utils import construct_policy_id
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
+from nucypher.utilities.logging import Logger
 
 
 class Arrangement:

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -21,17 +21,22 @@ from contextlib import contextmanager
 import pathlib
 from twisted.logger import (
     FileLogObserver,
-    LogLevel,
     formatEvent,
     formatEventAsClassicLogText,
     globalLogPublisher,
-    jsonFileLogObserver
+    jsonFileLogObserver,
+    LogLevel,
 )
 from twisted.logger import Logger as TwistedLogger
 from twisted.python.logfile import LogFile
 
 import nucypher
-from nucypher.config.constants import NUCYPHER_SENTRY_ENDPOINT, USER_LOG_DIR
+from nucypher.config.constants import (
+    DEFAULT_JSON_LOG_FILENAME,
+    DEFAULT_LOG_FILENAME,
+    NUCYPHER_SENTRY_ENDPOINT,
+    USER_LOG_DIR,
+)
 
 ONE_MEGABYTE = 1_048_576
 MAXIMUM_LOG_SIZE = ONE_MEGABYTE * 10
@@ -171,14 +176,14 @@ def _ensure_dir_exists(path):
     pathlib.Path(path).mkdir(parents=True, exist_ok=True)
 
 
-def get_json_file_observer(name="nucypher.json", path=USER_LOG_DIR):
+def get_json_file_observer(name=DEFAULT_JSON_LOG_FILENAME, path=USER_LOG_DIR):
     _ensure_dir_exists(path)
     logfile = LogFile(name=name, directory=path, rotateLength=MAXIMUM_LOG_SIZE, maxRotatedFiles=MAX_LOG_FILES)
     observer = jsonFileLogObserver(outFile=logfile)
     return observer
 
 
-def get_text_file_observer(name="nucypher.log", path=USER_LOG_DIR):
+def get_text_file_observer(name=DEFAULT_LOG_FILENAME, path=USER_LOG_DIR):
     _ensure_dir_exists(path)
     logfile = LogFile(name=name, directory=path, rotateLength=MAXIMUM_LOG_SIZE, maxRotatedFiles=MAX_LOG_FILES)
     observer = FileLogObserver(formatEvent=formatEventAsClassicLogText, outFile=logfile)

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -15,11 +15,19 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import re
 from contextlib import contextmanager
 
 import pathlib
-from twisted.logger import FileLogObserver, LogLevel, formatEvent, formatEventAsClassicLogText, globalLogPublisher, \
+from twisted.logger import (
+    FileLogObserver,
+    LogLevel,
+    formatEvent,
+    formatEventAsClassicLogText,
+    globalLogPublisher,
     jsonFileLogObserver
+)
+from twisted.logger import Logger as TwistedLogger
 from twisted.python.logfile import LogFile
 
 import nucypher
@@ -175,3 +183,31 @@ def get_text_file_observer(name="nucypher.log", path=USER_LOG_DIR):
     logfile = LogFile(name=name, directory=path, rotateLength=MAXIMUM_LOG_SIZE, maxRotatedFiles=MAX_LOG_FILES)
     observer = FileLogObserver(formatEvent=formatEventAsClassicLogText, outFile=logfile)
     return observer
+
+
+class Logger(TwistedLogger):
+    """Drop-in replacement of Twisted's Logger, patching the emit() method to tolerate inputs with curly braces,
+    i.e., not compliant with PEP 3101.
+
+    See Issue #724 and, particularly, https://github.com/nucypher/nucypher/issues/724#issuecomment-600190455"""
+
+    CURLY_BRACES_REGEX = re.compile('{+|}+')
+
+    @classmethod
+    def escape_format_string(cls, string):
+        """
+        Escapes curly braces from a PEP-3101's format string when there's a sequence of odd length
+        """
+
+        def escape_group_of_curly_braces(match):
+            curlies = match.group()
+            if len(curlies) % 2 == 1:
+                curlies += curlies
+            return curlies
+
+        escaped_string = cls.CURLY_BRACES_REGEX.sub(escape_group_of_curly_braces, string)
+        return escaped_string
+
+    def emit(self, level, format=None, **kwargs):
+        clean_format = self.escape_format_string(str(format))
+        super().emit(level=level, format=clean_format, **kwargs)

--- a/tests/acceptance/cli/test_bob.py
+++ b/tests/acceptance/cli/test_bob.py
@@ -21,7 +21,6 @@ from unittest import mock
 
 import os
 import pytest
-from twisted.logger import Logger
 
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter
 from nucypher.characters.lawful import Ursula
@@ -32,7 +31,7 @@ from nucypher.config.characters import BobConfiguration
 from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import SigningPower
-from nucypher.utilities.logging import GlobalLoggerSettings
+from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 from tests.constants import (
     FAKE_PASSWORD_CONFIRMED,
     INSECURE_DEVELOPMENT_PASSWORD,

--- a/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
@@ -21,7 +21,6 @@ import random
 import maya
 import os
 import pytest
-from twisted.logger import Logger
 from web3 import Web3
 
 from nucypher.blockchain.eth.actors import Staker
@@ -33,13 +32,14 @@ from nucypher.blockchain.eth.token import NU, Stake, StakeList
 from nucypher.characters.lawful import Enrico, Ursula
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
+from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.utilities.logging import Logger
 from tests.constants import (FAKE_PASSWORD_CONFIRMED, INSECURE_DEVELOPMENT_PASSWORD,
                              MOCK_INDIVIDUAL_ALLOCATION_FILEPATH, MOCK_IP_ADDRESS,
                              ONE_YEAR_IN_SECONDS,
                              TEST_PROVIDER_URI)
-from tests.utils.ursula import MOCK_KNOWN_URSULAS_CACHE, MOCK_URSULA_STARTING_PORT, select_test_port
-from nucypher.config.constants import TEMPORARY_DOMAIN
 from tests.utils.middleware import MockRestMiddleware
+from tests.utils.ursula import MOCK_KNOWN_URSULAS_CACHE, MOCK_URSULA_STARTING_PORT, select_test_port
 
 
 #

--- a/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
@@ -21,7 +21,6 @@ from unittest import mock
 
 import maya
 import os
-from twisted.logger import Logger
 
 from nucypher.blockchain.eth.actors import Staker
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
@@ -31,6 +30,8 @@ from nucypher.cli.literature import SUCCESSFUL_MINTING
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import StakeHolderConfiguration, UrsulaConfiguration
 from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.utilities.logging import Logger
+
 from tests.constants import FAKE_PASSWORD_CONFIRMED, FEE_RATE_RANGE, INSECURE_DEVELOPMENT_PASSWORD, MOCK_IP_ADDRESS, \
     TEST_PROVIDER_URI
 from tests.utils.middleware import MockRestMiddleware

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -28,9 +28,7 @@ import tempfile
 from click.testing import CliRunner
 from datetime import datetime, timedelta
 from eth_utils import to_checksum_address
-from io import StringIO
 from sqlalchemy.engine import create_engine
-from twisted.logger import Logger
 from typing import Tuple
 from umbral import pre
 from umbral.curvebn import CurveBN
@@ -69,7 +67,8 @@ from nucypher.crypto.utils import canonical_address_from_umbral_key
 from nucypher.datastore import datastore
 from nucypher.datastore.db import Base
 from nucypher.policy.collections import IndisputableEvidence, WorkOrder
-from nucypher.utilities.logging import GlobalLoggerSettings
+from nucypher.utilities.logging import GlobalLoggerSettings, Logger
+
 from tests.constants import (
     BASE_TEMP_DIR,
     BASE_TEMP_PREFIX,

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -27,7 +27,7 @@ import re
 import sys
 import tabulate
 import time
-from twisted.logger import ILogObserver, Logger, globalLogPublisher, jsonFileLogObserver
+from twisted.logger import ILogObserver, globalLogPublisher, jsonFileLogObserver
 from umbral.keys import UmbralPrivateKey
 from umbral.signing import Signer
 from unittest.mock import Mock
@@ -38,6 +38,7 @@ from nucypher.blockchain.eth.agents import AdjudicatorAgent, NucypherTokenAgent,
 from nucypher.blockchain.eth.constants import NUCYPHER_CONTRACT_NAMES
 from nucypher.crypto.signing import SignatureStamp
 from nucypher.policy.policies import Policy
+from nucypher.utilities.logging import Logger
 from tests.utils.blockchain import TesterBlockchain
 
 # FIXME: Needed to use a fixture here, but now estimate_gas.py only runs if executed from main directory

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,69 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from twisted.logger import Logger as TwistedLogger, formatEvent
+
+from nucypher.utilities.logging import Logger
+
+
+def naive_print_observer(event):
+    print(formatEvent(event), end="")
+
+
+ordinary_string = "And you're boring, and you're totally ordinary, and you know it"
+quirky_but_ok_strings = (
+    "{{}}", "{{hola}}", "{{{{}}}}"
+)
+normal_strings = (ordinary_string, *quirky_but_ok_strings)
+
+freak_format_strings = (
+    "{}", "{", "}", "}{", "{{{}}}", "{{{{{}}}}}", "{bananas}", str({'bananas': '🍌🍌🍌'})
+)
+
+
+def test_twisted_logger_doesnt_like_curly_braces(capsys):
+    twisted_logger = TwistedLogger('twisted', observer=naive_print_observer)
+
+    # Normal strings are logged normally
+    for string in normal_strings:
+        twisted_logger.info(string)
+        captured = capsys.readouterr()
+        assert string.format() == captured.out
+
+    # But curly braces are not
+    for string in freak_format_strings:
+        twisted_logger.info(string)
+        captured = capsys.readouterr()
+        assert string != captured.out
+        assert "Unable to format event" in captured.out
+
+
+def test_but_nucypher_logger_is_cool_with_that(capsys):
+    nucypher_logger = Logger('twisted', observer=naive_print_observer)
+
+    # Normal strings are logged normally
+    for string in normal_strings:
+        nucypher_logger.info(string)
+        captured = capsys.readouterr()
+        assert string.format() == captured.out
+
+    # And curly braces too!
+    for string in freak_format_strings:
+        nucypher_logger.info(string)
+        captured = capsys.readouterr()
+        assert "Unable to format event" not in captured.out
+        assert string == captured.out

--- a/tests/utils/blockchain.py
+++ b/tests/utils/blockchain.py
@@ -21,7 +21,6 @@ import os
 from eth_tester.exceptions import TransactionFailed
 from eth_utils import to_canonical_address
 from hexbytes import HexBytes
-from twisted.logger import Logger
 from typing import List, Tuple, Union
 from web3 import Web3
 
@@ -33,6 +32,8 @@ from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.utils import epoch_to_period
 from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.logging import Logger
+
 from tests.constants import (
     DEVELOPMENT_ETH_AIRDROP_AMOUNT,
     INSECURE_DEVELOPMENT_PASSWORD,


### PR DESCRIPTION
Drop-in replacement of Twisted's Logger, patching the emit() method to tolerate inputs with curly braces, i.e., not compliant with PEP 3101's format strings.

See Issue #724 and, particularly, https://github.com/nucypher/nucypher/issues/724#issuecomment-600190455

Fixes #724