### PR TITLE
Simplify Bob.retrieve()

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -590,7 +590,7 @@ class Bob(Character):
         return unknown_ursulas, known_ursulas, treasure_map.m
 
     def get_treasure_map(self, alice_verifying_key, label):
-        _hrac, map_id = self.construct_hrac_and_map_id(verifying_key=alice_verifying_key, label=label)
+        map_identifier = self.construct_map_id(verifying_key=alice_verifying_key, label=label)
 
         if not self.known_nodes and not self._learning_task.running:
             # Quick sanity check - if we don't know of *any* Ursulas, and we have no
@@ -602,11 +602,6 @@ class Bob(Character):
             if not self.known_nodes:
                 raise self.NotEnoughTeachers("Can't retrieve without knowing about any nodes at all.  Pass a teacher or seed node.")
 
-        # Ugh stupid federated only mode....
-        if not self.federated_only:
-            map_identifier = _hrac.hex()
-        else:
-            map_identifier = map_id
         treasure_map = self.get_treasure_map_from_known_ursulas(self.network_middleware,
                                                                 map_identifier)
 
@@ -628,10 +623,16 @@ class Bob(Character):
         _hrac = keccak_digest(bytes(verifying_key) + self.stamp + label)[:HRAC_LENGTH]
         return _hrac
 
-    def construct_hrac_and_map_id(self, verifying_key, label):
+    def construct_map_id(self, verifying_key, label):
         hrac = self.construct_policy_hrac(verifying_key, label)
-        map_id = keccak_digest(bytes(verifying_key) + hrac).hex()
-        return hrac, map_id
+
+        # Ugh stupid federated only mode....
+        if not self.federated_only:
+            map_id = hrac.hex()
+        else:
+            map_id = keccak_digest(bytes(verifying_key) + hrac).hex()
+
+        return map_id
 
     def get_treasure_map_from_known_ursulas(self, network_middleware, map_identifier, timeout=3):
         """
@@ -769,7 +770,7 @@ class Bob(Character):
         # Part I: Assembling the WorkOrders.
         capsules_to_activate = set(mk.capsule for mk in message_kits)
 
-        hrac, map_id = self.construct_hrac_and_map_id(alice_verifying_key, label)
+        map_id = self.construct_map_id(alice_verifying_key, label)
         if treasure_map is not None:
             alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
             compass = self.make_compass_for_alice(alice)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -822,21 +822,23 @@ class Bob(Character):
             capsule.set_correctness_keys(receiving=self.public_keys(DecryptingPower))
             capsule.set_correctness_keys(verifying=alice_verifying_key)
 
-            new_work_orders, complete_work_orders = self.work_orders_for_capsules(
-                treasure_map=treasure_map,
-                alice_verifying_key=alice_verifying_key,
-                *capsules_to_activate)
+        new_work_orders, complete_work_orders = self.work_orders_for_capsules(
+            treasure_map=treasure_map,
+            alice_verifying_key=alice_verifying_key,
+            *capsules_to_activate)
 
-            self.log.debug(f"Found {len(complete_work_orders)} complete WorkOrders for this Capsule ({capsule}).")
+        self.log.info(f"Found {len(complete_work_orders)} for Capsules ({capsules_to_activate}).")
 
-            if complete_work_orders:
-                if use_precedent_work_orders:
+        if complete_work_orders:
+            if use_precedent_work_orders:
+                for capsule in capsules_to_activate:
                     for work_order in complete_work_orders.values():
-                        cfrag_in_question = work_order.tasks[capsule].cfrag
-                        capsule.attach_cfrag(cfrag_in_question)
-                else:
-                    self.log.warn(
-                        "Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")
+                        if capsule in work_order.tasks:
+                            cfrag_in_question = work_order.tasks[capsule].cfrag
+                            capsule.attach_cfrag(cfrag_in_question)
+            else:
+                self.log.warn(
+                    "Found existing complete WorkOrders, but use_precedent_work_orders is set to False.  To use Bob in 'KMS mode', set retain_cfrags=False as well.")
 
         # Part II: Getting the cleartexts.
         cleartexts = []

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -481,26 +481,6 @@ class Alice(Character, BlockchainPolicyAuthor):
         return controller
 
 
-def ensure_correct_sender(message_kit: UmbralMessageKit,
-                          enrico: Optional["Enrico"] = None,
-                          policy_encrypting_key: Optional[UmbralPublicKey] = None):
-    """
-    Make sure that the sender of the message kit is set and corresponds to
-    the given ``enrico``, or create it from the given ``policy_encrypting_key``.
-    """
-    if message_kit.sender:
-        if enrico and message_kit.sender != enrico:
-            raise ValueError
-    elif enrico:
-        message_kit.sender = enrico
-    elif message_kit.sender_verifying_key and policy_encrypting_key:
-        # Well, after all, this is all we *really* need.
-        message_kit.sender = Enrico.from_public_keys(verifying_key=message_kit.sender_verifying_key,
-                                                     policy_encrypting_key=policy_encrypting_key)
-    else:
-        raise TypeError
-
-
 class Bob(Character):
     banner = BOB_BANNER
     _interface_class = BobInterface
@@ -864,9 +844,8 @@ class Bob(Character):
 
         # Normalization
         for message in message_kits:
-            ensure_correct_sender(message,
-                                  enrico=enrico,
-                                  policy_encrypting_key=policy_encrypting_key)
+            message.ensure_correct_sender(enrico=enrico,
+                                          policy_encrypting_key=policy_encrypting_key)
 
         # Sanity check: If we're not using attached cfrags, we don't want a Capsule which has them.
         if not use_attached_cfrags and any(len(message.capsule) > 0 for message in message_kits):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -575,6 +575,14 @@ class Bob(Character):
 
         return unknown_ursulas, known_ursulas, treasure_map.m
 
+    def _try_orient(self, treasure_map, alice_verifying_key):
+        alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
+        compass = self.make_compass_for_alice(alice)
+        try:
+            treasure_map.orient(compass)
+        except treasure_map.InvalidSignature:
+            raise  # TODO: Maybe do something here?  NRN
+
     def get_treasure_map(self, alice_verifying_key, label):
         map_identifier = self.construct_map_id(verifying_key=alice_verifying_key, label=label)
 
@@ -591,15 +599,8 @@ class Bob(Character):
         treasure_map = self.get_treasure_map_from_known_ursulas(self.network_middleware,
                                                                 map_identifier)
 
-        alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
-        compass = self.make_compass_for_alice(alice)
-        try:
-            treasure_map.orient(compass)
-        except treasure_map.InvalidSignature:
-            raise  # TODO: Maybe do something here?  NRN
-        else:
-            self.treasure_maps[map_id] = treasure_map
-
+        self._try_orient(treasure_map, alice_verifying_key)
+        self.treasure_maps[map_identifier] = treasure_map # TODO: make a part of _try_orient()?
         return treasure_map
 
     def make_compass_for_alice(self, alice):
@@ -752,12 +753,7 @@ class Bob(Character):
         # Try our best to get an UmbralPublicKey from input
         alice_verifying_key = UmbralPublicKey.from_bytes(bytes(alice_verifying_key))
 
-        # Part I: Assembling the WorkOrders.
-        capsules_to_activate = set(mk.capsule for mk in message_kits)
-
         if treasure_map is not None:
-            alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
-            compass = self.make_compass_for_alice(alice)
 
             if self.federated_only:
                 from nucypher.policy.collections import TreasureMap as _MapClass
@@ -771,12 +767,17 @@ class Bob(Character):
             if isinstance(treasure_map, str):
                 tmap_bytes = treasure_map.encode()
                 treasure_map = _MapClass.from_bytes(b64decode(tmap_bytes))
-            treasure_map.orient(compass)
+
+            self._try_orient(treasure_map, alice_verifying_key)
+            # self.treasure_maps[treasure_map.public_id()] = treasure_map # TODO: Can we?
         else:
             map_id = self.construct_map_id(alice_verifying_key, label)
             treasure_map = self.treasure_maps[map_id]
 
         _unknown_ursulas, _known_ursulas, m = self.follow_treasure_map(treasure_map=treasure_map, block=True)
+
+        # Part I: Assembling the WorkOrders.
+        capsules_to_activate = set(mk.capsule for mk in message_kits)
 
         for message in message_kits:
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -45,6 +45,7 @@ from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate, NameOID, load_pem_x509_certificate
 from datetime import datetime
+from eth_typing.evm import ChecksumAddress
 from eth_utils import to_checksum_address
 from flask import Response, request
 from functools import partial
@@ -54,8 +55,7 @@ from random import shuffle
 from twisted.internet import reactor, stdio, threads
 from twisted.internet.task import LoopingCall
 from twisted.logger import Logger
-from typing import Dict, Iterable, List, Tuple, Union
-from typing import Optional
+from typing import Dict, Iterable, List, Tuple, Union, Optional, Sequence, Set
 from umbral import pre
 from umbral.keys import UmbralPublicKey
 from umbral.kfrags import KFrag
@@ -689,7 +689,7 @@ class Bob(Character):
                                  alice_verifying_key: UmbralPublicKey,
                                  treasure_map: 'TreasureMap' = None,
                                  num_ursulas: int = None,
-                                 ):
+                                 ) -> Tuple[Dict[ChecksumAddress, 'WorkOrder'], Dict['Capsule', 'WorkOrder']]:
 
         from nucypher.policy.collections import WorkOrder  # Prevent circular import
 
@@ -744,22 +744,83 @@ class Bob(Character):
 
         return incomplete_work_orders, complete_work_orders
 
-    def get_reencrypted_cfrags(self, work_order, retain_cfrags=False):
-        if work_order.completed:
-            raise TypeError("This WorkOrder is already complete; "
-                            "if you want Ursula to perform additional service, make a new WorkOrder.")
-
-        cfrags_and_signatures = self.network_middleware.reencrypt(work_order)
-        cfrags = work_order.complete(cfrags_and_signatures)
-        self._completed_work_orders.save_work_order(work_order, as_replete=retain_cfrags)
-
-        return cfrags
-
     def join_policy(self, label, alice_verifying_key, node_list=None, block=False):
         if node_list:
             self._node_ids_to_learn_about_immediately.update(node_list)
         treasure_map = self.get_treasure_map(alice_verifying_key, label)
         self.follow_treasure_map(treasure_map=treasure_map, block=block)
+
+    def _filter_work_orders_and_capsules(self,
+                                         work_orders: Dict[ChecksumAddress, 'WorkOrder'],
+                                         capsules: Sequence['Capsule'],
+                                         m: int,
+                                         ) -> Tuple[List['WorkOrder'], Set['Capsule']]:
+        remaining_work_orders = []
+        remaining_capsules = set(capsule for capsule in capsules if len(capsule) < m)
+        for work_order in work_orders.values():
+            for capsule in work_order.tasks:
+                work_order_is_useful = False
+                if len(capsule) >= m:
+                    remaining_capsules.discard(capsule)
+                else:
+                    work_order_is_useful = True
+                    break
+
+            # If all the capsules are now activated, we can stop here.
+            if not remaining_capsules:
+                break
+
+            if not work_order_is_useful:
+                # None of the Capsules for this particular WorkOrder need to be activated.  Move on to the next one.
+                continue
+
+            remaining_work_orders.append(work_order)
+
+        return remaining_work_orders, remaining_capsules
+
+    def _reencrypt(self,
+                   work_order: 'WorkOrder',
+                   retain_cfrags: bool = False
+                   ) -> Tuple[bool, Union[List['IndisputableEvidence'], List['CapsuleFrag']]]:
+
+        if work_order.completed:
+            raise TypeError(
+                "This WorkOrder is already complete; if you want Ursula to perform additional service, make a new WorkOrder.")
+
+        # We don't have enough CFrags yet.  Let's get another one from a WorkOrder.
+        try:
+            cfrags_and_signatures = self.network_middleware.reencrypt(work_order)
+        except NodeSeemsToBeDown as e:
+            # TODO: What to do here?  Ursula isn't supposed to be down.  NRN
+            self.log.info(f"Ursula ({work_order.ursula}) seems to be down while trying to complete WorkOrder: {work_order}")
+            return False, [] # TODO: return a grievance?
+        except self.network_middleware.NotFound:
+            # This Ursula claims not to have a matching KFrag.  Maybe this has been revoked?
+            # TODO: What's the thing to do here?  Do we want to track these Ursulas in some way in case they're lying?  567
+            self.log.warn(f"Ursula ({work_order.ursula}) claims not to have the KFrag to complete WorkOrder: {work_order}.  Has accessed been revoked?")
+            return False, [] # TODO: return a grievance?
+        except self.network_middleware.UnexpectedResponse:
+            raise # TODO: Handle this
+
+        cfrags = work_order.complete(cfrags_and_signatures)
+
+        # TODO: hopefully GIL will allow this to execute concurrently...
+        # or we'll have to modify tests that rely on it
+        self._completed_work_orders.save_work_order(work_order, as_replete=retain_cfrags)
+
+        the_airing_of_grievances = []
+        for capsule, pre_task in work_order.tasks.items():
+            if not pre_task.cfrag.verify_correctness(capsule):
+                # TODO: WARNING - This block is untested.
+                from nucypher.policy.collections import IndisputableEvidence
+                evidence = IndisputableEvidence(task=pre_task, work_order=work_order)
+                # I got a lot of problems with you people ...
+                the_airing_of_grievances.append(evidence)
+
+        if the_airing_of_grievances:
+            return False, the_airing_of_grievances
+        else:
+            return True, cfrags
 
     def retrieve(self,
                  *message_kits: UmbralMessageKit,
@@ -849,62 +910,34 @@ class Bob(Character):
             # TODO Optimization: Block here (or maybe even later) until map is done being followed (instead of blocking above). #1114
             the_airing_of_grievances = []
 
-            for work_order in new_work_orders.values():
-                for capsule in work_order.tasks:
-                    work_order_is_useful = False
-                    if len(capsule) >= m:
-                        capsules_to_activate.discard(capsule)
-                    else:
-                        work_order_is_useful = True
-                        break
+            remaining_work_orders, capsules_to_activate = self._filter_work_orders_and_capsules(
+                new_work_orders, capsules_to_activate, m)
 
-                # If all the capsules are now activated, we can stop here.
-                if not capsules_to_activate:
-                    break
-
-                if not work_order_is_useful:
-                    # None of the Capsules for this particular WorkOrder need to be activated.  Move on to the next one.
-                    continue
+            # If all the capsules are now activated, we can stop here.
+            if capsules_to_activate and remaining_work_orders:
 
                 # OK, so we're going to need to do some network activity for this retrieval.  Let's make sure we've seeded.
                 if not self.done_seeding:
                     self.learn_from_teacher_node()
 
-                # We don't have enough CFrags yet.  Let's get another one from a WorkOrder.
-                try:
-                    self.get_reencrypted_cfrags(work_order, retain_cfrags=retain_cfrags)
-                except NodeSeemsToBeDown as e:
-                    # TODO: What to do here?  Ursula isn't supposed to be down.  NRN
-                    self.log.info(f"Ursula ({work_order.ursula}) seems to be down while trying to complete WorkOrder: {work_order}")
-                    continue
-                except self.network_middleware.NotFound:
-                    # This Ursula claims not to have a matching KFrag.  Maybe this has been revoked?
-                    # TODO: What's the thing to do here?  Do we want to track these Ursulas in some way in case they're lying?  567
-                    self.log.warn(f"Ursula ({work_order.ursula}) claims not to have the KFrag to complete WorkOrder: {work_order}.  Has accessed been revoked?")
-                    continue
-                except self.network_middleware.UnexpectedResponse:
-                    raise # TODO: Handle this
+                for work_order in remaining_work_orders:
+                    success, result = self._reencrypt(work_order, retain_cfrags)
 
-                for capsule, pre_task in work_order.tasks.items():
-                    try:
-                        capsule.attach_cfrag(pre_task.cfrag)
-                    except UmbralCorrectnessError:
-                        task = work_order.tasks[0]
-                        # TODO: WARNING - This block is untested.
-                        from nucypher.policy.collections import IndisputableEvidence
-                        evidence = IndisputableEvidence(task=task, work_order=work_order)
-                        # I got a lot of problems with you people ...
-                        the_airing_of_grievances.append(evidence)
+                    if not success:
+                        the_airing_of_grievances.extend(result)
+                        continue
 
-                    if len(capsule) >= m:
-                        capsules_to_activate.discard(capsule)
+                    for capsule, pre_task in work_order.tasks.items():
+                        capsule.attach_cfrag(pre_task.cfrag) # already verified, will not fail
+                        if len(capsule) >= m:
+                            capsules_to_activate.discard(capsule)
 
-                # If all the capsules are now activated, we can stop here.
-                if not capsules_to_activate:
-                    break
-            else:
-                raise Ursula.NotEnoughUrsulas(
-                    "Unable to reach m Ursulas.  See the logs for which Ursulas are down or noncompliant.")
+                    # If all the capsules are now activated, we can stop here.
+                    if not capsules_to_activate:
+                        break
+                else:
+                    raise Ursula.NotEnoughUrsulas(
+                        "Unable to reach m Ursulas.  See the logs for which Ursulas are down or noncompliant.")
 
             if the_airing_of_grievances:
                 # ... and now you're gonna hear about it!
@@ -918,7 +951,8 @@ class Bob(Character):
                 cleartexts.append(delivered_cleartext)
         finally:
             if not retain_cfrags:
-                capsule.clear_cfrags()
+                for message in message_kits:
+                    message.capsule.clear_cfrags()
                 for work_order in new_work_orders.values():
                     work_order.sanitize()
 

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -174,7 +174,7 @@ def test_bob_can_issue_a_work_order_to_a_specific_ursula(enacted_federated_polic
     assert work_order.completed is False
 
     # **** RE-ENCRYPTION HAPPENS HERE! ****
-    cfrags = federated_bob.get_reencrypted_cfrags(work_order, retain_cfrags=True)
+    _success, cfrags = federated_bob._reencrypt(work_order, retain_cfrags=True)
 
     # We only gave one Capsule, so we only got one cFrag.
     assert len(cfrags) == 1
@@ -245,7 +245,7 @@ def test_bob_can_use_cfrag_attached_to_completed_workorder(enacted_federated_pol
 
     # As such, we will get TypeError if we try to get CFrags again.
     with pytest.raises(TypeError):
-        federated_bob.get_reencrypted_cfrags(new_work_order)
+        federated_bob._reencrypt(new_work_order)
 
 
 def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_federated_policy, federated_alice,
@@ -294,7 +294,7 @@ def test_bob_remembers_that_he_has_cfrags_for_a_particular_capsule(enacted_feder
     assert new_work_order != saved_work_order
 
     # This WorkOrder has never been completed
-    cfrags = federated_bob.get_reencrypted_cfrags(new_work_order, retain_cfrags=True)
+    _success, cfrags = federated_bob._reencrypt(new_work_order, retain_cfrags=True)
 
     # Again: one Capsule, one cFrag.
     assert len(cfrags) == 1
@@ -334,7 +334,7 @@ def test_bob_gathers_and_combines(enacted_federated_policy, federated_bob, feder
         num_ursulas=number_left_to_collect)
     _id_of_yet_another_ursula, new_work_order = list(new_incomplete_work_orders.items())[0]
 
-    cfrags = federated_bob.get_reencrypted_cfrags(new_work_order)
+    _success, cfrags = federated_bob._reencrypt(new_work_order)
     cfrag = cfrags[0]
     assert cfrag not in the_message_kit.capsule._attached_cfrags
 

--- a/tests/integration/network/test_treasure_map_integration.py
+++ b/tests/integration/network/test_treasure_map_integration.py
@@ -64,7 +64,7 @@ def test_treasure_map_stored_by_ursula_is_the_correct_one_for_bob(federated_alic
     hrac_by_bob = federated_bob.construct_policy_hrac(federated_alice.stamp, enacted_federated_policy.label)
     assert enacted_federated_policy.hrac() == hrac_by_bob
 
-    hrac, map_id_by_bob = federated_bob.construct_hrac_and_map_id(federated_alice.stamp, enacted_federated_policy.label)
+    map_id_by_bob = federated_bob.construct_map_id(federated_alice.stamp, enacted_federated_policy.label)
     assert map_id_by_bob == treasure_map_on_network.public_id()
 
 


### PR DESCRIPTION
Since PR #2063 (parallel `retrieve()`) is currently blocked by LMDB issues, this PR is created to at least make some progress on the parts of #2063 that simplify the logic flow in `retrieve()` and prepare it to be split into independent worker processes. 

