### PR TITLE
Batch/Throttle events filter results 1000 (default) blocks at a time for CommitmentMade prometheus metrics collector

### DIFF
--- a/nucypher/blockchain/eth/events.py
+++ b/nucypher/blockchain/eth/events.py
@@ -77,3 +77,41 @@ class ContractEvents:
     def __iter__(self):
         for event_name in self.names:
             yield self[event_name]
+
+
+class ContractEventsThrottler:
+    """
+    Enables Contract events to be retrieved in batches.
+    """
+    def __init__(self,
+                 agent: 'EthereumContractAgent',
+                 event_name: str,
+                 from_block: int,
+                 to_block: int = None,  # defaults to latest block
+                 max_events_per_call: int = 1000,  # smallest default heard about so far (alchemy)
+                 **argument_filters):
+        if not agent:
+            raise ValueError(f"Contract agent must be provided")
+        if not event_name:
+            raise ValueError(f"Event name must be provided")
+
+        self.event_filter = agent.events[event_name]
+        self.from_block = from_block
+        self.to_block = to_block if to_block else agent.blockchain.client.block_number
+        # validity check of block range
+        if to_block <= from_block:
+            raise ValueError(f"Invalid block range provided ({from_block} - {to_block})")
+
+        self.max_events_per_call = max_events_per_call
+        self.argument_filters = argument_filters
+
+    def __iter__(self):
+        current_from_block = self.from_block
+        current_to_block = min(self.from_block + self.max_events_per_call, self.to_block)
+        while current_from_block < current_to_block:
+            for event_record in self.event_filter(from_block=current_from_block,
+                                                  to_block=current_to_block,
+                                                  **self.argument_filters):
+                yield event_record
+            current_from_block = current_to_block
+            current_to_block = min(current_from_block + self.max_events_per_call, self.to_block)

--- a/nucypher/blockchain/eth/events.py
+++ b/nucypher/blockchain/eth/events.py
@@ -120,4 +120,6 @@ class ContractEventsThrottler:
                                                   **self.argument_filters):
                 yield event_record
             current_from_block = current_to_block
+            # update the 'to block' to the lesser of either the next `max_blocks_per_call` blocks,
+            # or the remainder of blocks
             current_to_block = min(current_from_block + self.max_blocks_per_call, self.to_block)

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -15,13 +15,17 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+from decimal import Decimal
+from typing import Union
+
 import maya
 from constant_sorrow.constants import UNKNOWN_DEVELOPMENT_CHAIN_ID
-from decimal import Decimal
+from eth_typing import BlockNumber
 from eth_utils import is_address, is_hex, to_checksum_address
-from typing import Union
 from web3 import Web3
 from web3.contract import ContractConstructor, ContractFunction
+
+from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS
 
 
 def epoch_to_period(epoch: int, seconds_per_period: int) -> int:
@@ -64,6 +68,18 @@ def calculate_period_duration(future_time: maya.MayaDT, seconds_per_period: int,
     current_period = datetime_to_period(datetime=now, seconds_per_period=seconds_per_period)
     periods = future_period - current_period
     return periods
+
+
+def estimate_block_number_for_period(period: int, seconds_per_period: int,  latest_block: BlockNumber) -> BlockNumber:
+    """Logic for getting the approximate block height of the start of the specified period."""
+    period_start = datetime_at_period(period=period,
+                                      seconds_per_period=seconds_per_period,
+                                      start_of_period=True)
+    seconds_from_midnight = int((maya.now() - period_start).total_seconds())
+    blocks_from_midnight = seconds_from_midnight // AVERAGE_BLOCK_TIME_IN_SECONDS
+
+    block_number_for_period = latest_block - blocks_from_midnight
+    return block_number_for_period
 
 
 def etherscan_url(item, network: str, is_token=False) -> str:

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -384,6 +384,11 @@ def run(general_config, character_options, config_file, interactive, dry_run, me
 
     prometheus_config: 'PrometheusMetricsConfig' = None
     if prometheus:
+        # ensure metrics port is provided
+        if not metrics_port:
+            raise click.BadOptionUsage(option_name='metrics-port',
+                                       message='--metrics-port is required when using --prometheus')
+
         # Locally scoped to prevent import without prometheus explicitly installed
         from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
         prometheus_config = PrometheusMetricsConfig(port=metrics_port,

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -66,3 +66,7 @@ MAX_UPLOAD_CONTENT_LENGTH = 1024 * 50
 
 # Dev Mode
 TEMPORARY_DOMAIN = ":temporary-domain:"  # for use with `--dev` node runtimes
+
+
+# Event Blocks Throttling
+NUCYPHER_EVENTS_THROTTLE_MAX_BLOCKS = 'NUCYPHER_EVENTS_THROTTLE_MAX_BLOCKS'

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -57,9 +57,15 @@ class PrometheusMetricsConfig:
     def __init__(self,
                  port: int,
                  metrics_prefix: str,
-                 listen_address: str,
+                 listen_address: str = '',  # default to localhost ip
                  collection_interval: int = 10,
                  start_now: bool = False):
+
+        if not port:
+            raise ValueError('port must be provided')
+        if not metrics_prefix:
+            raise ValueError('metrics prefix must be provided')
+
         self.port = port
         self.metrics_prefix = metrics_prefix
         self.listen_address = listen_address

--- a/tests/unit/test_blockchain_utils.py
+++ b/tests/unit/test_blockchain_utils.py
@@ -1,0 +1,66 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+import maya
+from eth_typing import BlockNumber
+from unittest.mock import patch
+
+from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS
+from nucypher.blockchain.eth.utils import epoch_to_period, estimate_block_number_for_period, period_to_epoch
+
+SECONDS_PER_PERIOD = 60 * 60 * 24
+
+
+def test_epoch_to_period():
+    timestamp = maya.now().epoch
+
+    current_period = epoch_to_period(epoch=timestamp, seconds_per_period=SECONDS_PER_PERIOD)
+    assert current_period == (timestamp // SECONDS_PER_PERIOD)
+
+
+def test_period_to_epoch():
+    current_period = 12345678
+    epoch = period_to_epoch(period=current_period, seconds_per_period=SECONDS_PER_PERIOD)
+    assert epoch == (current_period * SECONDS_PER_PERIOD)
+
+
+def test_estimate_block_number_for_period():
+    timestamp = maya.now().epoch
+    period = timestamp // SECONDS_PER_PERIOD
+
+    three_periods_back = period - 3
+    ten_periods_back = period - 10
+    latest_block_number = BlockNumber(12345678)
+
+    now = maya.now()
+    now_epoch = now.epoch
+    # ensure the same time is used in method and in test
+    with patch.object(maya, 'now', return_value=maya.MayaDT(epoch=now_epoch)):
+        block_number_for_three_periods_back = estimate_block_number_for_period(period=three_periods_back,
+                                                                               seconds_per_period=SECONDS_PER_PERIOD,
+                                                                               latest_block=latest_block_number)
+        block_number_for_ten_periods_back = estimate_block_number_for_period(period=ten_periods_back,
+                                                                             seconds_per_period=SECONDS_PER_PERIOD,
+                                                                             latest_block=latest_block_number)
+
+    for past_period, block_number_for_past_period in ((three_periods_back, block_number_for_three_periods_back),
+                                                      (ten_periods_back, block_number_for_ten_periods_back)):
+        start_of_past_period = maya.MayaDT(epoch=(past_period * SECONDS_PER_PERIOD))
+        diff_in_seconds = int((now - start_of_past_period).total_seconds())
+        diff_in_blocks = diff_in_seconds // AVERAGE_BLOCK_TIME_IN_SECONDS
+
+        assert block_number_for_past_period < latest_block_number
+        assert block_number_for_past_period == (latest_block_number - diff_in_blocks)

--- a/tests/unit/test_prometheus.py
+++ b/tests/unit/test_prometheus.py
@@ -44,27 +44,37 @@ TEST_PREFIX = 'test_prefix'
 
 
 def test_prometheus_metrics_config():
-    listen_address = '111.111.111.111'
     port = 2020
+
+    # no port
+    with pytest.raises(ValueError):
+        PrometheusMetricsConfig(port=None, metrics_prefix=TEST_PREFIX)
+
+    # no prefix
+    with pytest.raises(ValueError):
+        PrometheusMetricsConfig(port=port, metrics_prefix=None)
+
     prometheus_config = PrometheusMetricsConfig(port=port,
-                                                metrics_prefix=TEST_PREFIX,
-                                                listen_address=listen_address)
+                                                metrics_prefix=TEST_PREFIX)
 
     assert prometheus_config.port == 2020
     assert prometheus_config.metrics_prefix == TEST_PREFIX
-    assert prometheus_config.listen_address == listen_address
+    assert prometheus_config.listen_address == ''
 
     # defaults
     assert prometheus_config.collection_interval == 10
     assert not prometheus_config.start_now
+    assert prometheus_config.listen_address == ''
 
     # non-defaults
     collection_interval = 5
+    listen_address = '111.111.111.111'
     prometheus_config = PrometheusMetricsConfig(port=port,
                                                 metrics_prefix=TEST_PREFIX,
                                                 listen_address=listen_address,
                                                 collection_interval=collection_interval,
                                                 start_now=True)
+    assert prometheus_config.listen_address == listen_address
     assert prometheus_config.collection_interval == collection_interval
     assert prometheus_config.start_now
 


### PR DESCRIPTION
Some node providers limit the number of blocks for which events can be checked in one call. The smallest I've heard of so far is alchemy with 1000. Without limiting the number of blocks and iterating the calls, the one filter query will fail.

Example
```
  File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.7/site-packages/web3/eth.py", line 498, in getFilterLogs
    RPC.eth_getFilterLogs, [filter_id],
  File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.7/site-packages/web3/manager.py", line 153, in request_blocking
    raise ValueError(response["error"])
ValueError: {'code': -32600, 'message': 'Requested block range for eth_getLogs is greater than the limit of 1000 blocks. Please reduce range and retry.'}
```

This PR has limited scope relative to #2239. Instead of trying to tackle all instances of event filters, only tackle the prometheus metrics collection for now, since the scope of the query for this purposes is limited - a max 2 periods of ethereum blocks is searched. The CLI commands (`nucypher status events`, and `nucypher stake events`) can search many more blocks and throttling would cause efficiency issues.

The problem with modifying CLI commands is that their scope cannot be enforced. `status events` can specify the `--from-block` option to increase the number of blocks to search, and `stake events` searches from block 0 by default. We could improve these by limiting the from-block to be from contract creation, since searching earlier than the contract is useless, but that is only sufficient in the short-term, and will be eventually still be an issue later on and thereby needs more thought.

For this PR we settle for fixing prometheus event data collection now, and we will address CLI commands at a later time.