### PR TITLE
Commit without haste

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1596,11 +1596,12 @@ class Worker(NucypherTokenActor):
         return period
 
     @only_me
-    @save_receipt
-    def commit_to_next_period(self) -> TxReceipt:
+    @save_receipt  # saves txhash instead of receipt if `fire_and_forget` is True
+    def commit_to_next_period(self, fire_and_forget: bool = True) -> TxReceipt:
         """For each period that the worker makes a commitment, the staker is rewarded"""
-        receipt = self.staking_agent.commit_to_next_period(worker_address=self.__worker_address)
-        return receipt
+        txhash_or_receipt = self.staking_agent.commit_to_next_period(worker_address=self.__worker_address,
+                                                                     fire_and_forget=fire_and_forget)
+        return txhash_or_receipt
 
     @property
     def missing_commitments(self) -> int:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -570,12 +570,14 @@ class StakingEscrowAgent(EthereumContractAgent):
         return self.bond_worker(staker_address=staker_address, worker_address=NULL_ADDRESS)
 
     @contract_api(TRANSACTION)
-    def commit_to_next_period(self, worker_address: ChecksumAddress) -> TxReceipt:
+    def commit_to_next_period(self, worker_address: ChecksumAddress, fire_and_forget: bool) -> TxReceipt:
         """
         For each period that the worker makes a commitment, the staker is rewarded.
         """
         contract_function: ContractFunction = self.contract.functions.commitToNextPeriod()
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=worker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=worker_address,
+                                                              fire_and_forget=fire_and_forget)  # TODO: Hardcode this to True
         return receipt
 
     @contract_api(TRANSACTION)

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -570,14 +570,14 @@ class StakingEscrowAgent(EthereumContractAgent):
         return self.bond_worker(staker_address=staker_address, worker_address=NULL_ADDRESS)
 
     @contract_api(TRANSACTION)
-    def commit_to_next_period(self, worker_address: ChecksumAddress, fire_and_forget: bool) -> TxReceipt:
+    def commit_to_next_period(self, worker_address: ChecksumAddress, fire_and_forget: bool = True) -> TxReceipt:  # TODO: make fire_and_forget required
         """
         For each period that the worker makes a commitment, the staker is rewarded.
         """
         contract_function: ContractFunction = self.contract.functions.commitToNextPeriod()
         receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                               sender_address=worker_address,
-                                                              fire_and_forget=fire_and_forget)  # TODO: Hardcode this to True
+                                                              fire_and_forget=fire_and_forget)
         return receipt
 
     @contract_api(TRANSACTION)

--- a/nucypher/blockchain/eth/decorators.py
+++ b/nucypher/blockchain/eth/decorators.py
@@ -117,13 +117,13 @@ def only_me(func: Callable) -> Callable:
     return wrapped
 
 
-def save_receipt(actor_method) -> Callable:
-    """Decorator to save the receipts of transmitted transactions from actor methods"""
+def save_receipt(actor_method) -> Callable:  # TODO: rename to "save_result"?
+    """Decorator to save the result of a function with a timestamp"""
     @functools.wraps(actor_method)
     def wrapped(self, *args, **kwargs) -> dict:
-        receipt = actor_method(self, *args, **kwargs)
-        self._saved_receipts.append((datetime.utcnow(), receipt))
-        return receipt
+        receipt_or_txhash = actor_method(self, *args, **kwargs)
+        self._saved_receipts.append((datetime.utcnow(), receipt_or_txhash))
+        return receipt_or_txhash
     return wrapped
 
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -535,10 +535,10 @@ class BlockchainInterface:
                                        ) -> Union[TxReceipt, HexBytes]:
         """
         Takes a transaction dictionary, signs it with the configured signer, then broadcasts the signed
-        transaction the ethereum provider's eth_sendRawTransaction RPC endpoint.
+        transaction using the ethereum provider's eth_sendRawTransaction RPC endpoint.
         Optionally blocks for receipt and confirmation with 'confirmations', and 'fire_and_forget' flags.
 
-        If 'fire and forget' is True this method returns the transaction hash only -
+        If 'fire and forget' is True this method returns the transaction hash only, without waiting for a receipt -
         otherwise return the transaction receipt.
 
         """

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -535,10 +535,10 @@ class BlockchainInterface:
                                        ) -> Union[TxReceipt, HexBytes]:
         """
         Takes a transaction dictionary, signs it with the configured signer, then broadcasts the signed
-        transaction the ethereum provider's eth_sendRawTransaction RPC endpoint. Optionally blocks for receipt or
-        confirmation with `confirmations`, and `fire_and_forget.
+        transaction the ethereum provider's eth_sendRawTransaction RPC endpoint.
+        Optionally blocks for receipt and confirmation with 'confirmations', and 'fire_and_forget' flags.
 
-        If `fire and forget` is True this method returns the transaction hash only -
+        If 'fire and forget' is True this method returns the transaction hash only -
         otherwise return the transaction receipt.
 
         """

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -643,11 +643,11 @@ class BlockchainInterface:
         except AttributeError:
             transaction_name = 'DEPLOY' if isinstance(contract_function, ContractConstructor) else 'UNKNOWN'
 
-        receipt = self.sign_and_broadcast_transaction(transaction_dict=transaction,
-                                                      transaction_name=transaction_name,
-                                                      confirmations=confirmations,
-                                                      fire_and_forget=fire_and_forget)
-        return receipt
+        txhash_or_receipt = self.sign_and_broadcast_transaction(transaction_dict=transaction,
+                                                                transaction_name=transaction_name,
+                                                                confirmations=confirmations,
+                                                                fire_and_forget=fire_and_forget)
+        return txhash_or_receipt
 
     def get_contract_by_name(self,
                              registry: BaseContractRegistry,

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -637,7 +637,7 @@ class WorkTracker:
         self.log.info("Made a commitment to period {}".format(self.current_period))
         transacting_power = self.worker.transacting_power
         with transacting_power:
-            self.worker.commit_to_next_period()  # < --- blockchain WRITE
+            self.worker.commit_to_next_period(fire_and_forget=True)  # < --- blockchain WRITE | Do not wait for receipt
 
 
 class StakeList(UserList):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1217,7 +1217,7 @@ class Ursula(Teacher, Character, Worker):
                 emitter.message(f"✓ Availability Checks", color='green')
 
         if worker and not self.federated_only:
-            self.work_tracker.start(act_now=True, requirement_func=self._availability_tracker.status)
+            self.work_tracker.start(act_now=True)  # requirement_func=self._availability_tracker.status)  # TODO: #2277
             if emitter:
                 emitter.message(f"✓ Work Tracking", color='green')
 

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -452,7 +452,7 @@ def commit_to_next_period(general_config, character_options, config_file):
 
     committed_period = URSULA.staking_agent.get_current_period() + 1
     click.echo(CONFIRMING_ACTIVITY_NOW.format(committed_period=committed_period), color='blue')
-    receipt = URSULA.commit_to_next_period()
+    receipt = URSULA.commit_to_next_period(fire_and_forget=False)
 
     economics = EconomicsFactory.get_economics(registry=URSULA.registry)
     date = datetime_at_period(period=committed_period, seconds_per_period=economics.seconds_per_period)

--- a/nucypher/cli/processes.py
+++ b/nucypher/cli/processes.py
@@ -171,7 +171,7 @@ class UrsulaCommandProtocol(LineReceiver):
         """
         manually make a commitment to the next period
         """
-        return self.ursula.commit_to_next_period()
+        return self.ursula.commit_to_next_period(fire_and_forget=False)
 
     def stop(self):
         """

--- a/tests/acceptance/blockchain/agents/test_policy_manager_agent.py
+++ b/tests/acceptance/blockchain/agents/test_policy_manager_agent.py
@@ -116,7 +116,7 @@ def test_calculate_refund(testerchain, agency, policy_meta, mock_transacting_pow
     mock_transacting_power_activation(account=worker, password=INSECURE_DEVELOPMENT_PASSWORD)
 
     testerchain.time_travel(hours=9)
-    _receipt = staking_agent.commit_to_next_period(worker_address=worker)
+    staking_agent.commit_to_next_period(worker_address=worker)
 
     mock_transacting_power_activation(account=testerchain.alice_account, password=INSECURE_DEVELOPMENT_PASSWORD)
 
@@ -163,7 +163,7 @@ def test_collect_policy_fee(testerchain, agency, policy_meta, token_economics, m
     old_eth_balance = token_agent.blockchain.client.get_balance(staker)
 
     for _ in range(token_economics.minimum_locked_periods):
-        _receipt = staking_agent.commit_to_next_period(worker_address=worker)
+        staking_agent.commit_to_next_period(worker_address=worker)
         testerchain.time_travel(periods=1)
 
     mock_transacting_power_activation(account=staker, password=INSECURE_DEVELOPMENT_PASSWORD)

--- a/tests/acceptance/blockchain/agents/test_preallocation_escrow_agent.py
+++ b/tests/acceptance/blockchain/agents/test_preallocation_escrow_agent.py
@@ -196,9 +196,9 @@ def test_collect_policy_fees(testerchain, agent, agency, token_economics, mock_t
                                           node_addresses=[agent.contract_address])
 
     mock_transacting_power_activation(account=worker, password=INSECURE_DEVELOPMENT_PASSWORD)
-    _receipt = staking_agent.commit_to_next_period(worker_address=worker)
+    staking_agent.commit_to_next_period(worker_address=worker)
     testerchain.time_travel(periods=2)
-    _receipt = staking_agent.commit_to_next_period(worker_address=worker)
+    staking_agent.commit_to_next_period(worker_address=worker)
 
     old_balance = testerchain.client.get_balance(account=agent.beneficiary)
 

--- a/tests/acceptance/blockchain/agents/test_staking_escrow_agent.py
+++ b/tests/acceptance/blockchain/agents/test_staking_escrow_agent.py
@@ -178,7 +178,8 @@ def test_commit_to_next_period(agency, testerchain, mock_transacting_power_activ
 
     mock_transacting_power_activation(account=worker_account, password=INSECURE_DEVELOPMENT_PASSWORD)
 
-    receipt = staking_agent.commit_to_next_period(worker_address=worker_account)
+    txhash = staking_agent.commit_to_next_period(worker_address=worker_account)
+    receipt = testerchain.wait_for_receipt(txhash)
     assert receipt['status'] == 1, "Transaction Rejected"
     assert receipt['logs'][0]['address'] == staking_agent.contract_address
 
@@ -305,7 +306,7 @@ def test_collect_staking_reward(agency, testerchain, mock_transacting_power_acti
     staker_account, worker_account, *other = testerchain.unassigned_accounts
 
     # Commit to next period
-    _receipt = staking_agent.commit_to_next_period(worker_address=worker_account)
+    staking_agent.commit_to_next_period(worker_address=worker_account)
     testerchain.time_travel(periods=2)
 
     mock_transacting_power_activation(account=staker_account, password=INSECURE_DEVELOPMENT_PASSWORD)

--- a/tests/acceptance/cli/test_worklock_cli.py
+++ b/tests/acceptance/cli/test_worklock_cli.py
@@ -245,7 +245,8 @@ def test_refund(click_runner, testerchain, agency_local_registry, token_economic
 
     # Do some work
     for i in range(3):
-        receipt = worker.commit_to_next_period()
+        txhash = worker.commit_to_next_period()
+        testerchain.wait_for_receipt(txhash)
         assert receipt['status'] == 1
         testerchain.time_travel(periods=1)
 

--- a/tests/acceptance/cli/ursula/test_local_keystore_integration.py
+++ b/tests/acceptance/cli/ursula/test_local_keystore_integration.py
@@ -158,7 +158,8 @@ def test_ursula_and_local_keystore_signer_integration(click_runner,
         assert pre_config_signer.path == ursula.signer.path
 
         # ...and that transactions are signed by the keytore signer
-        receipt = ursula.commit_to_next_period()
+        txhash = ursula.commit_to_next_period()
+        receipt = testerchain.wait_for_receipt(txhash)
         transaction_data = testerchain.client.w3.eth.getTransaction(receipt['transactionHash'])
         assert transaction_data['from'] == worker_account.address
     finally:


### PR DESCRIPTION
* Immediate help for issues that cause nodes to crash
* Don't leave the cursor hanging, polling the provider for a receipt and confirmations.  
* Allows the work tracker to track transaction hashes instead of receipts, by broadcasting commitment transactions when they are indicated by the staking contract without waiting for a receipt.
* Removes default work tracker qualification callable until #2277 is resolved. (`__requirement`)
* Advances #2070 #1852 #2141 

Additional follow-up in #2141 