### PR TITLE
WorkLock: `restake` lock while claiming tokens

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -407,6 +407,7 @@ class ContractAdministrator(NucypherTokenActor):
 
     def batch_deposits(self,
                        allocation_data_filepath: str,
+                       release_period: int,
                        interactive: bool = True,
                        emitter: StdoutEmitter = None,
                        gas_limit: int = None
@@ -431,7 +432,7 @@ class ContractAdministrator(NucypherTokenActor):
         if interactive and not emitter:
             raise ValueError("'emitter' is a required keyword argument when interactive is True.")
 
-        allocator = Allocator(allocation_data_filepath, self.registry, self.deployer_address)
+        allocator = Allocator(allocation_data_filepath, self.registry, self.deployer_address, release_period)
 
         # TODO: Check validity of input address (check TX)
 
@@ -532,7 +533,7 @@ class Allocator:
 
     OCCUPATION_RATIO = 0.9  # When there's no explicit gas limit, we'll try to use the block limit up to this ratio
 
-    def __init__(self, filepath: str, registry, deployer_address):
+    def __init__(self, filepath: str, registry, deployer_address, release_period):
 
         self.log = Logger("allocator")
         self.staking_agent = ContractAgency.get_agent(StakingEscrowAgent,
@@ -541,6 +542,7 @@ class Allocator:
         self.allocations = dict()
         self.deposited = set()
         self.economics = EconomicsFactory.get_economics(registry)
+        self.release_period = release_period
 
         self.__total_to_allocate = 0
         self.__process_allocation_data(str(filepath))
@@ -631,6 +633,7 @@ class Allocator:
             batch_parameters = self.staking_agent.construct_batch_deposit_parameters(deposits=test_batch)
             try:
                 estimated_gas = self.staking_agent.batch_deposit(*batch_parameters,
+                                                                 release_period=self.release_period,
                                                                  sender_address=sender_address,
                                                                  dry_run=True,
                                                                  gas_limit=gas_limit)
@@ -649,6 +652,7 @@ class Allocator:
 
         batch_parameters = self.staking_agent.construct_batch_deposit_parameters(deposits=last_good_batch)
         receipt = self.staking_agent.batch_deposit(*batch_parameters,
+                                                   release_period=self.release_period,
                                                    sender_address=sender_address,
                                                    gas_limit=gas_limit)
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -480,6 +480,7 @@ class StakingEscrowAgent(EthereumContractAgent):
                       number_of_substakes: List[int],
                       amounts: List[NuNits],
                       lock_periods: List[PeriodDelta],
+                      release_period: Period,
                       sender_address: ChecksumAddress,
                       dry_run: bool = False,
                       gas_limit: Optional[Wei] = None
@@ -489,7 +490,8 @@ class StakingEscrowAgent(EthereumContractAgent):
         if gas_limit and gas_limit < min_gas_batch_deposit:
             raise ValueError(f"{gas_limit} is not enough gas for any batch deposit")
 
-        contract_function: ContractFunction = self.contract.functions.batchDeposit(stakers, number_of_substakes, amounts, lock_periods)
+        contract_function: ContractFunction = self.contract.functions.batchDeposit(
+            stakers, number_of_substakes, amounts, lock_periods, release_period)
         if dry_run:
             payload: TxParams = {'from': sender_address}
             if gas_limit:

--- a/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/WorkLock.sol
@@ -503,7 +503,7 @@ contract WorkLock is Ownable {
 
         info.claimed = true;
         token.approve(address(escrow), claimedTokens);
-        escrow.deposit(msg.sender, claimedTokens, stakingPeriods);
+        escrow.depositFromWorkLock(msg.sender, claimedTokens, stakingPeriods);
         info.completedWork = escrow.setWorkMeasurement(msg.sender, true);
         emit Claimed(msg.sender, claimedTokens);
     }

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -73,7 +73,7 @@ from nucypher.cli.literature import (
     SUCCESSFUL_SAVE_DEPLOY_RECEIPTS,
     SUCCESSFUL_SAVE_MULTISIG_TX_PROPOSAL,
     SUCCESSFUL_UPGRADE,
-    UNKNOWN_CONTRACT_NAME
+    UNKNOWN_CONTRACT_NAME, PROMPT_FOR_RELEASE_PERIOD
 )
 from nucypher.cli.options import (
     group_options,
@@ -509,14 +509,18 @@ def contracts(general_config, actor_options, mode, activate, gas, ignore_deploye
 @group_general_config
 @group_actor_options
 @click.option('--allocation-infile', help="Input path for token allocation JSON file", type=EXISTING_READABLE_FILE)
+@click.option('--release-period', help="Period number when re-stake lock will be released", type=click.INT)
 @option_gas
-def allocations(general_config, actor_options, allocation_infile, gas):
+def allocations(general_config, actor_options, allocation_infile, gas, release_period):
     """Deposit stake allocations in batches"""
     emitter = general_config.emitter
     ADMINISTRATOR, _, deployer_interface, local_registry = actor_options.create_actor(emitter)
     if not allocation_infile:
         allocation_infile = click.prompt(PROMPT_FOR_ALLOCATION_DATA_FILEPATH)
+    if release_period is None:
+        release_period = click.prompt(PROMPT_FOR_RELEASE_PERIOD)
     receipts = ADMINISTRATOR.batch_deposits(allocation_data_filepath=allocation_infile,
+                                            release_period=release_period,
                                             emitter=emitter,
                                             gas_limit=gas,
                                             interactive=not actor_options.force)

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -395,6 +395,8 @@ DISPLAY_SENDER_TOKEN_BALANCE_BEFORE_TRANSFER = "Deployer NU balance: {token_bala
 
 PROMPT_FOR_ALLOCATION_DATA_FILEPATH = "Enter allocations data filepath"
 
+PROMPT_FOR_RELEASE_PERIOD = "Enter period number when re-stake lock should be released"
+
 SUCCESSFUL_SAVE_BATCH_DEPOSIT_RECEIPTS = "Saved batch deposits receipts to {receipts_filepath}"
 
 SUCCESSFUL_SAVE_DEPLOY_RECEIPTS = "Saved deployment receipts to {receipts_filepath}"

--- a/tests/acceptance/blockchain/actors/test_deployer.py
+++ b/tests/acceptance/blockchain/actors/test_deployer.py
@@ -21,6 +21,7 @@ import random
 import pytest
 
 from nucypher.blockchain.eth.actors import ContractAdministrator
+from nucypher.blockchain.eth.agents import StakingEscrowAgent, ContractAgency
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.characters.control.emitters import StdoutEmitter
 from nucypher.crypto.powers import TransactingPower
@@ -76,7 +77,9 @@ def test_rapid_deployment(token_economics, test_registry, tmpdir, get_random_che
     with open(filepath, 'w') as f:
         json.dump(allocation_data, f)
 
-    administrator.batch_deposits(allocation_data_filepath=str(filepath), interactive=False)
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=test_registry)
+    current_period = staking_agent.get_current_period()
+    administrator.batch_deposits(allocation_data_filepath=str(filepath), interactive=False, release_period=current_period+10)
 
     minimum, default, maximum = 10, 20, 30
     administrator.set_fee_rate_range(minimum, default, maximum)

--- a/tests/acceptance/cli/test_deploy_commands.py
+++ b/tests/acceptance/cli/test_deploy_commands.py
@@ -214,6 +214,8 @@ def test_batch_deposits(click_runner,
                         agency_local_registry,
                         mock_allocation_infile,
                         token_economics):
+    staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=agency_local_registry)
+    current_period = staking_agent.get_current_period()
 
     #
     # Main
@@ -222,6 +224,7 @@ def test_batch_deposits(click_runner,
     deploy_command = ('allocations',
                       '--registry-infile', agency_local_registry.filepath,
                       '--allocation-infile', mock_allocation_infile,
+                      '--release-period', current_period + 10,
                       '--provider', TEST_PROVIDER_URI)
 
     account_index = '0\n'

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -257,13 +257,20 @@ contract Intermediary {
 */
 contract WorkLockForStakingEscrowMock {
 
+    NuCypherToken public immutable token;
     StakingEscrow public immutable escrow;
 
-    constructor(StakingEscrow _escrow) {
+    constructor(NuCypherToken _token, StakingEscrow _escrow) {
+        token = _token;
         escrow = _escrow;
     }
 
     function setWorkMeasurement(address _staker, bool _measureWork) external returns (uint256) {
         return escrow.setWorkMeasurement(_staker, _measureWork);
+    }
+
+    function depositFromWorkLock(address _staker, uint256 _value, uint16 _periods) external {
+        token.approve(address(escrow), _value);
+        escrow.depositFromWorkLock(_staker, _value, _periods);
     }
 }

--- a/tests/contracts/contracts/WorkLockTestSet.sol
+++ b/tests/contracts/contracts/WorkLockTestSet.sol
@@ -47,7 +47,7 @@ contract StakingEscrowForWorkLockMock {
         return stakerInfo[_staker].completedWork;
     }
 
-    function deposit(address _staker, uint256 _value, uint16 _periods) external {
+    function depositFromWorkLock(address _staker, uint256 _value, uint16 _periods) external {
         stakerInfo[_staker].value = _value;
         stakerInfo[_staker].periods = _periods;
         token.transferFrom(msg.sender, address(this), _value);

--- a/tests/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow.py
@@ -1620,7 +1620,6 @@ def test_batch_deposit(testerchain, token, escrow_contract, deploy_contract):
     assert event_args['lockUntilPeriod'] == current_period + 3
 
 
-@pytest.mark.slow
 def test_staking_from_worklock(testerchain, token, escrow_contract, token_economics, deploy_contract):
     """
     Tests for staking method: depositFromWorkLock

--- a/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
@@ -88,7 +88,7 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
     tx = contract.functions.setPolicyManager(policy_manager.address).transact()
     testerchain.wait_for_receipt(tx)
     worklock, _ = deploy_contract(
-        'WorkLockForStakingEscrowMock', contract.address
+        'WorkLockForStakingEscrowMock', token.address, contract.address
     )
     tx = contract.functions.setWorkLock(worklock.address).transact()
     testerchain.wait_for_receipt(tx)
@@ -810,7 +810,7 @@ def test_measure_work(testerchain, token, escrow_contract, deploy_contract):
     testerchain.wait_for_receipt(tx)
 
     # Deploy WorkLock mock
-    worklock, _ = deploy_contract('WorkLockForStakingEscrowMock', escrow.address)
+    worklock, _ = deploy_contract('WorkLockForStakingEscrowMock', token.address, escrow.address)
     tx = escrow.functions.setWorkLock(worklock.address).transact()
     testerchain.wait_for_receipt(tx)
 

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -236,12 +236,14 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     #
     # Batch deposit tokens
     #
+    current_period = staking_agent.get_current_period()
     transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 10), {'from': origin})
     transact_and_log("Batch deposit tokens for 5 owners x 2 sub-stakes",
                      staker_functions.batchDeposit(everyone_else[0:5],
                                                    [2] * 5,
                                                    [MIN_ALLOWED_LOCKED] * 10,
-                                                   [MIN_LOCKED_PERIODS] * 10),
+                                                   [MIN_LOCKED_PERIODS] * 10,
+                                                   current_period + 5),
                      {'from': origin})
 
     transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 24), {'from': origin})
@@ -249,7 +251,8 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
                      staker_functions.batchDeposit([everyone_else[6]],
                                                    [24],
                                                    [MIN_ALLOWED_LOCKED] * 24,
-                                                   [MIN_LOCKED_PERIODS] * 24),
+                                                   [MIN_LOCKED_PERIODS] * 24,
+                                                   current_period + 5),
                      {'from': origin})
 
     transact(token_functions.approve(staking_agent.contract_address, MIN_ALLOWED_LOCKED * 24 * 5), {'from': origin})
@@ -257,7 +260,8 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
                      staker_functions.batchDeposit(everyone_else[7:12],
                                                    [24]*5,
                                                    [MIN_ALLOWED_LOCKED] * (24 * 5),
-                                                   [MIN_LOCKED_PERIODS] * (24 * 5)),
+                                                   [MIN_LOCKED_PERIODS] * (24 * 5),
+                                                   current_period + 5),
                      {'from': origin})
 
     #


### PR DESCRIPTION
* special method in `StakingEscrow` for depositing tokens from `WorkLock`
* force re-stake lock in `claim` and `batchDeposit`
* removed one slashing test from intercontract test because it's hard to maintain and there is already one test fro this there
* `onlyOwner` modifier for `batchDeposit` method to protect force lock from malicious using