### PR TITLE
Introduce gas limit overestimation. Fixes to `nucypher stake` password handling with Trezor. 

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1749,7 +1749,7 @@ class Wallet:
 
         # Blockchain
         self.blockchain = BlockchainInterfaceFactory.get_interface(provider_uri)
-        self.__signer = signer
+        self.signer = signer
 
         self.__get_accounts()
         if client_addresses:
@@ -1764,8 +1764,8 @@ class Wallet:
         return self.blockchain.transacting_power.account
 
     def __get_accounts(self) -> None:
-        if self.__signer:
-            signer_accounts = self.__signer.accounts
+        if self.signer:
+            signer_accounts = self.signer.accounts
             self.__client_accounts.extend([a for a in signer_accounts if a not in self.__client_accounts])
         client_accounts = self.blockchain.client.accounts  # Accounts via connected provider
         self.__client_accounts.extend([a for a in client_accounts if a not in self.__client_accounts])
@@ -1782,8 +1782,8 @@ class Wallet:
                          ) -> None:
 
         if checksum_address not in self:
-            self.__signer = signer or Web3Signer(client=self.blockchain.client)
-            if isinstance(self.__signer, KeystoreSigner):
+            self.signer = signer or Web3Signer(client=self.blockchain.client)
+            if isinstance(self.signer, KeystoreSigner):
                 raise BaseActor.ActorError(f"Staking operations are not permitted while using a local keystore signer.")
             self.__get_accounts()
             if checksum_address not in self:
@@ -1791,7 +1791,7 @@ class Wallet:
         try:
             transacting_power = self.__transacting_powers[checksum_address]
         except KeyError:
-            transacting_power = TransactingPower(signer=self.__signer or Web3Signer(client=self.blockchain.client),
+            transacting_power = TransactingPower(signer=self.signer or Web3Signer(client=self.blockchain.client),
                                                  password=password,
                                                  account=checksum_address)
             self.__transacting_powers[checksum_address] = transacting_power

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1269,7 +1269,8 @@ class WorkLockAgent(EthereumContractAgent):
         """
         contract_function: ContractFunction = self.contract.functions.claim()
         receipt = self.blockchain.send_transaction(contract_function=contract_function,
-                                                   sender_address=checksum_address)
+                                                   sender_address=checksum_address,
+                                                   gas_estimation_multiplier=1.5)  # FIXME
         return receipt
 
     @contract_api(TRANSACTION)

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -577,6 +577,7 @@ class StakingEscrowAgent(EthereumContractAgent):
         contract_function: ContractFunction = self.contract.functions.commitToNextPeriod()
         receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                               sender_address=worker_address,
+                                                              gas_estimation_multiplier=1.5,  # TODO: Workaround for #2337
                                                               fire_and_forget=fire_and_forget)
         return receipt
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -413,7 +413,8 @@ class StakingEscrowAgent(EthereumContractAgent):
         if not sender_address:
             sender_address = staker_address
         contract_function: ContractFunction = self.contract.functions.deposit(staker_address, amount, lock_periods)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=sender_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=sender_address)
         return receipt
 
     @contract_api(TRANSACTION)
@@ -428,7 +429,8 @@ class StakingEscrowAgent(EthereumContractAgent):
         Note that this resolved to two separate contract function signatures.
         """
         contract_function: ContractFunction = self.contract.functions.depositAndIncrease(stake_index, amount)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=staker_address)
         return receipt
 
     @contract_api(TRANSACTION)
@@ -441,7 +443,8 @@ class StakingEscrowAgent(EthereumContractAgent):
         Locks tokens amount and creates new sub-stake
         """
         contract_function: ContractFunction = self.contract.functions.lockAndCreate(amount, lock_periods)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=staker_address)
         return receipt
 
     @contract_api(TRANSACTION)
@@ -454,7 +457,8 @@ class StakingEscrowAgent(EthereumContractAgent):
         Locks tokens amount and add them to selected sub-stake
         """
         contract_function: ContractFunction = self.contract.functions.lockAndIncrease(stake_index, amount)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=staker_address)
         return receipt
 
     @contract_api(CONTRACT_CALL)
@@ -562,7 +566,8 @@ class StakingEscrowAgent(EthereumContractAgent):
     @contract_api(TRANSACTION)
     def bond_worker(self, staker_address: ChecksumAddress, worker_address: ChecksumAddress) -> TxReceipt:
         contract_function: ContractFunction = self.contract.functions.bondWorker(worker_address)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=staker_address)
         return receipt
 
     @contract_api(TRANSACTION)
@@ -589,7 +594,8 @@ class StakingEscrowAgent(EthereumContractAgent):
         when you intend to withdraw 100% of tokens.
         """
         contract_function: ContractFunction = self.contract.functions.mint()
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=staker_address)
         return receipt
 
     @contract_api(CONTRACT_CALL)
@@ -650,14 +656,16 @@ class StakingEscrowAgent(EthereumContractAgent):
         If set to True, then all staking rewards will be automatically added to locked stake.
         """
         contract_function: ContractFunction = self.contract.functions.setReStake(value)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=staker_address)
         # TODO: Handle ReStakeSet event (see #1193)
         return receipt
 
     @contract_api(TRANSACTION)
     def lock_restaking(self, staker_address: ChecksumAddress, release_period: Period) -> TxReceipt:
         contract_function: ContractFunction = self.contract.functions.lockReStake(release_period)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=staker_address)
         # TODO: Handle ReStakeLocked event (see #1193)
         return receipt
 
@@ -679,7 +687,8 @@ class StakingEscrowAgent(EthereumContractAgent):
         If set to True, then stakes duration will decrease in each period with `commitToNextPeriod()`.
         """
         contract_function: ContractFunction = self.contract.functions.setWindDown(value)
-        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=staker_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                   sender_address=staker_address)
         # TODO: Handle WindDownSet event (see #1193)
         return receipt
 
@@ -1259,21 +1268,24 @@ class WorkLockAgent(EthereumContractAgent):
         Claim tokens - will be deposited and locked as stake in the StakingEscrow contract.
         """
         contract_function: ContractFunction = self.contract.functions.claim()
-        receipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
+        receipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                   sender_address=checksum_address)
         return receipt
 
     @contract_api(TRANSACTION)
     def refund(self, checksum_address: ChecksumAddress) -> TxReceipt:
         """Refund ETH for completed work."""
         contract_function: ContractFunction = self.contract.functions.refund()
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=checksum_address)
         return receipt
 
     @contract_api(TRANSACTION)
     def withdraw_compensation(self, checksum_address: ChecksumAddress) -> TxReceipt:
         """Withdraw compensation after force refund."""
         contract_function: ContractFunction = self.contract.functions.withdrawCompensation()
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=checksum_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=checksum_address)
         return receipt
 
     @contract_api(CONTRACT_CALL)
@@ -1575,7 +1587,8 @@ class MultiSigAgent(EthereumContractAgent):
                 sender_address: ChecksumAddress,
                 ) -> TxReceipt:
         contract_function: ContractFunction = self.contract.functions.execute(v, r, s, destination, value, data)
-        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function, sender_address=sender_address)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              sender_address=sender_address)
         return receipt
 
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -831,7 +831,7 @@ class BlockchainDeployerInterface(BlockchainInterface):
                                                             constructor_function,
                                                             *constructor_args,
                                                             **constructor_kwargs)
-        if not constructor_calldata:
+        if constructor_calldata:
             self.log.info(f"Constructor calldata: {constructor_calldata}")
 
         #

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -15,7 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
+import math
 import os
 import pprint
 import time
@@ -508,8 +508,17 @@ class BlockchainInterface:
                                    contract_function: ContractFunction,
                                    sender_address: str,
                                    payload: dict = None,
-                                   transaction_gas_limit: int = None,
+                                   transaction_gas_limit: Optional[int] = None,
+                                   gas_estimation_multiplier: Optional[float] = None,
                                    ) -> dict:
+
+        # Sanity checks for the gas estimation multiplier
+        if gas_estimation_multiplier is not None:
+            if not 1 <= gas_estimation_multiplier <= 3:  # TODO: Arbitrary upper bound.
+                raise ValueError(f"The gas estimation multiplier should be a float between 1 and 3, "
+                                 f"but we received {gas_estimation_multiplier}.")
+            elif transaction_gas_limit is not None:
+                raise ValueError("'transaction_gas_limit' and 'gas_estimation_multiplier' can't be used together.")
 
         payload = self.build_payload(sender_address=sender_address,
                                      payload=payload,
@@ -524,6 +533,16 @@ class BlockchainInterface:
                                                   transaction_dict=payload,
                                                   contract_function=contract_function,
                                                   logger=self.log)
+
+        # Overestimate the transaction gas limit according to the gas estimation multiplier, if any
+        if gas_estimation_multiplier:
+            gas_estimation = transaction_dict['gas']
+            overestimation = int(math.ceil(gas_estimation * gas_estimation_multiplier))
+            self.log.debug(f"Gas limit for this TX was increased from {gas_estimation} to {overestimation}, "
+                           f"using a multiplier of {gas_estimation_multiplier}.")
+            transaction_dict['gas'] = overestimation
+            # TODO: What if we're going over the block limit? Not likely, but perhaps worth checking (NRN)
+
         return transaction_dict
 
     def sign_and_broadcast_transaction(self,
@@ -626,7 +645,8 @@ class BlockchainInterface:
                          contract_function: Union[ContractFunction, ContractConstructor],
                          sender_address: str,
                          payload: dict = None,
-                         transaction_gas_limit: int = None,
+                         transaction_gas_limit: Optional[int] = None,
+                         gas_estimation_multiplier: Optional[float] = None,
                          confirmations: int = 0,
                          fire_and_forget: bool = False  # do not wait for receipt.
                          ) -> dict:
@@ -637,7 +657,8 @@ class BlockchainInterface:
         transaction = self.build_contract_transaction(contract_function=contract_function,
                                                       sender_address=sender_address,
                                                       payload=payload,
-                                                      transaction_gas_limit=transaction_gas_limit)
+                                                      transaction_gas_limit=transaction_gas_limit,
+                                                      gas_estimation_multiplier=gas_estimation_multiplier)
 
         # Get transaction name
         try:

--- a/nucypher/blockchain/eth/signers/software.py
+++ b/nucypher/blockchain/eth/signers/software.py
@@ -115,7 +115,7 @@ class ClefSigner(Signer):
     DEFAULT_CONTENT_TYPE = SIGN_DATA_FOR_ECRECOVER
     SIGN_DATA_CONTENT_TYPES = (SIGN_DATA_FOR_VALIDATOR, SIGN_DATA_FOR_CLIQUE, SIGN_DATA_FOR_ECRECOVER)
 
-    TIMEOUT = 60  # Default timeout for Clef of 60 seconds
+    TIMEOUT = 180  # Default timeout for Clef of 180 seconds
 
     def __init__(self,
                  ipc_path: str = DEFAULT_IPC_PATH,


### PR DESCRIPTION
- Attempt to fix #2337 by using an overestimation of 50% for the gas limit when committing to next period.
- Fixes wrong password handling in `nucypher stake` when using Trezor as a signer