### PR TITLE
Check for inconsistent dependencies on docs build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -679,7 +679,7 @@ jobs:
       - prepare_environment
       - run:
           name: Install Documentation Build Dependencies
-          command: pip3 install --user .[docs]
+          command: pip3 install --use-feature=2020-resolver --user .[docs]
       - run:
           name: Build Sphinx Documentation
           command: make docs


### PR DESCRIPTION
At the moment we have to update `docs-dependencies.txt` manually, so sometimes inconsistent deps might creep in. ReadTheDocs uses the new `pip` dependency resolution scheme (https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020) which is strict about that, so if that happens, the `build_docs` CI task passes, but the RTD build fails. This PR makes `build_docs` just as strict.

Case in point: CI for this PR fails at the moment exactly because docs-deps are inconsistent (fixed in PR #2381)

*Edit:* now that I rebased it after the merge of #2381, it should build properly.