### PR TITLE
Confirmations and pre-flight for upgrade CLI

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -331,13 +331,16 @@ class ContractAdministrator(NucypherTokenActor):
         return receipts
 
     def retarget_proxy(self,
+                       confirmations: int,
                        contract_name: str,
                        target_address: str,
-                       just_build_transaction: bool = False):
+                       just_build_transaction: bool = False
+                       ):
         Deployer = self.__get_deployer(contract_name=contract_name)
         deployer = Deployer(registry=self.registry, deployer_address=self.deployer_address)
         result = deployer.retarget(target_address=target_address,
-                                   just_build_transaction=just_build_transaction)
+                                   just_build_transaction=just_build_transaction,
+                                   confirmations=confirmations)
         return result
 
     def rollback_contract(self, contract_name: str):

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -322,11 +322,12 @@ class ContractAdministrator(NucypherTokenActor):
 
     def upgrade_contract(self,
                          contract_name: str,
-                         ignore_deployed: bool = False
+                         confirmations: int,
+                         ignore_deployed: bool = False,
                          ) -> dict:
         Deployer = self.__get_deployer(contract_name=contract_name)
         deployer = Deployer(registry=self.registry, deployer_address=self.deployer_address)
-        receipts = deployer.upgrade(ignore_deployed=ignore_deployed)
+        receipts = deployer.upgrade(ignore_deployed=ignore_deployed, confirmations=confirmations)
         return receipts
 
     def retarget_proxy(self,

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -19,6 +19,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 from collections import OrderedDict
 
 from constant_sorrow.constants import (BARE, CONTRACT_NOT_DEPLOYED, FULL, IDLE, NO_BENEFICIARY, NO_DEPLOYER_CONFIGURED)
+from eth_typing.evm import ChecksumAddress
 from typing import Dict, List, Tuple
 from web3 import Web3
 from web3.contract import Contract
@@ -189,6 +190,13 @@ class OwnableContractMixin:
 
     class ContractNotOwnable(RuntimeError):
         pass
+
+    @property
+    def owner(self) -> ChecksumAddress:
+        if self._upgradeable:
+            proxy_deployer = self.get_proxy_deployer()
+            owner_address = ChecksumAddress(proxy_deployer.contract.functions.owner().call())
+        return owner_address
 
     def transfer_ownership(self, new_owner: str, transaction_gas_limit: int = None) -> dict:
         if not self._ownable:

--- a/nucypher/blockchain/eth/deployers.py
+++ b/nucypher/blockchain/eth/deployers.py
@@ -194,8 +194,12 @@ class OwnableContractMixin:
     @property
     def owner(self) -> ChecksumAddress:
         if self._upgradeable:
-            proxy_deployer = self.get_proxy_deployer()
-            owner_address = ChecksumAddress(proxy_deployer.contract.functions.owner().call())
+            # Get the address of the proxy
+            contract = self.get_proxy_deployer()
+        else:
+            # Get the address of the implementation
+            contract = self.blockchain.get_contract_by_name(contract_name=self.contract_name, registry=self.registry)
+        owner_address = ChecksumAddress(contract.contract.functions.owner().call())  # blockchain read
         return owner_address
 
     def transfer_ownership(self, new_owner: str, transaction_gas_limit: int = None) -> dict:

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -630,9 +630,8 @@ class BlockchainInterface:
                          fire_and_forget: bool = False  # do not wait for receipt.
                          ) -> dict:
 
-        # TODO: Are confirmations and fire_and_forget conflicting options?
-        # if fire_and_forget and confirmations > 0:
-        #     raise ValueError
+        if fire_and_forget and confirmations > 0:
+            raise ValueError('Transaction Prevented: Cannot use confirmations and fire_and_forget options together.')
 
         transaction = self.build_contract_transaction(contract_function=contract_function,
                                                       sender_address=sender_address,

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -627,8 +627,12 @@ class BlockchainInterface:
                          payload: dict = None,
                          transaction_gas_limit: int = None,
                          confirmations: int = 0,
-                         fire_and_forget: bool = False
+                         fire_and_forget: bool = False  # do not wait for receipt.
                          ) -> dict:
+
+        # TODO: Are confirmations and fire_and_forget conflicting options?
+        # if fire_and_forget and confirmations > 0:
+        #     raise ValueError
 
         transaction = self.build_contract_transaction(contract_function=contract_function,
                                                       sender_address=sender_address,

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -152,7 +152,7 @@ class RegistrySourceManager:
     def get_primary_sources(cls):
         return [source for source in cls._FALLBACK_CHAIN if source.is_primary]
 
-    def fetch_latest_publication(self, registry_class, network: str = NetworksInventory.DEFAULT):  # TODO: see #1496
+    def fetch_latest_publication(self, registry_class, network: str):  # TODO: see #1496
         """
         Get the latest contract registry data available from a registry source chain.
         """

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -152,7 +152,7 @@ class RegistrySourceManager:
     def get_primary_sources(cls):
         return [source for source in cls._FALLBACK_CHAIN if source.is_primary]
 
-    def fetch_latest_publication(self, registry_class, network: str):  # TODO: see #1496
+    def fetch_latest_publication(self, registry_class, network: str):
         """
         Get the latest contract registry data available from a registry source chain.
         """

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -364,7 +364,8 @@ def upgrade(general_config, actor_options, retarget, target_address, ignore_depl
                                                                     target_address=target_address), abort=True)
         transaction = ADMINISTRATOR.retarget_proxy(contract_name=contract_name,
                                                    target_address=target_address,
-                                                   just_build_transaction=True)
+                                                   just_build_transaction=True,
+                                                   confirmations=confirmations)
 
         trustee_address = select_client_account(emitter=emitter,
                                                 prompt="Select trustee address",

--- a/nucypher/cli/commands/deploy.py
+++ b/nucypher/cli/commands/deploy.py
@@ -225,7 +225,7 @@ group_actor_options = group_options(
     provider_uri=option_provider_uri(),
     gas_strategy=option_gas_strategy,
     signer_uri=option_signer_uri,
-    contract_name=option_contract_name(required=True),
+    contract_name=option_contract_name(required=False),  # TODO: Make this required see Issue #2314
     poa=option_poa,
     force=option_force,
     hw_wallet=option_hw_wallet,
@@ -391,7 +391,7 @@ def upgrade(general_config, actor_options, retarget, target_address, ignore_depl
             raise click.BadArgumentUsage(message="--target-address is required when using --retarget")
         if not actor_options.force:
             click.confirm(CONFIRM_RETARGET.format(contract_name=contract_name, target_address=target_address), abort=True)
-        receipt = ADMINISTRATOR.retarget_proxy(contract_name=contract_name,target_address=target_address)
+        receipt = ADMINISTRATOR.retarget_proxy(contract_name=contract_name,target_address=target_address, confirmations=0)
         message = SUCCESSFUL_RETARGET.format(contract_name=contract_name, target_address=target_address)
         emitter.message(message, color='green')
         paint_receipt_summary(emitter=emitter, receipt=receipt)

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -115,7 +115,7 @@ def locked_tokens(general_config, registry_options, periods):
 @status.command()
 @group_registry_options
 @group_general_config
-@option_contract_name
+@option_contract_name(required=False)
 @option_event_name
 @click.option('--from-block', help="Collect events from this block number", type=click.INT)
 @click.option('--to-block', help="Collect events until this block number", type=click.INT)

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -477,6 +477,8 @@ IDENTICAL_REGISTRY_WARNING = "Local registry ({local_registry.id}) is identical 
 
 DEPLOYER_IS_NOT_OWNER = "Address {deployer_address} is not the owner of {contract_name}'s Dispatcher ({agent.contract_address}). Aborting."
 
+CONFIRM_VERSIONED_UPGRADE = "Confirm upgrade {contract_name} from version {old_contract.version} to version {new_contract.version}?"
+
 #
 # Multisig
 #

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -469,6 +469,12 @@ ETHERSCAN_FLAG_DISABLED_WARNING = """
 WARNING: --etherscan is disabled. If you want to see deployed contracts and TXs in your browser, activate --etherscan.
 """
 
+#
+# Upgrade
+#
+
+IDENTICAL_REGISTRY_WARNING = "Local registry ({local_registry.id}) is identical to the one on GitHub ({github_registry.id})."
+
 
 #
 # Multisig

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -475,6 +475,7 @@ WARNING: --etherscan is disabled. If you want to see deployed contracts and TXs 
 
 IDENTICAL_REGISTRY_WARNING = "Local registry ({local_registry.id}) is identical to the one on GitHub ({github_registry.id})."
 
+DEPLOYER_IS_NOT_OWNER = "Address {deployer_address} is not the owner of {contract_name}'s Dispatcher ({agent.contract_address}). Aborting."
 
 #
 # Multisig

--- a/nucypher/cli/options.py
+++ b/nucypher/cli/options.py
@@ -35,7 +35,6 @@ from nucypher.utilities.logging import Logger
 option_checksum_address = click.option('--checksum-address', help="Run with a specified account", type=EIP55_CHECKSUM_ADDRESS)
 option_config_file = click.option('--config-file', help="Path to configuration file", type=EXISTING_READABLE_FILE)
 option_config_root = click.option('--config-root', help="Custom configuration directory", type=click.Path())
-option_contract_name = click.option('--contract-name', help="Specify a single contract by name", type=click.Choice(NUCYPHER_CONTRACT_NAMES))
 option_dev = click.option('--dev', '-d', help="Enable development mode", is_flag=True)
 option_db_filepath = click.option('--db-filepath', help="The database filepath to connect to", type=click.STRING)
 option_dry_run = click.option('--dry-run', '-x', help="Execute normally without actually starting the node", is_flag=True)
@@ -66,6 +65,15 @@ option_rate = click.option('--rate', help="Policy rate per period (in wei)", typ
 #
 # Alphabetical
 #
+
+def option_contract_name(required: bool = False):
+    return click.option(
+        '--contract-name',
+        help="Specify a single contract by name",
+        type=click.Choice(NUCYPHER_CONTRACT_NAMES),
+        required=required
+    )
+
 
 def option_controller_port(default=None):
     return click.option(

--- a/nucypher/cli/painting/deployment.py
+++ b/nucypher/cli/painting/deployment.py
@@ -153,6 +153,7 @@ Registry  ................ {registry.filepath}
 
             proxy_payload = f"""
 {agent.contract_name} .... {bare_contract.address}
+    ~ Version ............ {bare_contract.version}
     ~ Owner .............. {bare_contract.functions.owner().call()}
     ~ Ethers ............. {Web3.fromWei(blockchain.client.get_balance(bare_contract.address), 'ether')} ETH
     ~ Tokens ............. {NU.from_nunits(token_agent.get_balance(bare_contract.address))}

--- a/nucypher/cli/utils.py
+++ b/nucypher/cli/utils.py
@@ -121,6 +121,7 @@ def establish_deployer_registry(emitter,
     filepath = registry_infile
     default_registry_filepath = os.path.join(DEFAULT_CONFIG_ROOT, BaseContractRegistry.REGISTRY_NAME)
     if registry_outfile:
+        # mutative usage of existing registry
         registry_infile = registry_infile or default_registry_filepath
         if use_existing_registry:
             try:

--- a/nucypher/cli/utils.py
+++ b/nucypher/cli/utils.py
@@ -105,6 +105,7 @@ def make_cli_character(character_config,
 
 
 def establish_deployer_registry(emitter,
+                                network: str = None,
                                 registry_infile: str = None,
                                 registry_outfile: str = None,
                                 use_existing_registry: bool = False,
@@ -113,7 +114,7 @@ def establish_deployer_registry(emitter,
                                 ) -> BaseContractRegistry:
 
     if download_registry:
-        registry = InMemoryContractRegistry.from_latest_publication()
+        registry = InMemoryContractRegistry.from_latest_publication(network=network)
         emitter.message(PRODUCTION_REGISTRY_ADVISORY.format(source=registry.source))
         return registry
 

--- a/tests/acceptance/blockchain/deployers/test_policy_manager_deployer.py
+++ b/tests/acceptance/blockchain/deployers/test_policy_manager_deployer.py
@@ -88,7 +88,7 @@ def test_upgrade(testerchain, test_registry):
                                                      use_proxy_address=False)
     old_address = bare_contract.address
 
-    receipts = deployer.upgrade(ignore_deployed=True)
+    receipts = deployer.upgrade(ignore_deployed=True, confirmations=0)
 
     bare_contract = testerchain.get_contract_by_name(registry=test_registry,
                                                      contract_name=PolicyManagerDeployer.contract_name,
@@ -114,7 +114,7 @@ def test_rollback(testerchain, test_registry):
     current_target = policy_manager_agent.contract.functions.target().call()
 
     # Let's do one more upgrade
-    receipts = deployer.upgrade(ignore_deployed=True)
+    receipts = deployer.upgrade(ignore_deployed=True, confirmations=0)
     for title, receipt in receipts.items():
         assert receipt['status'] == 1
 

--- a/tests/acceptance/blockchain/deployers/test_preallocation_escrow_deployer.py
+++ b/tests/acceptance/blockchain/deployers/test_preallocation_escrow_deployer.py
@@ -103,7 +103,7 @@ def test_upgrade_staking_interface(testerchain, test_registry):
     staking_interface_deployer = StakingInterfaceDeployer(deployer_address=testerchain.etherbase_account,
                                                           registry=test_registry)
 
-    receipts = staking_interface_deployer.upgrade(ignore_deployed=True)
+    receipts = staking_interface_deployer.upgrade(ignore_deployed=True, confirmations=0)
 
     assert len(receipts) == 2
 

--- a/tests/acceptance/blockchain/deployers/test_staking_escrow_deployer.py
+++ b/tests/acceptance/blockchain/deployers/test_staking_escrow_deployer.py
@@ -169,14 +169,15 @@ def test_manual_proxy_retargeting(testerchain, test_registry, token_economics):
 
     # Build retarget transaction (just for informational purposes)
     transaction = deployer.retarget(target_address=latest_deployment.address,
-                                    just_build_transaction=True)
+                                    just_build_transaction=True,
+                                    confirmations=0)
 
     assert transaction['to'] == proxy_deployer.contract.address
     upgrade_function, _params = proxy_deployer.contract.decode_function_input(transaction['data']) # TODO: this only tests for ethtester
     assert upgrade_function.fn_name == proxy_deployer.contract.functions.upgrade.fn_name
 
     # Retarget, for real
-    receipt = deployer.retarget(target_address=latest_deployment.address)
+    receipt = deployer.retarget(target_address=latest_deployment.address, confirmations=0)
 
     assert receipt['status'] == 1
 

--- a/tests/acceptance/blockchain/deployers/test_staking_escrow_deployer.py
+++ b/tests/acceptance/blockchain/deployers/test_staking_escrow_deployer.py
@@ -82,7 +82,7 @@ def test_upgrade(testerchain, test_registry, token_economics):
                                      economics=token_economics,
                                      deployer_address=testerchain.etherbase_account)
 
-    receipts = deployer.upgrade(ignore_deployed=True)
+    receipts = deployer.upgrade(ignore_deployed=True, confirmations=0)
     for title, receipt in receipts.items():
         assert receipt['status'] == 1
 
@@ -96,7 +96,7 @@ def test_rollback(testerchain, test_registry):
     current_target = staking_agent.contract.functions.target().call()
 
     # Let's do one more upgrade
-    receipts = deployer.upgrade(ignore_deployed=True)
+    receipts = deployer.upgrade(ignore_deployed=True, confirmations=0)
 
     for title, receipt in receipts.items():
         assert receipt['status'] == 1

--- a/tests/acceptance/blockchain/interfaces/test_chains.py
+++ b/tests/acceptance/blockchain/interfaces/test_chains.py
@@ -165,6 +165,7 @@ def test_multiversion_contract():
     assert contract.functions.VERSION().call() == 2
 
 
+# TODO: Move to integrations tests
 def test_block_confirmations(testerchain, test_registry, mocker):
     origin = testerchain.etherbase_account
 

--- a/tests/acceptance/cli/test_deploy.py
+++ b/tests/acceptance/cli/test_deploy.py
@@ -187,7 +187,9 @@ def test_upgrade_contracts(click_runner, registry_filepath, testerchain):
     #
 
     cli_action = 'upgrade'
-    base_command = ('--registry-infile', registry_filepath, '--provider', TEST_PROVIDER_URI)
+    base_command = ('--registry-infile', registry_filepath,
+                    '--provider', TEST_PROVIDER_URI,
+                    '--confirmations', 1)
 
     #
     # Stage Upgrades

--- a/tests/acceptance/cli/test_deploy.py
+++ b/tests/acceptance/cli/test_deploy.py
@@ -45,6 +45,7 @@ def test_echo_solidity_version(click_runner):
     assert str(SOLIDITY_COMPILER_VERSION) in result.output, 'Solidity version text was not produced.'
 
 
+@pytest.mark.skip("Retired test")
 def test_nucypher_deploy_contracts(click_runner,
                                    token_economics,
                                    registry_filepath,

--- a/tests/acceptance/cli/test_deploy_cli.py
+++ b/tests/acceptance/cli/test_deploy_cli.py
@@ -94,7 +94,8 @@ def test_upgrade_contracts(click_runner, test_registry_source_manager, test_regi
                     '--provider', TEST_PROVIDER_URI,
                     '--confirmations', 1,
                     '--network', TEMPORARY_DOMAIN,
-                    '--force')  # skip registry preflight for tests
+                    '--force'  # skip registry preflight check for tests
+                    )
 
     #
     # Stage Upgrades
@@ -151,7 +152,7 @@ def test_upgrade_contracts(click_runner, test_registry_source_manager, test_regi
 
         # Select upgrade interactive input scenario
         current_version = version_tracker[contract_name]
-        user_input = '0\n' + YES_ENTER + YES_ENTER
+        user_input = '0\n' + YES_ENTER + YES_ENTER + YES_ENTER
 
         # Execute upgrade (Meat)
         result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)

--- a/tests/acceptance/cli/test_deploy_cli.py
+++ b/tests/acceptance/cli/test_deploy_cli.py
@@ -92,9 +92,9 @@ def test_upgrade_contracts(click_runner, test_registry_source_manager, test_regi
     cli_action = 'upgrade'
     base_command = ('--registry-infile', registry_filepath,
                     '--provider', TEST_PROVIDER_URI,
-                    '--confirmations', 30,
+                    '--confirmations', 1,
                     '--network', TEMPORARY_DOMAIN,
-                    '--force')  # skip some preflights
+                    '--force')  # skip registry preflight for tests
 
     #
     # Stage Upgrades

--- a/tests/acceptance/cli/test_deploy_commands.py
+++ b/tests/acceptance/cli/test_deploy_commands.py
@@ -15,6 +15,7 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 import os
 import pytest
 

--- a/tests/acceptance/cli/test_deploy_commands.py
+++ b/tests/acceptance/cli/test_deploy_commands.py
@@ -19,16 +19,16 @@
 import os
 import pytest
 
-from nucypher.config.constants import TEMPORARY_DOMAIN
-from nucypher.blockchain.eth.clients import EthereumClient
 from nucypher.blockchain.eth.agents import (AdjudicatorAgent, ContractAgency, PolicyManagerAgent, StakingEscrowAgent)
+from nucypher.blockchain.eth.clients import EthereumClient
 from nucypher.blockchain.eth.constants import (ADJUDICATOR_CONTRACT_NAME, DISPATCHER_CONTRACT_NAME,
                                                NUCYPHER_TOKEN_CONTRACT_NAME, POLICY_MANAGER_CONTRACT_NAME,
                                                STAKING_ESCROW_CONTRACT_NAME)
 from nucypher.blockchain.eth.deployers import StakingEscrowDeployer
 from nucypher.blockchain.eth.registry import InMemoryContractRegistry, LocalContractRegistry
 from nucypher.cli.commands.deploy import deploy
-from tests.constants import (INSECURE_DEVELOPMENT_PASSWORD, TEST_PROVIDER_URI)
+from nucypher.config.constants import TEMPORARY_DOMAIN
+from tests.constants import (INSECURE_DEVELOPMENT_PASSWORD, TEST_PROVIDER_URI, YES_ENTER)
 
 ALTERNATE_REGISTRY_FILEPATH = '/tmp/nucypher-test-registry-alternate.json'
 ALTERNATE_REGISTRY_FILEPATH_2 = '/tmp/nucypher-test-registry-alternate-2.json'
@@ -214,7 +214,7 @@ def test_manual_proxy_retargeting(monkeypatch, testerchain, click_runner, token_
                '--network', TEMPORARY_DOMAIN)
 
     # Upgrade
-    user_input = '0\n' + 'Y\n' + 'Y\n'
+    user_input = '0\n' + YES_ENTER + YES_ENTER + YES_ENTER
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 

--- a/tests/acceptance/cli/test_deploy_commands.py
+++ b/tests/acceptance/cli/test_deploy_commands.py
@@ -92,7 +92,7 @@ def test_nucypher_deploy_inspect_fully_deployed(click_runner, agency_local_regis
     assert policy_agent.owner in result.output
     assert adjudicator_agent.owner in result.output
 
-    minimum, default, maximum = 10, 20, 30
+    minimum, default, maximum = 10, 10, 10 # TODO: Fix with skipped test see Issue #2314
     assert 'Range' in result.output
     assert f"{minimum} wei" in result.output
     assert f"{default} wei" in result.output

--- a/tests/acceptance/cli/test_deploy_commands.py
+++ b/tests/acceptance/cli/test_deploy_commands.py
@@ -238,8 +238,7 @@ def test_batch_deposits(click_runner,
                       '--provider', TEST_PROVIDER_URI)
 
     account_index = '0\n'
-    yes = 'Y\n'
-    user_input = account_index + yes + yes
+    user_input = account_index + YES_ENTER + YES_ENTER
 
     result = click_runner.invoke(deploy,
                                  deploy_command,
@@ -264,7 +263,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--provider', TEST_PROVIDER_URI,
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2)
 
-    user_input = '0\n' + 'Y\n' + INSECURE_DEVELOPMENT_PASSWORD
+    user_input = '0\n' + YES_ENTER + INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -281,7 +280,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--provider', TEST_PROVIDER_URI,
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2)
 
-    user_input = '0\n' + 'Y\n'
+    user_input = '0\n' + YES_ENTER + INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -294,7 +293,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--provider', TEST_PROVIDER_URI,
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2)
 
-    user_input = '0\n' + 'Y\n'
+    user_input = '0\n' + YES_ENTER + INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -307,7 +306,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--provider', TEST_PROVIDER_URI,
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2)
 
-    user_input = '0\n' + 'Y\n'
+    user_input = '0\n' + YES_ENTER + INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
 
@@ -321,7 +320,7 @@ def test_manual_deployment_of_idle_network(click_runner):
                '--provider', TEST_PROVIDER_URI,
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH_2)
 
-    user_input = '0\n' + 'Y\n' + 'Y\n'
+    user_input = '0\n' + YES_ENTER + YES_ENTER + INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(deploy, command, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
     assert list(new_registry.enrolled_names) == deployed_contracts

--- a/tests/acceptance/cli/test_deploy_commands.py
+++ b/tests/acceptance/cli/test_deploy_commands.py
@@ -19,6 +19,7 @@
 import os
 import pytest
 
+from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.blockchain.eth.clients import EthereumClient
 from nucypher.blockchain.eth.agents import (AdjudicatorAgent, ContractAgency, PolicyManagerAgent, StakingEscrowAgent)
 from nucypher.blockchain.eth.constants import (ADJUDICATOR_CONTRACT_NAME, DISPATCHER_CONTRACT_NAME,
@@ -52,7 +53,6 @@ def test_nucypher_deploy_inspect_no_deployments(click_runner, testerchain, new_l
     assert 'not enrolled' in result.output
 
 
-@pytest.mark.skip('See Issue #2314')
 def test_set_range(click_runner, testerchain, agency_local_registry):
 
     minimum, default, maximum = 10, 20, 30
@@ -93,7 +93,7 @@ def test_nucypher_deploy_inspect_fully_deployed(click_runner, agency_local_regis
     assert policy_agent.owner in result.output
     assert adjudicator_agent.owner in result.output
 
-    minimum, default, maximum = 10, 10, 10 # TODO: Fix with skipped test see Issue #2314
+    minimum, default, maximum = 10, 10, 10  # TODO: Fix with skipped test see Issue #2314
     assert 'Range' in result.output
     assert f"{minimum} wei" in result.output
     assert f"{default} wei" in result.output
@@ -210,7 +210,8 @@ def test_manual_proxy_retargeting(monkeypatch, testerchain, click_runner, token_
                '--target-address', untargeted_deployment.address,
                '--provider', TEST_PROVIDER_URI,
                '--registry-infile', ALTERNATE_REGISTRY_FILEPATH,
-               '--confirmations', 4)
+               '--confirmations', 4,
+               '--network', TEMPORARY_DOMAIN)
 
     # Upgrade
     user_input = '0\n' + 'Y\n' + 'Y\n'
@@ -244,7 +245,7 @@ def test_batch_deposits(click_runner,
                                  deploy_command,
                                  input=user_input,
                                  catch_exceptions=False)
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     for allocation_address in testerchain.unassigned_accounts:
         assert allocation_address in result.output
 

--- a/tests/contracts/test_contracts_upgradeability.py
+++ b/tests/contracts/test_contracts_upgradeability.py
@@ -133,17 +133,17 @@ def test_upgradeability(temp_dir_path):
         staking_escrow_deployer = StakingEscrowDeployer(registry=registry, deployer_address=origin)
         deploy_earliest_contract(blockchain_interface, staking_escrow_deployer)
         if test_staking_escrow:
-            staking_escrow_deployer.upgrade(contract_version="latest")
+            staking_escrow_deployer.upgrade(contract_version="latest", confirmations=0)
 
         if test_policy_manager:
             policy_manager_deployer = PolicyManagerDeployer(registry=registry, deployer_address=origin)
             deploy_earliest_contract(blockchain_interface, policy_manager_deployer)
-            policy_manager_deployer.upgrade(contract_version="latest")
+            policy_manager_deployer.upgrade(contract_version="latest", confirmations=0)
 
         if test_adjudicator:
             adjudicator_deployer = AdjudicatorDeployer(registry=registry, deployer_address=origin)
             deploy_earliest_contract(blockchain_interface, adjudicator_deployer)
-            adjudicator_deployer.upgrade(contract_version="latest")
+            adjudicator_deployer.upgrade(contract_version="latest", confirmations=0)
 
     finally:
         # Unregister interface


### PR DESCRIPTION
Co-Author: @derekpierre 


- Support block confirmations for upgrade, re-targeting, rollback, etc.
- Display current contract version numbers with `inspect` command
- Eager "Pre-flight" checks for upgrade CLI 
- Deprecated `nucypher deploy transfer tokens`
- Deprecates automated deployment series test (needs further actor-level deprecation)