### PR TITLE
Status page fixes

### DIFF
--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -77,6 +77,9 @@ class FleetSensor:
     def __repr__(self):
         return self._nodes.__repr__()
 
+    def population(self):
+        return len(self) + len(self.additional_nodes_to_track)
+
     @property
     def checksum(self):
         return self._checksum

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -855,7 +855,7 @@ class Learner:
             current_teacher.update_snapshot(checksum=checksum,
                                             updated=maya.MayaDT(
                                                 int.from_bytes(fleet_state_updated_bytes, byteorder="big")),
-                                            number_of_known_nodes=len(self.known_nodes))
+                                            number_of_known_nodes=self.known_nodes.population())
             return FLEET_STATES_MATCH
 
         # Note: There was previously a version check here, but that required iterating through node bytestrings twice,

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -127,7 +127,11 @@ ${fleet_state_icon(state.checksum, state.nickname, state.population())}
     }
 
     .this-node-info {
-        margin-bottom: 1em;
+        margin-bottom: 2em;
+    }
+
+    h3 {
+        margin-bottom: 0em;
     }
 
     .this-node {

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -192,7 +192,7 @@ ${fleet_state_icon(state.checksum, state.nickname, state.population())}
         </tr>
     </table>
 
-    <h3>Known nodes</h3>
+    <h3>${len(known_nodes)} ${"known node" if len(known_nodes) == 1 else "known nodes"}:</h3>
 
     <table class="known-nodes">
         <thead>

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -45,7 +45,12 @@ NO FLEET STATE AVAILABLE
 
 
 <%def name="fleet_state_icon_from_state(state)">
-${fleet_state_icon(state.checksum, state.nickname, len(state))}
+${fleet_state_icon(state.checksum, state.nickname, len(state.nodes))}
+</%def>
+
+
+<%def name="fleet_state_icon_from_known_nodes(state)">
+${fleet_state_icon(state.checksum, state.nickname, state.population())}
 </%def>
 
 
@@ -170,9 +175,7 @@ ${fleet_state_icon(state.checksum, state.nickname, len(state))}
         </tr>
         <tr>
             <td><i>Fleet state:</i></td>
-            <td>    ${fleet_state_icon(this_node.fleet_state_checksum,
-                       this_node.fleet_state_nickname,
-                       this_node.fleet_state_population)}</td>
+            <td>${fleet_state_icon_from_known_nodes(this_node.known_nodes)}</td>
         </tr>
         <tr>
             <td><i>Previous states:</i></td>

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -176,11 +176,11 @@ ${fleet_state_icon(state.checksum, state.nickname, state.population())}
         </tr>
         <tr>
             <td><i>Running:</i></td>
-            <td><span class="version">v${ version }</span></td>
+            <td>v${ version }</td>
         </tr>
         <tr>
             <td><i>Domain:</i></td>
-            <td><span class="domain">${ domain }</span></td>
+            <td>${ domain }</td>
         </tr>
         <tr>
             <td><i>Fleet state:</i></td>

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -20,7 +20,7 @@ def contrast_color(color_hex):
         return "white"
 
 def character_span(character):
-    return f'<span style="color: {contrast_color(character.color_hex)}; background-color: {character.color_hex}">{character.symbol}</span>'
+    return f'<span class="symbol" style="color: {contrast_color(character.color_hex)}; background-color: {character.color_hex}">{character.symbol}</span>'
 %>
 
 <%def name="fleet_state_icon(checksum, nickname, population)">
@@ -148,6 +148,11 @@ ${fleet_state_icon(state.checksum, state.nickname, state.population())}
         font-size: 2em;
         font-family: monospace;
         margin-right: 0.2em;
+    }
+
+    .symbol {
+        padding-left: 0.05em;
+        padding-right: 0.05em;
     }
 
     .checksum {


### PR DESCRIPTION
* Fixes #2368 (NO_FLEET_STATE_AVAILABLE and related issues). I was taking the current state info from the attributes set by `update_snapshot()`, while the most recent one is actually contained in `.known_nodes`. 
* Displays the correct state population.
* Displays the total number of known nodes (as @cygnusv suggested).
* Spaces out nickname symbols a little (thanks, @jMyles).
    Before:
    <img width="620" alt="Screen Shot 2020-10-16 at 16 23 16" src="https://user-images.githubusercontent.com/30720/96321922-fe0d6300-0fcb-11eb-92f4-c8a19f5c8d28.png">
    After:
    <img width="620" alt="Screen Shot 2020-10-16 at 16 22 34" src="https://user-images.githubusercontent.com/30720/96321937-05cd0780-0fcc-11eb-8b2b-1f72f46096a7.png">
