### PR TITLE
Simple GitHub action to ensure release note entry included in PRs into main.

### DIFF
--- a/.github/workflows/pr_release_note_entry.yml
+++ b/.github/workflows/pr_release_note_entry.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          test -f '${{ github.workspace }}/newsfragments/${{ github.event.number }}.*'
+          test -f ${{ github.workspace }}/newsfragments/${{ github.event.number }}.*

--- a/.github/workflows/pr_release_note_entry.yml
+++ b/.github/workflows/pr_release_note_entry.yml
@@ -1,0 +1,17 @@
+name: 'Check PR Release Note Entry'
+
+on:
+  pull_request:
+    branches:
+      - main
+    tags-ignore:
+      - '*.*'  # ignore releases
+
+jobs:
+  release-note-entry:
+    name: 'Checking release note entry for PR ${{ github.event.number }}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          test -f './newsfragments/${{ github.event.number }}.*'

--- a/.github/workflows/pr_release_note_entry.yml
+++ b/.github/workflows/pr_release_note_entry.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          test -f './newsfragments/${{ github.event.number }}.*'
+          test -f '${{ github.workspace }}/newsfragments/${{ github.event.number }}.*'

--- a/newsfragments/2396.feature.rst
+++ b/newsfragments/2396.feature.rst
@@ -1,0 +1,1 @@
+GitHub Action to ensure that each pull request into main makes an associated release note entry.


### PR DESCRIPTION
The check that this PR adds, is expected to fail for this PR hehehe 😅 .

Release note entry format readme can be viewed - https://github.com/derekpierre/nucypher/blob/release-notes-action/newsfragments/README.md.