### PR TITLE
Improving restoration of store nodes metadata

### DIFF
--- a/examples/run_demo_ursula_fleet.py
+++ b/examples/run_demo_ursula_fleet.py
@@ -32,6 +32,7 @@ ursula_maker = partial(Ursula, rest_host='127.0.0.1',
                        federated_only=True,
                        domain=TEMPORARY_DOMAIN)
 
+
 def spin_up_federated_ursulas(quantity: int = FLEET_POPULATION):
     # Ports
     starting_port = DEMO_NODE_STARTING_PORT
@@ -39,7 +40,7 @@ def spin_up_federated_ursulas(quantity: int = FLEET_POPULATION):
 
     ursulas = []
 
-    sage = ursula_maker(rest_port=ports[0], db_filepath=f"{Path(APP_DIR.user_cache_dir) / 'sage.db'}")
+    sage = ursula_maker(rest_port=ports[0], db_filepath=str(Path(APP_DIR.user_cache_dir) / 'sage.db'))
 
     ursulas.append(sage)
     for index, port in enumerate(ports[1:]):

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -342,6 +342,7 @@ class Character(Learner):
         # If we're federated only, we assume that all other nodes in our domain are as well.
         known_node_class.set_federated_mode(federated_only)
 
+    # TODO: Unused
     def store_metadata(self, filepath: str) -> str:
         """
         Save this node to the disk.

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -448,7 +448,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
                     known_nodes.add(node)
 
             if invalid_metadata:
-                self.log.warn(f"Couldn't read metadata at {metadata_path} for the following files: {invalid_metadata}")
+                self.log.warn(f"Couldn't read metadata in {self.metadata_dir} for the following files: {invalid_metadata}")
             return known_nodes
 
     @validate_checksum_address
@@ -543,7 +543,6 @@ class TemporaryFileBasedNodeStorage(LocalFileBasedNodeStorage):
         self.__temp_metadata_dir = None
         self.__temp_certificates_dir = None
         self.__temp_root_dir = None
-        self.initialize()
         super().__init__(metadata_dir=self.__temp_metadata_dir,
                          certificates_dir=self.__temp_certificates_dir,
                          storage_root=self.__temp_root_dir,

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -288,11 +288,9 @@ class ForgetfulNodeStorage(NodeStorage):
             raise cls.NodeStorageError
         return cls(*args, **kwargs)
 
-    def initialize(self) -> bool:
-        """Returns True if initialization was successful"""
+    def initialize(self):
         self.__metadata = dict()
         self.__certificates = dict()
-        return not bool(self.__metadata or self.__certificates)
 
 
 class LocalFileBasedNodeStorage(NodeStorage):
@@ -526,7 +524,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
 
         return cls(*args, **payload, **kwargs)
 
-    def initialize(self) -> bool:
+    def initialize(self):
         storage_dirs = (self.root_dir, self.metadata_dir, self.certificates_dir)
         for storage_dir in storage_dirs:
             try:
@@ -536,8 +534,6 @@ class LocalFileBasedNodeStorage(NodeStorage):
                 self.log.info(message)
             except FileNotFoundError:
                 raise self.NodeStorageError("There is no existing configuration at {}".format(self.root_dir))
-
-        return bool(all(map(os.path.isdir, (self.root_dir, self.metadata_dir, self.certificates_dir))))
 
 
 class TemporaryFileBasedNodeStorage(LocalFileBasedNodeStorage):
@@ -559,7 +555,7 @@ class TemporaryFileBasedNodeStorage(LocalFileBasedNodeStorage):
     #         shutil.rmtree(self.__temp_metadata_dir, ignore_errors=True)
     #         shutil.rmtree(self.__temp_certificates_dir, ignore_errors=True)
 
-    def initialize(self) -> bool:
+    def initialize(self):
         # Root
         self.__temp_root_dir = tempfile.mkdtemp(prefix="nucypher-tmp-nodes-")
         self.root_dir = self.__temp_root_dir
@@ -571,5 +567,3 @@ class TemporaryFileBasedNodeStorage(LocalFileBasedNodeStorage):
         # Certificates
         self.__temp_certificates_dir = str(Path(self.__temp_root_dir) / "certs")
         self.certificates_dir = self.__temp_certificates_dir
-
-        return all(map(os.path.isdir, (self.root_dir, self.metadata_dir, self.certificates_dir)))

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -201,7 +201,7 @@ class ForgetfulNodeStorage(NodeStorage):
         # Certificates
         self.__certificates = dict()
         self.__temporary_certificates = list()
-        self._temp_certificates_dir = tempfile.mkdtemp(prefix='nucypher-temp-certs-', dir=parent_dir)
+        self._temp_certificates_dir = tempfile.mkdtemp(prefix=self.__base_prefix, dir=parent_dir)
 
     @property
     def source(self) -> str:
@@ -209,7 +209,7 @@ class ForgetfulNodeStorage(NodeStorage):
         return self._name
 
     def all(self, federated_only: bool, certificates_only: bool = False) -> set:
-        return set(self.__metadata.values() if not certificates_only else self.__certificates.values())
+        return set(self.__certificates.values() if certificates_only else self.__metadata.values())
 
     @validate_checksum_address
     def get(self,
@@ -448,11 +448,6 @@ class LocalFileBasedNodeStorage(NodeStorage):
         filepath = self.__generate_metadata_filepath(checksum_address=address, metadata_dir=filepath)
         self.__write_metadata(filepath=filepath, node=node)
         return filepath
-
-    def save_node(self, node, force) -> Tuple[str, str]:
-        certificate_filepath = self.store_node_certificate(certificate=node.certificate, force=force)
-        metadata_filepath = self.store_node_metadata(node=node)
-        return metadata_filepath, certificate_filepath
 
     @validate_checksum_address
     def remove(self, checksum_address: str, metadata: bool = True, certificate: bool = True) -> None:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -348,8 +348,12 @@ class Learner:
         stored_nodes = self.node_storage.all(federated_only=self.federated_only)  # TODO: #466
 
         restored_from_disk = []
-
         for node in stored_nodes:
+            node_domain = node.domain.decode('utf-8')
+            if node_domain != self.learning_domain.encode():
+                self.log.warn(f"Restored {node} metadata from storage, but appears to be for domain '{node_domain}'; "
+                              f"we're learning about '{self.learning_domain}'. Let's ignore it.")
+                continue
             restored_node = self.remember_node(node, record_fleet_state=False)  # TODO: Validity status 1866
             restored_from_disk.append(restored_node)
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -21,7 +21,7 @@ import time
 from collections import defaultdict, deque
 from contextlib import suppress
 from queue import Queue
-from typing import Iterable
+from typing import Iterable, List
 from typing import Set, Tuple, Union
 
 import maya
@@ -344,7 +344,7 @@ class Learner:
 
         return discovered
 
-    def read_nodes_from_storage(self) -> None:
+    def read_nodes_from_storage(self) -> List:
         stored_nodes = self.node_storage.all(federated_only=self.federated_only)  # TODO: #466
 
         restored_from_disk = []

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -396,9 +396,9 @@ def federated_ursulas(ursula_federated_test_config):
 def lonely_ursula_maker(ursula_federated_test_config):
     class _PartialUrsulaMaker:
         _partial = partial(make_federated_ursulas,
-                         ursula_config=ursula_federated_test_config,
-                         know_each_other=False,
-                         )
+                           ursula_config=ursula_federated_test_config,
+                           know_each_other=False,
+                           )
         _made = []
 
         def __call__(self, *args, **kwargs):

--- a/tests/integration/config/test_storages.py
+++ b/tests/integration/config/test_storages.py
@@ -18,10 +18,9 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import pytest
 
 from nucypher.characters.lawful import Ursula
-from nucypher.config.storages import (ForgetfulNodeStorage, NodeStorage,
-                                      TemporaryFileBasedNodeStorage)
-from tests.constants import (
-    MOCK_URSULA_DB_FILEPATH)
+from nucypher.config.storages import ForgetfulNodeStorage, NodeStorage, TemporaryFileBasedNodeStorage
+
+from tests.constants import MOCK_URSULA_DB_FILEPATH
 from tests.utils.ursula import MOCK_URSULA_STARTING_PORT
 
 

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -21,35 +21,36 @@ from tests.utils.ursula import make_federated_ursulas
 
 
 def test_learner_learns_about_domains_separately(lonely_ursula_maker, caplog):
-        _lonely_ursula_maker = partial(lonely_ursula_maker, know_each_other=True, quantity=3)
+    _lonely_ursula_maker = partial(lonely_ursula_maker, know_each_other=True, quantity=3)
 
-        global_learners = _lonely_ursula_maker(domain="nucypher1.test_suite")
-        first_domain_learners = _lonely_ursula_maker(domain="nucypher1.test_suite")
-        second_domain_learners = _lonely_ursula_maker(domain="nucypher2.test_suite")
+    global_learners = _lonely_ursula_maker(domain="nucypher1.test_suite")
+    first_domain_learners = _lonely_ursula_maker(domain="nucypher1.test_suite")
+    second_domain_learners = _lonely_ursula_maker(domain="nucypher2.test_suite")
 
-        big_learner = global_learners.pop()
+    big_learner = global_learners.pop()
 
-        assert len(big_learner.known_nodes) == 2
+    assert len(big_learner.known_nodes) == 2
 
-        # Learn about the fist domain.
-        big_learner._current_teacher_node = first_domain_learners.pop()
-        big_learner.learn_from_teacher_node()
+    # Learn about the fist domain.
+    big_learner._current_teacher_node = first_domain_learners.pop()
+    big_learner.learn_from_teacher_node()
 
-        # Learn about the second domain.
-        big_learner._current_teacher_node = second_domain_learners.pop()
-        big_learner.learn_from_teacher_node()
+    # Learn about the second domain.
+    big_learner._current_teacher_node = second_domain_learners.pop()
+    big_learner.learn_from_teacher_node()
 
-        # All domain 1 nodes
-        assert len(big_learner.known_nodes) == 5
+    # All domain 1 nodes
+    assert len(big_learner.known_nodes) == 5
 
-        new_first_domain_learner = _lonely_ursula_maker(domain="nucypher1.test_suite").pop()
-        _new_second_domain_learner = _lonely_ursula_maker(domain="nucypher2.test_suite")
+    new_first_domain_learner = _lonely_ursula_maker(domain="nucypher1.test_suite").pop()
+    _new_second_domain_learner = _lonely_ursula_maker(domain="nucypher2.test_suite")
 
-        new_first_domain_learner._current_teacher_node = big_learner
-        new_first_domain_learner.learn_from_teacher_node()
+    new_first_domain_learner._current_teacher_node = big_learner
+    new_first_domain_learner.learn_from_teacher_node()
 
-        # This node, in the first domain, didn't learn about the second domain.
-        assert not set(second_domain_learners).intersection(new_first_domain_learner.known_nodes)
+    # This node, in the first domain, didn't learn about the second domain.
+    assert not set(second_domain_learners).intersection(new_first_domain_learner.known_nodes)
 
-        # However, it learned about *all* of the nodes in its own domain.
-        assert set(first_domain_learners).intersection(n.mature() for n in new_first_domain_learner.known_nodes) == first_domain_learners
+    # However, it learned about *all* of the nodes in its own domain.
+    assert set(first_domain_learners).intersection(
+            n.mature() for n in new_first_domain_learner.known_nodes) == first_domain_learners

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -17,7 +17,8 @@
 
 from functools import partial
 
-from tests.utils.ursula import make_federated_ursulas
+from nucypher.acumen.perception import FleetSensor
+from nucypher.config.storages import TemporaryFileBasedNodeStorage, LocalFileBasedNodeStorage
 
 
 def test_learner_learns_about_domains_separately(lonely_ursula_maker, caplog):
@@ -54,3 +55,40 @@ def test_learner_learns_about_domains_separately(lonely_ursula_maker, caplog):
     # However, it learned about *all* of the nodes in its own domain.
     assert set(first_domain_learners).intersection(
             n.mature() for n in new_first_domain_learner.known_nodes) == first_domain_learners
+
+
+def test_learner_restores_metadata_from_storage(lonely_ursula_maker, tmpdir):
+
+    # Create a local file-based node storage
+    root = tmpdir.mkdir("known_nodes")
+    metadata = root.mkdir("metadata")
+    certs = root.mkdir("certs")
+    old_storage = LocalFileBasedNodeStorage(federated_only=True,
+                                            metadata_dir=metadata,
+                                            certificates_dir=certs,
+                                            storage_root=root)
+
+    # Use the ursula maker with this storage so it's populated with nodes from one domain
+    _some_ursulas = lonely_ursula_maker(domain="fistro",
+                                        node_storage=old_storage,
+                                        know_each_other=True,
+                                        quantity=3,
+                                        save_metadata=True)
+
+    # Create a pair of new learners in a different domain, using the previous storage, and learn from it
+    new_learners = lonely_ursula_maker(domain="duodenal",
+                                       node_storage=old_storage,
+                                       quantity=2,
+                                       know_each_other=True,
+                                       save_metadata=False)
+    learner, buddy = new_learners
+    buddy._Learner__known_nodes = FleetSensor()
+
+    # The learner shouldn't learn about any node from the first domain, since it's different.
+    learner.learn_from_teacher_node()
+    for restored_node in learner.known_nodes:
+        assert restored_node.mature().serving_domain == learner.learning_domain
+
+    # In fact, since the storage only contains nodes from a different domain,
+    # the learner should only know its buddy from the second domain.
+    assert set(learner.known_nodes) == {buddy}


### PR DESCRIPTION
This PR demonstrates that currently it's possible to learn about nodes from a different domain when they are recovered from storage, which can happen for example when a staker reuses the configuration from a testnet. It then fixes it by introducing a simple domain check when restoring nodes from disk, ignoring nodes that don't belong to current domain.

Closes #1843 
Closes #1623 

