### PR TITLE
Fix for nucypher stake set-min-rate

### DIFF
--- a/newsfragments/2390.bugfix.rst
+++ b/newsfragments/2390.bugfix.rst
@@ -1,0 +1,1 @@
+Correct CLI problems when setting the min fee rate. Also, simplifies usage by expressing rates in GWEI.

--- a/newsfragments/2395.bugfix.rst
+++ b/newsfragments/2395.bugfix.rst
@@ -1,0 +1,1 @@
+Tone-down learning logging messages even more (see issue #1712). Fixes some CLI and exception messages.

--- a/nucypher/blockchain/eth/signers/hardware.py
+++ b/nucypher/blockchain/eth/signers/hardware.py
@@ -101,7 +101,7 @@ class TrezorSigner(Signer):
         try:
             client = get_default_client()
         except TransportException:
-            raise self.NoDeviceDetected("Could not find a TREZOR device to connect to."
+            raise self.NoDeviceDetected("Could not find a TREZOR device to connect to. "
                                         "Is it connected and unlocked?")
         return client
 

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-
+from decimal import Decimal
 
 import click
 from web3 import Web3
@@ -101,8 +101,7 @@ from nucypher.cli.painting.transactions import paint_receipt_summary
 from nucypher.cli.types import (
     EIP55_CHECKSUM_ADDRESS,
     EXISTING_READABLE_FILE,
-    WEI
-)
+    DecimalRange)
 from nucypher.cli.utils import setup_emitter
 from nucypher.config.characters import StakeHolderConfiguration
 
@@ -1296,7 +1295,7 @@ def events(general_config, staker_options, config_file, event_name):
 @option_config_file
 @option_force
 @group_general_config
-@click.option('--min-rate', help="Minimum acceptable fee rate, set by staker", type=WEI)
+@click.option('--min-rate', help="Minimum acceptable fee rate (in GWEI), set by staker", type=DecimalRange(min=0))
 def set_min_rate(general_config: GroupGeneralConfig,
                  transacting_staker_options: TransactingStakerOptions,
                  config_file, force, min_rate):
@@ -1315,11 +1314,19 @@ def set_min_rate(general_config: GroupGeneralConfig,
         force=force)
 
     if not min_rate:
-        paint_min_rate(emitter, STAKEHOLDER.registry, STAKEHOLDER.policy_agent, staking_address)
-        # TODO check range
-        min_rate = click.prompt(PROMPT_STAKER_MIN_POLICY_RATE, type=WEI)
+        paint_min_rate(emitter, STAKEHOLDER)
+        minimum, _default, maximum = STAKEHOLDER.policy_agent.get_fee_rate_range()
+        lower_bound_in_gwei = Web3.fromWei(minimum, 'gwei')
+        upper_bound_in_gwei = Web3.fromWei(maximum, 'gwei')
+        min_rate = click.prompt(PROMPT_STAKER_MIN_POLICY_RATE, type=DecimalRange(min=lower_bound_in_gwei,
+                                                                                 max=upper_bound_in_gwei))
+
+    min_rate = int(Web3.toWei(Decimal(min_rate), 'gwei'))
+
     if not force:
-        click.confirm(CONFIRM_NEW_MIN_POLICY_RATE.format(min_rate=min_rate), abort=True)
+        min_rate_in_gwei = Web3.fromWei(min_rate, 'gwei')
+        click.confirm(CONFIRM_NEW_MIN_POLICY_RATE.format(min_rate=min_rate_in_gwei), abort=True)
+
     password = get_password(stakeholder=STAKEHOLDER,
                             blockchain=blockchain,
                             client_account=client_account,

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -432,7 +432,6 @@ def config(general_config, config_options, config_file):
         config_file = select_config_file(emitter=emitter,
                                          checksum_address=config_options.worker_address,
                                          config_class=UrsulaConfiguration)
-    emitter.echo(f"Ursula Configuration {config_file} \n {'='*55}")
     updates = config_options.get_updates()
     get_or_update_configuration(emitter=emitter,
                                 config_class=UrsulaConfiguration,

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -237,11 +237,11 @@ DETACH_DETAILS = "Detached at period #{current_period} ({bonded_date})"
 # Worker Rate
 #
 
-PROMPT_STAKER_MIN_POLICY_RATE = "Enter new value so the minimum fee rate falls within global fee range"
+PROMPT_STAKER_MIN_POLICY_RATE = "Enter new value (in GWEI) so the minimum fee rate falls within global fee range"
 
-CONFIRM_NEW_MIN_POLICY_RATE = "Commit new value {min_rate} for minimum fee rate?"
+CONFIRM_NEW_MIN_POLICY_RATE = "Commit new value {min_rate} GWEI for minimum fee rate?"
 
-SUCCESSFUL_SET_MIN_POLICY_RATE = "\nMinimum fee rate {min_rate} successfully set by staker {staking_address}"
+SUCCESSFUL_SET_MIN_POLICY_RATE = "\nMinimum fee rate {min_rate} GWEI successfully set by staker {staking_address}"
 
 
 #

--- a/nucypher/cli/painting/staking.py
+++ b/nucypher/cli/painting/staking.py
@@ -224,10 +224,10 @@ Global fee Range:
     emitter.echo(range_payload)
 
 
-def paint_min_rate(emitter, registry, policy_agent, staker_address):
-    paint_fee_rate_range(emitter, policy_agent)
-    minimum = policy_agent.min_fee_rate(staker_address)
-    raw_minimum = policy_agent.raw_min_fee_rate(staker_address)
+def paint_min_rate(emitter, staker):
+    paint_fee_rate_range(emitter, staker.policy_agent)
+    minimum = staker.min_fee_rate
+    raw_minimum = staker.raw_min_fee_rate
 
     rate_payload = f"""
 Minimum acceptable fee rate (set by staker for their associated worker):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -559,9 +559,9 @@ class Learner:
         self._learning_deferred = Deferred(canceller=self._discovery_canceller)  # TODO: No longer relevant.
 
         def _discover_or_abort(_first_result):
-            self.log.debug(f"{self} learning at {datetime.datetime.now()}")
+            # self.log.debug(f"{self} learning at {datetime.datetime.now()}")   # 1712
             result = self.learn_from_teacher_node(eager=False, canceller=self._discovery_canceller)
-            self.log.debug(f"{self} finished learning at {datetime.datetime.now()}")
+            # self.log.debug(f"{self} finished learning at {datetime.datetime.now()}")  # 1712
             return result
 
         self._learning_deferred.addCallback(_discover_or_abort)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -184,7 +184,7 @@ def _make_rest_app(datastore: Datastore, this_node, serving_domain: str, log: Lo
         # If these nodes already have the same fleet state, no exchange is necessary.
         learner_fleet_state = request.args.get('fleet')
         if learner_fleet_state == this_node.known_nodes.checksum:
-            log.debug("Learner already knew fleet state {}; doing nothing.".format(learner_fleet_state))
+            # log.debug("Learner already knew fleet state {}; doing nothing.".format(learner_fleet_state))  # 1712
             headers = {'Content-Type': 'application/octet-stream'}
             payload = this_node.known_nodes.snapshot() + bytes(FLEET_STATES_MATCH)
             signature = this_node.stamp(payload)

--- a/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
@@ -22,11 +22,13 @@ import tempfile
 from unittest import mock
 
 import maya
+from web3 import Web3
 
 from nucypher.blockchain.eth.actors import Staker
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.token import NU, Stake
+from nucypher.blockchain.eth.utils import prettify_eth_amount
 from nucypher.characters.lawful import Enrico, Ursula
 from nucypher.cli.literature import SUCCESSFUL_MINTING
 from nucypher.cli.main import nucypher_cli
@@ -779,8 +781,10 @@ def test_set_min_rate(click_runner,
     staker = Staker(is_me=True, checksum_address=manual_staker, registry=agency_local_registry)
     assert staker.raw_min_fee_rate == 0
 
+    min_rate_in_gwei = Web3.fromWei(min_rate, 'gwei')
+
     restake_args = ('stake', 'set-min-rate',
-                    '--min-rate', min_rate,
+                    '--min-rate', min_rate_in_gwei,
                     '--config-file', stakeholder_configuration_file_location,
                     '--staking-address', manual_staker,
                     '--force')
@@ -799,7 +803,7 @@ def test_set_min_rate(click_runner,
     user_input = INSECURE_DEVELOPMENT_PASSWORD
     result = click_runner.invoke(nucypher_cli, stake_args, input=user_input, catch_exceptions=False)
     assert result.exit_code == 0
-    assert f"{min_rate} wei" in result.output
+    assert f"{prettify_eth_amount(min_rate)}" in result.output
 
 
 def test_mint(click_runner,


### PR DESCRIPTION
- Fixes broken references when using `nucypher stake set-min-rate` (Fixes #2390)
- Reduces even more the learning logging. It's very difficult to try to debug anything with all that learning chatter.
- Other minor fixes here and there for CLI output and exception messages