### PR TITLE
Since web3=5.12.2 its methods need positional arguments

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -629,7 +629,7 @@ class Allocator:
 
         batch_size = 1
         if not gas_limit:
-            block_limit = self.staking_agent.blockchain.client.w3.eth.getBlock(block_identifier='latest').gasLimit
+            block_limit = self.staking_agent.blockchain.client.w3.eth.getBlock('latest').gasLimit
             gas_limit = int(self.OCCUPATION_RATIO * block_limit)
         self.log.debug(f"Gas limit for this batch is {gas_limit}")
 

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -365,7 +365,7 @@ class EthereumClient:
     def check_transaction_is_on_chain(self, receipt: TxReceipt) -> bool:
         transaction_hash = Web3.toHex(receipt['transactionHash'])
         try:
-            new_receipt = self.w3.eth.getTransactionReceipt(transaction_hash=transaction_hash)
+            new_receipt = self.w3.eth.getTransactionReceipt(transaction_hash)
         except TransactionNotFound:
             reorg_detected = True
         else:
@@ -382,13 +382,13 @@ class EthereumClient:
         raise NotImplementedError
 
     def get_transaction(self, transaction_hash) -> dict:
-        return self.w3.eth.getTransaction(transaction_hash=transaction_hash)
+        return self.w3.eth.getTransaction(transaction_hash)
 
     def send_transaction(self, transaction_dict: dict) -> str:
-        return self.w3.eth.sendTransaction(transaction=transaction_dict)
+        return self.w3.eth.sendTransaction(transaction_dict)
 
     def send_raw_transaction(self, transaction_bytes: bytes) -> str:
-        return self.w3.eth.sendRawTransaction(raw_transaction=transaction_bytes)
+        return self.w3.eth.sendRawTransaction(transaction_bytes)
 
     def sign_message(self, account: str, message: bytes) -> str:
         """
@@ -505,7 +505,7 @@ class GethClient(EthereumClient):
             transaction_dict = dissoc(transaction_dict, 'to')
 
         # Sign
-        result = self.w3.eth.signTransaction(transaction=transaction_dict)
+        result = self.w3.eth.signTransaction(transaction_dict)
 
         # Return RLP bytes
         rlp_encoded_transaction = result.raw

--- a/tests/acceptance/blockchain/agents/test_policy_manager_agent.py
+++ b/tests/acceptance/blockchain/agents/test_policy_manager_agent.py
@@ -37,7 +37,7 @@ def policy_meta(testerchain, agency, token_economics, blockchain_ursulas):
     _policy_id = os.urandom(16)
     staker_addresses = list(staking_agent.get_stakers_reservoir(duration=1).draw(3))
     number_of_periods = 10
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     _txhash = agent.create_policy(policy_id=_policy_id,
                                   author_address=testerchain.alice_account,
                                   value=to_wei(1, 'gwei') * len(staker_addresses) * number_of_periods,
@@ -57,7 +57,7 @@ def test_create_policy(testerchain, agency, token_economics, mock_transacting_po
 
     policy_id = os.urandom(16)
     node_addresses = list(staking_agent.get_stakers_reservoir(duration=1).draw(3))
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     receipt = agent.create_policy(policy_id=policy_id,
                                   author_address=testerchain.alice_account,
                                   value=token_economics.minimum_allowed_locked,

--- a/tests/acceptance/blockchain/agents/test_preallocation_escrow_agent.py
+++ b/tests/acceptance/blockchain/agents/test_preallocation_escrow_agent.py
@@ -187,7 +187,7 @@ def test_collect_policy_fees(testerchain, agent, agency, token_economics, mock_t
     testerchain.time_travel(periods=1)
 
     mock_transacting_power_activation(account=author, password=INSECURE_DEVELOPMENT_PASSWORD)
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     policy_id = os.urandom(16)
     _receipt = policy_agent.create_policy(policy_id=policy_id,
                                           author_address=author,

--- a/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
@@ -546,7 +546,7 @@ def test_collect_rewards_integration(click_runner,
 
     M, N = 1, 1
     days = 3
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     expiration = maya.MayaDT(now).add(days=days-1)
     blockchain_policy = blockchain_alice.grant(bob=blockchain_bob,
                                                label=random_policy_label,

--- a/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
@@ -586,7 +586,7 @@ def test_collect_rewards_integration(click_runner,
 
     M, N = 1, 1
     days = 3
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     expiration = maya.MayaDT(now).add(days=days-1)
     blockchain_policy = blockchain_alice.grant(bob=blockchain_bob,
                                                label=random_policy_label,

--- a/tests/contracts/integration/test_intercontract_integration.py
+++ b/tests/contracts/integration/test_intercontract_integration.py
@@ -187,7 +187,7 @@ def staking_interface_router(testerchain, staking_interface, deploy_contract):
 @pytest.fixture(scope='module')
 def worklock(testerchain, token, escrow, token_economics, deploy_contract):
     # Creator deploys the worklock using test values
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     start_bid_date = ((now + 3600) // 3600 + 1) * 3600  # beginning of the next hour plus 1 hour
     end_bid_date = start_bid_date + 3600
     end_cancellation_date = end_bid_date + 3600
@@ -701,7 +701,7 @@ def test_policy(testerchain,
     rate = 200
     one_node_value = number_of_periods * rate
     value = 2 * one_node_value
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id_1, alice1, end_timestamp, [staker1]) \
         .transact({'from': alice1, 'value': one_node_value, 'gas_price': 0})
@@ -768,7 +768,7 @@ def test_policy(testerchain,
 
     # Create other policies
     policy_id_1 = os.urandom(16)
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id_1, alice1, end_timestamp, [staker1, staker2]) \
         .transact({'from': alice1, 'value': value, 'gas_price': 0})

--- a/tests/contracts/main/policy_manager/test_policy_manager.py
+++ b/tests/contracts/main/policy_manager/test_policy_manager.py
@@ -81,7 +81,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert 0 < policy_manager.functions.nodes(node2).call()[PREVIOUS_FEE_PERIOD_FIELD]
     assert 0 < policy_manager.functions.nodes(node3).call()[PREVIOUS_FEE_PERIOD_FIELD]
     assert 0 == policy_manager.functions.nodes(bad_node).call()[PREVIOUS_FEE_PERIOD_FIELD]
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     policy_id = os.urandom(POLICY_ID_LENGTH)
 
@@ -111,7 +111,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [node1])\
         .transact({'from': policy_sponsor, 'value': value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     # Check balances and policy info
     assert value == testerchain.client.get_balance(policy_manager.address)
     assert policy_sponsor_balance - 200 == testerchain.client.get_balance(policy_sponsor)
@@ -192,7 +192,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     tx = policy_manager.functions.createPolicy(policy_id_2, policy_owner, end_timestamp, [node1, node2, node3])\
         .transact({'from': policy_sponsor, 'value': 6 * value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     assert 6 * value == testerchain.client.get_balance(policy_manager.address)
     assert policy_sponsor_balance - 6 * value == testerchain.client.get_balance(policy_sponsor)
     policy = policy_manager.functions.policies(policy_id_2).call()
@@ -382,7 +382,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert event_args['value'] == 20
 
     # Try to create policy with low rate
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + 10
     with pytest.raises((TransactionFailed, ValueError)):
         tx = policy_manager.functions.createPolicy(policy_id_3, policy_sponsor, end_timestamp, [node1])\
@@ -399,7 +399,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
         policy_id_3, NULL_ADDRESS, end_timestamp, [node1, node2]) \
         .transact({'from': policy_sponsor, 'value': 2 * value, 'gas_price': 0})
     testerchain.wait_for_receipt(tx)
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     assert 2 * value == testerchain.client.get_balance(policy_manager.address)
     assert policy_sponsor_balance - 2 * value == testerchain.client.get_balance(policy_sponsor)
     policy = policy_manager.functions.policies(policy_id_3).call()
@@ -497,7 +497,7 @@ def test_create_revoke(testerchain, escrow, policy_manager):
     assert event_args['max'] == max_rate
 
     # Try to create policy with low rate
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + 10
     policy_id_5 = os.urandom(POLICY_ID_LENGTH)
     with pytest.raises((TransactionFailed, ValueError)):

--- a/tests/contracts/main/policy_manager/test_policy_manager_operations.py
+++ b/tests/contracts/main/policy_manager/test_policy_manager_operations.py
@@ -53,7 +53,7 @@ def test_fee(testerchain, escrow, policy_manager):
         testerchain.wait_for_receipt(tx)
 
     # Create policy
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id, policy_sponsor, end_timestamp, [node1, node3])\
         .transact({'from': policy_sponsor, 'value': 2 * value})
@@ -179,7 +179,7 @@ def test_refund(testerchain, escrow, policy_manager):
     policy_refund_log = policy_manager.events.RefundForPolicy.createFilter(fromBlock='latest')
 
     # Create policy
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id, policy_owner, end_timestamp, [node1]) \
         .transact({'from': policy_creator, 'value': value, 'gas_price': 0})
@@ -273,7 +273,7 @@ def test_refund(testerchain, escrow, policy_manager):
     period = escrow.functions.getCurrentPeriod().call()
     tx = escrow.functions.setLastCommittedPeriod(period).transact()
     testerchain.wait_for_receipt(tx)
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id_2, policy_creator, end_timestamp, [node1, node2, node3]) \
         .transact({'from': policy_creator, 'value': 3 * value, 'gas_price': 0})
@@ -428,7 +428,7 @@ def test_refund(testerchain, escrow, policy_manager):
 
     # Create new policy
     period = escrow.functions.getCurrentPeriod().call()
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id_3, policy_creator, end_timestamp, [node1])\
         .transact({'from': policy_creator, 'value': value, 'gas_price': 0})
@@ -496,7 +496,7 @@ def test_refund(testerchain, escrow, policy_manager):
     testerchain.time_travel(hours=number_of_periods + 2)
     policy_id_4 = os.urandom(POLICY_ID_LENGTH)
     number_of_periods_4 = 3
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods_4 - 1) * one_period
     tx = policy_manager.functions.createPolicy(policy_id_4, policy_creator, end_timestamp, [node1]) \
         .transact({'from': policy_creator, 'value': number_of_periods_4 * rate, 'gas_price': 0})
@@ -566,7 +566,7 @@ def test_reentrancy(testerchain, escrow, policy_manager, deploy_contract):
     # Create policy and mint one period
     periods = 3
     policy_value = int(periods * rate)
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (periods - 1) * one_period
     transaction = policy_manager.functions.createPolicy(policy_id, contract_address, end_timestamp, [contract_address])\
         .buildTransaction({'gas': 0})

--- a/tests/contracts/main/worklock/test_worklock.py
+++ b/tests/contracts/main/worklock/test_worklock.py
@@ -50,7 +50,7 @@ MIN_ALLOWED_BID = to_wei(1, 'ether')
 def worklock_factory(testerchain, token, escrow, token_economics, deploy_contract):
     def deploy_worklock(supply, bidding_delay, additional_time_to_cancel, boosting_refund):
 
-        now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+        now = testerchain.w3.eth.getBlock('latest').timestamp
         start_bid_date = now + bidding_delay
         end_bid_date = start_bid_date + BIDDING_DURATION
         end_cancellation_date = end_bid_date + additional_time_to_cancel
@@ -1148,7 +1148,7 @@ def test_force_refund(testerchain, token_economics, deploy_contract, worklock_fa
     testerchain.wait_for_receipt(tx)
 
     end_cancellation_date = worklock.functions.endCancellationDate().call()
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     assert end_cancellation_date > now
     assert token.functions.balanceOf(worklock.address).call() == 0
     assert token.functions.balanceOf(creator).call() == creator_tokens + worklock_tokens

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -258,7 +258,7 @@ def idle_blockchain_policy(testerchain, blockchain_alice, blockchain_bob, token_
     """
     random_label = generate_random_label()
     days = token_economics.minimum_locked_periods // 2
-    now = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = testerchain.w3.eth.getBlock('latest').timestamp
     expiration = maya.MayaDT(now).add(days=days - 1)
     n = 3
     m = 2
@@ -430,7 +430,7 @@ def lonely_ursula_maker(ursula_federated_test_config):
 
 def make_token_economics(blockchain):
     # Get current blocktime
-    now = blockchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    now = blockchain.w3.eth.getBlock('latest').timestamp
 
     # Calculate instant start time
     one_hour_in_seconds = (60 * 60)

--- a/tests/metrics/estimate_gas.py
+++ b/tests/metrics/estimate_gas.py
@@ -315,7 +315,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     rate = 100
     one_period = economics.hours_per_period * 60 * 60
     value = number_of_periods * rate
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 10 periods, pre-committed), first",
                      policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [staker1]),
@@ -390,7 +390,7 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     policy_id_3 = os.urandom(int(Policy.POLICY_ID_LENGTH))
     number_of_periods = 100
     value = 3 * number_of_periods * rate
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (3 nodes, 100 periods, pre-committed), first",
                      policy_functions.createPolicy(policy_id_1, alice1, end_timestamp, [staker1, staker2, staker3]),
@@ -419,13 +419,13 @@ def estimate_gas(analyzer: AnalyzeGas = None) -> None:
     policy_id_3 = os.urandom(int(Policy.POLICY_ID_LENGTH))
     number_of_periods = 100
     value = number_of_periods * rate
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 100 periods)",
                      policy_functions.createPolicy(policy_id_1, alice2, end_timestamp, [staker2]),
                      {'from': alice1, 'value': value})
     testerchain.time_travel(periods=1)
-    current_timestamp = testerchain.w3.eth.getBlock(block_identifier='latest').timestamp
+    current_timestamp = testerchain.w3.eth.getBlock('latest').timestamp
     end_timestamp = current_timestamp + (number_of_periods - 1) * one_period
     transact_and_log("Creating policy (1 node, 100 periods), next period",
                      policy_functions.createPolicy(policy_id_2, alice2, end_timestamp, [staker2]),

--- a/tests/mock/agents.py
+++ b/tests/mock/agents.py
@@ -31,7 +31,7 @@ from tests.utils.blockchain import free_gas_price_strategy
 
 MOCK_TESTERCHAIN = BlockchainInterfaceFactory.get_or_create_interface(provider_uri=MOCK_PROVIDER_URI,
                                                                       gas_strategy=free_gas_price_strategy)
-CURRENT_BLOCK = MOCK_TESTERCHAIN.w3.eth.getBlock(block_identifier='latest')
+CURRENT_BLOCK = MOCK_TESTERCHAIN.w3.eth.getBlock('latest')
 
 
 class MockContractAgent:

--- a/tests/utils/blockchain.py
+++ b/tests/utils/blockchain.py
@@ -200,7 +200,7 @@ class TesterBlockchain(BlockchainDeployerInterface):
         else:
             raise ValueError("Specify either hours, seconds, or periods.")
 
-        now = self.w3.eth.getBlock(block_identifier='latest').timestamp
+        now = self.w3.eth.getBlock('latest').timestamp
         end_timestamp = ((now+duration)//base) * base
 
         self.w3.eth.web3.testing.timeTravel(timestamp=end_timestamp)
@@ -224,8 +224,8 @@ class TesterBlockchain(BlockchainDeployerInterface):
         testerchain.transacting_power = power
 
         origin = testerchain.client.etherbase
-        deployer = ContractAdministrator(deployer_address=origin, 
-                                         registry=registry, 
+        deployer = ContractAdministrator(deployer_address=origin,
+                                         registry=registry,
                                          economics=economics or cls._default_token_economics,
                                          staking_escrow_test_mode=True)
 


### PR DESCRIPTION
`web3` was bumped from `5.12.1` to `5.12.2` in commit ad7935c725df. Evidently, they changed their method calls to some generalized `Method` class, so it is very strict about positional arguments being passed as positional arguments.

Update:

I'm using https://github.com/ethereum/web3.py/blob/a7ed9070e37c34f0e411a7441d4b79d8e5932a36/web3/eth.py to find all methods that are now `Method` instances. For some reason, not all of these changes were caught in tests. The list of changed methods:
* `getBlock()`
* `sendRawTransaction()`
* `getTransactionReceipt()`
* `getTransaction()`
* `sendTransaction()`
* `signTransaction()`

I think I got them all now.

