### PR TITLE
Fleet sensor refactor

### DIFF
--- a/deploy/ansible/worker/include/check_running_ursula.yml
+++ b/deploy/ansible/worker/include/check_running_ursula.yml
@@ -53,7 +53,7 @@
       debug:
         msg:
           "local nickname: {{host_nickname}}\n
-          {% if serving and 'json' in status_data %}nickname: {{status_data.json.nickname}}\n
+          {% if serving and 'json' in status_data %}nickname: {{status_data.json.nickname.text}}\n
           staker address:          {{status_data.json.staker_address}}\n
           worker address:          {{status_data.json.worker_address}}\n
           rest url:                https://{{status_data.json.rest_url}}\n

--- a/newsfragments/2352.misc.rst
+++ b/newsfragments/2352.misc.rst
@@ -1,0 +1,1 @@
+Refactor FleetSensor; add "/status/?omit_known_nodes=true" argument; prevent internal constants from leaking into the status page.

--- a/nucypher/acumen/nicknames.py
+++ b/nucypher/acumen/nicknames.py
@@ -74,7 +74,7 @@ class NicknameCharacter:
         self.color_hex = color_hex
         self._text = color_name + " " + _SYMBOLS[symbol]
 
-    def payload(self):
+    def to_json(self):
         return dict(symbol=self.symbol,
                     color_name=self.color_name,
                     color_hex=self.color_hex)
@@ -103,8 +103,9 @@ class Nickname:
         self.icon = "[" + "".join(character.symbol for character in characters) + "]"
         self.characters = characters
 
-    def payload(self):
-        return [character.payload() for character in self.characters]
+    def to_json(self):
+        return dict(text=self._text,
+                    characters=[character.to_json() for character in self.characters])
 
     def __str__(self):
         return self._text

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -16,7 +16,9 @@
 """
 
 import binascii
+import itertools
 import random
+import weakref
 
 import maya
 
@@ -30,45 +32,137 @@ from nucypher.crypto.api import keccak_digest
 from nucypher.utilities.logging import Logger
 
 
-class FleetSensor:
-    """
-    A representation of a fleet of NuCypher nodes.
-    """
-    _checksum = NO_KNOWN_NODES.bool_value(False)
-    _nickname = NO_KNOWN_NODES
-    _tracking = False
-    most_recent_node_change = NO_KNOWN_NODES
-    snapshot_splitter = BytestringSplitter(32, 4)
-    log = Logger("Learning")
-    FleetState = namedtuple("FleetState", ("nickname", "icon", "nodes", "updated", "checksum"))
+class BaseFleetState:
 
-    def __init__(self, domain: str):
-        self.domain = domain
-        self.additional_nodes_to_track = []
-        self.updated = maya.now()
-        self._nodes = OrderedDict()
-        self._marked = defaultdict(list)  # Beginning of bucketing.
-        self.states = OrderedDict()
-
-    def __setitem__(self, checksum_address, node_or_sprout):
-        if node_or_sprout.domain == self.domain:
-            self._nodes[checksum_address] = node_or_sprout
-
-            if self._tracking:
-                self.log.info("Updating fleet state after saving node {}".format(node_or_sprout))
-                self.record_fleet_state()
+    def __str__(self):
+        if len(self) != 0:
+            # TODO: draw the icon in color, similarly to the web version?
+            return '{checksum} ⇀{nickname}↽ {icon}'.format(icon=self.nickname.icon,
+                                                           nickname=self.nickname,
+                                                           checksum=self.checksum[:7])
         else:
-            msg = f"Rejected node {node_or_sprout} because its domain is '{node_or_sprout.domain}' but we're only tracking '{self.domain}'"
-            self.log.warn(msg)
+            return 'No Known Nodes'
+
+
+class ArchivedFleetState(BaseFleetState):
+
+    def __init__(self, checksum, nickname, timestamp, population):
+        self.checksum = checksum
+        self.nickname = nickname
+        self.timestamp = timestamp
+        self.population = population
+
+    def to_json(self):
+        return dict(checksum=self.checksum,
+                    nickname=self.nickname.to_json() if self.nickname is not None else 'NO_KNOWN_NODES',
+                    timestamp=self.timestamp.rfc2822(),
+                    population=self.population)
+
+
+# Assumptions we're based on:
+# - Every supplied node object, after its constructor has finished,
+#   has a ``.checksum_address`` and ``bytes()`` (metadata)
+# - checksum address or metadata does not change for the same Python object
+# - ``this_node`` (the owner of FleetSensor) may not have a checksum address initially
+#   (when the constructor is first called), but will have one at the time of the first
+#   `record_fleet_state()` call. This applies to its metadata as well.
+# - The metadata of ``this_node`` **can** change.
+# - For the purposes of the fleet state, nodes with different metadata are considered different,
+#   even if they have the same checksum address.
+
+class FleetState(BaseFleetState):
+
+    @classmethod
+    def new(cls, this_node=None):
+        this_node_ref = weakref.ref(this_node) if this_node is not None else None
+        # Using empty checksum so that JSON library is not confused.
+        # Plus, we do need some checksum anyway. It's a legitimate state after all.
+        return cls(checksum=keccak_digest(b"").hex(),
+                   nodes={},
+                   this_node_ref=this_node_ref,
+                   this_node_metadata=None)
+
+    def __init__(self, checksum, nodes, this_node_ref, this_node_metadata):
+        self.checksum = checksum
+        self.nickname = None if checksum is None else Nickname.from_seed(checksum, length=1)
+        self._nodes = nodes
+        self.timestamp = maya.now()
+        self._this_node_ref = this_node_ref
+        self._this_node_metadata = this_node_metadata
+
+    def archived(self):
+        return ArchivedFleetState(checksum=self.checksum,
+                                  nickname=self.nickname,
+                                  timestamp=self.timestamp,
+                                  population=self.population)
+
+    def with_updated_nodes(self, new_nodes, marked_nodes):
+
+        # Checking if the node already has a checksum address
+        # (it may be created later during the constructor)
+        # or if it mutated since the last check.
+        if self._this_node_ref is not None and getattr(self._this_node_ref(), 'finished_initializing', False):
+            this_node = self._this_node_ref()
+            this_node_metadata = bytes(this_node)
+            this_node_changed = self._this_node_metadata != this_node_metadata
+            this_node_list = [this_node]
+        else:
+            this_node_metadata = self._this_node_metadata
+            this_node_changed = False
+            this_node_list = []
+
+        new_nodes = {checksum_address: node for checksum_address, node in new_nodes.items()
+                     if checksum_address not in marked_nodes}
+
+        remote_nodes_updated = any(
+            (checksum_address not in self._nodes or bytes(self._nodes[checksum_address]) != bytes(node))
+                and checksum_address not in marked_nodes
+            for checksum_address, node in new_nodes.items())
+
+        remote_nodes_slashed = any(checksum_address in self._nodes for checksum_address in marked_nodes)
+
+        if this_node_changed or remote_nodes_updated or remote_nodes_slashed:
+            # TODO: if nodes were kept in a Merkle tree,
+            # we'd have to only recalculate log(N) checksums.
+            # Is it worth it?
+            nodes = dict(self._nodes)
+            nodes.update(new_nodes)
+            for checksum_address in marked_nodes:
+                if checksum_address in nodes:
+                    del nodes[checksum_address]
+
+            all_nodes_sorted = sorted(itertools.chain(this_node_list, nodes.values()),
+                                      key=lambda node: node.checksum_address)
+            joined_metadata = b"".join(bytes(node) for node in all_nodes_sorted)
+            checksum = keccak_digest(joined_metadata).hex()
+        else:
+            nodes = self._nodes
+            checksum = self.checksum
+
+        return FleetState(checksum=checksum,
+                          nodes=nodes,
+                          this_node_ref=self._this_node_ref,
+                          this_node_metadata=this_node_metadata)
+
+    @property
+    def population(self):
+        """Returns the number of all known nodes, including itself, if applicable."""
+        return len(self) + int(self._this_node_metadata is not None)
 
     def __getitem__(self, checksum_address):
         return self._nodes[checksum_address]
 
+    def addresses(self):
+        return self._nodes.keys()
+
     def __bool__(self):
-        return bool(self._nodes)
+        return len(self) != 0
 
     def __contains__(self, item):
-        return item in self._nodes.keys() or item in self._nodes.values()
+        if isinstance(item, str):
+            return item in self._nodes
+        else:
+            return item.checksum_address in self._nodes
 
     def __iter__(self):
         yield from self._nodes.values()
@@ -76,100 +170,182 @@ class FleetSensor:
     def __len__(self):
         return len(self._nodes)
 
-    def __eq__(self, other):
-        return self._nodes == other._nodes
-
-    def __repr__(self):
-        return self._nodes.__repr__()
-
-    def population(self):
-        return len(self) + len(self.additional_nodes_to_track)
-
-    @property
-    def checksum(self):
-        return self._checksum
-
-    @checksum.setter
-    def checksum(self, checksum_value):
-        self._checksum = checksum_value
-        self._nickname = Nickname.from_seed(checksum_value, length=1)
-
-    @property
-    def nickname(self):
-        return self._nickname
-
-    @property
-    def icon(self) -> str:
-        if self.nickname is NO_KNOWN_NODES:
-            return str(NO_KNOWN_NODES)
-        return self.nickname.icon
-
-    def addresses(self):
-        return self._nodes.keys()
-
+    # TODO: we only send it along with `FLEET_STATES_MATCH`, so it is essentially useless.
+    # But it's hard to change now because older nodes will be looking for it.
     def snapshot(self):
-        fleet_state_checksum_bytes = binascii.unhexlify(self.checksum)
-        fleet_state_updated_bytes = self.updated.epoch.to_bytes(4, byteorder="big")
-        return fleet_state_checksum_bytes + fleet_state_updated_bytes
+        checksum_bytes = binascii.unhexlify(self.checksum)
+        timestamp_bytes = self.timestamp.epoch.to_bytes(4, byteorder="big")
+        return checksum_bytes + timestamp_bytes
 
-    def record_fleet_state(self, additional_nodes_to_track=None):
-        if additional_nodes_to_track:
-            self.additional_nodes_to_track.extend(additional_nodes_to_track)
+    snapshot_splitter = BytestringSplitter(32, 4)
 
-        if not self._nodes:
-            # No news here.
-            return
-        sorted_nodes = self.sorted()
-
-        sorted_nodes_joined = b"".join(bytes(n) for n in sorted_nodes)
-        checksum = keccak_digest(sorted_nodes_joined).hex()
-        if checksum not in self.states:
-            self.checksum = keccak_digest(b"".join(bytes(n) for n in self.sorted())).hex()
-            self.updated = maya.now()
-            # For now we store the sorted node list.  Someday we probably spin this out into
-            # its own class, FleetState, and use it as the basis for partial updates.
-            new_state = self.FleetState(nickname=self.nickname,
-                                        nodes=sorted_nodes,
-                                        icon=self.icon,
-                                        updated=self.updated,
-                                        checksum=self.checksum)
-            self.states[checksum] = new_state
-            return checksum, new_state
-
-    def start_tracking_state(self, additional_nodes_to_track=None):
-        if additional_nodes_to_track is None:
-            additional_nodes_to_track = list()
-        self.additional_nodes_to_track.extend(additional_nodes_to_track)
-        self._tracking = True
-        self.update_fleet_state()
-
-    def sorted(self):
-        nodes_to_consider = list(self._nodes.values()) + self.additional_nodes_to_track
-        return sorted(nodes_to_consider, key=lambda n: n.checksum_address)
+    @staticmethod
+    def unpack_snapshot(data):
+        checksum_bytes, timestamp_bytes, remainder = FleetState.snapshot_splitter(data, return_remainder=True)
+        checksum = checksum_bytes.hex()
+        timestamp = maya.MayaDT(int.from_bytes(timestamp_bytes, byteorder="big"))
+        return checksum, timestamp, remainder
 
     def shuffled(self):
         nodes_we_know_about = list(self._nodes.values())
         random.shuffle(nodes_we_know_about)
         return nodes_we_know_about
 
-    def abridged_states_dict(self):
-        abridged_states = {}
-        for k, v in self.states.items():
-            abridged_states[k] = self.abridged_state_details(v)
-        return abridged_states
+    def to_json(self):
+        return dict(nickname=self.nickname.to_json(),
+                    updated=self.timestamp.rfc2822())
+
+    @property
+    def icon(self) -> str:
+        # FIXME: should it be called at all if there are no states recorded?
+        if len(self) == 0:
+            return str(NO_KNOWN_NODES)
+        return self.nickname.icon
+
+    def items(self):
+        return self._nodes.items()
+
+    def values(self):
+        return self._nodes.values()
+
+    def __repr__(self):
+        return f"FleetState({self.checksum}, {self._nodes}, {self._this_node_ref}, {self._this_node_metadata})"
+
+
+class FleetSensor:
+    """
+    A representation of a fleet of NuCypher nodes.
+
+    If `this_node` is provided, it will be included in the state checksum
+    (but not returned during iteration/lookups).
+    """
+    log = Logger("Learning")
+
+    def __init__(self, domain: str, this_node=None):
+
+        self._domain = domain
+
+        self._current_state = FleetState.new(this_node)
+        self._archived_states = [self._current_state.archived()]
+        self.remote_states = {}
+
+        # temporary accumulator for new nodes to avoid updating the fleet state every time
+        self._new_nodes = {}
+        self._marked = set()  # Beginning of bucketing.
+
+        self._auto_update_state = False
+
+    def record_node(self, node):
+
+        if node.domain == self._domain:
+            self._new_nodes[node.checksum_address] = node
+
+            if self._auto_update_state:
+                self.log.info(f"Updating fleet state after saving node {node}")
+                self.record_fleet_state()
+        else:
+            msg = f"Rejected node {node} because its domain is '{node.domain}' but we're only tracking '{self._domain}'"
+            self.log.warn(msg)
+
+    def __getitem__(self, item):
+        return self._current_state[item]
+
+    def __bool__(self):
+        return bool(self._current_state)
+
+    def __contains__(self, item):
+        """
+        Checks if the node *with the same metadata* is recorded in the current state.
+        Does not compare ``item`` with the owner node of this FleetSensor.
+        """
+        return item in self._current_state
+
+    def __iter__(self):
+        yield from self._current_state
+
+    def __len__(self):
+        return len(self._current_state)
+
+    def __repr__(self):
+        return f"FleetSensor({self._current_state.__repr__()})"
+
+    @property
+    def current_state(self):
+        return self._current_state
+
+    @property
+    def checksum(self):
+        # FIXME: should it be called at all if there are no states recorded?
+        if self._current_state.population == 0:
+            return NO_KNOWN_NODES
+        return self._current_state.checksum
+
+    @property
+    def population(self):
+        return self._current_state.population
+
+    @property
+    def nickname(self):
+        # FIXME: should it be called at all if there are no states recorded?
+        if self._current_state.population == 0:
+            return NO_KNOWN_NODES
+        return self._current_state.nickname
+
+    @property
+    def icon(self) -> str:
+        # FIXME: should it be called at all if there are no states recorded?
+        return self._current_state.icon
+
+    @property
+    def timestamp(self):
+        return self._current_state.timestamp
+
+    def items(self):
+        return self._current_state.items()
+
+    def values(self):
+        return self._current_state.values()
+
+    def latest_states(self, quantity):
+        """
+        Returns at most ``quantity`` latest archived states (including the current one),
+        in chronological order.
+        """
+        return self._archived_states[-min(len(self._archived_states), quantity):]
+
+    def addresses(self):
+        return self._current_state.addresses()
+
+    def snapshot(self):
+        return self._current_state.snapshot()
 
     @staticmethod
-    def abridged_state_details(state):
-        return {"nickname": str(state.nickname),
-                # FIXME: generalize in case we want to extend the number of symbols in the state nickname
-                "symbol": state.nickname.characters[0].symbol,
-                "color_hex": state.nickname.characters[0].color_hex,
-                "color_name": state.nickname.characters[0].color_name,
-                "updated": state.updated.rfc2822(),
-                }
+    def unpack_snapshot(data):
+        return FleetState.unpack_snapshot(data)
+
+    def record_fleet_state(self):
+        new_state = self._current_state.with_updated_nodes(self._new_nodes, self._marked)
+        self._new_nodes = {}
+        self._marked = set()
+        self._current_state = new_state
+
+        # TODO: set a limit on the number of archived states?
+        # Two ways to collect archived states:
+        # 1. (current) add a state to the archive every time it changes
+        # 2. (possible) keep a dictionary of known states
+        #    and bump the timestamp of a previously encountered one
+        if new_state.checksum != self._archived_states[-1].checksum:
+            self._archived_states.append(new_state.archived())
+
+    def shuffled(self):
+        return self._current_state.shuffled()
 
     def mark_as(self, label: Exception, node: "Teacher"):
-        self._marked[label].append(node)
+        # TODO: for now we're not using `label` in any way, so we're just ignoring it
+        self._marked.add(node.checksum_address)
 
-        if self._nodes.get(node):
-            del self._nodes[node]
+    def record_remote_fleet_state(self, checksum_address, state_checksum, timestamp, population):
+        # TODO: really we can just create the timestamp here
+
+        nickname = Nickname.from_seed(state_checksum, length=1) # TODO: create in a single place
+        self.remote_states[checksum_address] = ArchivedFleetState(state_checksum, nickname, timestamp, population)

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -242,12 +242,6 @@ class Character(Learner):
                     raise
 
         #
-        # Fleet state
-        #
-        if is_me is True:
-            self.known_nodes.record_fleet_state()
-
-        #
         # Character Control
         #
         self.controller = NO_CONTROL_PROTOCOL

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -73,6 +73,7 @@ class Character(Learner):
                  provider_uri: str = None,
                  signer: Signer = None,
                  registry: BaseContractRegistry = None,
+                 include_self_in_the_state: bool = False,
                  *args, **kwargs
                  ) -> None:
 
@@ -191,6 +192,7 @@ class Character(Learner):
                              domain=domain,
                              network_middleware=self.network_middleware,
                              node_class=known_node_class,
+                             include_self_in_the_state=include_self_in_the_state,
                              *args, **kwargs)
 
         #

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1233,19 +1233,12 @@ class Ursula(Teacher, Character, Worker):
                          decentralized_identity_evidence=decentralized_identity_evidence)
 
         if is_me:
-            self.known_nodes.record_fleet_state()  # Initial Impression
-
             message = "THIS IS YOU: {}: {}".format(self.__class__.__name__, self)
             self.log.info(message)
             self.log.info(self.banner.format(self.nickname))
         else:
             message = "Initialized Stranger {} | {}".format(self.__class__.__name__, self)
             self.log.debug(message)
-
-        # FIXME: we need to know when Ursula is ready to be recorded in a fleet state.
-        # The first time fleet state is updated may be still within this constructor.
-        # Any better way to solve this?
-        self.finished_initializing = True
 
     def __prune_datastore(self) -> None:
         """Deletes all expired arrangements, kfrags, and treasure maps in the datastore."""

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -981,7 +981,7 @@ class Bob(Character):
                 # Not enough matching nodes.  Fine, we'll just publish to the first few.
                 try:
                     # TODO: This is almost certainly happening in a test.  If it does happen in production, it's a bit of a problem.  Need to fix #2124 to mitigate.
-                    target_nodes = list(nodes._nodes.values())[0:6]
+                    target_nodes = list(nodes.values())[0:6]
                     return target_nodes
                 except IndexError:
                     raise self.NotEnoughNodes("There aren't enough nodes on the network to enact this policy.  Unless this is day one of the network and nodes are still getting spun up, something is bonkers.")
@@ -1113,6 +1113,7 @@ class Ursula(Teacher, Character, Worker):
                            known_nodes=known_nodes,
                            domain=domain,
                            known_node_class=Ursula,
+                           include_self_in_the_state=True,
                            **character_kwargs)
 
         if is_me:
@@ -1232,7 +1233,7 @@ class Ursula(Teacher, Character, Worker):
                          decentralized_identity_evidence=decentralized_identity_evidence)
 
         if is_me:
-            self.known_nodes.record_fleet_state(additional_nodes_to_track=[self])  # Initial Impression
+            self.known_nodes.record_fleet_state()  # Initial Impression
 
             message = "THIS IS YOU: {}: {}".format(self.__class__.__name__, self)
             self.log.info(message)
@@ -1240,6 +1241,11 @@ class Ursula(Teacher, Character, Worker):
         else:
             message = "Initialized Stranger {} | {}".format(self.__class__.__name__, self)
             self.log.debug(message)
+
+        # FIXME: we need to know when Ursula is ready to be recorded in a fleet state.
+        # The first time fleet state is updated may be still within this constructor.
+        # Any better way to solve this?
+        self.finished_initializing = True
 
     def __prune_datastore(self) -> None:
         """Deletes all expired arrangements, kfrags, and treasure maps in the datastore."""

--- a/nucypher/cli/painting/nodes.py
+++ b/nucypher/cli/painting/nodes.py
@@ -15,7 +15,6 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 import maya
-from constant_sorrow.constants import NO_KNOWN_NODES
 
 from nucypher.config.constants import SEEDNODES
 from nucypher.datastore.datastore import RecordNotFound
@@ -23,19 +22,7 @@ from nucypher.datastore.models import Workorder
 
 
 def build_fleet_state_status(ursula) -> str:
-    # Build FleetState status line
-    if ursula.known_nodes.checksum is not NO_KNOWN_NODES:
-        fleet_state_checksum = ursula.known_nodes.checksum[:7]
-        fleet_state_nickname = ursula.known_nodes.nickname
-        fleet_state = '{checksum} ⇀{nickname}↽ {icon}'.format(icon=fleet_state_nickname.icon,
-                                                              nickname=fleet_state_nickname,
-                                                              checksum=fleet_state_checksum)
-    elif ursula.known_nodes.checksum is NO_KNOWN_NODES:
-        fleet_state = 'No Known Nodes'
-    else:
-        fleet_state = 'Unknown'
-
-    return fleet_state
+    return str(ursula.known_nodes.current_state)
 
 
 def paint_node_status(emitter, ursula, start_time):
@@ -61,7 +48,7 @@ def paint_node_status(emitter, ursula, start_time):
     except RecordNotFound:
         num_work_orders = 0
 
-    stats = ['⇀URSULA {}↽'.format(ursula.nickname_icon),
+    stats = ['⇀URSULA {}↽'.format(ursula.nickname.icon),
              '{}'.format(ursula),
              'Uptime .............. {}'.format(maya.now() - start_time),
              'Start Time .......... {}'.format(start_time.slang_time()),

--- a/nucypher/cli/processes.py
+++ b/nucypher/cli/processes.py
@@ -114,8 +114,7 @@ class UrsulaCommandProtocol(LineReceiver):
         Display information about the network-wide fleet state as the attached Ursula node sees it.
         """
         from nucypher.cli.painting.nodes import build_fleet_state_status
-        line = '{}'.format(build_fleet_state_status(ursula=self.ursula))
-        self.emitter.echo(line)
+        self.emitter.echo(build_fleet_state_status(ursula=self.ursula))
 
     def connectionMade(self):
         self.emitter.echo("\nType 'help' or '?' for help")

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -250,10 +250,12 @@ class Learner:
         self.unresponsive_startup_nodes = list()  # TODO: Buckets - Attempt to use these again later  #567
         for node in known_nodes:
             try:
-                self.remember_node(node, eager=True)
+                self.remember_node(node, eager=True, record_fleet_state=False)
             except self.UnresponsiveTeacher:
                 self.unresponsive_startup_nodes.append(node)
-        self.known_nodes.record_fleet_state()
+
+        # This node has not initialized its metadata yet.
+        self.known_nodes.record_fleet_state(skip_this_node=True)
 
         self.teacher_nodes = deque()
         self._current_teacher_node = None  # type: Teacher

--- a/nucypher/network/trackers.py
+++ b/nucypher/network/trackers.py
@@ -188,7 +188,7 @@ class AvailabilityTracker:
                     return
 
     def sample(self, quantity: int) -> list:
-        population = tuple(self._ursula.known_nodes._nodes.values())
+        population = tuple(self._ursula.known_nodes.values())
         ursulas = random.sample(population=population, k=quantity)
         return ursulas
 

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -118,7 +118,7 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
                         'host': str(self.ursula.rest_interface),
                         'domain': self.ursula.domain,
                         'nickname': str(self.ursula.nickname),
-                        'nickname_icon': self.ursula.nickname_icon,
+                        'nickname_icon': self.ursula.nickname.icon,
                         'fleet_state': str(self.ursula.known_nodes.checksum),
                         'known_nodes': str(len(self.ursula.known_nodes))
                         }

--- a/tests/acceptance/characters/test_ursula_web_status.py
+++ b/tests/acceptance/characters/test_ursula_web_status.py
@@ -46,9 +46,11 @@ def test_ursula_html_renders(ursula, client):
     assert str(ursula.nickname).encode() in response.data
 
 
-def test_decentralized_json_status_endpoint(ursula, client):
-    response = client.get('/status/?json=true')
+@pytest.mark.parametrize('omit_known_nodes', [False, True])
+def test_decentralized_json_status_endpoint(ursula, client, omit_known_nodes):
+    omit_known_nodes_str = 'true' if omit_known_nodes else 'false'
+    response = client.get(f'/status/?json=true&omit_known_nodes={omit_known_nodes_str}')
     assert response.status_code == 200
     json_status = response.get_json()
-    status = ursula.abridged_node_details()
+    status = ursula.status_info(omit_known_nodes=omit_known_nodes)
     assert json_status == status

--- a/tests/acceptance/network/test_network_actors.py
+++ b/tests/acceptance/network/test_network_actors.py
@@ -118,9 +118,6 @@ def test_vladimir_illegal_interface_key_does_not_propagate(blockchain_ursulas):
     # Indeed, Ursula noticed that something was up.
     vladimir in other_ursula.suspicious_activities_witnessed['vladimirs']
 
-    # She marked him as Invalid...
-    vladimir in other_ursula.known_nodes._marked[vladimir.InvalidNode]
-
     # ...and booted him from known_nodes
     vladimir not in other_ursula.known_nodes
 
@@ -143,7 +140,8 @@ def test_alice_refuses_to_make_arrangement_unless_ursula_is_valid(blockchain_ali
     # Ideally, a fishy node shouldn't be present in `known_nodes`,
     # but I guess we're testing the case when it became fishy somewhere between we learned about it
     # and the proposal arrangement.
-    blockchain_alice.known_nodes[vladimir.checksum_address] = vladimir
+    blockchain_alice.known_nodes.record_node(vladimir)
+    blockchain_alice.known_nodes.record_fleet_state()
 
     with pytest.raises(vladimir.InvalidNode):
         idle_blockchain_policy._propose_arrangement(address=vladimir.checksum_address,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -954,8 +954,8 @@ def fleet_of_highperf_mocked_ursulas(ursula_federated_test_config, request):
                 all_ursulas = {u.checksum_address: u for u in _ursulas}
 
                 for ursula in _ursulas:
-                    ursula.known_nodes._nodes = all_ursulas
-                    ursula.known_nodes.checksum = b"This is a fleet state checksum..".hex()
+                    ursula.known_nodes.current_state._nodes = all_ursulas
+                    ursula.known_nodes.current_state.checksum = b"This is a fleet state checksum..".hex()
     yield _ursulas
 
     for ursula in _ursulas:
@@ -972,7 +972,7 @@ def highperf_mocked_alice(fleet_of_highperf_mocked_ursulas):
                                 save_metadata=False,
                                 reload_metadata=False)
 
-    with mock_cert_storage, mock_verify_node, mock_record_fleet_state, mock_message_verification, mock_keep_learning:
+    with mock_cert_storage, mock_verify_node, mock_message_verification, mock_keep_learning:
         alice = config.produce(known_nodes=list(fleet_of_highperf_mocked_ursulas)[:1])
     yield alice
     # TODO: Where does this really, truly belong?

--- a/tests/integration/characters/test_ursula_startup.py
+++ b/tests/integration/characters/test_ursula_startup.py
@@ -24,7 +24,8 @@ def test_new_federated_ursula_announces_herself(lonely_ursula_maker):
     ursula_in_a_house, ursula_with_a_mouse = lonely_ursula_maker(quantity=2, domain="useless_domain")
 
     # Neither Ursula knows about the other.
-    assert ursula_in_a_house.known_nodes == ursula_with_a_mouse.known_nodes
+    assert ursula_with_a_mouse not in ursula_in_a_house.known_nodes
+    assert ursula_in_a_house not in ursula_with_a_mouse.known_nodes
 
     ursula_in_a_house.remember_node(ursula_with_a_mouse)
 

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -114,7 +114,7 @@ def test_learner_ignores_stored_nodes_from_other_domains(lonely_ursula_maker, tm
 
     # Once pest made its way into learner, learner taught passed it to other mainnet nodes.
 
-    learner.known_nodes._nodes[pest.checksum_address] = pest  # This used to happen anyway.
+    learner.known_nodes.record_node(pest)  # This used to happen anyway.
     other_staker._current_teacher_node = learner
     other_staker.learn_from_teacher_node()  # And once it did, the node from the wrong domain spread.
     assert pest not in other_staker.known_nodes  # But not anymore.

--- a/tests/integration/learning/test_firstula_circumstances.py
+++ b/tests/integration/learning/test_firstula_circumstances.py
@@ -51,7 +51,7 @@ def test_get_cert_from_running_seed_node(lonely_ursula_maker):
                                            network_middleware=RestMiddleware()).pop()
     assert not any_other_ursula.known_nodes
 
-    yield deferToThread(any_other_ursula.load_seednodes)
+    yield deferToThread(lambda: any_other_ursula.load_seednodes(record_fleet_state=True))
     assert firstula in any_other_ursula.known_nodes
 
     firstula_as_learned = any_other_ursula.known_nodes[firstula.checksum_address]

--- a/tests/integration/learning/test_fleet_state.py
+++ b/tests/integration/learning/test_fleet_state.py
@@ -105,7 +105,12 @@ def test_state_is_recorded_after_learning(federated_ursulas, lonely_ursula_maker
 
     some_ursula_in_the_fleet = list(federated_ursulas)[0]
     lonely_learner.remember_node(some_ursula_in_the_fleet)
-    assert len(states) == 2  # Saved a fleet state when we remembered this node.
+    # Archived states at this point:
+    # - inital one (empty, Ursula's metadata is not ready yet, no known nodes)
+    # - the one created in Learner.__init__(). Metadata is still not ready, so it's the same
+    #   as the previous one and is not recorded.
+    # - the one created after Ursula learned about a remote node
+    assert len(states) == 2
 
     # The first fleet state is just us and the one about whom we learned, which is part of the fleet.
     assert states[-1].population == 2
@@ -135,14 +140,14 @@ def test_teacher_records_new_fleet_state_upon_hearing_about_new_node(federated_u
     lonely_learner.learn_from_teacher_node()
     states_after = len(states)
 
-    # FIXME: some kind of a timeout is required here to wait for the learning to end
+    # TODO #2568: some kind of a timeout is required here to wait for the learning to end
     return
 
     # `some_ursula_in_the_fleet` learned about `lonely_learner`
     assert states_before + 1 == states_after
 
     # The current fleet state of the Teacher...
-    teacher_fleet_state_checksum = some_ursula_in_the_fleet.fleet_state_checksum
+    teacher_fleet_state_checksum = some_ursula_in_the_fleet.known_nodes.checksum
 
     # ...is the same as the learner, because both have learned about everybody at this point.
     assert teacher_fleet_state_checksum == states[-1].checksum

--- a/tests/integration/network/test_failure_modes.py
+++ b/tests/integration/network/test_failure_modes.py
@@ -35,7 +35,7 @@ def test_alice_can_grant_even_when_the_first_nodes_she_tries_are_down(federated_
     m, n = 2, 3
     policy_end_datetime = maya.now() + datetime.timedelta(days=5)
     label = b"this_is_the_path_to_which_access_is_being_granted"
-    federated_alice.known_nodes._nodes = {}
+    federated_alice.known_nodes.current_state._nodes = {}
 
     federated_alice.network_middleware = NodeIsDownMiddleware()
 
@@ -92,7 +92,7 @@ def test_alice_can_grant_even_when_the_first_nodes_she_tries_are_down(federated_
 
 
 def test_node_has_changed_cert(federated_alice, federated_ursulas):
-    federated_alice.known_nodes._nodes = {}
+    federated_alice.known_nodes.current_state._nodes = {}
     federated_alice.network_middleware = NodeIsDownMiddleware()
     federated_alice.network_middleware.client.certs_are_broken = True
 

--- a/tests/mock/performance_mocks.py
+++ b/tests/mock/performance_mocks.py
@@ -159,8 +159,7 @@ def do_not_create_cert(*args, **kwargs):
 
 
 def simple_remember(ursula, node, *args, **kwargs):
-    address = node.checksum_address
-    ursula.known_nodes[address] = node
+    ursula.known_nodes.record_node(node)
 
 
 class NotARestApp:


### PR DESCRIPTION
The goal of this PR is to make interactions with `FleetSensor` consistent and avoid exposing implementation details, or carrying around ad-hoc states (`fleet_state_*` attributes). More specifically:

* `FleetState` is made into a real class. It encapsulates incremental updates and collection-like interface to iterate over the state's nodes. It is exposed from `FleetSensor` as `current_state`. 
* `FleetSensor` itself manages the buffers with new/deleted nodes and a list of previous states.
* Previous states are kept as simple `ArchivedFleetState` instances that do not retain references to actual nodes (since we don't use them anyway), only checksum/nickname/population. 
* The user (meaning the higher levels of the codebase) must call `record_fleet_state()` in order for the state to get updated. Currently there are multiple cases of accessing the node list without an explicit update.
* Fleet states for remote nodes are kept in `FleetSensor.remote_states` instead of in `fleet_state_*` attributes.
* `abridged_*` methods are renamed to better represent their purpose. The former `abridged_node_details()` (now `status_info()` is now used for both JSON and HTML `/status` endpoints outputs.

Rough edges and possible improvements:

* This PR may include a fix for #1995, if we decide on the course of actions.
* It is possible to avoid calculating the new state's checksum in some cases. Since remote nodes are immutable, if we retain the local node's metadata and remote nodes' addresses in archived states, we can compare those with the current ones, and use the archived state's checksum if there's a match. Not sure if there will be a noticeable benefit.
* The usage of the current state can be made more explicit if we don't forward most of the calls from `FleetSensor` to `FleetSensor.current_state`. 
* An alternative to the explicit `record_fleet_state()` call is to automatically update the state (if there are new nodes) whenever `current_state` is accessed. 
* In case of matching fleet states, the teacher sends `FLEET_STATES_MATCH` *along with* the fleet state. That seems excessive, but changing that without a proper protocol versioning will be a problem.

**Note:** if this PR is merged, https://github.com/nucypher/nucypher-monitor/blob/master/monitor/crawler.py will need to be updated.