### PR TITLE
One more time: `commitToNextPeriod` gas optimizations

### DIFF
--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -291,7 +291,7 @@ class BlockchainInterface:
         self.log.debug(f"Currently, our gas strategy returns a gas price of {gwei_gas_price} gwei")
 
         self.client.add_middleware(middleware.time_based_cache_middleware)
-        self.client.add_middleware(middleware.latest_block_based_cache_middleware)
+        # self.client.add_middleware(middleware.latest_block_based_cache_middleware)
         self.client.add_middleware(middleware.simple_cache_middleware)
 
     def connect(self):

--- a/nucypher/blockchain/eth/sol/__conf__.py
+++ b/nucypher/blockchain/eth/sol/__conf__.py
@@ -15,4 +15,4 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-SOLIDITY_COMPILER_VERSION = 'v0.7.1'
+SOLIDITY_COMPILER_VERSION = 'v0.7.3'

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -544,7 +544,7 @@ contract StakingEscrow is Issuer, IERC900History {
         uint256 _value,
         uint16 _periods
     )
-        external isInitialized
+        external
     {
         require(msg.sender == address(workLock));
         StakerInfo storage info = stakerInfo[_staker];

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -16,9 +16,13 @@ import "zeppelin/token/ERC20/SafeERC20.sol";
 */
 interface PolicyManagerInterface {
     function register(address _node, uint16 _period) external;
-    function updateFee(address _node, uint16 _period) external;
     function escrow() external view returns (address);
-    function setDefaultFeeDelta(address _node, uint16 _period) external;
+    function ping(
+        address _node,
+        uint16 _processedPeriod1,
+        uint16 _processedPeriod2,
+        uint16 _periodToSetDefault
+    ) external;
 }
 
 
@@ -41,7 +45,7 @@ interface WorkLockInterface {
 /**
 * @notice Contract holds and locks stakers tokens.
 * Each staker that locks their tokens will receive some compensation
-* @dev |v5.4.3|
+* @dev |v5.4.4|
 */
 contract StakingEscrow is Issuer, IERC900History {
 
@@ -1086,7 +1090,7 @@ contract StakingEscrow is Issuer, IERC900History {
         require(msg.sender == tx.origin);
 
         uint16 lastCommittedPeriod = getLastCommittedPeriod(staker);
-        mint(staker);
+        (uint16 processedPeriod1, uint16 processedPeriod2) = mint(staker);
         uint16 currentPeriod = getCurrentPeriod();
         uint16 nextPeriod = currentPeriod + 1;
 
@@ -1108,7 +1112,8 @@ contract StakingEscrow is Issuer, IERC900History {
         if (lastCommittedPeriod < currentPeriod) {
             info.pastDowntime.push(Downtime(lastCommittedPeriod + 1, currentPeriod));
         }
-        policyManager.setDefaultFeeDelta(staker, nextPeriod);
+
+        policyManager.ping(staker, processedPeriod1, processedPeriod2, nextPeriod);
         emit CommitmentMade(staker, nextPeriod, lockedTokens);
     }
 
@@ -1143,37 +1148,46 @@ contract StakingEscrow is Issuer, IERC900History {
         if (info.nextCommittedPeriod <= previousPeriod && info.nextCommittedPeriod != 0) {
             info.lastCommittedPeriod = info.nextCommittedPeriod;
         }
-        mint(msg.sender);
+        (uint16 processedPeriod1, uint16 processedPeriod2) = mint(msg.sender);
+
+        if (processedPeriod1 != 0 || processedPeriod2 != 0) {
+            policyManager.ping(msg.sender, processedPeriod1, processedPeriod2, 0);
+        }
     }
 
     /**
     * @notice Mint tokens for previous periods if staker locked their tokens and made a commitment
     * @param _staker Staker
+    * @return processedPeriod1 Processed period: currentCommittedPeriod or zero
+    * @return processedPeriod2 Processed period: nextCommittedPeriod or zero
     */
-    function mint(address _staker) internal {
+    function mint(address _staker) internal returns (uint16 processedPeriod1, uint16 processedPeriod2) {
         uint16 currentPeriod = getCurrentPeriod();
-        uint16 previousPeriod = currentPeriod  - 1;
+        uint16 previousPeriod = currentPeriod - 1;
         StakerInfo storage info = stakerInfo[_staker];
 
         if (info.nextCommittedPeriod == 0 ||
             info.currentCommittedPeriod == 0 &&
             info.nextCommittedPeriod > previousPeriod ||
             info.currentCommittedPeriod > previousPeriod) {
-            return;
+            return (0, 0);
         }
 
         uint16 startPeriod = getStartPeriod(info, currentPeriod);
         uint256 reward = 0;
         bool reStake = !info.flags.bitSet(RE_STAKE_DISABLED_INDEX);
+
         if (info.currentCommittedPeriod != 0) {
-            reward = mint(_staker, info, info.currentCommittedPeriod, currentPeriod, startPeriod, reStake);
+            reward = mint(info, info.currentCommittedPeriod, currentPeriod, startPeriod, reStake);
+            processedPeriod1 = info.currentCommittedPeriod;
             info.currentCommittedPeriod = 0;
             if (reStake) {
                 lockedPerPeriod[info.nextCommittedPeriod] += reward;
             }
         }
         if (info.nextCommittedPeriod <= previousPeriod) {
-            reward += mint(_staker, info, info.nextCommittedPeriod, currentPeriod, startPeriod, reStake);
+            reward += mint(info, info.nextCommittedPeriod, currentPeriod, startPeriod, reStake);
+            processedPeriod2 = info.nextCommittedPeriod;
             info.nextCommittedPeriod = 0;
         }
 
@@ -1188,14 +1202,12 @@ contract StakingEscrow is Issuer, IERC900History {
 
     /**
     * @notice Calculate reward for one period
-    * @param _staker Staker's address
     * @param _info Staker structure
     * @param _mintingPeriod Period for minting calculation
     * @param _currentPeriod Current period
     * @param _startPeriod Pre-calculated start period
     */
     function mint(
-        address _staker,
         StakerInfo storage _info,
         uint16 _mintingPeriod,
         uint16 _currentPeriod,
@@ -1220,7 +1232,6 @@ contract StakingEscrow is Issuer, IERC900History {
                 }
             }
         }
-        policyManager.updateFee(_staker, _mintingPeriod);
         return reward;
     }
 

--- a/tests/contracts/contracts/PolicyManagerTestSet.sol
+++ b/tests/contracts/contracts/PolicyManagerTestSet.sol
@@ -86,24 +86,15 @@ contract StakingEscrowForPolicyMock {
     }
 
     /**
-    * @notice Emulate mint method
-    * @param _staker Staker on behalf of whom minting will be
-    * @param _startPeriod Start period for minting
-    * @param _numberOfPeriods Number periods for minting
+    * @notice Emulate ping method call
     */
-    function mint(address _staker, uint16 _startPeriod, uint16 _numberOfPeriods) public {
-        for (uint16 i = 0; i < _numberOfPeriods; i++) {
-            policyManager.updateFee(_staker, i + _startPeriod);
-        }
-    }
-
-    /**
-    * @notice Emulate mint method
-    * @param _startPeriod Start period for minting
-    * @param _numberOfPeriods Number periods for minting
-    */
-    function mint(uint16 _startPeriod, uint16 _numberOfPeriods) external {
-        mint(msg.sender, _startPeriod, _numberOfPeriods);
+    function ping(
+        address _node,
+        uint16 _processedPeriod1,
+        uint16 _processedPeriod2,
+        uint16 _periodToSetDefault
+    ) external {
+        policyManager.ping(_node, _processedPeriod1, _processedPeriod2, _periodToSetDefault);
     }
 
     /**
@@ -142,12 +133,6 @@ contract StakingEscrowForPolicyMock {
             if (_period <= downtime[index].endPeriod) {
                 return index;
             }
-        }
-    }
-
-    function setDefaultFeeDelta(address _node, uint16 _startPeriod, uint16 _numberOfPeriods) public {
-        for (uint16 i = 0; i < _numberOfPeriods; i++) {
-            policyManager.setDefaultFeeDelta(_node, i + _startPeriod);
         }
     }
 

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -181,12 +181,15 @@ contract PolicyManagerForStakingEscrowMock {
         nodes[_node].push(_period);
     }
 
-    function updateFee(address _node, uint16 _period) external {
-        nodes[_node].push(_period);
-    }
-
-    function setDefaultFeeDelta(address _node, uint16 _period) external {
-        nodes[_node].push(_period);
+    function ping(
+        address _node,
+        uint16 _processedPeriod1,
+        uint16 _processedPeriod2,
+        uint16 _periodToSetDefault
+    ) external {
+        nodes[_node].push(_processedPeriod1);
+        nodes[_node].push(_processedPeriod2);
+        nodes[_node].push(_periodToSetDefault);
     }
 
     function getPeriodsLength(address _node) public view returns (uint256) {

--- a/tests/contracts/main/policy_manager/test_policy_manager_operations.py
+++ b/tests/contracts/main/policy_manager/test_policy_manager_operations.py
@@ -41,7 +41,6 @@ def test_fee(testerchain, escrow, policy_manager):
     creator, policy_sponsor, bad_node, node1, node2, node3, *everyone_else = testerchain.client.accounts
     node_balance = testerchain.client.get_balance(node1)
     withdraw_log = policy_manager.events.Withdrawn.createFilter(fromBlock='latest')
-    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
 
     # Emulate minting period without policies
     period = escrow.functions.getCurrentPeriod().call()
@@ -168,8 +167,6 @@ def test_fee(testerchain, escrow, policy_manager):
     assert node1 == event_args['recipient']
     assert 200 == event_args['value']
 
-    assert len(warn_log.get_all_entries()) == 0
-
 
 def test_refund(testerchain, escrow, policy_manager):
     creator, policy_creator, bad_node, node1, node2, node3, policy_owner, *everyone_else = testerchain.client.accounts
@@ -180,7 +177,6 @@ def test_refund(testerchain, escrow, policy_manager):
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
     arrangement_refund_log = policy_manager.events.RefundForArrangement.createFilter(fromBlock='latest')
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
-    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
 
     # Create policy
     current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
@@ -554,8 +550,6 @@ def test_refund(testerchain, escrow, policy_manager):
     events = policy_created_log.get_all_entries()
     assert 4 == len(events)
 
-    assert len(warn_log.get_all_entries()) == 0
-
 
 def test_reentrancy(testerchain, escrow, policy_manager, deploy_contract):
     withdraw_log = policy_manager.events.Withdrawn.createFilter(fromBlock='latest')
@@ -563,7 +557,6 @@ def test_reentrancy(testerchain, escrow, policy_manager, deploy_contract):
     policy_revoked_log = policy_manager.events.PolicyRevoked.createFilter(fromBlock='latest')
     arrangement_refund_log = policy_manager.events.RefundForArrangement.createFilter(fromBlock='latest')
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
-    warn_log = policy_manager.events.NodeBrokenState.createFilter(fromBlock='latest')
 
     reentrancy_contract, _ = deploy_contract('ReentrancyTest')
     contract_address = reentrancy_contract.address
@@ -624,5 +617,3 @@ def test_reentrancy(testerchain, escrow, policy_manager, deploy_contract):
     assert 0 == len(policy_revoked_log.get_all_entries())
     assert 0 == len(arrangement_refund_log.get_all_entries())
     assert 0 == len(policy_refund_log.get_all_entries())
-
-    assert len(warn_log.get_all_entries()) == 0

--- a/tests/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow.py
@@ -1583,14 +1583,7 @@ def test_staking_from_worklock(testerchain, token, escrow_contract, token_econom
         testerchain.wait_for_receipt(tx)
     assert token.functions.balanceOf(escrow.address).call() == 0
 
-    # Can't claim before initialization
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = worklock.functions.depositFromWorkLock(staker1, value, duration).transact()
-        testerchain.wait_for_receipt(tx)
-    tx = escrow.functions.initialize(0, creator).transact({'from': creator})
-    testerchain.wait_for_receipt(tx)
-
-    # Deposit tokens from WorkLock
+    # Can claim before initialization
     wind_down, _re_stake, _measure_work, _snapshots = escrow.functions.getFlags(staker1).call()
     assert not wind_down
     current_period = escrow.functions.getCurrentPeriod().call()
@@ -1632,6 +1625,9 @@ def test_staking_from_worklock(testerchain, token, escrow_contract, token_econom
     tx = token.functions.approve(escrow.address, maximum_allowed_locked).transact({'from': staker2})
     testerchain.wait_for_receipt(tx)
     tx = escrow.functions.deposit(staker2, value, duration).transact({'from': staker2})
+    testerchain.wait_for_receipt(tx)
+
+    tx = escrow.functions.initialize(0, creator).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
     wind_down, _re_stake, _measure_work, _snapshots = escrow.functions.getFlags(staker2).call()


### PR DESCRIPTION
Result for now: -6k gas, +92 bytes
Allow `claim` from `WorkLock` before `StakingEscrow` initialization