### PR TITLE
We don't need no stinking stakers

### DIFF
--- a/deploy/ansible/worker/backup_remote_workers.yml
+++ b/deploy/ansible/worker/backup_remote_workers.yml
@@ -1,0 +1,5 @@
+- name: "Backup Remote Worker Data"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+
+- import_playbook: include/backup_ursula_data.yml

--- a/deploy/ansible/worker/include/backup_ursula_data.yml
+++ b/deploy/ansible/worker/include/backup_ursula_data.yml
@@ -1,0 +1,69 @@
+- name: "Create local backup of remote Ursula data"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+  gather_facts: no
+  tasks:
+
+    - name: find keystore files
+      find:
+        paths: "{{geth_dir}}keystore"
+      register: keystore_files
+
+    - name: find Ursula private keyring files
+      become: yes
+      find:
+        paths: /home/nucypher/nucypher/keyring/private
+      register: private_keyrings
+
+    - name: find Ursula public keyring files
+      become: yes
+      find:
+        paths: /home/nucypher/nucypher/keyring/public
+      register: public_keyrings
+
+    - name: find Ursula database files
+      find:
+        paths: /home/nucypher/nucypher/ursula.db
+      register: database_files
+
+    - name: "Backup Worker Nucypher Keystore locally to: {{deployer_config_path}}/remote_worker_backups/"
+      become: yes
+      become_user: nucypher
+      fetch:
+        src: "{{item.path}}"
+        dest: "{{deployer_config_path}}/remote_worker_backups/"
+      with_items: "{{keystore_files.files}}"
+
+    - name: "Backup remote worker config files: {{deployer_config_path}}/remote_worker_backups/"
+      become: yes
+      become_user: nucypher
+      fetch:
+        src: "{{item}}"
+        dest: "{{deployer_config_path}}/remote_worker_backups/"
+      with_items:
+        - "/home/nucypher/nucypher/ursula.json"
+        - "{{geth_dir}}account.txt"
+
+    - name: "Backup Public Keyrings locally to: {{deployer_config_path}}/remote_worker_backups/"
+      become: yes
+      # become_user: nucypher
+      fetch:
+        src: "{{item.path}}"
+        dest: "{{deployer_config_path}}/remote_worker_backups/"
+      with_items: "{{public_keyrings.files}}"
+
+    - name: "Backup Private Keyrings locally to: {{deployer_config_path}}/remote_worker_backups/"
+      become: yes
+      # become_user: nucypher
+      fetch:
+        src: "{{item.path}}"
+        dest: "{{deployer_config_path}}/remote_worker_backups/"
+      with_items: "{{private_keyrings.files}}"
+
+    - name: "Backup ursula.db to: {{deployer_config_path}}/remote_worker_backups/"
+      become: yes
+      # become_user: nucypher
+      fetch:
+        src: "{{item.path}}"
+        dest: "{{deployer_config_path}}/remote_worker_backups/"
+      with_items: "{{database_files.files}}"

--- a/deploy/ansible/worker/include/check_running_ursula.yml
+++ b/deploy/ansible/worker/include/check_running_ursula.yml
@@ -3,11 +3,41 @@
   remote_user: "{{default_user}}"
   gather_facts: no
   tasks:
+
     - name: Get public ip
       uri:
         url: http://ifconfig.me/ip
         return_content: yes
       register: ip_response
+
+    - name: "Get LogPath"
+      become: yes
+      shell:
+        cmd: docker ps --no-trunc | grep ursula | cut -f 1 -d " "
+      register: ursula_container_name
+
+    - name: "Wait for Ursula Log"
+      become: yes
+      lineinfile:
+        dest: "/var/lib/docker/containers/{{ursula_container_name['stdout']}}/{{ursula_container_name['stdout']}}-json.log"
+        line: "Working ~ Keep Ursula Online!"
+      check_mode: yes
+      register: serving
+
+    - name: "Read Ursula Log"
+      become: yes
+      command: docker logs ursula
+      register: ursula_logs
+
+    - name: "Get Current running Image"
+      become: yes
+      command: sudo docker ps --no-trunc --format \"\{\{.Image\}\}\"
+      register: running_docker_image
+
+    - name: "Get Current running Command"
+      become: yes
+      command: sudo docker ps --no-trunc --format \"\{\{.Command\}\}\"
+      register: running_docker_command
 
     - name: "Request Ursula Status"
       become: yes
@@ -15,18 +45,22 @@
         url: "https://{{ip_response.content}}:9151/status/?json=true"
         validate_certs: no
       register: status_data
+      ignore_errors: yes
+      when: serving
 
-    - name: Print Result
+    - name: Print Ursula Status Data
+      ignore_errors: no
       debug:
         msg:
-          "{{status_data.json.nickname}}\n
-          nucypher version:      {{status_data.json.version}}\n
-          staker address:        {{status_data.json.staker_address}}\n
-          worker address:        {{status_data.json.worker_address}}\n
-          rest url:              https://{{status_data.json.rest_url}}\n
-          missing commitments:   {{status_data.json.missing_commitments}}\n
-          last committed period: {{status_data.json.last_committed_period}}\n
-          balances:\n
-            ETH:                {{status_data.json.balances.eth}}\n
-            NU:                 {{status_data.json.balances.nu}}\n
-          {{inventory_hostname}}:worker address:{{status_data.json.worker_address}}\n"
+          "local nickname: {{host_nickname}}\n
+          {% if serving and 'json' in status_data %}nickname: {{status_data.json.nickname}}\n
+          staker address:          {{status_data.json.staker_address}}\n
+          worker address:          {{status_data.json.worker_address}}\n
+          rest url:                https://{{status_data.json.rest_url}}\n
+          \tmissing commitments:   {{status_data.json.missing_commitments}}\n
+          \tlast committed period: {{status_data.json.last_committed_period}}\n
+          \tETH:                   {{status_data.json.balances.eth}}\n{% endif %}
+          \tprovider:              {{blockchain_provider}}\n
+          \tursula docker image:   {{running_docker_image.stdout}}\n
+          \tursula command:        {{running_docker_command.stdout}}\n
+          \tlast log line:         {{ursula_logs['stdout_lines'][-1]}}\n"

--- a/deploy/ansible/worker/include/print_ursula_log.yml
+++ b/deploy/ansible/worker/include/print_ursula_log.yml
@@ -1,0 +1,22 @@
+- name: "Ursula Status"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+  gather_facts: no
+  tasks:
+
+    - name: "Get LogPath"
+      become: yes
+      shell:
+        cmd: docker ps --no-trunc | grep ursula | cut -f 1 -d " "
+      register: ursula_container_name
+
+    - name: read log file
+      become: yes
+      shell:
+        cmd: cat "/var/lib/docker/containers/{{ursula_container_name['stdout']}}/{{ursula_container_name['stdout']}}-json.log"
+      register: log_output
+
+    - name: Print Ursula Log
+      debug:
+        msg:
+          "{{log_output.stdout}}"

--- a/deploy/ansible/worker/include/run_ursula.yml
+++ b/deploy/ansible/worker/include/run_ursula.yml
@@ -19,28 +19,28 @@
         signer_options: ""
       when: node_is_decentralized is not undefined and node_is_decentralized
 
-    - name: "remove known nodes"
-      become: yes
-      file:
-        path: /home/nucypher/nucypher/known_nodes/
-        state: absent
+    # - name: "remove known nodes"
+    #   become: yes
+    #   file:
+    #     path: /home/nucypher/nucypher/known_nodes/
+    #     state: absent
 
     - name: "get account address from file"
       become: yes
       command: 'cat {{geth_dir}}account.txt'
       register: active_account
 
-    - name: "ensure known nodes certificates directory"
-      become: yes
-      file:
-        path: /home/nucypher/nucypher/known_nodes/certificates
-        state: directory
+    # - name: "ensure known nodes certificates directory"
+    #   become: yes
+    #   file:
+    #     path: /home/nucypher/nucypher/known_nodes/certificates
+    #     state: directory
 
-    - name: "ensure known nodes directory"
-      become: yes
-      file:
-        path: /home/nucypher/nucypher/known_nodes/metadata
-        state: directory
+    # - name: "ensure known nodes directory"
+    #   become: yes
+    #   file:
+    #     path: /home/nucypher/nucypher/known_nodes/metadata
+    #     state: directory
 
     - name: Find my public ip
       uri:
@@ -54,6 +54,13 @@
       command: "docker run -v /home/nucypher:/root/.local/share/ -e NUCYPHER_KEYRING_PASSWORD -it {{ nucypher_image | default('nucypher/nucypher:latest') }}  nucypher ursula config --provider {{ blockchain_provider }} --worker-address {{active_account.stdout}} --rest-host {{ip_response.content}} --network {{network_name}} {{nucypher_ursula_init_options | default('')}} {{signer_options}} --config-file /root/.local/share/nucypher/ursula.json"
       environment:
         NUCYPHER_KEYRING_PASSWORD: "{{NUCYPHER_KEYRING_PASSWORD}}"
+
+    - name: "Backup Worker Nucypher Keystore locally to: {{deployer_config_path}}/remote_worker_backups/"
+      become: yes
+      become_user: nucypher
+      fetch:
+        src: "{{keystore_output.files[0].path}}"
+        dest: "{{deployer_config_path}}/remote_worker_backups/"
 
     - name: "Run Staked Ursula (seed node)"
       become: yes
@@ -70,7 +77,7 @@
           max-file: "5"
         image: "{{ nucypher_image | default('nucypher/nucypher:latest') }}"
         restart_policy: "unless-stopped"
-        command: "nucypher ursula run {{nucypher_ursula_run_options | default('')}} {{signer_options}} --lonely {{prometheus | default('')}}"
+        command: "nucypher ursula run {{nucypher_ursula_run_options | default('')}} --lonely {{prometheus | default('')}} {{gas_strategy | default('')}} --network {{network_name}}"
         volumes:
           - /home/nucypher:/root/.local/share/
         ports:
@@ -80,7 +87,7 @@
           NUCYPHER_KEYRING_PASSWORD: "{{NUCYPHER_KEYRING_PASSWORD}}"
           NUCYPHER_WORKER_ETH_PASSWORD: "{{NUCYPHER_WORKER_ETH_PASSWORD}}"
           NUCYPHER_SENTRY_DSN: "{{SENTRY_DSN | default('')}}"
-          NUCYPHER_SENTRY_LOGS: "1"
+          NUCYPHER_SENTRY_LOGS: "{{SENTRY_LOGS | default('no')}}"
 
     - name: "wait a few seconds for the seed node to become available"
       when: SEED_NODE_URI is not undefined
@@ -102,7 +109,7 @@
           max-file: "5"
         image: "{{ nucypher_image | default('nucypher/nucypher:latest') }}"
         restart_policy: "unless-stopped"
-        command: "nucypher ursula run {{nucypher_ursula_run_options | default('')}} {{signer_options}} --disable-availability-check --teacher {{SEED_NODE_URI}} {{prometheus | default('')}}"
+        command: "nucypher ursula run {{nucypher_ursula_run_options | default('')}} --disable-availability-check {{teacher_options}} {{prometheus | default('')}} {{gas_strategy | default('')}} --network {{network_name}}"
         volumes:
           - /home/nucypher:/root/.local/share/
         ports:
@@ -112,8 +119,27 @@
           NUCYPHER_KEYRING_PASSWORD: "{{NUCYPHER_KEYRING_PASSWORD}}"
           NUCYPHER_WORKER_ETH_PASSWORD: "{{NUCYPHER_WORKER_ETH_PASSWORD}}"
           NUCYPHER_SENTRY_DSN: "{{SENTRY_DSN | default('')}}"
-          NUCYPHER_SENTRY_LOGS: "1"
+          NUCYPHER_SENTRY_LOGS: "{{SENTRY_LOGS | default('no')}}"
 
-    - name: "wait a few seconds Ursula to startup"
-      pause:
-        seconds: 15
+    - name: "Get LogPath"
+      become: yes
+      shell:
+        cmd: docker ps --no-trunc | grep ursula | cut -f 1 -d " "
+      register: ursula_container_name
+
+    - name: "Read Ursula Log"
+      become: yes
+      command: docker logs ursula
+      register: ursula_logs
+
+    - name: Print Ursula Log Output
+      debug:
+        msg:
+          "{{ursula_logs['stdout']}}"
+
+    - name: "Wait until we see that Ursula has decrypted her keyring and gotten started"
+      become: yes
+      wait_for:
+        path: "/var/lib/docker/containers/{{ursula_container_name['stdout']}}/{{ursula_container_name['stdout']}}-json.log"
+        search_regex: "Checking worker settings:"
+        timeout: 30

--- a/deploy/ansible/worker/include/stop_containers.yml
+++ b/deploy/ansible/worker/include/stop_containers.yml
@@ -5,7 +5,6 @@
   tasks:
     - name: Stop Ursula
       become: yes
-      become_user: nucypher
       docker_container:
         name: ursula
         state: stopped

--- a/deploy/ansible/worker/restore_ursula_from_backup.yml
+++ b/deploy/ansible/worker/restore_ursula_from_backup.yml
@@ -1,0 +1,92 @@
+- import_playbook: include/setup_user.yml
+- import_playbook: include/setup_docker.yml
+- import_playbook: include/stop_containers.yml
+
+- name: "Restore from local backup of remote Ursula data"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+  gather_facts: no
+  tasks:
+
+    - name: Remove Existing Data
+      become: yes
+      file:
+        state: absent
+        path: "{{item}}"
+      with_items:
+        - "{{geth_dir}}keystore"
+        - /home/nucypher/nucypher/ursula.db
+        - /home/nucypher/nucypher/keyring/
+        - "{{geth_dir}}account.txt"
+        - home/nucypher/nucypher/ursula.json
+
+    - name: Ensure directories exist
+      become: yes
+      file:
+        state: directory
+        path: "{{item}}"
+      with_items:
+        - "{{geth_dir}}keystore"
+        - /home/nucypher/nucypher/ursula.db
+        - /home/nucypher/nucypher/keyring/private
+        - /home/nucypher/nucypher/keyring/public
+
+    - name: Restore Geth Keystore
+      become: yes
+      copy:
+        src: "{{ item }}"
+        dest: "{{geth_dir}}keystore/"
+        owner: "nucypher"
+        mode: 0600
+      with_fileglob:
+        - "{{restore_path}}{{geth_dir}}keystore/*"
+
+    - name: Restore private keyring
+      become: yes
+      copy:
+        src: "{{ item }}"
+        dest: /home/nucypher/nucypher/keyring/private/
+        owner: "nucypher"
+        mode: 0600
+      with_fileglob:
+        - "{{restore_path}}/home/nucypher/nucypher/keyring/private/*"
+
+    - name: Restore public keyring
+      become: yes
+      copy:
+        src: "{{ item }}"
+        dest: /home/nucypher/nucypher/keyring/public/
+        owner: "nucypher"
+        mode: 0600
+      with_fileglob:
+        - "{{restore_path}}/home/nucypher/nucypher/keyring/public/*"
+
+    - name: Restore Ursula database files
+      become: yes
+      copy:
+        src: "{{ item }}"
+        dest: /home/nucypher/nucypher/ursula.db/
+        owner: "nucypher"
+        mode: 0600
+      with_fileglob:
+        - "{{restore_path}}/home/nucypher/nucypher/ursula.db/*"
+
+    - name: Restore Ursula Config
+      become: yes
+      copy:
+        src: "{{restore_path}}/home/nucypher/nucypher/ursula.json"
+        dest: /home/nucypher/nucypher/
+        owner: "nucypher"
+        mode: 0600
+
+    - name: Restore Checksum
+      become: yes
+      copy:
+        src: "{{restore_path}}{{geth_dir}}account.txt"
+        dest: "{{geth_dir}}account.txt"
+        owner: "nucypher"
+        mode: 0600
+
+- import_playbook: include/update_existing_ursula.yml
+- import_playbook: include/check_running_ursula.yml
+- import_playbook: include/backup_ursula_data.yml

--- a/deploy/ansible/worker/setup_remote_workers.yml
+++ b/deploy/ansible/worker/setup_remote_workers.yml
@@ -10,3 +10,4 @@
 - import_playbook: include/init_ursula.yml
 - import_playbook: include/run_ursula.yml
 - import_playbook: include/check_running_ursula.yml
+- import_playbook: include/backup_ursula_data.yml

--- a/deploy/ansible/worker/update_remote_workers.yml
+++ b/deploy/ansible/worker/update_remote_workers.yml
@@ -4,3 +4,4 @@
 
 - import_playbook: include/update_existing_ursula.yml
 - import_playbook: include/check_running_ursula.yml
+- import_playbook: include/backup_ursula_data.yml

--- a/docs/source/guides/network_node/nucypher_host_management_cli.rst
+++ b/docs/source/guides/network_node/nucypher_host_management_cli.rst
@@ -19,15 +19,31 @@ to keep your Nucypher Ursula nodes working and up to date.
 +----------------------+-------------------------------------------------------------------------------+
 | Action               |  Description                                                                  |
 +======================+===============================================================================+
-|  ``up``              | Create hosts, configure and deploy an Ursula on AWS or Digital Ocean          |
+|  ``up``              | Creates and deploys hosts for all active local stakers.                       |
++----------------------+-------------------------------------------------------------------------------+
+|  ``create``          | Creates and deploys the given number of hosts independent of stakes           |
 +----------------------+-------------------------------------------------------------------------------+
 |  ``add``             | Add an existing host to be managed by cloudworkers CLI tools                  |
 +----------------------+-------------------------------------------------------------------------------+
-|  ``deploy``          | Update and deploy Ursula on existing hosts.                                   |
+|  ``add_for_stake``   | Add an existing host to be managed for a specified local staker address       |
++----------------------+-------------------------------------------------------------------------------+
+|  ``deploy``          | Install and run Ursula on existing managed hosts.                             |
++----------------------+-------------------------------------------------------------------------------+
+|  ``update``          | Update or manage existing installed Ursula.                                   |
 +----------------------+-------------------------------------------------------------------------------+
 |  ``destroy``         | Shut down and cleanup resources deployed on AWS or Digital Ocean              |
 +----------------------+-------------------------------------------------------------------------------+
-|  ``status``          | Query the status of all managed hosts.                                        |
+|  ``status``          | Prints a formatted status of selected managed hosts.                          |
++----------------------+-------------------------------------------------------------------------------+
+|  ``logs``            | Download and display the accumulated stdout logs of selected hosts            |
++----------------------+-------------------------------------------------------------------------------+
+|  ``backup``          | Download local copies of critical data from selected installed Ursulas        |
++----------------------+-------------------------------------------------------------------------------+
+|  ``restore``         | Reconstitute and deploy an operating Ursula from backed up data               |
++----------------------+-------------------------------------------------------------------------------+
+|  ``list_hosts``      | Print local nicknames of all managed hosts under a given namespace            |
++----------------------+-------------------------------------------------------------------------------+
+|  ``list_namespaces`` | Print namespaces under a given network                                        |
 +----------------------+-------------------------------------------------------------------------------+
 
 
@@ -35,7 +51,7 @@ Some examples:
 
 .. code:: bash
 
-    # You have created stakes already.  Now run an Ursula for each one
+    # You have some local stakes.  Now run an Ursula for each one with a single command.
 
     # on Digital Ocean
     $ export DIGITALOCEAN_ACCESS_TOKEN=<your access token>
@@ -50,11 +66,45 @@ Some examples:
     # on AWS
     $ nucypher cloudworkers up --cloudprovider aws --aws-profile my-aws-profile --remote-provider http://mainnet.infura..3epifj3rfioj
 
-    # add your ubuntu machine at the office
-    $ nucypher cloudworkers add --staker-address 0x9a92354D3811938A1f35644825188cAe3103bA8e --host-address somebox.myoffice.net --login-name root --key-path ~/.ssh/id_rsa
+    # add your ubuntu machine at the office to an existing locally managed stake
+    $ nucypher cloudworkers add_for_stake --staker-address 0x9a92354D3811938A1f35644825188cAe3103bA8e --host-address somebox.myoffice.net --login-name ubuntu --key-path ~/.ssh/id_rsa
 
-    # deploy or update all your existing hosts to the latest code
-    $ nucypher cloudworkers deploy --nucypher-image nucypher/nucypher:latest
+    # update all your existing hosts to the latest code
+    $ nucypher cloudworkers update --nucypher-image nucypher/nucypher:latest
 
     # change two of your existing hosts to use alchemy instead of infura as a delegated blockchain
-    $ nucypher cloudworkers deploy --remote-provider wss://eth-mainnet.ws.alchemyapi.io/v2/aodfh298fh2398fh2398hf3924f... --include-stakeholder 0x9a92354D3811938A1f35644825188cAe3103bA8e --include-stakeholder 0x1Da644825188cAe3103bA8e92354D3811938A1f35
+    # note: hosts created for local stakers will have the staker's checksum address as their nickname by default
+    $ nucypher cloudworkers update --remote-provider wss://eth-mainnet.ws.alchemyapi.io/v2/aodfh298fh2398fh2398hf3924f... --include-host 0x9a92354D3811938A1f35644825188cAe3103bA8e --include-host 0x1Da644825188cAe3103bA8e92354D3811938A1f35
+
+    # add some random host and then deploy an Ursula on it
+    $ nucypher cloudworkers add --host-address somebox.myoffice.net --login-name ubuntu --key-path ~/.ssh/id_rsa --nickname my_new_host
+    $ nucypher cloudworkers deploy --include-host my_new_host --remote-provider http://mainnet.infura..3epifj3rfioj
+
+    # deploy nucypher on all your managed hosts
+    $ nucypher cloudworkers deploy --remote-provider http://mainnet.infura..3epifj3rfioj
+
+    # deploy nucypher on all your managed hosts
+    $ nucypher cloudworkers deploy --remote-provider http://mainnet.infura..3epifj3rfioj
+
+    # print the current status of all workers across all namespaces (in bash)
+    $ for ns in $(nucypher cloudworkers list-namespaces); do nucypher cloudworkers status --namespace $ns; done
+    > local nickname: Project11-mainnet-2
+    >  nickname: Aquamarine Nine DarkViolet Foxtrot
+    >  staker address:          0xFBC052299b8B3Df05CB8351151E71f21562096F4
+    >  worker address:          0xe88bF385a6ed8C86aA153f08F999d8698B5326e0
+    >  rest url:                https://xxx.xxx.xxx.xxx:9151
+    >      missing commitments:   0
+    >      last committed period: 18601
+    >      ETH:                   0.xxx
+    >      provider:              https://mainnet.infura.io/v3/xxxx
+    >      ursula docker image:   "nucypher/nucypher:latest"
+    >      ursula command:        ""nucypher ursula run --network mainnet""
+    >      last log line:         Working ~ Keep Ursula Online!
+    .....
+
+    # see if all your managed hosts successfully committed to the next period
+    for ns in $(nucypher cloudworkers list-namespaces); do nucypher cloudworkers status --namespace $ns; done | grep "last committed period: \|last log line: \|local nickname:"
+
+    # backup all your worker's critical data
+    # note: this is also done after any update or deploy operations
+    for ns in $(nucypher cloudworkers list-namespaces); do nucypher cloudworkers backup --namespace $ns; done

--- a/newsfragments/2365.feature.rst
+++ b/newsfragments/2365.feature.rst
@@ -1,0 +1,1 @@
+- nucypher cloudworkers now contains a complete and comprehensive set of features for easily managing, backing up and restoring one to many workers

--- a/nucypher/cli/commands/cloudworkers.py
+++ b/nucypher/cli/commands/cloudworkers.py
@@ -142,7 +142,7 @@ def add(general_config, host_address, login_name, key_path, ssh_port, host_nickn
     emitter = setup_emitter(general_config)
     name = f'{namespace}-{network}-{host_nickname}'
 
-    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, namespace=namespace, network=network)
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, namespace=namespace, network=network, action='add')
     config = deployer.create_nodes([name], host_address, login_name, key_path, ssh_port)
     emitter.echo(f'Success.  Now run `nucypher cloudworkers deploy --namespace {namespace} --remote-provider <an eth provider>` to deploy Nucypher on this node.', color='green')
 
@@ -176,7 +176,7 @@ def add_for_stake(general_config, staker_address, host_address, login_name, key_
 
     config_file = config_file or StakeHolderConfiguration.default_filepath()
 
-    deployer = CloudDeployers.get_deployer('generic')(emitter, STAKEHOLDER, config_file, namespace=namespace, network=STAKEHOLDER.network)
+    deployer = CloudDeployers.get_deployer('generic')(emitter, STAKEHOLDER, config_file, namespace=namespace, network=STAKEHOLDER.network, action='add_for_stake')
     config = deployer.create_nodes(staker_addresses, host_address, login_name, key_path, ssh_port)
 
 

--- a/nucypher/cli/commands/cloudworkers.py
+++ b/nucypher/cli/commands/cloudworkers.py
@@ -16,6 +16,8 @@
 """
 
 import click
+import json
+import os
 
 try:
     from nucypher.utilities.clouddeploy import CloudDeployers
@@ -55,8 +57,9 @@ def cloudworkers():
 @click.option('--include-stakeholder', 'stakes', help="limit worker to specified stakeholder addresses", multiple=True)
 @click.option('--wipe', help="Clear nucypher configs on existing nodes and start a fresh node with new keys.", default=False, is_flag=True)
 @click.option('--prometheus', help="Run Prometheus on workers.", default=False, is_flag=True)
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
 @group_general_config
-def up(general_config, staker_options, config_file, cloudprovider, aws_profile, remote_provider, nucypher_image, seed_network, sentry_dsn, stakes, wipe, prometheus):
+def up(general_config, staker_options, config_file, cloudprovider, aws_profile, remote_provider, nucypher_image, seed_network, sentry_dsn, stakes, wipe, prometheus, namespace):
     """Creates workers for all stakes owned by the user for the given network."""
 
     emitter = setup_emitter(general_config)
@@ -75,15 +78,76 @@ def up(general_config, staker_options, config_file, cloudprovider, aws_profile, 
 
     config_file = config_file or StakeHolderConfiguration.default_filepath()
 
-    deployer = CloudDeployers.get_deployer(cloudprovider)(emitter, STAKEHOLDER, config_file, remote_provider, nucypher_image, seed_network, sentry_dsn, aws_profile, prometheus)
-    config = deployer.create_nodes_for_stakers(staker_addresses)
+    deployer = CloudDeployers.get_deployer(cloudprovider)(emitter, STAKEHOLDER, config_file, remote_provider, nucypher_image, seed_network, sentry_dsn, aws_profile, prometheus, namespace=namespace, network=STAKEHOLDER.network)
+    if staker_addresses:
+        config = deployer.create_nodes(staker_addresses)
 
     if config.get('instances') and len(config.get('instances')) >= len(staker_addresses):
         emitter.echo('Nodes exist for all requested stakes', color="yellow")
         deployer.deploy_nucypher_on_existing_nodes(staker_addresses, wipe_nucypher=wipe)
 
 
+@cloudworkers.command('create')
+@click.option('--cloudprovider', help="aws or digitalocean", default='aws')
+@click.option('--aws-profile', help="The AWS account profile you'd like to use (option not required for DigitalOcean users)", default=None)
+@click.option('--remote-provider', help="The blockchain provider for the remote node, if not provided, nodes will run geth.", default=None)
+@click.option('--nucypher-image', help="The docker image containing the nucypher code to run on the remote nodes. (default is nucypher/nucypher:latest)", default=None)
+@click.option('--seed-network', help="Do you want the 1st node to be --lonely and act as a seed node for this network", default=False, is_flag=True)
+@click.option('--sentry-dsn', help="a sentry dsn for these workers (https://sentry.io/)", default=None)
+@click.option('--prometheus', help="Run Prometheus on workers.", default=False, is_flag=True)
+@click.option('--count', help="Create this many nodes.", type=click.INT, default=1)
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@group_general_config
+def create(general_config, cloudprovider, aws_profile, remote_provider, nucypher_image, seed_network, sentry_dsn, prometheus, count, namespace, network):
+    """Creates the required number of workers to be staked later under a namespace"""
+
+    emitter = setup_emitter(general_config)
+
+    if not CloudDeployers:
+        emitter.echo("Ansible is required to use this command.  (Please run 'pip install ansible'.)", color="red")
+        return
+
+    deployer = CloudDeployers.get_deployer(cloudprovider)(emitter, None, None, remote_provider, nucypher_image, seed_network, sentry_dsn, aws_profile, prometheus, namespace=namespace, network=network)
+    if not namespace:
+        emitter.echo("A namespace is required. Choose something to help differentiate between hosts, such as their specific purpose, or even just today's date.", color="red")
+        return
+
+    names = []
+    i = 1
+    while len(names) < count:
+        name = f'{namespace}-{network}-{i}'
+        if name not in deployer.config.get('instances', {}):
+            names.append(name)
+        i += 1
+    config = deployer.create_nodes(names, unstaked=True)
+
+    if config.get('instances') and len(config.get('instances')) >= count:
+        emitter.echo('The requested number of nodes now exist', color="green")
+        deployer.deploy_nucypher_on_existing_nodes(names)
+
+
 @cloudworkers.command('add')
+@click.option('--host-address', help="The IP address or Hostname of the host you are adding.", required=True)
+@click.option('--login-name', help="The name username of a user with root privileges we can ssh as on the host.", required=True)
+@click.option('--key-path', help="The path to a keypair we will need to ssh into this host", default="~/.ssh/id_rsa.pub")
+@click.option('--ssh-port', help="The port this host's ssh daemon is listening on", default=22)
+@click.option('--host-nickname', help="A nickname to remember this host by", type=click.STRING, required=True)
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, required=True, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@group_general_config
+def add(general_config, host_address, login_name, key_path, ssh_port, host_nickname, namespace, network):
+    """Adds an existing node to the local config for future management."""
+
+    emitter = setup_emitter(general_config)
+    name = f'{namespace}-{network}-{host_nickname}'
+
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, namespace=namespace, network=network)
+    config = deployer.create_nodes([name], host_address, login_name, key_path, ssh_port)
+    emitter.echo(f'Success.  Now run `nucypher cloudworkers deploy --namespace {namespace} --remote-provider <an eth provider>` to deploy Nucypher on this node.', color='green')
+
+
+@cloudworkers.command('add_for_stake')
 @group_staker_options
 @option_config_file
 @click.option('--staker-address',  help="The staker account address for whom you are adding a worker host.", required=True)
@@ -91,9 +155,10 @@ def up(general_config, staker_options, config_file, cloudprovider, aws_profile, 
 @click.option('--login-name', help="The name username of a user with root privileges we can ssh as on the host.", required=True)
 @click.option('--key-path', help="The path to a keypair we will need to ssh into this host", default="~/.ssh/id_rsa.pub")
 @click.option('--ssh-port', help="The port this host's ssh daemon is listening on", default=22)
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
 @group_general_config
-def add(general_config, staker_options, config_file, staker_address, host_address, login_name, key_path, ssh_port):
-    """Creates workers for all stakes owned by the user for the given network."""
+def add_for_stake(general_config, staker_address, host_address, login_name, key_path, ssh_port, namespace):
+    """Sets an existing node as the host for the given staker address."""
 
     emitter = setup_emitter(general_config)
 
@@ -111,103 +176,227 @@ def add(general_config, staker_options, config_file, staker_address, host_addres
 
     config_file = config_file or StakeHolderConfiguration.default_filepath()
 
-    deployer = CloudDeployers.get_deployer('generic')(emitter, STAKEHOLDER, config_file)
-    config = deployer.create_nodes_for_stakers(staker_addresses, host_address, login_name, key_path, ssh_port)
+    deployer = CloudDeployers.get_deployer('generic')(emitter, STAKEHOLDER, config_file, namespace=namespace, network=STAKEHOLDER.network)
+    config = deployer.create_nodes(staker_addresses, host_address, login_name, key_path, ssh_port)
 
 
 
 @cloudworkers.command('deploy')
-@group_staker_options
-@option_config_file
 @click.option('--remote-provider', help="The blockchain provider for the remote node, if not provided nodes will run geth.", default=None)
 @click.option('--nucypher-image', help="The docker image containing the nucypher code to run on the remote nodes.", default=None)
 @click.option('--seed-network', help="Do you want the 1st node to be --lonely and act as a seed node for this network", default=False, is_flag=True)
 @click.option('--sentry-dsn', help="a sentry dsn for these workers (https://sentry.io/)", default=None)
-@click.option('--include-stakeholder', 'stakes', help="limit worker to specified stakeholder addresses", multiple=True)
-@click.option('--wipe', help="Clear your nucypher config and start a fresh node with new kets", default=False, is_flag=True)
+@click.option('--wipe', help="Clear your nucypher config and start a fresh node with new keys", default=False, is_flag=True)
 @click.option('--prometheus', help="Run Prometheus on workers.", default=False, is_flag=True)
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@click.option('--gas-strategy', help="Which gas strategy?  (glacial, slow, medium, fast)", type=click.STRING)
+@click.option('--include-host', 'include_hosts', help="specify hosts to update", multiple=True, type=click.STRING)
 @group_general_config
-def deploy(general_config, staker_options, config_file, remote_provider, nucypher_image, seed_network, sentry_dsn, stakes, wipe, prometheus):
-    """Deploys NuCypher on existing hardware."""
+def deploy(general_config, remote_provider, nucypher_image, seed_network, sentry_dsn, wipe, prometheus, namespace, network, gas_strategy, include_hosts):
+    """Deploys NuCypher on managed hosts."""
 
     emitter = setup_emitter(general_config)
 
     if not CloudDeployers:
         emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
         return
-    STAKEHOLDER = staker_options.create_character(emitter, config_file)
 
-    stakers = STAKEHOLDER.get_stakers()
-    if not stakers:
-        emitter.echo("No staking accounts found.")
-        return
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, remote_provider, nucypher_image, seed_network, sentry_dsn, prometheus=prometheus, namespace=namespace, network=network, gas_strategy=gas_strategy)
 
-    staker_addresses = filter_staker_addresses(stakers, stakes)
-
-    config_file = config_file or StakeHolderConfiguration.default_filepath()
-
-    deployer = CloudDeployers.get_deployer('generic')(emitter, STAKEHOLDER, config_file, remote_provider, nucypher_image, seed_network, sentry_dsn, prometheus=prometheus)
-
-    emitter.echo("found nodes for the following stakers:")
-    for staker_address in staker_addresses:
-        if deployer.config['instances'].get(staker_address):
-            data = deployer.config['instances'].get(staker_address)
-            emitter.echo(f'\t{staker_address}: {data["publicaddress"]}', color="yellow")
-    deployer.deploy_nucypher_on_existing_nodes(staker_addresses, wipe_nucypher=wipe)
+    hostnames = deployer.config['instances'].keys()
+    if include_hosts:
+        hostnames = include_hosts
+    for name, hostdata in [(n, d) for n, d in deployer.config['instances'].items() if n in hostnames]:
+        emitter.echo(f'\t{name}: {hostdata["publicaddress"]}', color="yellow")
+    deployer.deploy_nucypher_on_existing_nodes(hostnames, wipe_nucypher=wipe)
 
 
-@cloudworkers.command('destroy')
-@group_staker_options
-@option_config_file
-@click.option('--cloudprovider', help="aws or digitalocean")
-@click.option('--include-stakeholder', 'stakes', help="one or more stakeholder addresses to whom we should limit worker destruction", multiple=True)
+@cloudworkers.command('update')
+@click.option('--remote-provider', help="The blockchain provider for the remote node – e.g. an Infura endpoint address. If not provided nodes will run geth.", default=None)
+@click.option('--nucypher-image', help="The docker image containing the nucypher code to run on the remote nodes.", default=None)
+@click.option('--seed-network', help="Do you want the 1st node to be --lonely and act as a seed node for this network", default=False, is_flag=True)
+@click.option('--sentry-dsn', help="a sentry dsn for these workers (https://sentry.io/)", default=None)
+@click.option('--wipe', help="Clear your nucypher config and start a fresh node with new keys", default=False, is_flag=True)
+@click.option('--prometheus', help="Run Prometheus on workers.", default=False, is_flag=True)
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@click.option('--gas-strategy', help="Which gas strategy?  (glacial, slow, medium, fast)", type=click.STRING)
+@click.option('--include-host', 'include_hosts', help="specify hosts to update", multiple=True, type=click.STRING)
 @group_general_config
-def destroy(general_config, staker_options, config_file, cloudprovider, stakes):
-    """Cleans up all previously created resources for the given netork for the cloud providern"""
+def update(general_config, remote_provider, nucypher_image, seed_network, sentry_dsn, wipe, prometheus, namespace, network, gas_strategy, include_hosts):
+    """Updates existing installations of Nucypher on existing managed remote hosts."""
 
     emitter = setup_emitter(general_config)
+
     if not CloudDeployers:
         emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
         return
-    STAKEHOLDER = staker_options.create_character(emitter, config_file)
 
-    stakers = STAKEHOLDER.get_stakers()
-    if not stakers:
-        emitter.echo("No staking accounts found.")
-        return
+    deployer = CloudDeployers.get_deployer('generic')(
+        emitter, None, None, remote_provider, nucypher_image,
+        seed_network, sentry_dsn,
+        prometheus=prometheus, namespace=namespace, network=network, gas_strategy=gas_strategy
+    )
 
-    staker_addresses = filter_staker_addresses(stakers, stakes)
+    emitter.echo(f"found deploying {nucypher_image} on the following existing hosts:")
 
-    config_file = config_file or StakeHolderConfiguration.default_filepath()
-
-    if not cloudprovider:
-        hosts = CloudDeployers.get_deployer('generic')(emitter, STAKEHOLDER, config_file).get_all_hosts()
-        if len(set(host['provider'] for address, host in hosts)) == 1:
-            cloudprovider = hosts[0][1]['provider']
-        else:
-            emitter.echo("Please specify which provider's hosts you'd like to destroy using --cloudprovider (digitalocean or aws)")
-    deployer = CloudDeployers.get_deployer(cloudprovider)(emitter, STAKEHOLDER, config_file)
-    deployer.destroy_resources(staker_addresses=staker_addresses)
+    hostnames = deployer.config['instances'].keys()
+    if include_hosts:
+        hostnames = include_hosts
+    for name, hostdata in [(n, d) for n, d in deployer.config['instances'].items() if n in hostnames]:
+        emitter.echo(f'\t{name}: {hostdata["publicaddress"]}', color="yellow")
+    deployer.update_nucypher_on_existing_nodes(hostnames)
 
 
 @cloudworkers.command('status')
-@group_staker_options
-@option_config_file
-@click.option('--cloudprovider', help="aws or digitalocean")
-@click.option('--include-stakeholder', 'stakes', help="only show nodes for included stakeholder addresses", multiple=True)
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@click.option('--include-host', 'include_hosts', help="Query status on only the named hosts", multiple=True, type=click.STRING)
 @group_general_config
-def status(general_config, staker_options, config_file, cloudprovider, stakes):
+def status(general_config, namespace, network, include_hosts):
     """Displays worker status and updates worker data in stakeholder config"""
 
     emitter = setup_emitter(general_config)
     if not CloudDeployers:
         emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
         return
-    STAKEHOLDER = staker_options.create_character(emitter, config_file)
-    config_file = config_file or StakeHolderConfiguration.default_filepath()
-    deployer = CloudDeployers.get_deployer('generic')(emitter, STAKEHOLDER, config_file)
 
-    stakers = STAKEHOLDER.get_stakers()
-    staker_addresses = filter_staker_addresses(stakers, stakes)
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, namespace=namespace, network=network)
 
-    deployer.get_worker_status(staker_addresses)
+    hostnames = deployer.config['instances'].keys()
+    if include_hosts:
+        hostnames = include_hosts
+
+    deployer.get_worker_status(hostnames)
+
+
+@cloudworkers.command('logs')
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@click.option('--include-host', 'include_hosts', help="Query status on only the named hosts", multiple=True, type=click.STRING)
+@group_general_config
+def logs(general_config, namespace, network, include_hosts):
+    """Displays worker status and updates worker data in stakeholder config"""
+
+    emitter = setup_emitter(general_config)
+    if not CloudDeployers:
+        emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
+        return
+
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, namespace=namespace, network=network)
+
+    hostnames = deployer.config['instances'].keys()
+    if include_hosts:
+        hostnames = include_hosts
+    deployer.print_worker_logs(hostnames)
+
+
+@cloudworkers.command('backup')
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@click.option('--include-host', 'include_hosts', help="Query status on only the named hosts", multiple=True, type=click.STRING)
+@group_general_config
+def backup(general_config, namespace, network, include_hosts):
+    """Creates backups of important data from selected remote workers"""
+
+    emitter = setup_emitter(general_config)
+    if not CloudDeployers:
+        emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
+        return
+
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, namespace=namespace, network=network)
+
+    hostnames = deployer.config['instances'].keys()
+    if include_hosts:
+        hostnames = include_hosts
+    deployer.backup_remote_data(hostnames)
+
+
+@cloudworkers.command('destroy')
+@click.option('--cloudprovider', help="aws or digitalocean")
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@click.option('--include-host', 'include_hosts', help="Query status on only the named hosts", multiple=True, type=click.STRING)
+@group_general_config
+def destroy(general_config, cloudprovider, namespace, network, include_hosts):
+    """Cleans up all previously created resources for the given netork for the cloud providern"""
+
+    emitter = setup_emitter(general_config)
+    if not CloudDeployers:
+        emitter.echo("Ansible is required to use many `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
+        return
+
+    if not cloudprovider:
+        hosts = CloudDeployers.get_deployer('generic')(emitter, None, None, network=network, namespace=namespace).get_all_hosts()
+        if len(set(host['provider'] for address, host in hosts)) == 1: # check if there are hosts in this namespace
+            cloudprovider = hosts[0][1]['provider']
+        else:
+            emitter.echo("Found hosts from multiple cloudproviders.")
+            emitter.echo("We can only destroy hosts from one cloudprovider at a time.")
+            emitter.echo("Please specify which provider's hosts you'd like to destroy using --cloudprovider (digitalocean or aws)")
+            return
+    deployer = CloudDeployers.get_deployer(cloudprovider)(emitter, None, None, network=network, namespace=namespace)
+
+    hostnames = [name for name, data in deployer.get_provider_hosts()]
+    if include_hosts:
+        hostnames = include_hosts
+
+    deployer.destroy_resources(hostnames)
+
+
+
+@cloudworkers.command('list-namespaces')
+@click.option('--network', help="The network whose namespaces you want to see.", type=click.STRING, default='mainnet')
+@group_general_config
+def list_namespaces(general_config, network):
+    """Displays worker status and updates worker data in stakeholder config"""
+
+    emitter = setup_emitter(general_config)
+    if not CloudDeployers:
+        emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
+        return
+
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, network=network, pre_config={"namespace": None})
+    for ns in os.listdir(deployer.network_config_path):
+        emitter.echo(ns)
+
+
+@cloudworkers.command('list-hosts')
+@click.option('--network', help="The network whose hosts you want to see.", type=click.STRING, default='mainnet')
+@click.option('--namespace', help="The network whose hosts you want to see.", type=click.STRING, default='local-stakeholders')
+@click.option('--include-data', help="Print the full config data for each node.", is_flag=True, default=False)
+@group_general_config
+def list_hosts(general_config, network, namespace, include_data):
+    """Prints local config info about known hosts"""
+
+    emitter = setup_emitter(general_config)
+    if not CloudDeployers:
+        emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
+        return
+
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, network=network, namespace=namespace)
+    for name, data in deployer.get_all_hosts():
+        emitter.echo(name)
+        if include_data:
+            for k, v in data.items():
+                emitter.echo(f"\t{k}: {v}")
+
+
+@cloudworkers.command('restore')
+@click.option('--namespace', help="Namespace for these operations.  Used to address hosts and data locally and name hosts on cloud platforms.", type=click.STRING, default='local-stakeholders')
+@click.option('--network', help="The Nucypher network name these hosts will run on.", type=click.STRING, default='mainnet')
+@click.option('--target-host', 'target_host', help="The nickname managed host where we are putting the restored state.", multiple=False, type=click.STRING)
+@click.option('--source-path', 'source_path', help="The absolute path to the backup data you are restoring", type=click.STRING, required=True)
+@group_general_config
+def restore(general_config, namespace, network, target_host, source_path):
+    """Restores a backup of a worker to a running host"""
+
+    emitter = setup_emitter(general_config)
+    if not CloudDeployers:
+        emitter.echo("Ansible is required to use `nucypher cloudworkers *` commands.  (Please run 'pip install ansible'.)", color="red")
+        return
+
+    deployer = CloudDeployers.get_deployer('generic')(emitter, None, None, namespace=namespace, network=network)
+
+    deployer.restore_from_backup(target_host, source_path)

--- a/nucypher/utilities/clouddeploy.py
+++ b/nucypher/utilities/clouddeploy.py
@@ -59,13 +59,16 @@ class AnsiblePlayBookResultsCollector(CallbackBase):
 
     """
 
-    def __init__(self, sock, *args, return_results=None, **kwargs):
+    def __init__(self, sock, *args, return_results=None, filter_output=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.playbook_results = []
         self.sock = sock
         self.results = return_results
+        self.filter_output = filter_output
 
     def v2_playbook_on_play_start(self, play):
+        if self.filter_output is not None:
+            return
         name = play.get_name().strip()
         if not name:
             msg = '\nPLAY {}\n'.format('*' * 100)
@@ -74,19 +77,31 @@ class AnsiblePlayBookResultsCollector(CallbackBase):
         self.send_save(msg)
 
     def v2_playbook_on_task_start(self, task, is_conditional):
+
+        if self.filter_output is not None:
+            return
+        if task.get_name() == 'Gathering Facts':
+            return
+
         msg = '\nTASK [{}] {}\n'.format(task.get_name(), '*' * 100)
         self.send_save(msg)
 
     def v2_runner_on_ok(self, result, *args, **kwargs):
-        if result.is_changed():
-            data = '[{}]=> changed'.format(result._host.name)
-        else:
-            data = '[{}]=> ok'.format(result._host.name)
-        self.send_save(data, color='yellow' if result.is_changed() else 'green')
+        task_name = result._task.get_name()
+
+        if self.filter_output is not None and not task_name in self.filter_output:
+            return
+
+        if self.filter_output is None:
+            if result.is_changed():
+                data = '[{}]=> changed'.format(result._host.name)
+            else:
+                data = '[{}]=> ok'.format(result._host.name)
+            self.send_save(data, color='yellow' if result.is_changed() else 'green')
         if 'msg' in result._task_fields['args']:
-            msg = result._task_fields['args']['msg']
-            self.send_save(msg, color='yellow')
             self.send_save('\n')
+            msg = result._task_fields['args']['msg']
+            self.send_save(msg, color='white',)
             if self.results:
                 for k in self.results.keys():
                     regex = fr'{k}:\s*(?P<data>.*)'
@@ -96,20 +111,29 @@ class AnsiblePlayBookResultsCollector(CallbackBase):
 
 
     def v2_runner_on_failed(self, result, *args, **kwargs):
+        if self.filter_output is not None:
+            return
         if 'changed' in result._result:
             del result._result['changed']
-        data = 'fail: [{}]=> {}: {}'.format(result._host.name, 'failed',
-                                                                            self._dump_results(result._result))
+        data = 'fail: [{}]=> {}: {}'.format(
+            result._host.name, 'failed',
+            self._dump_results(result._result)
+        )
         self.send_save(data, color='red')
 
     def v2_runner_on_unreachable(self, result):
         if 'changed' in result._result:
             del result._result['changed']
-        data = '[{}]=> {}: {}'.format(result._host.name, 'unreachable',
-                                                                            self._dump_results(result._result))
+        data = '[{}]=> {}: {}'.format(
+            result._host.name,
+            'unreachable',
+            self._dump_results(result._result)
+        )
         self.send_save(data)
 
     def v2_runner_on_skipped(self, result):
+        if self.filter_output is not None:
+            return
         if 'changed' in result._result:
             del result._result['changed']
         data = '[{}]=> {}: {}'.format(
@@ -120,6 +144,8 @@ class AnsiblePlayBookResultsCollector(CallbackBase):
         self.send_save(data, color='blue')
 
     def v2_playbook_on_stats(self, stats):
+        if self.filter_output is not None:
+            return
         hosts = sorted(stats.processed.keys())
         data = '\nPLAY RECAP {}\n'.format('*' * 100)
         self.send_save(data)
@@ -148,38 +174,47 @@ class BaseCloudNodeConfigurator:
         sentry_dsn=None,
         profile=None,
         prometheus=False,
-        pre_config=False
+        pre_config=False,
+        network=None,
+        namespace=None,
+        gas_strategy=None,
         ):
 
         self.emitter = emitter
         self.stakeholder = stakeholder
-        self.config_filename = f'{self.stakeholder.network}.json'
-        self.network = self.stakeholder.network
+        self.network = network
+        self.namespace = namespace or 'local-stakeholders'
+
+        self.config_filename = f'{self.network}-{self.namespace}.json'
+
         self.created_new_nodes = False
 
         # the keys in this dict are used as search patterns by the anisble result collector and it will return
         # these values for each node if it happens upon them in some output
         self.output_capture = {'worker address': [], 'rest url': [], 'nucypher version': [], 'nickname': []}
 
-        # where we save our state data so we can remember the resources we created for future use
-        self.config_path = os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, self.config_filename)
         if pre_config:
             self.config = pre_config
-            self.namespace = self.config['namespace']
+            self.namespace_network = self.config.get('namespace')
             return
+
+        # where we save our state data so we can remember the resources we created for future use
+        self.config_path = os.path.join(self.network_config_path, self.namespace, self.config_filename)
+        self.config_dir = os.path.dirname(self.config_path)
 
         if os.path.exists(self.config_path):
             self.config = json.load(open(self.config_path))
-            self.namespace = self.config['namespace']
+            self.namespace_network = self.config['namespace']
         else:
-            self.namespace = f'{self.stakeholder.network}-{maya.now().date.isoformat()}'
+            self.namespace_network = f'{self.network}-{self.namespace}-{maya.now().date.isoformat()}'
+            self.emitter.echo(f"Configuring Cloud Deployer with namespace: '{self.namespace_network}'")
+            time.sleep(3)
+
             self.config = {
-                "namespace": self.namespace,
+                "namespace": self.namespace_network,
                 "keyringpassword": b64encode(os.urandom(64)).decode('utf-8'),
                 "ethpassword": b64encode(os.urandom(64)).decode('utf-8'),
             }
-            configdir = os.path.dirname(self.config_path)
-            os.makedirs(configdir, exist_ok=True)
 
         # configure provider specific attributes
         self._configure_provider_params(profile)
@@ -190,24 +225,40 @@ class BaseCloudNodeConfigurator:
         self.host_level_overrides = {
             'blockchain_provider': blockchain_provider,
             'nucypher_image': nucypher_image,
-            'sentry_dsn': sentry_dsn
+            'sentry_dsn': sentry_dsn,
+            'gas_strategy': f'--gas-strategy {gas_strategy}' if gas_strategy else '',
         }
 
         self.config['blockchain_provider'] = blockchain_provider or self.config.get('blockchain_provider') or f'/root/.local/share/geth/.ethereum/{self.chain_name}/geth.ipc' # the default for nodes that run their own geth container
         self.config['nucypher_image'] = nucypher_image or self.config.get('nucypher_image') or 'nucypher/nucypher:latest'
         self.config['sentry_dsn'] = sentry_dsn or self.config.get('sentry_dsn')
-        self.config['seed_network'] = seed_network or self.config.get('seed_network')
+        self.config['gas_strategy'] = f'--gas-strategy {gas_strategy}' if gas_strategy else self.config.get('gas-strategy', '')
+
+        self.config['seed_network'] = seed_network if seed_network is not None else self.config.get('seed_network')
         if not self.config['seed_network']:
             self.config.pop('seed_node', None)
         self.nodes_are_decentralized = 'geth.ipc' in self.config['blockchain_provider']
         self.config['stakeholder_config_file'] = stakeholder_config_path
         self.config['use-prometheus'] = prometheus
 
+        # add instance key as host_nickname for use in inventory
+        if self.config.get('instances'):
+            for k, v in self.config['instances'].items():
+                self.config['instances'][k]['host_nickname'] = k
+
         self._write_config()
 
     def _write_config(self):
+
+        configdir = os.path.dirname(self.config_path)
+        os.makedirs(configdir, exist_ok=True)
+
         with open(self.config_path, 'w') as outfile:
             json.dump(self.config, outfile, indent=4)
+
+    @property
+    def network_config_path(self):
+        return os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, self.network)
 
     @property
     def _provider_deploy_attrs(self):
@@ -232,16 +283,15 @@ class BaseCloudNodeConfigurator:
 
     @property
     def inventory_path(self):
-        return os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, f'{self.namespace}.ansible_inventory.yml')
+        return os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, f'{self.namespace_network}.ansible_inventory.yml')
 
-    def generate_ansible_inventory(self, staker_addresses, wipe_nucypher=False):
+    def generate_ansible_inventory(self, node_names, **kwargs):
 
         inventory_content = self._inventory_template.render(
             deployer=self,
-            nodes=[value for key, value in self.config['instances'].items() if key in staker_addresses],
-            wipe_nucypher=wipe_nucypher
+            nodes=[value for key, value in self.config['instances'].items() if key in node_names],
+            extra=kwargs
         )
-
 
         with open(self.inventory_path, 'w') as outfile:
             outfile.write(inventory_content)
@@ -249,10 +299,10 @@ class BaseCloudNodeConfigurator:
 
         return self.inventory_path
 
-    def create_nodes_for_stakers(self, stakers):
-        count = len(stakers)
-        self.emitter.echo(f"ensuring cloud nodes exist for the following {count} stakers:")
-        for s in stakers:
+    def create_nodes(self, node_names, unstaked=False):
+        count = len(node_names)
+        self.emitter.echo(f"ensuring cloud nodes exist for the following {count} node names:")
+        for s in node_names:
             self.emitter.echo(f'\t{s}')
         time.sleep(3)
         self._do_setup_for_instance_creation()
@@ -260,18 +310,20 @@ class BaseCloudNodeConfigurator:
         if not self.config.get('instances'):
             self.config['instances'] = {}
 
-        for address in stakers:
-            existing_node = self.config['instances'].get(address)
+        for node_name in node_names:
+            existing_node = self.config['instances'].get(node_name)
             if not existing_node:
-                self.emitter.echo(f'creating new node for {address}', color='yellow')
+                self.emitter.echo(f'creating new node for {node_name}', color='yellow')
                 time.sleep(3)
-                node_data = self.create_new_node_for_staker(address)
+                node_data = self.create_new_node(node_name)
+                node_data['host_nickname'] = node_name
                 node_data['provider'] = self.provider_name
-                self.config['instances'][address] = node_data
+                self.config['instances'][node_name] = node_data
                 if self.config['seed_network'] and not self.config.get('seed_node'):
                     self.config['seed_node'] = node_data['publicaddress']
                 self._write_config()
                 self.created_new_nodes = True
+
 
         return self.config
 
@@ -280,19 +332,20 @@ class BaseCloudNodeConfigurator:
         template_path = os.path.join(os.path.dirname(__file__), 'templates', 'cloud_deploy_ansible_inventory.mako')
         return Template(filename=template_path)
 
-    def deploy_nucypher_on_existing_nodes(self, staker_addresses, wipe_nucypher=False):
+    def deploy_nucypher_on_existing_nodes(self, node_names, wipe_nucypher=False):
+
+        playbook = 'deploy/ansible/worker/setup_remote_workers.yml'
 
         # first update any specified input in our node config
         for k, input_specified_value in self.host_level_overrides.items():
-            for address in staker_addresses:
-                if self.config['instances'].get(address):
+            for node_name in node_names:
+                if self.config['instances'].get(node_name):
                     # if an instance already has a specified value, we only override
                     # it if that value was input for this command invocation
                     if input_specified_value:
-                        self.config['instances'][address][k] = input_specified_value
-                    elif not self.config['instances'][address].get(k):
-                        self.config['instances'][address][k] = self.config[k]
-
+                        self.config['instances'][node_name][k] = input_specified_value
+                    elif not self.config['instances'][node_name].get(k):
+                        self.config['instances'][node_name][k] = self.config[k]
                     self._write_config()
 
         if self.created_new_nodes:
@@ -300,20 +353,19 @@ class BaseCloudNodeConfigurator:
             time.sleep(30)
         self.emitter.echo('Running ansible deployment for all running nodes.', color='green')
 
-        self.emitter.echo(f"using inventory file at {self.inventory_path}", color='yellow')
-        if self.config.get('keypair_path'):
-            self.emitter.echo(f"using keypair file at {self.config['keypair_path']}", color='yellow')
+        if self.config.get('seed_network') is True and not self.config.get('seed_node'):
+            self.config['seed_node'] = list(self.config['instances'].values())[0]['publicaddress']
+            self._write_config()
 
-        self.generate_ansible_inventory(staker_addresses, wipe_nucypher=wipe_nucypher)
+        self.generate_ansible_inventory(node_names, wipe_nucypher=wipe_nucypher)
 
-        results = self.output_capture
         loader = DataLoader()
         inventory = InventoryManager(loader=loader, sources=self.inventory_path)
         callback = AnsiblePlayBookResultsCollector(sock=self.emitter, return_results=self.output_capture)
         variable_manager = VariableManager(loader=loader, inventory=inventory)
 
         executor = PlaybookExecutor(
-            playbooks = ['deploy/ansible/worker/setup_remote_workers.yml'],
+            playbooks = [playbook],
             inventory=inventory,
             variable_manager=variable_manager,
             loader=loader,
@@ -323,20 +375,30 @@ class BaseCloudNodeConfigurator:
         executor.run()
 
         self.update_captured_instance_data(self.output_capture)
-        self.give_helpful_hints()
+        self.give_helpful_hints(node_names, backup=True, playbook=playbook)
 
 
-    def get_worker_status(self, staker_addresses):
+    def update_nucypher_on_existing_nodes(self, node_names):
 
-        self.emitter.echo('Running ansible status playbook.', color='green')
-        self.emitter.echo('If something goes wrong, it is generally safe to ctrl-c and run the previous command again.')
+        playbook = 'deploy/ansible/worker/update_remote_workers.yml'
 
-        self.emitter.echo(f"using inventory file at {self.inventory_path}", color='yellow')
-        if self.config.get('keypair_path'):
-            self.emitter.echo(f"using keypair file at {self.config['keypair_path']}", color='yellow')
+        # first update any specified input in our node config
+        for k, input_specified_value in self.host_level_overrides.items():
+            for node_name in node_names:
+                if self.config['instances'].get(node_name):
+                    # if an instance already has a specified value, we only override
+                    # it if that value was input for this command invocation
+                    if input_specified_value:
+                        self.config['instances'][node_name][k] = input_specified_value
+                    elif not self.config['instances'][node_name].get(k):
+                        self.config['instances'][node_name][k] = self.config[k]
+                    self._write_config()
 
+        if self.config.get('seed_network') is True and not self.config.get('seed_node'):
+            self.config['seed_node'] = list(self.config['instances'].values())[0]['publicaddress']
+            self._write_config()
 
-        self.generate_ansible_inventory(staker_addresses)
+        self.generate_ansible_inventory(node_names)
 
         loader = DataLoader()
         inventory = InventoryManager(loader=loader, sources=self.inventory_path)
@@ -344,7 +406,32 @@ class BaseCloudNodeConfigurator:
         variable_manager = VariableManager(loader=loader, inventory=inventory)
 
         executor = PlaybookExecutor(
-            playbooks = ['deploy/ansible/worker/get_workers_status.yml'],
+            playbooks = [playbook],
+            inventory=inventory,
+            variable_manager=variable_manager,
+            loader=loader,
+            passwords=dict(),
+        )
+        executor._tqm._stdout_callback = callback
+        executor.run()
+
+        self.update_captured_instance_data(self.output_capture)
+        self.give_helpful_hints(node_names, backup=True, playbook=playbook)
+
+
+    def get_worker_status(self, node_names):
+
+        playbook = 'deploy/ansible/worker/get_workers_status.yml'
+
+        self.generate_ansible_inventory(node_names)
+
+        loader = DataLoader()
+        inventory = InventoryManager(loader=loader, sources=self.inventory_path)
+        callback = AnsiblePlayBookResultsCollector(sock=self.emitter, return_results=self.output_capture, filter_output=["Print Ursula Status Data", "Print Last Log Line"])
+        variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+        executor = PlaybookExecutor(
+            playbooks = [playbook],
             inventory=inventory,
             variable_manager=variable_manager,
             loader=loader,
@@ -354,22 +441,93 @@ class BaseCloudNodeConfigurator:
         executor.run()
         self.update_captured_instance_data(self.output_capture)
 
-        self.give_helpful_hints()
+        self.give_helpful_hints(node_names, playbook=playbook)
+
+
+    def print_worker_logs(self, node_names):
+
+        playbook = 'deploy/ansible/worker/get_worker_logs.yml'
+
+        self.generate_ansible_inventory(node_names)
+
+        loader = DataLoader()
+        inventory = InventoryManager(loader=loader, sources=self.inventory_path)
+        callback = AnsiblePlayBookResultsCollector(sock=self.emitter, return_results=self.output_capture)
+        variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+        executor = PlaybookExecutor(
+            playbooks = [playbook],
+            inventory=inventory,
+            variable_manager=variable_manager,
+            loader=loader,
+            passwords=dict(),
+        )
+        executor._tqm._stdout_callback = callback
+        executor.run()
+        self.update_captured_instance_data(self.output_capture)
+
+        self.give_helpful_hints(node_names, playbook=playbook)
+
+
+    def backup_remote_data(self, node_names):
+
+        playbook = 'deploy/ansible/worker/backup_remote_workers.yml'
+        self.generate_ansible_inventory(node_names)
+
+        loader = DataLoader()
+        inventory = InventoryManager(loader=loader, sources=self.inventory_path)
+        callback = AnsiblePlayBookResultsCollector(sock=self.emitter, return_results=self.output_capture)
+        variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+        executor = PlaybookExecutor(
+            playbooks = [playbook],
+            inventory=inventory,
+            variable_manager=variable_manager,
+            loader=loader,
+            passwords=dict(),
+        )
+        executor._tqm._stdout_callback = callback
+        executor.run()
+
+        self.give_helpful_hints(node_names, backup=True, playbook=playbook)
+
+    def restore_from_backup(self, target_host, source_path):
+
+        playbook = 'deploy/ansible/worker/restore_ursula_from_backup.yml'
+
+        self.generate_ansible_inventory([target_host], restore_path=source_path)
+
+        loader = DataLoader()
+        inventory = InventoryManager(loader=loader, sources=self.inventory_path)
+        callback = AnsiblePlayBookResultsCollector(sock=self.emitter, return_results=self.output_capture)
+        variable_manager = VariableManager(loader=loader, inventory=inventory)
+
+        executor = PlaybookExecutor(
+            playbooks = [playbook],
+            inventory=inventory,
+            variable_manager=variable_manager,
+            loader=loader,
+            passwords=dict(),
+        )
+        executor._tqm._stdout_callback = callback
+        executor.run()
+        self.give_helpful_hints([target_host], backup=True, playbook=playbook)
 
     def get_provider_hosts(self):
         return [
-            (address, host_data) for address, host_data in self.get_all_hosts()
+            (node_name, host_data) for node_name, host_data in self.get_all_hosts()
             if host_data['provider'] == self.provider_name
         ]
 
     def get_all_hosts(self):
-        return [(address, host_data) for address, host_data in self.config['instances'].items()]
+        return [(node_name, host_data) for node_name, host_data in self.config['instances'].items()]
 
-    def destroy_resources(self, staker_addresses=None):
-        addresses = [s for s in staker_addresses if s in self.get_provider_hosts()]
-        self.emitter.echo(f"Destroying all {self.provider_name} instances for stakers: {' '.join(addresses)}")
-        if self._destroy_resources(addresses):
-            self.emitter.echo(f"deleted all requested resources for {self.provider_name}.  We are clean.  No money is being spent.", color="green")
+    def destroy_resources(self, node_names):
+        node_names = [s for s in node_names if s in [names for names, data in self.get_provider_hosts()]]
+        self.emitter.echo(f"Destroying {self.provider_name} instances for nodes: {' '.join(node_names)}")
+        if self._destroy_resources(node_names):
+            if not self.config.get('instances'):
+                self.emitter.echo(f"deleted all requested resources for {self.provider_name}.  We are clean.  No money is being spent.", color="green")
 
     def _destroy_resources(self):
         raise NotImplementedError
@@ -389,6 +547,8 @@ class BaseCloudNodeConfigurator:
         self.update_stakeholder_config()
 
     def update_stakeholder_config(self):
+        if not self.stakeholder:
+            return
         data = json.loads(open(self.config['stakeholder_config_file'], 'r').read())
         existing_worker_data = data.get('worker_data') or {}
 
@@ -397,20 +557,36 @@ class BaseCloudNodeConfigurator:
         with open(self.config['stakeholder_config_file'], 'w') as outfile:
             json.dump(data, outfile, indent=4)
 
-    def give_helpful_hints(self):
-        self.emitter.echo("You may wish to ssh into your running hosts:")
-        for address, n in self.get_all_hosts():
-            dep = CloudDeployers.get_deployer(n['provider'])(
+    def give_helpful_hints(self, node_names, backup=False, playbook=None):
+
+        self.emitter.echo("some relevant info:")
+        self.emitter.echo(f' config file: "{self.config_path}"')
+        self.emitter.echo(f" inventory file: {self.inventory_path}", color='yellow')
+        if self.config.get('keypair_path'):
+            self.emitter.echo(f" keypair file: {self.config['keypair_path']}", color='yellow')
+
+        if playbook:
+            self.emitter.echo(" If you like, you can run the same playbook directly in ansible with the following:")
+            self.emitter.echo(f'\tansible-playbook -i "{self.inventory_path}" "{playbook}"')
+
+        self.emitter.echo(" You may wish to ssh into your running hosts:")
+        for node_name, host_data in [h for h in self.get_all_hosts() if h[0] in node_names]:
+            dep = CloudDeployers.get_deployer(host_data['provider'])(
                 self.emitter,
                 self.stakeholder,
                 self.config['stakeholder_config_file'],
-                pre_config=self.config
+                pre_config=self.config,
+                namespace=self.namespace,
+                network=self.network
             )
-            self.emitter.echo(f"\t {dep.format_ssh_cmd(n)}", color="yellow")
+            self.emitter.echo(f"\t{dep.format_ssh_cmd(host_data)}", color="yellow")
+        if backup:
+            self.emitter.echo(" *** Local backups containing sensitive data have been created. ***", color="red")
+            self.emitter.echo(f" Backup data can be found here: {self.config_dir}/remote_worker_backups/")
 
-    def format_ssh_cmd(self, hostdata):
-        user = next(v['value'] for v in hostdata['provider_deploy_attrs'] if v['key'] == 'default_user')
-        return f"ssh {user}@{hostdata['publicaddress']}"
+    def format_ssh_cmd(self, host_data):
+        user = next(v['value'] for v in host_data['provider_deploy_attrs'] if v['key'] == 'default_user')
+        return f"ssh {user}@{host_data['publicaddress']}"
 
 
 class DigitalOceanConfigurator(BaseCloudNodeConfigurator):
@@ -435,10 +611,8 @@ class DigitalOceanConfigurator(BaseCloudNodeConfigurator):
         if not self.token:
             self.emitter.echo(f"Please `export DIGITALOCEAN_ACCESS_TOKEN=<your access token.>` from here:  https://cloud.digitalocean.com/account/api/tokens", color="red")
             raise AttributeError("Could not continue without DIGITALOCEAN_ACCESS_TOKEN environment variable.")
-        self.region = os.getenv('DIGITALOCEAN_REGION') or self.config.get('region')
-        if not self.region:
-            self.region = self.default_region
-        self.config['region'] = self.region
+        self.region = os.getenv('DIGITALOCEAN_REGION') or self.config.get('digital-ocean-region') or self.default_region
+
         self.emitter.echo(f'using DigitalOcean region: {self.region}, to change regions `export DIGITALOCEAN_REGION: https://www.digitalocean.com/docs/platform/availability-matrix/', color='yellow')
 
         self.sshkey = os.getenv('DIGITAL_OCEAN_KEY_FINGERPRINT') or self.config.get('sshkey')
@@ -447,14 +621,15 @@ class DigitalOceanConfigurator(BaseCloudNodeConfigurator):
             self.emitter.echo("it should look like `DIGITAL_OCEAN_KEY_FINGERPRINT=88:fb:53:51:09:aa:af:02:e2:99:95:2d:39:64:c1:64`", color="red")
             raise AttributeError("Could not continue without DIGITAL_OCEAN_KEY_FINGERPRINT environment variable.")
         self.config['sshkey'] = self.sshkey
+        self.config['digital-ocean-region'] = self.region
 
         self._write_config()
 
-    def create_new_node_for_staker(self, address):
+    def create_new_node(self, node_name):
 
         response = requests.post("https://api.digitalocean.com/v2/droplets",
             {
-                "name": f'{self.namespace}-{address}',
+                "name": f'{node_name}',
                 "region": self.region,
                 "size": self.instance_size,
                 "image":"ubuntu-20-04-x64",
@@ -496,25 +671,28 @@ class DigitalOceanConfigurator(BaseCloudNodeConfigurator):
             self.emitter.echo(response.text, color='red')
             raise BaseException("Error creating resources in DigitalOcean")
 
-    def _destroy_resources(self, stakes):
+    def _destroy_resources(self, node_names):
 
-        existing_instances = copy.copy(self.config.get('instances'))
+        existing_instances = {k: v for k, v in self.config.get('instances', {}).items() if k in node_names}
         if existing_instances:
-            for address, instance in existing_instances.items():
-                if stakes and not address in stakes:
+            for node_name, instance in existing_instances.items():
+                if node_names and not node_name in node_names:
                     continue
-                self.emitter.echo(f"deleting worker instance for {address} in 3 seconds...", color='red')
+                self.emitter.echo(f"deleting worker instance for {node_name} in 3 seconds...", color='red')
                 time.sleep(3)
-                if requests.delete(
+
+                result = requests.delete(
                     f'https://api.digitalocean.com/v2/droplets/{instance["InstanceId"]}/',
                     headers = {
                         "Authorization": f'Bearer {self.token}'
-                }).status_code == 204:
-                    self.emitter.echo(f"\tdestroyed instance for {address}")
-                    del self.config['instances'][address]
+                })
+
+                if result.status_code == 204 or 'not_found' in result.text:
+                    self.emitter.echo(f"\tdestroyed instance for {node_name}")
+                    del self.config['instances'][node_name]
                     self._write_config()
                 else:
-                    raise
+                    raise Exception(f"Errors occurred while deleting node: {result.text}")
 
         return True
 
@@ -530,7 +708,16 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
     EC2_INSTANCE_SIZE = 't3.small'
 
     # TODO: this probably needs to be region specific...
-    EC2_AMI = 'ami-09dd2e08d601bff67'
+    EC2_AMI_LOOKUP = {
+        'us-west-2': 'ami-09dd2e08d601bff67', # Oregon
+        'us-west-1': 'ami-021809d9177640a20', # California
+        'us-east-2': 'ami-07efac79022b86107', # Ohio
+        'us-east-1': 'ami-0dba2cb6798deb6d8', # Virginia
+        'eu-central-1': 'ami-0c960b947cbb2dd16', # Frankfurt
+        'ap-northeast-1': 'ami-09b86f9709b3c33d4', # Tokyo
+        'ap-southeast-1': 'ami-093da183b859d5a4b', # Singapore
+    }
+
     preferred_platform = 'ubuntu-focal' #unused
 
     @property
@@ -549,8 +736,8 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
         try:
             import boto3
         except ImportError:
-            self.emitter.echo("You need to have boto3 installed to use this feature (pip3 install boto3)", color='red')
-            raise AttributeError("boto3 not found.")
+            self.emitter.echo("You need to have boto3 installed to use this feature (pip install boto3)", color='red')
+            raise AttributeError("You need to have boto3 installed to use this feature (pip install boto3).")
         # figure out which AWS account to use.
 
         # find aws profiles on user's local environment
@@ -562,7 +749,10 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
             raise AttributeError("AWS profile not configured.")
         self.emitter.echo(f'using profile: {self.profile}')
         if self.profile in profiles:
-            self.session = boto3.Session(profile_name=self.profile)
+            self.AWS_REGION = self.config.get('aws-region') or os.getenv('AWS_DEFAULT_REGION') or 'us-east-1'
+            if not self.config.get('aws-region') or os.getenv('AWS_DEFAULT_REGION'):
+                self.emitter.echo(f"Using AWS Region: {self.AWS_REGION}.  Override this by setting environment variable: AWS_DEFAULT_REGION", color='yellow')
+            self.session = boto3.Session(profile_name=self.profile, region_name=self.AWS_REGION)
             self.ec2Client = self.session.client('ec2')
             self.ec2Resource = self.session.resource('ec2')
         else:
@@ -579,15 +769,17 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
             self.config['keypair_path'] = keypair_path
 
         self.config['keypair'] = self.keypair
+        self.config['aws-region'] = self.AWS_REGION
+        self._write_config()
 
     @property
     def aws_tags(self):
         # to keep track of the junk we put in the cloud
-        return [{"Key": "Name", "Value": self.namespace}]
+        return [{"Key": "Name", "Value": self.namespace_network}]
 
     def _create_keypair(self):
-        new_keypair_data = self.ec2Client.create_key_pair(KeyName=f'{self.namespace}')
-        outpath = os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, f'{self.namespace}.awskeypair')
+        new_keypair_data = self.ec2Client.create_key_pair(KeyName=f'{self.namespace_network}')
+        outpath = os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, f'{self.namespace_network}.awskeypair')
         os.makedirs(os.path.dirname(outpath), exist_ok=True)
         with open(outpath, 'w') as outfile:
             outfile.write(new_keypair_data['KeyMaterial'])
@@ -598,9 +790,9 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
 
     def _delete_keypair(self):
         # only use self.namespace here to avoid accidental deletions of pre-existing keypairs
-        deleted_keypair_data = self.ec2Client.delete_key_pair(KeyName=f'{self.namespace}')
+        deleted_keypair_data = self.ec2Client.delete_key_pair(KeyName=f'{self.namespace_network}')
         if deleted_keypair_data['HTTPStatusCode'] == 200:
-            outpath = os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, f'{self.namespace}.awskeypair')
+            outpath = os.path.join(DEFAULT_CONFIG_ROOT, NODE_CONFIG_STORAGE_KEY, f'{self.namespace_network}.awskeypair')
             os.remove(outpath)
             self.emitter.echo(f"keypair at {outpath}, was deleted", color='yellow')
 
@@ -666,7 +858,7 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
         routetable.associate_with_subnet(SubnetId=self.config['Subnet'])
 
         if not self.config.get('SecurityGroup'):
-            securitygroupdata = self.ec2Client.create_security_group(GroupName=f'Ursula-{self.namespace}', Description='ssh and Nucypher ports', VpcId=self.config['Vpc'])
+            securitygroupdata = self.ec2Client.create_security_group(GroupName=f'Ursula-{self.namespace_network}', Description='ssh and Nucypher ports', VpcId=self.config['Vpc'])
             self.config['SecurityGroup'] = sg_id = securitygroupdata['GroupId']
             self._write_config()
             securitygroup = self.ec2Resource.SecurityGroup(sg_id)
@@ -688,25 +880,27 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
         self._configure_path_to_internet()
         self.emitter.echo("all prerequisite cloud resources do exist.")
 
-    def _destroy_resources(self, stakes):
+    def _destroy_resources(self, node_names):
         try:
             from botocore import exceptions as botoexceptions
         except ImportError:
             self.emitter.echo("You need to have boto3 installed to use this feature (pip3 install boto3)")
             return
 
+        existing_instances = {k: v for k, v in self.config.get('instances', {}).items() if k in node_names}
         vpc = self.ec2Resource.Vpc(self.config['Vpc'])
-        if self.config.get('instances'):
-            for address, instance in self.config['instances'].items():
-                if stakes and not address in stakes:
+        if existing_instances:
+            for node_name, instance in existing_instances.items():
+                if node_names and not node_name in node_name:
                     continue
-                self.emitter.echo(f"deleting worker instance for {address} in 3 seconds...", color='red')
+                self.emitter.echo(f"deleting worker instance for {node_name} in 3 seconds...", color='red')
                 time.sleep(3)
                 self.ec2Resource.Instance(instance['InstanceId']).terminate()
-                del self.config['instances'][address]
+                del self.config['instances'][node_name]
+                self.emitter.echo(f"\tdestroyed instance for {node_name}")
                 self._write_config()
 
-        if not self.config.instances:
+        if not len(self.get_provider_hosts()):
             self.emitter.echo("waiting for instance termination...")
             time.sleep(10)
             for subresource in ['Subnet', 'RouteTable', 'SecurityGroup']:
@@ -730,12 +924,13 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
                 self.ec2Resource.InternetGateway(self.config['InternetGateway']).delete()
                 self.emitter.echo(f'deleted InternetGateway: {self.config["InternetGateway"]}')
                 del self.config['InternetGateway']
-            self._write_config()
+                self._write_config()
 
             if self.config.get('Vpc'):
                 vpc.delete()
                 self.emitter.echo(f'deleted Vpc: {self.config["Vpc"]}')
                 del self.config['Vpc']
+                self._write_config()
 
             if self.config.get('keypair'):
                 self.emitter.echo(f'deleting keypair {self.keypair} in 5 seconds...', color='red')
@@ -743,12 +938,14 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
                 self.ec2Client.delete_key_pair(KeyName=self.config.get('keypair'))
                 del self.config['keypair']
                 os.remove(self.config['keypair_path'])
+                del self.config['keypair_path']
+                self._write_config()
 
         return True
 
-    def create_new_node_for_staker(self, address):
+    def create_new_node(self, node_name):
         new_instance_data = self.ec2Client.run_instances(
-            ImageId=self.EC2_AMI,
+            ImageId=self.EC2_AMI_LOOKUP.get(self.AWS_REGION),
             InstanceType=self.EC2_INSTANCE_SIZE,
             MaxCount=1,
             MinCount=1,
@@ -770,7 +967,7 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
                     'Tags': [
                         {
                             'Key': 'Name',
-                            'Value': f'{self.namespace}-{address}'
+                            'Value': f'{node_name}'
                         },
                     ]
                 },
@@ -788,23 +985,31 @@ class AWSNodeConfigurator(BaseCloudNodeConfigurator):
 
         return node_data
 
-    def format_ssh_cmd(self, hostdata):
-        keypair_path = next(v['value'] for v in hostdata['provider_deploy_attrs'] if v['key'] == 'ansible_ssh_private_key_file')
-        return f'{super().format_ssh_cmd(hostdata)} -i "{keypair_path}"'
+    def format_ssh_cmd(self, host_data):
+        keypair_path = next(v['value'] for v in host_data['provider_deploy_attrs'] if v['key'] == 'ansible_ssh_private_key_file')
+        return f'{super().format_ssh_cmd(host_data)} -i "{keypair_path}"'
+
 
 class GenericConfigurator(BaseCloudNodeConfigurator):
 
     provider_name = 'generic'
 
-    def create_nodes_for_stakers(self, stakers, host_address, login_name, key_path, ssh_port):
+    def _write_config(self):
+        if not os.path.exists(self.config_path):
+            raise AttributeError(f"Namespace/config '{self.namespace}' does not exist. Show existing namespaces: `nucypher cloudworkers list-namespaces` or create a namespace: `nucypher cloudworkers create`")
+
+        super()._write_config()
+
+
+    def create_nodes(self, node_names, host_address, login_name, key_path, ssh_port):
 
         if not self.config.get('instances'):
             self.config['instances'] = {}
 
-        for address in stakers:
-            node_data = self.config['instances'].get(address, {})
+        for node_name in node_names:
+            node_data = self.config['instances'].get(node_name, {})
             if node_data:
-                self.emitter.echo(f"Host info already exists for staker {address}; Updating and proceeding.", color="yellow")
+                self.emitter.echo(f"Host info already exists for staker {node_name}; Updating and proceeding.", color="yellow")
                 time.sleep(3)
 
             node_data['publicaddress'] = host_address
@@ -815,7 +1020,7 @@ class GenericConfigurator(BaseCloudNodeConfigurator):
                 {'key': 'ansible_port', 'value': ssh_port}
             ]
 
-            self.config['instances'][address] = node_data
+            self.config['instances'][node_name] = node_data
             if self.config['seed_network'] and not self.config.get('seed_node'):
                 self.config['seed_node'] = node_data['publicaddress']
             self._write_config()

--- a/nucypher/utilities/templates/cloud_deploy_ansible_inventory.mako
+++ b/nucypher/utilities/templates/cloud_deploy_ansible_inventory.mako
@@ -17,6 +17,7 @@ all:
                 NUCYPHER_KEYRING_PASSWORD: ${deployer.config['keyringpassword']}
                 NUCYPHER_WORKER_ETH_PASSWORD: ${deployer.config['ethpassword']}
                 nucypher_image: ${deployer.config['nucypher_image']}
+                gas_strategy: ${deployer.config['gas_strategy']}
                 blockchain_provider: ${deployer.config['blockchain_provider']}
                 node_is_decentralized: ${deployer.nodes_are_decentralized}
                 %if deployer.config.get('use-prometheus'):
@@ -26,26 +27,35 @@ all:
                 %endif
                 %if deployer.config.get('seed_node'):
                 SEED_NODE_URI: ${deployer.config['seed_node']}
+                teacher_options: --teacher ${deployer.config['seed_node']}
                 %else:
                 SEED_NODE_URI:
+                teacher_options: ""
                 %endif
                 %if deployer.config.get('sentry_dsn'):
                 SENTRY_DSN: ${deployer.config['sentry_dsn']}
+                NUCYPHER_SENTRY_LOGS: yes
                 %endif
-                wipe_nucypher_config: ${wipe_nucypher}
+                wipe_nucypher_config: ${extra.get('wipe_nucypher', False)}
+                deployer_config_path: ${deployer.config_dir}
+                restore_path: ${extra.get('restore_path')}
               hosts:
                 %for node in nodes:
-                ${node.publicaddress}:
-                  %for attr in node.provider_deploy_attrs:
-                  ${attr.key}: ${attr.value}
+                ${node['publicaddress']}:
+                  host_nickname: ${node['host_nickname']}
+                  %for attr in node['provider_deploy_attrs']:
+                  ${attr['key']}: ${attr['value']}
                   %endfor
-                  % if node.blockchain_provider:
-                  blockchain_provider: {{node.blockchain_provider}}
+                  % if node.get('blockchain_provider'):
+                  blockchain_provider: ${node['blockchain_provider']}
                   %endif
-                  %if node.nucypher_image:
-                  nucypher_image: ${node.nucypher_image}
+                  %if node.get('nucypher_image'):
+                  nucypher_image: ${node['nucypher_image']}
                   %endif
-                  %if node.sentry_dsn:
-                  sentry_dsn: ${node.sentry_dsn}
+                  %if node.get('sentry_dsn'):
+                  sentry_dsn: ${node['sentry_dsn']}
+                  %endif
+                  %if node.get('gas_strategy'):
+                  gas_strategy: ${node['gas_strategy']}
                   %endif
                 %endfor


### PR DESCRIPTION
* up | Creates and deploys hosts for all active local stakers
* create | Creates and deploys the given number of hosts independent of stakes
* add | Add an existing host to be managed by cloudworkers CLI tools
* add_for_stake | Add an existing host to be managed for a specified local staker address
* deploy | Install and run Ursula on existing managed hosts.
* update | Update or manage existing installed Ursula.
* destroy | Shut down and cleanup resources deployed on AWS or Digital Ocean
* status | Prints a formatted status of selected managed hosts.
* logs | Download and display the accumulated stdout logs of selected hosts
* backup | Download local copies of critical data from selected installed Ursulas
* restore | Reconstitute and deploy an operating Ursula from backed up data
* list_hosts | Print local nicknames of all managed hosts under a given namespace
* list_namespaces | Print namespaces under a given network