### PR TITLE
Add default retry functionality to EthereumClients

### DIFF
--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -44,7 +44,8 @@ from web3._utils.threads import Timeout
 from web3.exceptions import TimeExhausted, TransactionNotFound
 
 from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS
-from nucypher.blockchain.middleware.retry import RetryRequestMiddleware, AlchemyRetryRequestMiddleware
+from nucypher.blockchain.middleware.retry import RetryRequestMiddleware, AlchemyRetryRequestMiddleware, \
+    InfuraRetryRequestMiddleware
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, DEPLOY_DIR, USER_LOG_DIR
 from nucypher.utilities.logging import Logger
 
@@ -548,6 +549,11 @@ class GanacheClient(EthereumClient):
 class InfuraClient(EthereumClient):
     is_local = False
     TRANSACTION_POLLING_TIME = 2  # seconds
+
+    def _add_middleware(self):
+        # default retry functionality
+        self.log.debug('Adding Infura RPC retry middleware to client')
+        self.w3.middleware_onion.add(InfuraRetryRequestMiddleware)
 
     def unlock_account(self, *args, **kwargs) -> bool:
         return True

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -160,12 +160,13 @@ class EthereumClient:
         self.platform = platform
         self.backend = backend
         self.log = Logger(self.__class__.__name__)
-        self._add_middleware()
 
-    def _add_middleware(self):
+        self._add_default_middleware()
+
+    def _add_default_middleware(self):
         # default retry functionality
         self.log.debug('Adding RPC retry middleware to client')
-        self.w3.middleware_onion.add(RetryRequestMiddleware)
+        self.add_middleware(RetryRequestMiddleware)
 
     @classmethod
     def _get_variant(cls, w3):
@@ -550,10 +551,10 @@ class InfuraClient(EthereumClient):
     is_local = False
     TRANSACTION_POLLING_TIME = 2  # seconds
 
-    def _add_middleware(self):
+    def _add_default_middleware(self):
         # default retry functionality
         self.log.debug('Adding Infura RPC retry middleware to client')
-        self.w3.middleware_onion.add(InfuraRetryRequestMiddleware)
+        self.add_middleware(InfuraRetryRequestMiddleware)
 
     def unlock_account(self, *args, **kwargs) -> bool:
         return True
@@ -564,10 +565,10 @@ class InfuraClient(EthereumClient):
 
 class AlchemyClient(EthereumClient):
 
-    def _add_middleware(self):
+    def _add_default_middleware(self):
         # default retry functionality
         self.log.debug('Adding Alchemy RPC retry middleware to client')
-        self.w3.middleware_onion.add(AlchemyRetryRequestMiddleware)
+        self.add_middleware(AlchemyRetryRequestMiddleware)
 
 
 class EthereumTesterClient(EthereumClient):

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -16,11 +16,14 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-import click
 import os
 import pprint
-import requests
 import time
+from typing import Callable, NamedTuple, Tuple, Union
+from urllib.parse import urlparse
+
+import click
+import requests
 from constant_sorrow.constants import (
     INSUFFICIENT_ETH,
     NO_BLOCKCHAIN_CONNECTION,
@@ -33,8 +36,6 @@ from eth_tester.exceptions import TransactionFailed as TestTransactionFailed
 from eth_typing import ChecksumAddress
 from eth_utils import to_checksum_address
 from hexbytes.main import HexBytes
-from typing import Callable, NamedTuple, Tuple, Union
-from urllib.parse import urlparse
 from web3 import Web3, middleware
 from web3.contract import Contract, ContractConstructor, ContractFunction
 from web3.exceptions import TimeExhausted, ValidationError
@@ -48,7 +49,6 @@ from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.providers import (
     _get_auto_provider,
     _get_HTTP_provider,
-    _get_infura_provider,
     _get_IPC_provider,
     _get_mock_test_provider,
     _get_pyevm_test_provider,
@@ -59,8 +59,8 @@ from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.blockchain.eth.utils import get_transaction_name, prettify_eth_amount
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter, StdoutEmitter
-from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 from nucypher.utilities.datafeeds import datafeed_fallback_gas_price_strategy
+from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 
 
 class VersionedContract(Contract):
@@ -396,7 +396,6 @@ class BlockchainInterface:
             else:
                 providers = {
                     'auto': _get_auto_provider,
-                    'infura': _get_infura_provider,
                     'ipc': _get_IPC_provider,
                     'file': _get_IPC_provider,
                     'ws': _get_websocket_provider,

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -29,18 +29,18 @@ from constant_sorrow.constants import (
     READ_ONLY_INTERFACE,
     UNKNOWN_TX_STATUS
 )
-from eth_tester import EthereumTester
 from eth_tester.exceptions import TransactionFailed as TestTransactionFailed
 from eth_typing import ChecksumAddress
 from eth_utils import to_checksum_address
 from hexbytes.main import HexBytes
 from typing import Callable, NamedTuple, Tuple, Union
 from urllib.parse import urlparse
-from web3 import HTTPProvider, IPCProvider, Web3, WebsocketProvider, middleware
+from web3 import Web3, middleware
 from web3.contract import Contract, ContractConstructor, ContractFunction
 from web3.exceptions import TimeExhausted, ValidationError
 from web3.gas_strategies import time_based
 from web3.middleware import geth_poa_middleware
+from web3.providers import BaseProvider
 from web3.types import TxReceipt
 
 from nucypher.blockchain.eth.clients import EthereumClient, POA_CHAINS, InfuraClient
@@ -61,8 +61,6 @@ from nucypher.blockchain.eth.utils import get_transaction_name, prettify_eth_amo
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter, StdoutEmitter
 from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 from nucypher.utilities.datafeeds import datafeed_fallback_gas_price_strategy
-
-Web3Providers = Union[IPCProvider, WebsocketProvider, HTTPProvider, EthereumTester]
 
 
 class VersionedContract(Contract):
@@ -156,7 +154,7 @@ class BlockchainInterface:
                  light: bool = False,
                  provider_process=NO_PROVIDER_PROCESS,
                  provider_uri: str = NO_BLOCKCHAIN_CONNECTION,
-                 provider: Web3Providers = NO_BLOCKCHAIN_CONNECTION,
+                 provider: BaseProvider = NO_BLOCKCHAIN_CONNECTION,
                  gas_strategy: Union[str, Callable] = DEFAULT_GAS_STRATEGY):
 
         """
@@ -370,11 +368,11 @@ class BlockchainInterface:
         return
 
     @property
-    def provider(self) -> Union[IPCProvider, WebsocketProvider, HTTPProvider]:
+    def provider(self) -> BaseProvider:
         return self._provider
 
     def _attach_provider(self,
-                         provider: Web3Providers = None,
+                         provider: BaseProvider = None,
                          provider_uri: str = None) -> None:
         """
         https://web3py.readthedocs.io/en/latest/providers.html#providers

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -19,7 +19,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import os
 import pprint
 import time
-from typing import Callable, NamedTuple, Tuple, Union
+from typing import Callable, NamedTuple, Tuple, Union, Optional
 from urllib.parse import urlparse
 
 import click
@@ -372,7 +372,7 @@ class BlockchainInterface:
         return self._provider
 
     def _attach_provider(self,
-                         provider: BaseProvider = None,
+                         provider: Optional[BaseProvider] = None,
                          provider_uri: str = None) -> None:
         """
         https://web3py.readthedocs.io/en/latest/providers.html#providers

--- a/nucypher/blockchain/eth/providers.py
+++ b/nucypher/blockchain/eth/providers.py
@@ -14,14 +14,12 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-import os
 from typing import Union
 from urllib.parse import urlparse
 
 from eth_tester import EthereumTester, PyEVMBackend
 from eth_tester.backends.mock.main import MockBackend
 from web3 import HTTPProvider, IPCProvider, WebsocketProvider
-from web3.exceptions import InfuraKeyNotFound
 from web3.providers import BaseProvider
 from web3.providers.eth_tester.main import EthereumTesterProvider
 
@@ -46,42 +44,9 @@ def _get_HTTP_provider(provider_uri) -> BaseProvider:
     return HTTPProvider(endpoint_uri=provider_uri, request_kwargs={'timeout': BlockchainInterface.TIMEOUT})
 
 
-
 def _get_websocket_provider(provider_uri) -> BaseProvider:
     from nucypher.blockchain.eth.interfaces import BlockchainInterface
     return WebsocketProvider(endpoint_uri=provider_uri, websocket_kwargs={'timeout': BlockchainInterface.TIMEOUT})
-
-
-
-def _get_infura_provider(provider_uri: str) -> BaseProvider:
-    # https://web3py.readthedocs.io/en/latest/providers.html#infura-mainnet
-
-    uri_breakdown = urlparse(provider_uri)
-    infura_envvar = 'WEB3_INFURA_PROJECT_ID'
-    os.environ[infura_envvar] = os.environ.get(infura_envvar, uri_breakdown.netloc)
-
-    try:
-        # TODO: Is this the right approach? Looks a little bit shabby... Also #1496
-        if "mainnet.infura.io" in provider_uri:
-            from web3.auto.infura.mainnet import w3
-        elif "goerli.infura.io" in provider_uri:
-            from web3.auto.infura.goerli import w3
-        elif "rinkeby.infura.io" in provider_uri:
-            from web3.auto.infura.rinkeby import w3
-        elif "ropsten.infura.io" in provider_uri:
-            from web3.auto.infura.ropsten import w3
-        else:
-            raise ValueError(f"Couldn't find an Infura provider for {provider_uri}")
-
-    except InfuraKeyNotFound:
-        raise ProviderError(f'{infura_envvar} must be provided in order to use an Infura Web3 provider {provider_uri}.')
-
-    # Verify Connection
-    connected = w3.isConnected()
-    if not connected:
-        raise ProviderError(f'Failed to connect to Infura node "{provider_uri}".')
-
-    return w3.provider
 
 
 def _get_auto_provider(provider_uri) -> BaseProvider:

--- a/nucypher/blockchain/eth/providers.py
+++ b/nucypher/blockchain/eth/providers.py
@@ -16,16 +16,16 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 import os
 import time
+from typing import Union, Callable
+from urllib.parse import urlparse
 
 from eth_tester import EthereumTester, PyEVMBackend
 from eth_tester.backends.mock.main import MockBackend
-from typing import Union, Callable
-from urllib.parse import urlparse
 from web3 import HTTPProvider, IPCProvider, WebsocketProvider
 from web3.exceptions import InfuraKeyNotFound
 from web3.providers import BaseProvider
 from web3.providers.eth_tester.main import EthereumTesterProvider
-from web3.types import RPCResponse, RPCError
+from web3.types import RPCResponse
 
 from nucypher.blockchain.eth.clients import NuCypherGethDevProcess
 from nucypher.exceptions import DevelopmentInstallationRequired
@@ -36,7 +36,7 @@ class ProviderError(Exception):
     pass
 
 
-def _get_IPC_provider(provider_uri):
+def _get_IPC_provider(provider_uri) -> BaseProvider:
     uri_breakdown = urlparse(provider_uri)
     from nucypher.blockchain.eth.interfaces import BlockchainInterface
     return IPCProvider(ipc_path=uri_breakdown.path,
@@ -44,7 +44,7 @@ def _get_IPC_provider(provider_uri):
                        request_kwargs={'timeout': BlockchainInterface.TIMEOUT})
 
 
-def _get_HTTP_provider(provider_uri):
+def _get_HTTP_provider(provider_uri) -> BaseProvider:
     from nucypher.blockchain.eth.interfaces import BlockchainInterface
     if 'alchemyapi.io' in provider_uri:
         return AlchemyHTTPProvider(endpoint_uri=provider_uri, request_kwargs={'timeout': BlockchainInterface.TIMEOUT})
@@ -52,7 +52,7 @@ def _get_HTTP_provider(provider_uri):
     return HTTPProvider(endpoint_uri=provider_uri, request_kwargs={'timeout': BlockchainInterface.TIMEOUT})
 
 
-def _get_websocket_provider(provider_uri):
+def _get_websocket_provider(provider_uri) -> BaseProvider:
     from nucypher.blockchain.eth.interfaces import BlockchainInterface
     if 'alchemyapi.io' in provider_uri:
         return AlchemyWebsocketProvider(endpoint_uri=provider_uri,
@@ -60,7 +60,7 @@ def _get_websocket_provider(provider_uri):
     return WebsocketProvider(endpoint_uri=provider_uri, websocket_kwargs={'timeout': BlockchainInterface.TIMEOUT})
 
 
-def _get_infura_provider(provider_uri: str):
+def _get_infura_provider(provider_uri: str) -> BaseProvider:
     # https://web3py.readthedocs.io/en/latest/providers.html#infura-mainnet
 
     uri_breakdown = urlparse(provider_uri)
@@ -91,7 +91,7 @@ def _get_infura_provider(provider_uri: str):
     return w3.provider
 
 
-def _get_auto_provider(provider_uri):
+def _get_auto_provider(provider_uri) -> BaseProvider:
     from web3.auto import w3
     # how-automated-detection-works: https://web3py.readthedocs.io/en/latest/providers.html
     connected = w3.isConnected()
@@ -120,7 +120,7 @@ def _get_ethereum_tester(test_backend: Union[PyEVMBackend, MockBackend]) -> Ethe
     return provider
 
 
-def _get_pyevm_test_provider(provider_uri):
+def _get_pyevm_test_provider(provider_uri) -> BaseProvider:
     """ Test provider entry-point"""
     # https://github.com/ethereum/eth-tester#pyevm-experimental
     pyevm_eth_tester = _get_pyevm_test_backend()
@@ -128,14 +128,14 @@ def _get_pyevm_test_provider(provider_uri):
     return provider
 
 
-def _get_mock_test_provider(provider_uri):
+def _get_mock_test_provider(provider_uri) -> BaseProvider:
     # https://github.com/ethereum/eth-tester#mockbackend
     mock_backend = MockBackend()
     provider = _get_ethereum_tester(test_backend=mock_backend)
     return provider
 
 
-def _get_test_geth_parity_provider(provider_uri):
+def _get_test_geth_parity_provider(provider_uri) -> BaseProvider:
     from nucypher.blockchain.eth.interfaces import BlockchainInterface
 
     # geth --dev
@@ -148,7 +148,7 @@ def _get_test_geth_parity_provider(provider_uri):
     return provider
 
 
-def _get_tester_ganache(provider_uri=None):
+def _get_tester_ganache(provider_uri=None) -> BaseProvider:
     endpoint_uri = provider_uri or 'http://localhost:7545'
     return HTTPProvider(endpoint_uri=endpoint_uri)
 

--- a/nucypher/blockchain/middleware/__init__.py
+++ b/nucypher/blockchain/middleware/__init__.py
@@ -1,0 +1,16 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""

--- a/nucypher/blockchain/middleware/retry.py
+++ b/nucypher/blockchain/middleware/retry.py
@@ -26,6 +26,9 @@ from nucypher.utilities.logging import Logger
 
 
 class RetryRequestMiddleware:
+    """
+    Automatically retries rpc requests whenever a 429 status code is returned.
+    """
     def __init__(self,
                  make_request: Callable[[RPCEndpoint, Any], RPCResponse],
                  w3: Web3,
@@ -91,6 +94,9 @@ class RetryRequestMiddleware:
 
 
 class AlchemyRetryRequestMiddleware(RetryRequestMiddleware):
+    """
+    Automatically retries rpc requests whenever a 429 status code or Alchemy-specific error message is returned.
+    """
 
     def is_request_result_retry(self, result: Union[RPCResponse, Exception]) -> bool:
         """
@@ -126,6 +132,9 @@ class AlchemyRetryRequestMiddleware(RetryRequestMiddleware):
 
 
 class InfuraRetryRequestMiddleware(RetryRequestMiddleware):
+    """
+    Automatically retries rpc requests whenever a 429 status code or Infura-specific error message is returned.
+    """
 
     def is_request_result_retry(self, result: Union[RPCResponse, Exception]) -> bool:
         """

--- a/nucypher/blockchain/middleware/retry.py
+++ b/nucypher/blockchain/middleware/retry.py
@@ -1,0 +1,125 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import time
+from typing import Callable, Any, Union
+
+from requests import HTTPError
+from web3 import Web3
+from web3.types import RPCEndpoint, RPCResponse
+
+from nucypher.utilities.logging import Logger
+
+
+class RetryRequestMiddleware:
+    def __init__(self,
+                 make_request: Callable[[RPCEndpoint, Any], RPCResponse],
+                 w3: Web3,
+                 retries: int = 3,
+                 exponential_backoff: bool = True):
+        self.w3 = w3
+        self.make_request = make_request
+        self.retries = retries
+        self.exponential_backoff = exponential_backoff
+        self.logger = Logger(self.__class__.__name__)
+
+    def is_request_result_retry(self, result: Union[RPCResponse, Exception]) -> bool:
+        # default retry functionality - look for 429 codes
+        # override for additional checks
+        if isinstance(result, HTTPError):
+            # HTTPError 429
+            status_code = result.response.status_code
+            if status_code == 429:
+                return True
+        elif not isinstance(result, Exception):
+            # must be RPCResponse
+            if 'error' in result:
+                error = result['error']
+                # either instance of RPCError or str
+                if not isinstance(error, str) and error.get('code') == 429:
+                    return True
+
+        # not retry result
+        return False
+
+    def __call__(self, method, params):
+        result = None
+        num_iterations = 1 + self.retries  # initial call and subsequent retries
+        for i in range(num_iterations):
+            try:
+                response = self.make_request(method, params)
+            except Exception as e:  # type: ignore
+                result = e
+            else:
+                result = response
+
+            # completed request
+            if not self.is_request_result_retry(result):
+                if i > 0:
+                    # not initial call and retry was actually performed
+                    self.logger.debug(f'Retried rpc request completed after {i} retries')
+                break
+
+            # max retries with no completion
+            if i == self.retries:
+                self.logger.warn(f'RPC request retried {self.retries} times but was not completed')
+                break
+
+            # backoff before next call
+            if self.exponential_backoff:
+                time.sleep(2 ** (i + 1))  # exponential back-off - 2^(retry number)
+
+        if isinstance(result, Exception):
+            raise result
+        else:
+            # RPCResponse
+            return result
+
+
+class AlchemyRetryRequestMiddleware(RetryRequestMiddleware):
+
+    def is_request_result_retry(self, result: Union[RPCResponse, Exception]) -> bool:
+        """
+        Check Alchemy request result for Alchemy-specific retry message.
+        """
+        # perform additional Alchemy-specific checks
+        # - Websocket result:
+        #   {'code': -32000,
+        #    'message': 'Your app has exceeded its compute units per second capacity. If you have retries enabled, you
+        #              can safely ignore this message. If not, check out https://docs.alchemyapi.io/guides/rate-limits'}
+        #
+        #
+        # - HTTP result: is a requests.exception.HTTPError with status code 429
+        # (will be checked in original `is_request_result_retry`)
+
+        if super().is_request_result_retry(result):
+            return True
+
+        if not isinstance(result, Exception):
+            # RPCResponse
+            if 'error' in result:
+                error = result['error']
+                if isinstance(error, str):
+                    return 'retries' in error
+                else:
+                    # RPCError TypeDict
+                    return 'retries' in error.get('message')
+        # else
+        #     exception already checked by superclass - no need to check here
+
+        # not a retry result
+        return False

--- a/nucypher/blockchain/middleware/retry.py
+++ b/nucypher/blockchain/middleware/retry.py
@@ -155,6 +155,7 @@ class InfuraRetryRequestMiddleware(RetryRequestMiddleware):
                 error = result['error']
                 if not isinstance(error, str):
                     # RPCError TypeDict
+                    # TODO should we utilize infura's backoff_seconds value in response?
                     return error.get('code') == -32005 and 'rate exceeded' in error.get('message')
         # else
         #     exceptions already checked by superclass - no need to check here

--- a/tests/unit/test_web3_clients.py
+++ b/tests/unit/test_web3_clients.py
@@ -26,7 +26,7 @@ from web3.types import RPCResponse, RPCError
 from nucypher.blockchain.eth.clients import (EthereumClient, GanacheClient, GethClient, InfuraClient, PUBLIC_CHAINS,
                                              ParityClient)
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
-from nucypher.blockchain.eth.providers import make_rpc_request_with_retry, _alchemy_should_retry_request
+from nucypher.blockchain.eth.providers import make_rpc_request_with_retry, _is_alchemy_retry_response
 
 DEFAULT_GAS_PRICE = 42
 GAS_PRICE_FROM_STRATEGY = 1234
@@ -368,7 +368,7 @@ def test_alchemy_rpc_request_with_retry():
         provider = Mock()
         provider.make_request.return_value = test_response
         retry_response = make_rpc_request_with_retry(provider,
-                                                     should_retry=_alchemy_should_retry_request,
+                                                     is_retry_response=_is_alchemy_retry_response,
                                                      logger=None,
                                                      num_retries=retries,
                                                      exponential_backoff=False)  # disable exponential backoff
@@ -382,7 +382,7 @@ def test_alchemy_rpc_request_success_with_no_retry():
     successful_response = RPCResponse(id=0, result='0xa1c054')
     provider.make_request.return_value = successful_response
     retry_response = make_rpc_request_with_retry(provider,
-                                                 should_retry=_alchemy_should_retry_request,
+                                                 is_retry_response=_is_alchemy_retry_response,
                                                  logger=None,
                                                  num_retries=10,
                                                  exponential_backoff=False)  # disable exponential backoff
@@ -400,7 +400,7 @@ def test_alchemy_rpc_request_with_retry_exponential_backoff():
     provider.make_request.return_value = test_response
     start = maya.now()
     retry_response = make_rpc_request_with_retry(provider,
-                                                 should_retry=_alchemy_should_retry_request,
+                                                 is_retry_response=_is_alchemy_retry_response,
                                                  logger=None,
                                                  num_retries=retries,
                                                  exponential_backoff=True)  # enable exponential backoff

--- a/tests/unit/test_web3_clients.py
+++ b/tests/unit/test_web3_clients.py
@@ -310,7 +310,7 @@ def test_detect_provider_type_ws():
 
 
 def test_infura_web3_client():
-    interface = InfuraTestClient(provider_uri='infura://1234567890987654321abcdef')
+    interface = InfuraTestClient(provider_uri='wss://:@goerli.infura.io/ws/v3/1234567890987654321abcdef')
     interface.connect()
 
     assert isinstance(interface.client, InfuraClient)

--- a/tests/unit/test_web3_middleware.py
+++ b/tests/unit/test_web3_middleware.py
@@ -1,0 +1,144 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from typing import Any
+from unittest.mock import Mock
+
+import maya
+import pytest
+from requests import HTTPError, Response
+from web3.types import RPCResponse, RPCError, RPCEndpoint
+
+from nucypher.blockchain.middleware.retry import RetryRequestMiddleware, AlchemyRetryRequestMiddleware
+
+
+def test_is_request_result_retry():
+    retry_middleware = RetryRequestMiddleware(make_request=Mock(), w3=Mock())
+
+    retry_response = RPCResponse(error=RPCError(code=429, message='Too many concurrent requests'))
+    assert retry_middleware.is_request_result_retry(result=retry_response)
+
+    response = Response()
+    response.status_code = 429
+    http_error = HTTPError(response=response)
+    assert retry_middleware.is_request_result_retry(result=http_error)
+
+    successful_response = RPCResponse(id=0, result='Geth/v1.9.20-stable-979fc968/linux-amd64/go1.15')
+    assert not retry_middleware.is_request_result_retry(result=successful_response)
+
+
+def test_request_with_retry():
+    retries = 4
+    make_request = Mock()
+    retry_middleware = RetryRequestMiddleware(make_request=make_request,
+                                              w3=Mock(),
+                                              retries=retries,
+                                              exponential_backoff=False)
+
+    # Retry Case - RPCResponse fails due to limits, and retry required
+    test_response = RPCResponse(error=RPCError(code=429, message='Too many concurrent requests'))
+    make_request.return_value = test_response
+
+    retry_response = retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
+    assert retry_response == test_response
+    assert make_request.call_count == (retries + 1)   # initial call, and then the number of retries
+
+
+def test_request_with_non_retry_exception():
+    def forbidden_request(method: RPCEndpoint, params: Any):
+        response = Response()
+        response.status_code = 400
+        raise HTTPError(response=response)
+
+    make_request = Mock()
+    make_request.side_effect = forbidden_request
+    retry_middleware = RetryRequestMiddleware(make_request=make_request, w3=Mock(), exponential_backoff=False)
+    with pytest.raises(HTTPError):
+        retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
+
+    assert make_request.call_count == 1  # only initial call, exception gets raised
+
+
+def test_request_success_with_no_retry():
+    # Success Case - retry not needed
+    make_request = Mock()
+    successful_response = RPCResponse(id=0, result=12345678)
+    make_request.return_value = successful_response
+
+    retry_middleware = RetryRequestMiddleware(make_request=make_request,
+                                              w3=Mock(),
+                                              retries=10,
+                                              exponential_backoff=False)
+    retry_response = retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
+    assert retry_response == successful_response
+    assert make_request.call_count == 1  # first call was successful, no need for retries
+
+
+# TODO - since this test does exponential backoff it takes >= 2^1 = 2s, should we only run on circleci?
+def test_request_with_retry_exponential_backoff():
+    retries = 1
+    make_request = Mock()
+
+    # Retry Case - RPCResponse fails due to limits, and retry required
+    test_response = RPCResponse(error=RPCError(code=429, message='Too many concurrent requests'))
+    make_request.return_value = test_response
+
+    retry_middleware = RetryRequestMiddleware(make_request=make_request,
+                                              w3=Mock(),
+                                              retries=1,
+                                              exponential_backoff=True)
+
+    start = maya.now()
+    retry_response = retry_middleware(RPCEndpoint('eth_blockNumber'), None)
+    end = maya.now()
+
+    assert retry_response == test_response
+    assert make_request.call_count == (retries + 1)  # initial call, and then the number of retries
+
+    # check exponential backoff
+    delta = end - start
+    assert delta.total_seconds() >= 2**retries
+
+
+def test_alchemy_request_with_retry():
+    retries = 4
+
+    # Retry Case - RPCResponse fails due to limits, and retry required
+    retry_responses = [
+        RPCResponse(error=RPCError(code=-32000,
+                                   message='Your app has exceeded its compute units per second capacity. If you have '
+                                           'retries enabled, you can safely ignore this message. If not, '
+                                           'check out https://docs.alchemyapi.io/guides/rate-limits')),
+        RPCResponse(error='Your app has exceeded its compute units per second capacity. If you have retries enabled, '
+                          'you can safely ignore this message. If not, '
+                          'check out https://docs.alchemyapi.io/guides/rate-limits'),
+
+        # on their website, but never observed in the wild
+        RPCResponse(error=RPCError(code=429, message='Too many concurrent requests'))
+    ]
+    for test_response in retry_responses:
+        make_request = Mock()
+        make_request.return_value = test_response
+        retry_middleware = AlchemyRetryRequestMiddleware(make_request=make_request,
+                                                         w3=Mock(),
+                                                         retries=retries,
+                                                         exponential_backoff=False)
+
+        response = retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
+
+        assert response == test_response
+        assert make_request.call_count == (retries + 1)   # initial call, and then the number of retries

--- a/tests/unit/test_web3_middleware.py
+++ b/tests/unit/test_web3_middleware.py
@@ -20,72 +20,85 @@ from unittest.mock import Mock
 
 import maya
 import pytest
-from requests import HTTPError, Response
+from requests import HTTPError
 from web3.types import RPCResponse, RPCError, RPCEndpoint
 
 from nucypher.blockchain.middleware.retry import RetryRequestMiddleware, AlchemyRetryRequestMiddleware, \
     InfuraRetryRequestMiddleware
 
+TOO_MANY_REQUESTS = {
+    "jsonrpc": "2.0",
+    "error": {
+        "code": 429,
+        "message": "Too many concurrent requests"
+    }
+}
 
-def test_is_request_result_retry():
-    retry_middleware = RetryRequestMiddleware(make_request=Mock(), w3=Mock())
+SUCCESSFUL_RESPONSE = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": "Geth/v1.9.20-stable-979fc968/linux-amd64/go1.15"
+}
 
-    retry_response = RPCResponse(error=RPCError(code=429, message='Too many concurrent requests'))
-    assert retry_middleware.is_request_result_retry(result=retry_response)
+RETRY_REQUEST_CLASSES = (RetryRequestMiddleware, AlchemyRetryRequestMiddleware, InfuraRetryRequestMiddleware)
 
-    response = Response()
-    response.status_code = 429
-    http_error = HTTPError(response=response)
+
+@pytest.mark.parametrize('retry_middleware_class', RETRY_REQUEST_CLASSES)
+def test_is_request_result_retry(retry_middleware_class):
+    # base checks
+    retry_middleware = retry_middleware_class(make_request=Mock(), w3=Mock())
+
+    assert retry_middleware.is_request_result_retry(result=TOO_MANY_REQUESTS)
+
+    http_error = HTTPError(response=Mock(status_code=429))
     assert retry_middleware.is_request_result_retry(result=http_error)
 
-    successful_response = RPCResponse(id=0, result='Geth/v1.9.20-stable-979fc968/linux-amd64/go1.15')
-    assert not retry_middleware.is_request_result_retry(result=successful_response)
+    assert not retry_middleware.is_request_result_retry(result=SUCCESSFUL_RESPONSE)
 
 
-def test_request_with_retry():
+@pytest.mark.parametrize('retry_middleware_class', RETRY_REQUEST_CLASSES)
+def test_request_with_retry(retry_middleware_class):
     retries = 4
     make_request = Mock()
-    retry_middleware = RetryRequestMiddleware(make_request=make_request,
+    retry_middleware = retry_middleware_class(make_request=make_request,
                                               w3=Mock(),
                                               retries=retries,
                                               exponential_backoff=False)
 
     # Retry Case - RPCResponse fails due to limits, and retry required
-    test_response = RPCResponse(error=RPCError(code=429, message='Too many concurrent requests'))
-    make_request.return_value = test_response
+    make_request.return_value = TOO_MANY_REQUESTS
 
-    retry_response = retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
-    assert retry_response == test_response
+    retry_response = retry_middleware(method=RPCEndpoint('web3_clientVersion'), params=None)
+    assert retry_response == TOO_MANY_REQUESTS
     assert make_request.call_count == (retries + 1)   # initial call, and then the number of retries
 
 
-def test_request_with_non_retry_exception():
+@pytest.mark.parametrize('retry_middleware_class', RETRY_REQUEST_CLASSES)
+def test_request_with_non_retry_exception(retry_middleware_class):
     def forbidden_request(method: RPCEndpoint, params: Any):
-        response = Response()
-        response.status_code = 400
-        raise HTTPError(response=response)
+        raise HTTPError(response=Mock(status_code=400))
 
     make_request = Mock()
     make_request.side_effect = forbidden_request
-    retry_middleware = RetryRequestMiddleware(make_request=make_request, w3=Mock(), exponential_backoff=False)
+    retry_middleware = retry_middleware_class(make_request=make_request, w3=Mock(), exponential_backoff=False)
     with pytest.raises(HTTPError):
-        retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
+        retry_middleware(method=RPCEndpoint('web3_clientVersion'), params=None)
 
     assert make_request.call_count == 1  # only initial call, exception gets raised
 
 
-def test_request_success_with_no_retry():
+@pytest.mark.parametrize('retry_middleware_class', RETRY_REQUEST_CLASSES)
+def test_request_success_with_no_retry(retry_middleware_class):
     # Success Case - retry not needed
     make_request = Mock()
-    successful_response = RPCResponse(id=0, result=12345678)
-    make_request.return_value = successful_response
+    make_request.return_value = SUCCESSFUL_RESPONSE
 
-    retry_middleware = RetryRequestMiddleware(make_request=make_request,
+    retry_middleware = retry_middleware_class(make_request=make_request,
                                               w3=Mock(),
                                               retries=10,
                                               exponential_backoff=False)
-    retry_response = retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
-    assert retry_response == successful_response
+    retry_response = retry_middleware(method=RPCEndpoint('web3_clientVersion'), params=None)
+    assert retry_response == SUCCESSFUL_RESPONSE
     assert make_request.call_count == 1  # first call was successful, no need for retries
 
 
@@ -95,8 +108,7 @@ def test_request_with_retry_exponential_backoff():
     make_request = Mock()
 
     # Retry Case - RPCResponse fails due to limits, and retry required
-    test_response = RPCResponse(error=RPCError(code=429, message='Too many concurrent requests'))
-    make_request.return_value = test_response
+    make_request.return_value = TOO_MANY_REQUESTS
 
     retry_middleware = RetryRequestMiddleware(make_request=make_request,
                                               w3=Mock(),
@@ -104,10 +116,10 @@ def test_request_with_retry_exponential_backoff():
                                               exponential_backoff=True)
 
     start = maya.now()
-    retry_response = retry_middleware(RPCEndpoint('eth_blockNumber'), None)
+    retry_response = retry_middleware(RPCEndpoint('web3_clientVersion'), None)
     end = maya.now()
 
-    assert retry_response == test_response
+    assert retry_response == TOO_MANY_REQUESTS
     assert make_request.call_count == (retries + 1)  # initial call, and then the number of retries
 
     # check exponential backoff
@@ -118,28 +130,18 @@ def test_request_with_retry_exponential_backoff():
 def test_alchemy_request_with_retry():
     retries = 4
 
-    # Retry Case - RPCResponse fails due to limits, and retry required
     test_responses = [
-        # failures
-        (RPCResponse(error=RPCError(code=-32000,
+        # alchemy-specific failures
+        RPCResponse(error=RPCError(code=-32000,
                                    message='Your app has exceeded its compute units per second capacity. If you have '
                                            'retries enabled, you can safely ignore this message. If not, '
                                            'check out https://docs.alchemyapi.io/guides/rate-limits')),
-         retries + 1),
 
-        (RPCResponse(error='Your app has exceeded its compute units per second capacity. If you have retries enabled, '
+        RPCResponse(error='Your app has exceeded its compute units per second capacity. If you have retries enabled, '
                           'you can safely ignore this message. If not, '
-                          'check out https://docs.alchemyapi.io/guides/rate-limits'),
-         retries + 1),
-
-        (RPCResponse(error=RPCError(code=429, message='Too many concurrent requests')),
-         retries + 1), # on their website, but never observed in the wild
-
-        # successes
-        (RPCResponse(id=0, result='Geth/v1.9.20-stable-979fc968/linux-amd64/go1.15'),
-         1)
+                          'check out https://docs.alchemyapi.io/guides/rate-limits')
     ]
-    for test_response, num_calls in test_responses:
+    for test_response in test_responses:
         make_request = Mock()
         make_request.return_value = test_response
         retry_middleware = AlchemyRetryRequestMiddleware(make_request=make_request,
@@ -147,28 +149,34 @@ def test_alchemy_request_with_retry():
                                                          retries=retries,
                                                          exponential_backoff=False)
 
-        response = retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
+        response = retry_middleware(method=RPCEndpoint('eth_call'), params=None)
 
         assert response == test_response
-        assert make_request.call_count == num_calls   # initial call, and then the number of retries
+        assert make_request.call_count == (retries + 1)   # initial call, and then the number of retries
 
 
 def test_infura_request_with_retry():
     retries = 4
 
-    # Retry Case - RPCResponse fails due to limits, and retry required
     test_responses = [
-        # failures
-        (RPCResponse(error=RPCError(code=-32005,
-                                    message='project ID request rate exceeded')),
-         retries + 1),
-
-        # successes
-        (RPCResponse(id=0, result='Geth/v1.9.20-stable-979fc968/linux-amd64/go1.15'),
-         1)
+        # infura-specific failures
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32005,
+                "message": "project ID request rate exceeded",
+                "data": {
+                   "see": "https://infura.io/docs/ethereum/jsonrpc/ratelimits",
+                   "current_rps": 13.333,
+                   "allowed_rps": 10.0,
+                   "backoff_seconds": 30.0,
+                }
+            }
+        },
     ]
 
-    for test_response, num_calls in test_responses:
+    for test_response in test_responses:
         make_request = Mock()
         make_request.return_value = test_response
         retry_middleware = InfuraRetryRequestMiddleware(make_request=make_request,
@@ -179,4 +187,4 @@ def test_infura_request_with_retry():
         response = retry_middleware(method=RPCEndpoint('eth_blockNumber'), params=None)
 
         assert response == test_response
-        assert make_request.call_count == num_calls
+        assert make_request.call_count == (retries + 1)  # initial call, and then the number of retries


### PR DESCRIPTION
Fixes #2284 .

- [x] Middleware layer (Alchemy and Infura)
- [x] Client layer (Alchemy)
- [x] Remove Infura provider i.e. `infura://` provider uri