### PR TITLE
Make sure datastores are not retained in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,7 @@ def check_character_state_after_test(request):
                 offending_tests.add(learner._FOR_TEST)
                 try:  # TODO: Deal with stop vs disenchant.  Currently stop is only for Ursula.
                     learner.stop()
+                    learner._finalize()
                 except AttributeError:
                     learner.disenchant()
             pytest.fail(f"Learners remaining: {still_running}.  Offending tests: {offending_tests} ")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -390,6 +390,11 @@ def federated_ursulas(ursula_federated_test_config):
 
     for u in _ursulas:
         u.stop()
+        u._finalize()
+
+    # Pytest will hold on to this object, need to clear it manually.
+    # See https://github.com/pytest-dev/pytest/issues/5642
+    _ursulas.clear()
 
 
 @pytest.fixture(scope="function")
@@ -411,6 +416,8 @@ def lonely_ursula_maker(ursula_federated_test_config):
                 ursula.stop()
             for ursula in self._made:
                 del MOCK_KNOWN_URSULAS_CACHE[ursula.rest_interface.port]
+            for ursula in self._made:
+                ursula._finalize()
     _maker = _PartialUrsulaMaker()
     yield _maker
     _maker.clean()
@@ -697,6 +704,14 @@ def blockchain_ursulas(testerchain, stakers, ursula_decentralized_test_config):
 
     for port in _ports_to_remove:
         del MOCK_KNOWN_URSULAS_CACHE[port]
+
+    for u in _ursulas:
+        u.stop()
+        u._finalize()
+
+    # Pytest will hold on to this object, need to clear it manually.
+    # See https://github.com/pytest-dev/pytest/issues/5642
+    _ursulas.clear()
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,7 +43,6 @@ from tests.constants import (
     MOCK_PROVIDER_URI,
     NUMBER_OF_MOCK_KEYSTORE_ACCOUNTS
 )
-from nucypher.datastore.datastore import Datastore  # yikes TODO
 from tests.fixtures import _make_testerchain, make_token_economics
 from tests.mock.agents import MockContractAgency, MockContractAgent
 from tests.mock.interfaces import MockBlockchain, mock_registry_source_manager
@@ -90,11 +89,6 @@ class TestLMDBEnv:
 @pytest.fixture(autouse=True)
 def JIT_lmdb_env(monkeypatch):
     monkeypatch.setattr("lmdb.open", TestLMDBEnv)
-
-
-@pytest.fixture(autouse=True)
-def reduced_memory_page_lmdb(monkeypatch):
-    monkeypatch.setattr(Datastore, "LMDB_MAP_SIZE", 10_000_000)
 
 
 @pytest.fixture(scope='function', autouse=True)

--- a/tests/integration/network/test_network_upgrade.py
+++ b/tests/integration/network/test_network_upgrade.py
@@ -27,7 +27,7 @@ from nucypher.datastore.models import PolicyArrangement
 from tests.utils.ursula import make_federated_ursulas
 
 
-def test_alice_enacts_policies_in_policy_group_via_rest(enacted_federated_policy, reduced_memory_page_lmdb):
+def test_alice_enacts_policies_in_policy_group_via_rest(enacted_federated_policy):
     """
     Now that Alice has made a PolicyGroup, she can enact its policies, using Ursula's Public Key to encrypt each offer
     and transmitting them via REST.

--- a/tests/mock/performance_mocks.py
+++ b/tests/mock/performance_mocks.py
@@ -195,9 +195,9 @@ class NotARestApp:
 
     def actual_rest_app(self):
         if self._actual_rest_app is None:
-            self._actual_rest_app, _datastore = make_rest_app(db_filepath=tempfile.mkdtemp(),
-                                                             this_node=self.this_node,
-                                                             serving_domains=(None,))
+            self._actual_rest_app, self._datastore = make_rest_app(db_filepath=tempfile.mkdtemp(),
+                                                                   this_node=self.this_node,
+                                                                   serving_domains=(None,))
             _new_view_functions = self._ViewFunctions(self._actual_rest_app.view_functions)
             self._actual_rest_app.view_functions = _new_view_functions
             self._actual_rest_apps.append(


### PR DESCRIPTION
Fixes #2172

The problem is not caused by the DB size (see the comments in the issue), but persistent `Datastore` objects. Fixing that is the main purpose of the PR. Reduced DB size is not relevant - LMDB files are dynamic anyway (although one could argue that the reduced DB size still helps catch some errors).

What it does:
- changes `make_rest_app()` to not retain a reference to `Ursula` or the created datastore in the returned REST app object, **now it is the caller's responsibility;**
- adds a cleanup method to `Ursula`, to be used in fixtures. Weakrefs will make sure the datastore is cleaned up if all references to `Ursula` is released, but that may not be the case in tests, so an explicit method is needed.
- removes the DB size reduction fixture. It doesn't affect file sizes, and doesn't really test anything. 

I was not sure where to place the cleanup method. Currently it's separate; other possibilities are (overridden) `disenchant()`, or `stop()`. If either of these is allowed to invalidate the `Ursula`, we can put the cleanup there.

**TODO:**
* Any other places where Ursulas are created in tests and need to be cleaned up?
