### PR TITLE
Some contract updates

### DIFF
--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -556,7 +556,7 @@ contract StakingEscrow is Issuer, IERC900History {
     * If true then stake's duration will be decreasing in each period with `commitToNextPeriod()`
     * @param _windDown Value for parameter
     */
-    function setWindDown(bool _windDown) external onlyStaker {
+    function setWindDown(bool _windDown) external {
         StakerInfo storage info = stakerInfo[msg.sender];
         if (info.flags.bitSet(WIND_DOWN_INDEX) == _windDown) {
             return;
@@ -660,7 +660,7 @@ contract StakingEscrow is Issuer, IERC900History {
             uint256 endIndex = j + numberOfSubStakes;
             require(numberOfSubStakes > 0 && subStakesLength >= endIndex);
             StakerInfo storage info = stakerInfo[staker];
-            require(info.subStakes.length == 0);
+            require(info.subStakes.length == 0 && !info.flags.bitSet(SNAPSHOTS_DISABLED_INDEX));
             // A staker can't be a worker for another staker
             require(stakerFromWorker[staker] == address(0));
             stakers.push(staker);

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -41,7 +41,7 @@ interface WorkLockInterface {
 /**
 * @notice Contract holds and locks stakers tokens.
 * Each staker that locks their tokens will receive some compensation
-* @dev |v5.4.2|
+* @dev |v5.4.3|
 */
 contract StakingEscrow is Issuer, IERC900History {
 
@@ -540,7 +540,7 @@ contract StakingEscrow is Issuer, IERC900History {
         uint256 _value,
         uint16 _periods
     )
-        external
+        external isInitialized
     {
         require(msg.sender == address(workLock));
         StakerInfo storage info = stakerInfo[_staker];

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -70,7 +70,7 @@ contract BaseStakingInterface {
 /**
 * @notice Interface for accessing main contracts from a staking contract
 * @dev All methods must be stateless because this code will be executed by delegatecall call, use immutable fields.
-* @dev |v1.5.2|
+* @dev |v1.6.1|
 */
 contract StakingInterface is BaseStakingInterface {
 

--- a/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/staking_contracts/StakingInterface.sol
@@ -89,6 +89,7 @@ contract StakingInterface is BaseStakingInterface {
     event WorkerBonded(address indexed sender, address worker);
     event Prolonged(address indexed sender, uint256 index, uint16 periods);
     event WindDownSet(address indexed sender, bool windDown);
+    event SnapshotSet(address indexed sender, bool snapshotsEnabled);
     event Bid(address indexed sender, uint256 depositedETH);
     event Claimed(address indexed sender, uint256 claimedTokens);
     event Refund(address indexed sender, uint256 refundETH);
@@ -255,6 +256,15 @@ contract StakingInterface is BaseStakingInterface {
     function setWindDown(bool _windDown) public onlyDelegateCall {
         escrow.setWindDown(_windDown);
         emit WindDownSet(msg.sender, _windDown);
+    }
+
+    /**
+    * @notice Set `snapshots` parameter in the staking escrow
+    * @param _enableSnapshots Value for parameter
+    */
+    function setSnapshots(bool _enableSnapshots) public onlyDelegateCall {
+        escrow.setSnapshots(_enableSnapshots);
+        emit SnapshotSet(msg.sender, _enableSnapshots);
     }
 
     /**

--- a/tests/contracts/contracts/StakingContractsTestSet.sol
+++ b/tests/contracts/contracts/StakingContractsTestSet.sol
@@ -23,6 +23,7 @@ contract StakingEscrowForStakingContractMock {
     uint16 public lockReStakeUntilPeriod;
     address public worker;
     bool public windDown;
+    bool public snapshots;
 
     constructor(NuCypherToken _token) {
         token = _token;
@@ -99,6 +100,10 @@ contract StakingEscrowForStakingContractMock {
 
     function setWindDown(bool _windDown) external {
         windDown = _windDown;
+    }
+
+    function setSnapshots(bool _snapshotsEnabled) external {
+        snapshots = _snapshotsEnabled;
     }
 }
 

--- a/tests/contracts/integration/test_intercontract_integration.py
+++ b/tests/contracts/integration/test_intercontract_integration.py
@@ -426,6 +426,9 @@ def test_staking_before_initialization(testerchain,
         tx = escrow.functions.commitToNextPeriod().transact({'from': staker3})
         testerchain.wait_for_receipt(tx)
 
+    tx = escrow.functions.setWindDown(True).transact({'from': staker2})
+    testerchain.wait_for_receipt(tx)
+
 
 def test_worklock_phases(testerchain,
                          token_economics,
@@ -435,7 +438,6 @@ def test_worklock_phases(testerchain,
                          preallocation_escrow_interface_1,
                          worklock,
                          multisig):
-    creator = testerchain.w3.eth.accounts[0]
     creator, staker1, staker2, staker3, staker4, alice1, alice2, *contracts_owners =\
         testerchain.client.accounts
 
@@ -606,8 +608,6 @@ def test_worklock_phases(testerchain,
     pytest.escrow_supply += staker2_tokens
     assert escrow.functions.getAllTokens(staker2).call() == staker2_tokens
     assert escrow.functions.getCompletedWork(staker2).call() == 0
-    tx = escrow.functions.setWindDown(True).transact({'from': staker2})
-    testerchain.wait_for_receipt(tx)
     wind_down, _re_stake, _measure_work, _snapshots = escrow.functions.getFlags(staker2).call()
     assert wind_down
 

--- a/tests/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow.py
@@ -1572,6 +1572,13 @@ def test_staking_from_worklock(testerchain, token, escrow_contract, token_econom
         testerchain.wait_for_receipt(tx)
     assert token.functions.balanceOf(escrow.address).call() == 0
 
+    # Can't claim before initialization
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = worklock.functions.depositFromWorkLock(staker1, value, duration).transact()
+        testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.initialize(0, creator).transact({'from': creator})
+    testerchain.wait_for_receipt(tx)
+
     # Deposit tokens from WorkLock
     wind_down, _re_stake, _measure_work, _snapshots = escrow.functions.getFlags(staker1).call()
     assert not wind_down

--- a/tests/contracts/main/staking_escrow/test_staking_escrow.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow.py
@@ -1272,8 +1272,17 @@ def test_batch_deposit(testerchain, token, escrow_contract, deploy_contract):
     tx = token.functions.approve(escrow.address, 10000).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
-    # Deposit tokens for 1 staker
+    # Can't deposit tokens if taking snapshots was disabled
     staker = testerchain.client.accounts[1]
+    tx = escrow.functions.setSnapshots(False).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    with pytest.raises((TransactionFailed, ValueError)):
+        tx = escrow.functions.batchDeposit([staker], [1], [1000], [10]).transact({'from': creator})
+        testerchain.wait_for_receipt(tx)
+
+    # Deposit tokens for 1 staker
+    tx = escrow.functions.setSnapshots(True).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
     tx = escrow.functions.batchDeposit([staker], [1], [1000], [10]).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
     escrow_balance = 1000
@@ -1366,6 +1375,8 @@ def test_batch_deposit(testerchain, token, escrow_contract, deploy_contract):
     tx = token.functions.approve(escrow.address, 1500).transact({'from': staker})
     testerchain.wait_for_receipt(tx)
     stakers = testerchain.client.accounts[2:7]
+    tx = escrow.functions.setWindDown(True).transact({'from': stakers[0]})
+    testerchain.wait_for_receipt(tx)
     current_period = escrow.functions.getCurrentPeriod().call()
     tx = escrow.functions.batchDeposit(
         stakers, [1, 1, 1, 1, 1], [100, 200, 300, 400, 500], [50, 100, 150, 200, 250]

--- a/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
@@ -903,13 +903,11 @@ def test_wind_down(testerchain, token, escrow_contract, token_economics):
     tx = escrow.functions.initialize(token_economics.reward_supply, creator).transact({'from': creator})
     testerchain.wait_for_receipt(tx)
 
-    # Only staker can set wind-down parameter
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.setWindDown(False).transact({'from': staker})
-        testerchain.wait_for_receipt(tx)
-    with pytest.raises((TransactionFailed, ValueError)):
-        tx = escrow.functions.setWindDown(True).transact({'from': staker})
-        testerchain.wait_for_receipt(tx)
+    # Anybody can set wind-down parameter
+    tx = escrow.functions.setWindDown(True).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
+    tx = escrow.functions.setWindDown(False).transact({'from': staker})
+    testerchain.wait_for_receipt(tx)
 
     # Staker deposits some tokens and makes a commitment
     sub_stake = token_economics.minimum_allowed_locked
@@ -921,7 +919,7 @@ def test_wind_down(testerchain, token, escrow_contract, token_economics):
 
     def check_events(wind_down: bool, length: int):
         events = wind_down_log.get_all_entries()
-        assert len(events) == length
+        assert len(events) == length + 2
         event_args = events[-1]['args']
         assert staker == event_args['staker'] == staker
         assert event_args['windDown'] == wind_down


### PR DESCRIPTION
* deposits  from worklock allowed only after initialization
* `setSnapshots` method for `StakingInterface`
* check snapshots in `batchDeposit`
* allow `setWindDown` without deposit