### PR TITLE
[WIP] Improvement and reorganization of gas strategies logic

### DIFF
--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -15,7 +15,6 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
 import os
 import pprint
 import time
@@ -59,7 +58,7 @@ from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.sol.compile import SolidityCompiler
 from nucypher.blockchain.eth.utils import get_transaction_name, prettify_eth_amount
 from nucypher.characters.control.emitters import JSONRPCStdoutEmitter, StdoutEmitter
-from nucypher.utilities.datafeeds import datafeed_fallback_gas_price_strategy
+from nucypher.utilities.gas_strategies import datafeed_fallback_gas_price_strategy
 from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 
 

--- a/nucypher/utilities/__init__.py
+++ b/nucypher/utilities/__init__.py
@@ -14,3 +14,10 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+from nucypher.utilities.datafeeds import EthereumGasPriceDatafeed, EtherchainGasPriceDatafeed, UpvestGasPriceDatafeed
+
+EthereumGasPriceDatafeed._DATAFEEDS = {
+    EtherchainGasPriceDatafeed.simple_name: EtherchainGasPriceDatafeed,
+    UpvestGasPriceDatafeed.simple_name: UpvestGasPriceDatafeed
+}

--- a/nucypher/utilities/datafeeds.py
+++ b/nucypher/utilities/datafeeds.py
@@ -134,22 +134,5 @@ class UpvestGasPriceDatafeed(EthereumGasPriceDatafeed):
         self.gas_prices = {k: int(Web3.toWei(v, 'gwei')) for k, v in self._raw_data['estimates'].items()}
 
 
-def datafeed_fallback_gas_price_strategy(web3: Web3, transaction_params: TxParams = None) -> Wei:
-    feeds = (EtherchainGasPriceDatafeed, UpvestGasPriceDatafeed)
-
-    for gas_price_feed_class in feeds:
-        try:
-            gas_strategy = gas_price_feed_class.construct_gas_strategy()
-            gas_price = gas_strategy(web3, transaction_params)
-        except Datafeed.DatafeedError:
-            continue
-        else:
-            return gas_price
-    else:
-        # Worst-case scenario, we get the price from the ETH node itself
-        return rpc_gas_price_strategy(web3, transaction_params)
-
-
-
 # TODO: We can implement here other datafeeds, like the ETH/USD (e.g., https://api.coinmarketcap.com/v1/ticker/ethereum/)
 # suggested in a comment in nucypher.blockchain.eth.interfaces.BlockchainInterface#sign_and_broadcast_transaction

--- a/nucypher/utilities/datafeeds.py
+++ b/nucypher/utilities/datafeeds.py
@@ -54,9 +54,16 @@ class EthereumGasPriceDatafeed(Datafeed):
     _speed_names = NotImplemented
     _default_speed = NotImplemented
 
+    _DATAFEEDS = NotImplemented  # set dynamically in __init__.py
+
+    @property
+    @abstractmethod
+    def simple_name(self):
+        raise NotImplementedError
+
     @abstractmethod
     def _parse_gas_prices(self):
-        return NotImplementedError
+        raise NotImplementedError
 
     def get_gas_price(self, speed: Optional[str] = None) -> Wei:
         speed = speed or self._default_speed
@@ -81,6 +88,9 @@ class EtherchainGasPriceDatafeed(EthereumGasPriceDatafeed):
     _speed_names = ('safeLow', 'standard', 'fast', 'fastest')
     _default_speed = 'fast'
 
+    def simple_name(self):
+        return "etherchain"
+
     def _parse_gas_prices(self):
         self._probe_feed()
         self.gas_prices = {k: int(Web3.toWei(v, 'gwei')) for k, v in self._raw_data.items()}
@@ -93,6 +103,9 @@ class UpvestGasPriceDatafeed(EthereumGasPriceDatafeed):
     api_url = "https://fees.upvest.co/estimate_eth_fees"
     _speed_names = ('slow', 'medium', 'fast', 'fastest')
     _default_speed = 'fastest'
+
+    def simple_name(self):
+        return "upvest"
 
     def _parse_gas_prices(self):
         self._probe_feed()

--- a/nucypher/utilities/datafeeds.py
+++ b/nucypher/utilities/datafeeds.py
@@ -15,7 +15,7 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 from abc import ABC, abstractmethod
-from typing import Optional
+from typing import Optional, Callable
 
 import requests
 from web3 import Web3
@@ -68,16 +68,38 @@ class EthereumGasPriceDatafeed(Datafeed):
     def get_gas_price(self, speed: Optional[str] = None) -> Wei:
         speed = speed or self._default_speed
         self._parse_gas_prices()
-        gas_price_wei = Wei(self.gas_prices[speed])
-        return gas_price_wei
+        try:
+            gas_price_wei = Wei(self.gas_prices[speed])
+        except KeyError:
+            raise self.DatafeedError  # TODO
+        else:
+            return gas_price_wei
 
     @classmethod
-    def construct_gas_strategy(cls):
+    def construct_gas_strategy(cls, speed: Optional[str] = None) -> Callable:
         def gas_price_strategy(web3: Web3, transaction_params: TxParams = None) -> Wei:
             feed = cls()
-            gas_price = feed.get_gas_price()
+            gas_price = feed.get_gas_price(speed=speed)
             return gas_price
         return gas_price_strategy
+
+    @classmethod
+    def get_strategy_from_string(cls, strategy_name: str) -> Callable:
+        """
+        Creates a data feed gas strategy from a string representing the strategy
+        :param strategy_name: A string of format "<datafeed_name>/<speed_name>"
+        :return: A web3 gas strategy that internally uses the specified datafeed and speed to compute gas prices
+        """
+        try:
+            datafeed, speed = strategy_name.split("/")
+            datafeed_class = cls._DATAFEEDS[datafeed]
+        except ValueError:
+            raise cls.DatafeedError  # TODO
+        except KeyError:
+            raise cls.DatafeedError  # TODO
+        else:
+            gas_strategy = datafeed_class.construct_gas_strategy(speed=speed)
+            return gas_strategy
 
 
 class EtherchainGasPriceDatafeed(EthereumGasPriceDatafeed):

--- a/nucypher/utilities/gas_strategies.py
+++ b/nucypher/utilities/gas_strategies.py
@@ -1,0 +1,39 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from web3 import Web3
+from web3.gas_strategies.rpc import rpc_gas_price_strategy
+from web3.types import Wei, TxParams
+
+from nucypher.utilities import EtherchainGasPriceDatafeed, UpvestGasPriceDatafeed
+from nucypher.utilities.datafeeds import Datafeed
+
+
+def datafeed_fallback_gas_price_strategy(web3: Web3, transaction_params: TxParams = None) -> Wei:
+    feeds = (EtherchainGasPriceDatafeed, UpvestGasPriceDatafeed)
+
+    for gas_price_feed_class in feeds:
+        try:
+            gas_strategy = gas_price_feed_class.construct_gas_strategy()
+            gas_price = gas_strategy(web3, transaction_params)
+        except Datafeed.DatafeedError:
+            continue
+        else:
+            return gas_price
+    else:
+        # Worst-case scenario, we get the price from the ETH node itself
+        return rpc_gas_price_strategy(web3, transaction_params)


### PR DESCRIPTION
Current gas strategies logic is still very primitive and inflexible. This PR aims to improve this by:
* Promoting gas strategies logic to a separate module as a starting point
* Introducing a simple string representation for gas strategies to facilitate finer-grained configuration of the possible gas strategies. For example, we currently only allow to select the web3 gas strategies, but our codebase supports data feeds, which cannot be used since there's no way to select them from the configuration. The idea is to allow the operator to configure the gas strategy with a string like `<strategy_provider>/<strategy_option>`, e.g., `web3/fast`. This is still WIP and any ideas are welcome!
* Introduce more complex strategies, such as the "increasing" strategy outlined in #2309, or others involving fallback chains.

TODO:
* #2243 
* #2309 
