### PR TITLE
Allow --from-unlocked flag to specify when only uncollected staking rewards and unlocked substakes are used for creating/increasing a stake.

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -20,19 +20,21 @@ import json
 import os
 import sys
 import time
-from decimal import Decimal
-from web3.types import TxReceipt
 import traceback
+from decimal import Decimal
+from typing import Callable
+from typing import Dict, Iterable, List, Optional, Tuple
+
 import click
 import maya
+from constant_sorrow.constants import FULL, WORKER_NOT_RUNNING
 from eth_tester.exceptions import TransactionFailed as TestTransactionFailed
 from eth_typing import ChecksumAddress
 from eth_utils import to_canonical_address, to_checksum_address
-from typing import Dict, Iterable, List, Optional, Tuple
 from web3 import Web3
 from web3.exceptions import ValidationError
+from web3.types import TxReceipt
 
-from constant_sorrow.constants import FULL, WORKER_NOT_RUNNING
 from nucypher.acumen.nicknames import nickname_from_seed
 from nucypher.blockchain.economics import BaseEconomics, EconomicsFactory, StandardTokenEconomics
 from nucypher.blockchain.eth.agents import (
@@ -75,8 +77,8 @@ from nucypher.blockchain.eth.deployers import (
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.multisig import Authorization, Proposal
 from nucypher.blockchain.eth.registry import BaseContractRegistry, IndividualAllocationRegistry
-from nucypher.blockchain.eth.signers.software import KeystoreSigner, Web3Signer
 from nucypher.blockchain.eth.signers.base import Signer
+from nucypher.blockchain.eth.signers.software import KeystoreSigner, Web3Signer
 from nucypher.blockchain.eth.token import NU, Stake, StakeList, WorkTracker, validate_prolong, validate_increase, \
     validate_divide, validate_merge
 from nucypher.blockchain.eth.utils import (
@@ -93,7 +95,6 @@ from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.powers import TransactingPower
 from nucypher.types import NuNits, Period
 from nucypher.utilities.logging import Logger
-from typing import Callable
 
 
 class BaseActor:
@@ -931,7 +932,7 @@ class Staker(NucypherTokenActor):
                          lock_periods: int = None,
                          expiration: maya.MayaDT = None,
                          entire_balance: bool = False,
-                         only_lock: bool = False
+                         use_rewards: bool = False
                          ) -> TxReceipt:
 
         """Create a new stake."""
@@ -949,7 +950,7 @@ class Staker(NucypherTokenActor):
         elif not entire_balance and not amount:
             raise ValueError("Specify an amount or entire balance, got neither")
 
-        token_balance = self.token_balance if not only_lock else self.calculate_staking_reward()
+        token_balance = self.calculate_staking_reward() if use_rewards else self.token_balance
         if entire_balance:
             amount = token_balance
         if not token_balance >= amount:
@@ -964,10 +965,10 @@ class Staker(NucypherTokenActor):
                                            lock_periods=lock_periods)
 
         # Create stake on-chain
-        if not only_lock:
-            receipt = self._deposit(amount=new_stake.value.to_nunits(), lock_periods=new_stake.duration)
-        else:
+        if use_rewards:
             receipt = self._lock_and_create(amount=new_stake.value.to_nunits(), lock_periods=new_stake.duration)
+        else:
+            receipt = self._deposit(amount=new_stake.value.to_nunits(), lock_periods=new_stake.duration)
 
         # Log and return receipt
         self.log.info(f"{self.checksum_address} initialized new stake: {amount} tokens for {lock_periods} periods")
@@ -1022,7 +1023,7 @@ class Staker(NucypherTokenActor):
                        stake: Stake,
                        amount: NU = None,
                        entire_balance: bool = False,
-                       only_lock: bool = False
+                       use_rewards: bool = False
                        ) -> TxReceipt:
         """Add tokens to existing stake."""
         self._ensure_stake_exists(stake)
@@ -1032,7 +1033,7 @@ class Staker(NucypherTokenActor):
             raise ValueError(f"Pass either an amount or entire balance; "
                              f"got {'both' if entire_balance else 'neither'}")
 
-        token_balance = self.token_balance if not only_lock else self.calculate_staking_reward()
+        token_balance = self.calculate_staking_reward() if use_rewards else self.token_balance
         if entire_balance:
             amount = token_balance
         if not token_balance >= amount:
@@ -1044,10 +1045,10 @@ class Staker(NucypherTokenActor):
         validate_increase(stake=stake, amount=amount)
 
         # Write to blockchain
-        if not only_lock:
-            receipt = self._deposit_and_increase(stake_index=stake.index, amount=int(amount))
-        else:
+        if use_rewards:
             receipt = self._lock_and_increase(stake_index=stake.index, amount=int(amount))
+        else:
+            receipt = self._deposit_and_increase(stake_index=stake.index, amount=int(amount))
 
         # Update staking cache element
         self.refresh_stakes()

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -932,7 +932,7 @@ class Staker(NucypherTokenActor):
                          lock_periods: int = None,
                          expiration: maya.MayaDT = None,
                          entire_balance: bool = False,
-                         use_rewards: bool = False
+                         from_unlocked: bool = False
                          ) -> TxReceipt:
 
         """Create a new stake."""
@@ -950,7 +950,7 @@ class Staker(NucypherTokenActor):
         elif not entire_balance and not amount:
             raise ValueError("Specify an amount or entire balance, got neither")
 
-        token_balance = self.calculate_staking_reward() if use_rewards else self.token_balance
+        token_balance = self.calculate_staking_reward() if from_unlocked else self.token_balance
         if entire_balance:
             amount = token_balance
         if not token_balance >= amount:
@@ -965,7 +965,7 @@ class Staker(NucypherTokenActor):
                                            lock_periods=lock_periods)
 
         # Create stake on-chain
-        if use_rewards:
+        if from_unlocked:
             receipt = self._lock_and_create(amount=new_stake.value.to_nunits(), lock_periods=new_stake.duration)
         else:
             receipt = self._deposit(amount=new_stake.value.to_nunits(), lock_periods=new_stake.duration)
@@ -1023,7 +1023,7 @@ class Staker(NucypherTokenActor):
                        stake: Stake,
                        amount: NU = None,
                        entire_balance: bool = False,
-                       use_rewards: bool = False
+                       from_unlocked: bool = False
                        ) -> TxReceipt:
         """Add tokens to existing stake."""
         self._ensure_stake_exists(stake)
@@ -1033,7 +1033,7 @@ class Staker(NucypherTokenActor):
             raise ValueError(f"Pass either an amount or entire balance; "
                              f"got {'both' if entire_balance else 'neither'}")
 
-        token_balance = self.calculate_staking_reward() if use_rewards else self.token_balance
+        token_balance = self.calculate_staking_reward() if from_unlocked else self.token_balance
         if entire_balance:
             amount = token_balance
         if not token_balance >= amount:
@@ -1045,7 +1045,7 @@ class Staker(NucypherTokenActor):
         validate_increase(stake=stake, amount=amount)
 
         # Write to blockchain
-        if use_rewards:
+        if from_unlocked:
             receipt = self._lock_and_increase(stake_index=stake.index, amount=int(amount))
         else:
             receipt = self._deposit_and_increase(stake_index=stake.index, amount=int(amount))

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -84,7 +84,7 @@ PROMPT_STAKE_CREATE_VALUE = "Enter stake value in NU ({lower_limit} - {upper_lim
 
 PROMPT_STAKE_CREATE_LOCK_PERIODS = "Enter stake duration ({min_locktime} - {max_locktime})"
 
-CONFIRM_USE_UNCOLLECTED_REWARDS = "Confirm only use uncollected staking rewards"
+CONFIRM_STAKE_USE_UNLOCKED = "Confirm only use uncollected staking rewards and unlocked sub-stakes; not tokens from staker address"
 
 CONFIRM_BROADCAST_CREATE_STAKE = "Publish staged stake to the blockchain?"
 

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -84,7 +84,7 @@ PROMPT_STAKE_CREATE_VALUE = "Enter stake value in NU ({lower_limit} - {upper_lim
 
 PROMPT_STAKE_CREATE_LOCK_PERIODS = "Enter stake duration ({min_locktime} - {max_locktime})"
 
-PROMPT_DEPOSIT_OR_LOCK = "Transfer tokens from the staker address? Otherwise, unlocked tokens in the escrow will be used"
+CONFIRM_USE_UNCOLLECTED_REWARDS = "Confirm only use uncollected staking rewards"
 
 CONFIRM_BROADCAST_CREATE_STAKE = "Publish staged stake to the blockchain?"
 

--- a/tests/integration/cli/test_stake_cli_functionality.py
+++ b/tests/integration/cli/test_stake_cli_functionality.py
@@ -34,7 +34,7 @@ from nucypher.cli.literature import (
     PROMPT_STAKE_CREATE_LOCK_PERIODS, CONFIRM_LARGE_STAKE_VALUE, CONFIRM_LARGE_STAKE_DURATION, CONFIRM_STAGED_STAKE,
     CONFIRM_BROADCAST_CREATE_STAKE, INSUFFICIENT_BALANCE_TO_INCREASE, MAXIMUM_STAKE_REACHED,
     INSUFFICIENT_BALANCE_TO_CREATE, ONLY_DISPLAYING_MERGEABLE_STAKES_NOTE, CONFIRM_MERGE, SUCCESSFUL_STAKES_MERGE,
-    CONFIRM_USE_UNCOLLECTED_REWARDS)
+    CONFIRM_STAKE_USE_UNLOCKED)
 from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.types import SubStakeInfo, StakerInfo
 from tests.constants import MOCK_PROVIDER_URI, YES, INSECURE_DEVELOPMENT_PASSWORD
@@ -637,7 +637,7 @@ def test_increase_interactive(click_runner,
     assert result.exit_code == 0
 
     upper_limit = NU.from_nunits(balance)
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS not in result.output  # default is use staker address
+    assert CONFIRM_STAKE_USE_UNLOCKED not in result.output  # default is use staker address
     assert PROMPT_STAKE_INCREASE_VALUE.format(upper_limit=upper_limit) in result.output
     assert CONFIRM_INCREASING_STAKE.format(stake_index=sub_stake_index, value=additional_value) in result.output
     assert SUCCESSFUL_STAKE_INCREASE in result.output
@@ -691,7 +691,7 @@ def test_increase_non_interactive(click_runner,
     assert PROMPT_STAKE_INCREASE_VALUE.format(upper_limit=upper_limit) not in result.output
     assert CONFIRM_INCREASING_STAKE.format(stake_index=sub_stake_index, value=additional_value) not in result.output
     assert SUCCESSFUL_STAKE_INCREASE in result.output
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS not in result.output  # default is use staker address
+    assert CONFIRM_STAKE_USE_UNLOCKED not in result.output  # default is use staker address
 
     mock_staking_agent.get_all_stakes.assert_called()
     mock_staking_agent.get_current_period.assert_called()
@@ -727,7 +727,7 @@ def test_increase_lock_interactive(click_runner,
     command = ('increase',
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
-               '--use-rewards')
+               '--from-unlocked')
 
     user_input = '\n'.join((str(selected_index),
                             str(sub_stake_index),
@@ -762,7 +762,7 @@ def test_increase_lock_interactive(click_runner,
     assert PROMPT_STAKE_INCREASE_VALUE.format(upper_limit=upper_limit) in result.output
     assert CONFIRM_INCREASING_STAKE.format(stake_index=sub_stake_index, value=additional_value) in result.output
     assert SUCCESSFUL_STAKE_INCREASE in result.output
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS in result.output  # value not provided but --use-rewards specified so prompted
+    assert CONFIRM_STAKE_USE_UNLOCKED in result.output  # value not provided but --from-unlocked specified so prompted
 
     mock_staking_agent.get_all_stakes.assert_called()
     mock_staking_agent.get_current_period.assert_called()
@@ -799,7 +799,7 @@ def test_increase_lock_non_interactive(click_runner,
                '--staking-address', surrogate_stakers[selected_index],
                '--index', sub_stake_index,
                '--value', additional_value.to_tokens(),
-               '--use-rewards',
+               '--from-unlocked',
                '--force')
 
     user_input = INSECURE_DEVELOPMENT_PASSWORD
@@ -807,7 +807,7 @@ def test_increase_lock_non_interactive(click_runner,
     assert result.exit_code == 0
 
     upper_limit = NU.from_nunits(unlocked_tokens)
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS not in result.output  # value provided so not prompted
+    assert CONFIRM_STAKE_USE_UNLOCKED not in result.output  # value provided so not prompted
     assert PROMPT_STAKE_INCREASE_VALUE.format(upper_limit=upper_limit) not in result.output
     assert CONFIRM_INCREASING_STAKE.format(stake_index=sub_stake_index, value=additional_value) not in result.output
     assert SUCCESSFUL_STAKE_INCREASE in result.output
@@ -879,7 +879,7 @@ def test_create_interactive(click_runner,
     min_locktime = token_economics.minimum_locked_periods
     max_locktime = MAX_UINT16 - 10  # MAX_UINT16 - current period
 
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS not in result.output  # default is to use staker address
+    assert CONFIRM_STAKE_USE_UNLOCKED not in result.output  # default is to use staker address
     assert PROMPT_STAKE_CREATE_VALUE.format(lower_limit=lower_limit, upper_limit=upper_limit) in result.output
     assert PROMPT_STAKE_CREATE_LOCK_PERIODS.format(min_locktime=min_locktime, max_locktime=max_locktime) in result.output
     assert CONFIRM_STAGED_STAKE.format(nunits=str(value.to_nunits()),
@@ -938,7 +938,7 @@ def test_create_non_interactive(click_runner,
     min_locktime = token_economics.minimum_locked_periods
     max_locktime = MAX_UINT16 - 10  # MAX_UINT16 - current period
 
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS not in result.output  # default is to use staker address
+    assert CONFIRM_STAKE_USE_UNLOCKED not in result.output  # default is to use staker address
     assert PROMPT_STAKE_CREATE_VALUE.format(lower_limit=lower_limit, upper_limit=upper_limit) not in result.output
     assert PROMPT_STAKE_CREATE_LOCK_PERIODS.format(min_locktime=min_locktime, max_locktime=max_locktime) not in result.output
     assert CONFIRM_STAGED_STAKE.format(nunits=str(value.to_nunits()),
@@ -979,7 +979,7 @@ def test_create_lock_interactive(click_runner,
     command = ('create',
                '--provider', MOCK_PROVIDER_URI,
                '--network', TEMPORARY_DOMAIN,
-               '--use-rewards')
+               '--from-unlocked')
 
     user_input = '\n'.join((str(selected_index),
                             YES,
@@ -1016,7 +1016,7 @@ def test_create_lock_interactive(click_runner,
     min_locktime = token_economics.minimum_locked_periods
     max_locktime = MAX_UINT16 - 10  # MAX_UINT16 - current period
 
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS in result.output  # value not provided but --use-rewards specified so prompted
+    assert CONFIRM_STAKE_USE_UNLOCKED in result.output  # value not provided but --from-unlocked specified so prompted
     assert PROMPT_STAKE_CREATE_VALUE.format(lower_limit=lower_limit, upper_limit=upper_limit) in result.output
     assert PROMPT_STAKE_CREATE_LOCK_PERIODS.format(min_locktime=min_locktime, max_locktime=max_locktime) in result.output
     assert CONFIRM_STAGED_STAKE.format(nunits=str(value.to_nunits()),
@@ -1061,7 +1061,7 @@ def test_create_lock_non_interactive(click_runner,
                '--staking-address', surrogate_stakers[selected_index],
                '--lock-periods', lock_periods,
                '--value', value.to_tokens(),
-               '--use-rewards',
+               '--from-unlocked',
                '--force')
 
     user_input = '\n'.join((YES, YES, INSECURE_DEVELOPMENT_PASSWORD))
@@ -1073,7 +1073,7 @@ def test_create_lock_non_interactive(click_runner,
     min_locktime = token_economics.minimum_locked_periods
     max_locktime = MAX_UINT16 - 10  # MAX_UINT16 - current period
 
-    assert CONFIRM_USE_UNCOLLECTED_REWARDS not in result.output  # value provided so not prompted
+    assert CONFIRM_STAKE_USE_UNLOCKED not in result.output  # value provided so not prompted
     assert PROMPT_STAKE_CREATE_VALUE.format(lower_limit=lower_limit, upper_limit=upper_limit) not in result.output
     assert PROMPT_STAKE_CREATE_LOCK_PERIODS.format(min_locktime=min_locktime, max_locktime=max_locktime) not in result.output
     assert CONFIRM_STAGED_STAKE.format(nunits=str(value.to_nunits()),


### PR DESCRIPTION
Fixes #2273 .