### PR TITLE
Nickname refactoring & changing nickname symbols to more common ones

### DIFF
--- a/nucypher/acumen/nicknames.py
+++ b/nucypher/acumen/nicknames.py
@@ -21,26 +21,49 @@ from typing import List
 import random
 from os.path import abspath, dirname, join
 
-import unicodedata
 
 _HERE = abspath(dirname(__file__))
 with open(join(_HERE, 'web_colors.json')) as f:
     _COLORS = json.load(f)['colors']
 
-_SYMBOLS = ("♈", "♉", "♊", "♋", "♌", "♍", "♎", "♏", "♐", "♑", "♒", "♓",
-           "♚", "♛", "♜", "♝", "♞", "♟", "⚓", "⚔", "⚖", "⚗", "⚑", "⚘",
-           "⚪", "⚵", "⚿", "⛇", "⛈", "⛰", "⛸", "⛴", "⛨", "✈", "☤",
-           "⏚", "☠", "☸", "☿", "☾", "♁", "♃", "♄", "☄", "☘", "⚜", "⚚",
-           "⏲", "☣", "☥", "♣", "♥", "♦", "♠", "♫", "🟒", "⚛", "⚙", "⎈",
-           "☮", "☕", "☈", "♯", "♭")
-
-
-def nicename(symbol):
-    unicode_name = unicodedata.name(symbol)
-    final_word = unicode_name.split()[-1]
-    if final_word in ("SYMBOL", "SUIT", "SIGN"):
-        final_word = unicode_name.split()[-2]
-    return final_word.capitalize()
+_SYMBOLS = {
+    "A": "Alfa",
+    "B": "Bravo",
+    "C": "Charlie",
+    "D": "Delta",
+    "E": "Echo",
+    "F": "Foxtrot",
+    "G": "Golf",
+    "H": "Hotel",
+    "I": "India",
+    "J": "Juliett",
+    "K": "Kilo",
+    "L": "Lima",
+    "M": "Mike",
+    "N": "November",
+    "O": "Oscar",
+    "P": "Papa",
+    "Q": "Quebec",
+    "R": "Romeo",
+    "S": "Sierra",
+    "T": "Tango",
+    "U": "Uniform",
+    "V": "Victor",
+    "W": "Whiskey",
+    "X": "X-ray",
+    "Y": "Yankee",
+    "Z": "Zulu",
+    "0": "Zero",
+    "1": "One",
+    "2": "Two",
+    "3": "Three",
+    "4": "Four",
+    "5": "Five",
+    "6": "Six",
+    "7": "Seven",
+    "8": "Eight",
+    "9": "Nine",
+}
 
 
 class NicknameCharacter:
@@ -49,7 +72,7 @@ class NicknameCharacter:
         self.symbol = symbol
         self.color_name = color_name
         self.color_hex = color_hex
-        self._text = color_name + " " + nicename(symbol)
+        self._text = color_name + " " + _SYMBOLS[symbol]
 
     def payload(self):
         return dict(symbol=self.symbol,
@@ -68,7 +91,7 @@ class Nickname:
         # if not seed:
         #     raise ValueError("No checksum provided to derive nickname.")
         rng = random.Random(seed)
-        nickname_symbols = rng.sample(_SYMBOLS, length)
+        nickname_symbols = rng.sample(list(_SYMBOLS), length)
         nickname_colors = rng.sample(_COLORS, length)
         characters = [
             NicknameCharacter(symbol, color['color'], color['hex'])

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -39,7 +39,7 @@ def icon_from_checksum(checksum,
     <div class="nucypher-nickname-icon" style="border-color:{color};">
     <div class="small">{number_of_nodes} nodes</div>
     <div class="symbols">
-        <span class="single-symbol" style="color: {color}">{symbol}&#xFE0E;</span>
+        <span class="single-symbol" style="color: {color}">{symbol}</span>
     </div>
     <br/>
     <span class="small-address">{fleet_state_checksum}</span>

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -35,7 +35,7 @@ from web3 import Web3
 from web3.exceptions import ValidationError
 from web3.types import TxReceipt
 
-from nucypher.acumen.nicknames import nickname_from_seed
+from nucypher.acumen.nicknames import Nickname
 from nucypher.blockchain.economics import BaseEconomics, EconomicsFactory, StandardTokenEconomics
 from nucypher.blockchain.eth.agents import (
     AdjudicatorAgent,
@@ -1549,7 +1549,7 @@ class Worker(NucypherTokenActor):
                 self._checksum_address = staking_address
 
                 # TODO: #1823 - Workaround for new nickname every restart
-                self.nickname, self.nickname_metadata = nickname_from_seed(self.checksum_address)
+                self.nickname = Nickname.from_seed(self.checksum_address)
                 break
 
             # Provide periodic feedback to the user

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -26,7 +26,7 @@ from constant_sorrow import default_constant_splitter
 from constant_sorrow.constants import (DO_NOT_SIGN, NO_BLOCKCHAIN_CONNECTION, NO_CONTROL_PROTOCOL,
                                        NO_DECRYPTION_PERFORMED, NO_NICKNAME, NO_SIGNING_POWER,
                                        SIGNATURE_IS_ON_CIPHERTEXT, SIGNATURE_TO_FOLLOW, STRANGER)
-from nucypher.acumen.nicknames import nickname_from_seed
+from nucypher.acumen.nicknames import Nickname
 from nucypher.blockchain.eth.registry import BaseContractRegistry, InMemoryContractRegistry
 from nucypher.blockchain.eth.signers.base import Signer
 from nucypher.characters.control.controllers import CLIController, JSONRPCController
@@ -218,18 +218,18 @@ class Character(Learner):
             # Sometimes we don't care about the nickname.  For example, if Alice is granting to Bob, she usually
             # doesn't know or care about his wallet.  Maybe this needs to change?
             # Currently, if this is a stranger and there's no blockchain connection, we assign NO_NICKNAME:
-            self.nickname = self.nickname_metadata = NO_NICKNAME
+            self.nickname = NO_NICKNAME
         else:
             try:
                 # TODO: It's possible that this is NO_BLOCKCHAIN_CONNECTION.
                 if self.checksum_address is NO_BLOCKCHAIN_CONNECTION:
-                    self.nickname = self.nickname_metadata = NO_NICKNAME
+                    self.nickname = NO_NICKNAME
                 else:
                     # This can call _set_checksum_address.
-                    self.nickname, self.nickname_metadata = nickname_from_seed(self.checksum_address)
+                    self.nickname = Nickname.from_seed(self.checksum_address)
             except SigningPower.not_found_error:  # TODO: Handle NO_BLOCKCHAIN_CONNECTION more coherently - #1547
                 if self.federated_only:
-                    self.nickname = self.nickname_metadata = NO_NICKNAME
+                    self.nickname = NO_NICKNAME
                 else:
                     raise
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -47,7 +47,7 @@ from constant_sorrow.constants import (INCLUDED_IN_BYTESTRING,
                                        UNKNOWN_VERSION,
                                        READY,
                                        INVALIDATED)
-from nucypher.acumen.nicknames import nickname_from_seed
+from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import FleetSensor
 from nucypher.blockchain.eth.actors import BlockchainPolicyAuthor, Worker
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
@@ -1506,7 +1506,7 @@ class Ursula(Teacher, Character, Worker):
             try:
                 canonical_address, _ = BytestringSplitter(ETH_ADDRESS_BYTE_LENGTH)(payload, return_remainder=True)
                 checksum_address = to_checksum_address(canonical_address)
-                nickname, _ = nickname_from_seed(checksum_address)
+                nickname = Nickname.from_seed(checksum_address)
                 display_name = cls._display_name_template.format(cls.__name__, nickname, checksum_address)
                 message = cls.unknown_version_message.format(display_name, version, cls.LEARNER_VERSION)
                 if version > cls.LEARNER_VERSION:

--- a/nucypher/cli/painting/nodes.py
+++ b/nucypher/cli/painting/nodes.py
@@ -27,8 +27,7 @@ def build_fleet_state_status(ursula) -> str:
     if ursula.known_nodes.checksum is not NO_KNOWN_NODES:
         fleet_state_checksum = ursula.known_nodes.checksum[:7]
         fleet_state_nickname = ursula.known_nodes.nickname
-        fleet_state_icon = ursula.known_nodes.icon
-        fleet_state = '{checksum} ⇀{nickname}↽ {icon}'.format(icon=fleet_state_icon,
+        fleet_state = '{checksum} ⇀{nickname}↽ {icon}'.format(icon=fleet_state_nickname.icon,
                                                               nickname=fleet_state_nickname,
                                                               checksum=fleet_state_checksum)
     elif ursula.known_nodes.checksum is NO_KNOWN_NODES:

--- a/nucypher/cli/painting/status.py
+++ b/nucypher/cli/painting/status.py
@@ -30,7 +30,7 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.utils import prettify_eth_amount
-from nucypher.acumen.nicknames import nickname_from_seed
+from nucypher.acumen.nicknames import Nickname
 
 
 def paint_contract_status(registry, emitter):
@@ -46,10 +46,10 @@ def paint_contract_status(registry, emitter):
 {token_agent.contract_name} ............ {token_agent.contract_address}
 {staking_agent.contract_name} ............ {staking_agent.contract_address}
 {policy_agent.contract_name} ............ {policy_agent.contract_address}
-{adjudicator_agent.contract_name} .............. {adjudicator_agent.contract_address} 
+{adjudicator_agent.contract_name} .............. {adjudicator_agent.contract_address}
     """
 
-    blockchain = f"""    
+    blockchain = f"""
 | '{blockchain.client.chain_name}' Blockchain Network |
 Gas Price ................ {Web3.fromWei(blockchain.client.gas_price, 'gwei')} Gwei
 Provider URI ............. {blockchain.provider_uri}
@@ -104,7 +104,7 @@ Locked until: ........ {maya.MayaDT(epoch=end_timestamp)}
 
 {" NU and ETH Balance ".center(width, "-")}
 NU balance: .......... {token_balance}
-    Available: ....... {available_amount} 
+    Available: ....... {available_amount}
 ETH balance: ......... {eth_balance} ETH
 """
     emitter.echo(output)
@@ -152,9 +152,8 @@ def paint_stakers(emitter, stakers: List[str], registry: BaseContractRegistry) -
 
     for staker_address in stakers:
         staker = Staker(is_me=False, checksum_address=staker_address, registry=registry)
-        nickname, pairs = nickname_from_seed(staker_address)
-        symbols = f"{pairs[0][1]}  {pairs[1][1]}"
-        emitter.echo(f"{staker_address}  {'Nickname:':10} {nickname} {symbols}")
+        nickname = Nickname.from_seed(staker_address)
+        emitter.echo(f"{staker_address}  {'Nickname:':10} {nickname} {nickname.icon}")
         tab = " " * len(staker_address)
 
         owned_tokens = staker.owned_tokens()

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -31,7 +31,7 @@ from cryptography.x509 import Certificate, NameOID
 from eth_utils import is_checksum_address
 from typing import Any, Callable, Set, Tuple, Union
 
-from nucypher.acumen.nicknames import nickname_from_seed
+from nucypher.acumen.nicknames import Nickname
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
@@ -136,7 +136,7 @@ class NodeStorage(ABC):
             public_pem_bytes = certificate.public_bytes(self.TLS_CERTIFICATE_ENCODING)
             certificate_file.write(public_pem_bytes)
 
-        nickname, pairs = nickname_from_seed(checksum_address)
+        nickname = Nickname.from_seed(checksum_address)
         self.log.debug(f"Saved TLS certificate for {nickname} {checksum_address}: {certificate_filepath}")
 
         return certificate_filepath

--- a/nucypher/network/templates/basic_status.j2
+++ b/nucypher/network/templates/basic_status.j2
@@ -103,7 +103,7 @@
 </style>
 
 <div id="this-node">
-    <h2>{{ this_node.nickname}}</h2>
+    <h2>{{ this_node.nickname }}</h2>
     <h5>({{ checksum_address }})</h5>
     {{ this_node.nickname_icon }}
     <h4>v{{ version }}</h4>

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -118,7 +118,7 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
                         'teacher_version': str(self.ursula.TEACHER_VERSION),
                         'host': str(self.ursula.rest_interface),
                         'domain': self.ursula.learning_domain,
-                        'nickname': self.ursula.nickname,
+                        'nickname': str(self.ursula.nickname),
                         'nickname_icon': self.ursula.nickname_icon,
                         'fleet_state': str(self.ursula.known_nodes.checksum),
                         'known_nodes': str(len(self.ursula.known_nodes))

--- a/tests/acceptance/characters/test_ursula_web_status.py
+++ b/tests/acceptance/characters/test_ursula_web_status.py
@@ -43,7 +43,7 @@ def test_ursula_html_renders(ursula, client):
     assert response.status_code == 200
     assert b'<!DOCTYPE html>' in response.data
     assert ursula.checksum_address.encode() in response.data
-    assert ursula.nickname.encode() in response.data
+    assert str(ursula.nickname).encode() in response.data
 
 
 def test_decentralized_json_status_endpoint(ursula, client):

--- a/tests/acceptance/network/test_network_actors.py
+++ b/tests/acceptance/network/test_network_actors.py
@@ -23,7 +23,7 @@ import pytest
 from hendrix.experience import crosstown_traffic
 from hendrix.utils.test_utils import crosstownTaskListDecoratorFactory
 
-from nucypher.acumen.nicknames import nickname_from_seed
+from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import FleetSensor
 from nucypher.characters.unlawful import Vladimir
 from nucypher.crypto.powers import SigningPower
@@ -42,7 +42,7 @@ def test_all_blockchain_ursulas_know_about_all_other_ursulas(blockchain_ursulas,
                 continue
             else:
                 assert address in propagating_ursula.known_nodes.addresses(), "{} did not know about {}". \
-                    format(propagating_ursula, nickname_from_seed(address))
+                    format(propagating_ursula, Nickname.from_seed(address))
 
 
 def test_blockchain_alice_finds_ursula_via_rest(blockchain_alice, blockchain_ursulas):

--- a/tests/integration/learning/test_learning_upgrade.py
+++ b/tests/integration/learning/test_learning_upgrade.py
@@ -22,7 +22,7 @@ from eth_utils.address import to_checksum_address
 from twisted.logger import LogLevel, globalLogPublisher
 
 from bytestring_splitter import VariableLengthBytestring
-from nucypher.acumen.nicknames import nickname_from_seed
+from nucypher.acumen.nicknames import Nickname
 from nucypher.characters.base import Character
 from tests.utils.middleware import MockRestMiddleware
 
@@ -81,7 +81,7 @@ def test_emit_warning_upon_new_version(lonely_ursula_maker, caplog):
 
     # If you really try, you can read a node representation from the garbage
     accidental_checksum = to_checksum_address(random_bytes[:20])
-    accidental_nickname = nickname_from_seed(accidental_checksum)[0]
+    accidental_nickname = Nickname.from_seed(accidental_checksum)
     accidental_node_repr = Character._display_name_template.format("Ursula", accidental_nickname, accidental_checksum)
 
     assert len(warnings) == 3


### PR DESCRIPTION
*Edit:* the scope of this PR has been limited to get done with public-visible changes first. Can't change the branch name, but it still kinda works.

* use a `Nickname` class to encapsulate nickname data instead of passing around tuples of tuples
* use NATO phonetic alphabet instead of Unicode glyphs for nicknames (to avoid problems with glyph representation in different fonts)

To get a few more bits in the nickname, we can add Æ and Þ (since they have convenient words to match with in English). 

**For reviewers:** please pay specific attention to correct serialization/deserialization. I'm not 100% sure I looked through all the instances where it happens.