### PR TITLE
Moving domain check into FleetSensor.

### DIFF
--- a/newsfragments/2423.bugfix.rst
+++ b/newsfragments/2423.bugfix.rst
@@ -1,0 +1,3 @@
+Domain "leakage", or nodes saving metadata about nodes from other domains (but never being able to verify them) was still possible because domain-checking only occurred in the high-level APIs (and not, for example, when checking metadata POSTed to the node_metadata_exchange endpoint).  This fixes that (fixes #2417).
+
+Additionally, domains are no longer separated into "serving" or "learning".  Each Learner instance now has exactly one domain, and it is called domain.

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -50,15 +50,19 @@ class FleetSensor:
         self._marked = defaultdict(list)  # Beginning of bucketing.
         self.states = OrderedDict()
 
-    def __setitem__(self, key, value):
-        self._nodes[key] = value
+    def __setitem__(self, checksum_address, node_or_sprout):
+        if node_or_sprout.domain == self.domain:
+            self._nodes[checksum_address] = node_or_sprout
 
-        if self._tracking:
-            self.log.info("Updating fleet state after saving node {}".format(value))
-            self.record_fleet_state()
+            if self._tracking:
+                self.log.info("Updating fleet state after saving node {}".format(node_or_sprout))
+                self.record_fleet_state()
+        else:
+            msg = f"Rejected node {node_or_sprout} because its domain is '{node_or_sprout.domain}' but we're only tracking '{self.domain}'"
+            self.log.warn(msg)
 
-    def __getitem__(self, item):
-        return self._nodes[item]
+    def __getitem__(self, checksum_address):
+        return self._nodes[checksum_address]
 
     def __bool__(self):
         return bool(self._nodes)

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -42,7 +42,8 @@ class FleetSensor:
     log = Logger("Learning")
     FleetState = namedtuple("FleetState", ("nickname", "icon", "nodes", "updated", "checksum"))
 
-    def __init__(self):
+    def __init__(self, domain: str):
+        self.domain = domain
         self.additional_nodes_to_track = []
         self.updated = maya.now()
         self._nodes = OrderedDict()

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1111,7 +1111,7 @@ class Ursula(Teacher, Character, Worker):
                 rest_app, datastore = make_rest_app(
                     this_node=self,
                     db_filepath=db_filepath,
-                    serving_domain=domain,
+                    domain=domain,
                 )
 
                 # TLSHostingPower (Ephemeral Powers and Private Keys)
@@ -1237,7 +1237,7 @@ class Ursula(Teacher, Character, Worker):
         # if learning:  # TODO: Include learning startup here with the rest of the services?
         #     self.start_learning_loop(now=self._start_learning_now)
         #     if emitter:
-        #         emitter.message(f"✓ Node Discovery ({','.join(self.learning_domain)})", color='green')
+        #         emitter.message(f"✓ Node Discovery ({','.join(self.domain)})", color='green')
 
         if self._availability_check and availability:
             self._availability_tracker.start(now=False)  # wait...
@@ -1352,7 +1352,7 @@ class Ursula(Teacher, Character, Worker):
 
         as_bytes = bytes().join((version,
                                  self.canonical_public_address,
-                                 bytes(VariableLengthBytestring(self.serving_domain.encode('utf-8'))),
+                                 bytes(VariableLengthBytestring(self.domain.encode('utf-8'))),
                                  self.timestamp_bytes(),
                                  bytes(self._interface_signature),
                                  bytes(VariableLengthBytestring(self.decentralized_identity_evidence)),  # FIXME: Fixed length doesn't work with federated

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -224,7 +224,7 @@ class Learner:
         self._learning_listeners = defaultdict(list)
         self._node_ids_to_learn_about_immediately = set()
 
-        self.__known_nodes = self.tracker_class()
+        self.__known_nodes = self.tracker_class(domain=domain)
         self._verify_node_bonding = verify_node_bonding
 
         self.lonely = lonely

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -103,6 +103,11 @@ class NodeSprout(PartiallyKwargifiedBytes):
         return self.processed_objects['verifying_key'][0]
 
     @property
+    def domain(self) -> str:
+        domain_bytes = PartiallyKwargifiedBytes.__getattr__(self, "domain")
+        return domain_bytes.decode("utf-8")
+
+    @property
     def checksum_address(self):
         if not self._checksum_address:
             self._checksum_address = to_checksum_address(self.public_address)

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -355,12 +355,8 @@ class Learner:
         restored_from_disk = []
         invalid_nodes = defaultdict(list)
         for node in stored_nodes:
-            try:  # Workaround until #2356 is fixed
-                node_domain = node.domain.decode('utf-8')
-            except:  # TODO: The heck is happening here?
-                node_domain = node.domain
-            if node_domain != self.domain:
-                invalid_nodes[node_domain].append(node)
+            if node.domain != self.domain:
+                invalid_nodes[node.domain].append(node)
                 continue
             restored_node = self.remember_node(node, record_fleet_state=False)  # TODO: Validity status 1866
             restored_from_disk.append(restored_node)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -80,7 +80,7 @@ class ProxyRESTServer:
 def make_rest_app(
         db_filepath: str,
         this_node,
-        serving_domain,
+        domain,
         log: Logger=Logger("http-application-layer")
         ) -> Tuple[Flask, Datastore]:
     """
@@ -97,12 +97,12 @@ def make_rest_app(
 
     log.info("Starting datastore {}".format(db_filepath))
     datastore = Datastore(db_filepath)
-    rest_app = _make_rest_app(weakref.proxy(datastore), weakref.proxy(this_node), serving_domain, log)
+    rest_app = _make_rest_app(weakref.proxy(datastore), weakref.proxy(this_node), domain, log)
 
     return rest_app, datastore
 
 
-def _make_rest_app(datastore: Datastore, this_node, serving_domain: str, log: Logger) -> Flask:
+def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) -> Flask:
 
     from nucypher.characters.lawful import Alice, Ursula
     _alice_class = Alice
@@ -436,7 +436,7 @@ def _make_rest_app(datastore: Datastore, this_node, serving_domain: str, log: Lo
                 content = status_template.render(this_node=this_node,
                                                  known_nodes=this_node.known_nodes,
                                                  previous_states=previous_states,
-                                                 domain=serving_domain,
+                                                 domain=domain,
                                                  version=nucypher.__version__,
                                                  checksum_address=this_node.checksum_address)
             except Exception as e:

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -116,7 +116,7 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
         base_payload = {'app_version': nucypher.__version__,
                         'teacher_version': str(self.ursula.TEACHER_VERSION),
                         'host': str(self.ursula.rest_interface),
-                        'domain': self.ursula.learning_domain,
+                        'domain': self.ursula.domain,
                         'nickname': str(self.ursula.nickname),
                         'nickname_icon': self.ursula.nickname_icon,
                         'fleet_state': str(self.ursula.known_nodes.checksum),

--- a/tests/acceptance/characters/test_decentralized_grant.py
+++ b/tests/acceptance/characters/test_decentralized_grant.py
@@ -104,8 +104,8 @@ def test_bob_retrieves_treasure_map_from_decentralized_node(enacted_blockchain_p
     except with an `enacted_blockchain_policy`.
     """
     bob = enacted_blockchain_policy.bob
-    _previous_domain = bob.learning_domain
-    bob.learning_domain = None  # Bob has no knowledge of the network.
+    _previous_domain = bob.domain
+    bob.domain = None  # Bob has no knowledge of the network.
 
     with pytest.raises(bob.NotEnoughTeachers):
         treasure_map_from_wire = bob.get_treasure_map(enacted_blockchain_policy.alice.stamp,
@@ -113,7 +113,7 @@ def test_bob_retrieves_treasure_map_from_decentralized_node(enacted_blockchain_p
 
     # Bob finds out about one Ursula (in the real world, a seed node, hardcoded based on his learning domain)
     bob.done_seeding = False
-    bob.learning_domain = _previous_domain
+    bob.domain = _previous_domain
 
     # ...and then learns about the rest of the network.
     bob.learn_from_teacher_node(eager=True)

--- a/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
@@ -526,7 +526,8 @@ def test_collect_rewards_integration(click_runner,
                     rest_port=ursula_port,
                     start_working_now=False,
                     network_middleware=MockRestMiddleware(),
-                    db_filepath=tempfile.mkdtemp())
+                    db_filepath=tempfile.mkdtemp(),
+                    domain=TEMPORARY_DOMAIN)
 
     MOCK_KNOWN_URSULAS_CACHE[ursula_port] = ursula
     assert ursula.worker_address == worker_address

--- a/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
@@ -595,7 +595,8 @@ def test_collect_rewards_integration(click_runner,
                     rest_host='127.0.0.1',
                     rest_port=ursula_port,
                     network_middleware=MockRestMiddleware(),
-                    db_filepath=tempfile.mkdtemp())
+                    db_filepath=tempfile.mkdtemp(),
+                    domain=TEMPORARY_DOMAIN)
 
     MOCK_KNOWN_URSULAS_CACHE[ursula_port] = ursula
     assert ursula.worker_address == worker_address

--- a/tests/acceptance/learning/test_fault_tolerance.py
+++ b/tests/acceptance/learning/test_fault_tolerance.py
@@ -20,6 +20,7 @@ from twisted.logger import LogLevel, globalLogPublisher
 
 from constant_sorrow.constants import NOT_SIGNED
 from nucypher.acumen.perception import FleetSensor
+from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Learner
 from tests.utils.middleware import MockRestMiddleware
@@ -45,7 +46,7 @@ def test_blockchain_ursula_stamp_verification_tolerance(blockchain_ursulas, mock
     unsigned._Teacher__decentralized_identity_evidence = NOT_SIGNED
 
     # Wipe known nodes!
-    lonely_blockchain_learner._Learner__known_nodes = FleetSensor()
+    lonely_blockchain_learner._Learner__known_nodes = FleetSensor(domain=TEMPORARY_DOMAIN)
     lonely_blockchain_learner._current_teacher_node = blockchain_teacher
     lonely_blockchain_learner.remember_node(blockchain_teacher)
 

--- a/tests/acceptance/network/test_network_actors.py
+++ b/tests/acceptance/network/test_network_actors.py
@@ -23,6 +23,7 @@ import pytest
 from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import FleetSensor
 from nucypher.characters.unlawful import Vladimir
+from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.crypto.powers import SigningPower
 from nucypher.datastore.models import TreasureMap
 from tests.utils.middleware import MockRestMiddleware
@@ -44,7 +45,7 @@ def test_all_blockchain_ursulas_know_about_all_other_ursulas(blockchain_ursulas,
 
 def test_blockchain_alice_finds_ursula_via_rest(blockchain_alice, blockchain_ursulas):
     # Imagine alice knows of nobody.
-    blockchain_alice._Learner__known_nodes = FleetSensor()
+    blockchain_alice._Learner__known_nodes = FleetSensor(domain=TEMPORARY_DOMAIN)
 
     blockchain_alice.remember_node(blockchain_ursulas[0])
     blockchain_alice.learn_from_teacher_node()

--- a/tests/integration/config/test_character_configuration.py
+++ b/tests/integration/config/test_character_configuration.py
@@ -77,7 +77,7 @@ def test_federated_development_character_configurations(character, configuration
     assert thing_one.federated_only is True
 
     # Domain
-    assert TEMPORARY_DOMAIN == thing_one.learning_domain
+    assert TEMPORARY_DOMAIN == thing_one.domain
 
     # Node Storage
     assert configuration.TEMP_CONFIGURATION_DIR_PREFIX in thing_one.keyring_root

--- a/tests/integration/config/test_configuration_persistence.py
+++ b/tests/integration/config/test_configuration_persistence.py
@@ -21,6 +21,7 @@ import os
 
 from nucypher.characters.lawful import Bob
 from nucypher.config.characters import AliceConfiguration
+from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.crypto.powers import DecryptingPower, SigningPower
 from tests.constants import INSECURE_DEVELOPMENT_PASSWORD
 from tests.utils.middleware import MockRestMiddleware
@@ -31,7 +32,7 @@ def test_alices_powers_are_persistent(federated_ursulas, tmpdir):
     alice_config = AliceConfiguration(
         config_root=os.path.join(tmpdir, 'nucypher-custom-alice-config'),
         network_middleware=MockRestMiddleware(),
-        known_nodes=federated_ursulas,
+        domain=TEMPORARY_DOMAIN,
         start_learning_now=False,
         federated_only=True,
         save_metadata=False,

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -82,7 +82,7 @@ def test_learner_restores_metadata_from_storage(lonely_ursula_maker, tmpdir):
                                        know_each_other=True,
                                        save_metadata=False)
     learner, buddy = new_learners
-    buddy._Learner__known_nodes = FleetSensor()
+    buddy._Learner__known_nodes = FleetSensor(domain="fistro")
 
     # The learner shouldn't learn about any node from the first domain, since it's different.
     learner.learn_from_teacher_node()

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -15,8 +15,6 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from functools import partial
-
 from nucypher.acumen.perception import FleetSensor
 from nucypher.config.storages import LocalFileBasedNodeStorage
 
@@ -59,8 +57,8 @@ def test_learner_learns_about_domains_separately(lonely_ursula_maker, caplog):
     assert other_first_domain_learner in new_first_domain_learner.known_nodes
     assert _nobody in new_first_domain_learner.known_nodes
 
-def test_learner_restores_metadata_from_storage(lonely_ursula_maker, tmpdir):
 
+def test_learner_restores_metadata_from_storage(lonely_ursula_maker, tmpdir):
     # Create a local file-based node storage
     root = tmpdir.mkdir("known_nodes")
     metadata = root.mkdir("metadata")
@@ -97,14 +95,13 @@ def test_learner_restores_metadata_from_storage(lonely_ursula_maker, tmpdir):
 
 
 def test_learner_ignores_stored_nodes_from_other_domains(lonely_ursula_maker, tmpdir):
-
     learner, other_staker = lonely_ursula_maker(domain="call-it-mainnet",
-                                        know_each_other=True,
-                                        quantity=2)
+                                                know_each_other=True,
+                                                quantity=2)
 
     pest, *other_ursulas_from_the_wrong_side_of_the_tracks = lonely_ursula_maker(domain="i-dunno-testt-maybe",
-                                       quantity=5,
-                                       know_each_other=True)
+                                                                                 quantity=5,
+                                                                                 know_each_other=True)
 
     assert pest not in learner.known_nodes
     pest._current_teacher_node = learner

--- a/tests/integration/learning/test_firstula_circumstances.py
+++ b/tests/integration/learning/test_firstula_circumstances.py
@@ -25,12 +25,11 @@ from tests.utils.ursula import make_federated_ursulas
 
 def test_proper_seed_node_instantiation(lonely_ursula_maker):
     _lonely_ursula_maker = partial(lonely_ursula_maker, quantity=1)
-    firstula = _lonely_ursula_maker().pop()
+    firstula = _lonely_ursula_maker(domain="this-is-meaningful-now").pop()
     firstula_as_seed_node = firstula.seed_node_metadata()
-    any_other_ursula = _lonely_ursula_maker(seed_nodes=[firstula_as_seed_node], domain="useless domain").pop()
+    any_other_ursula = _lonely_ursula_maker(seed_nodes=[firstula_as_seed_node], domain="this-is-meaningful-now").pop()
 
     assert not any_other_ursula.known_nodes
-    # print(f"**********************Starting {any_other_ursula} loop")
     any_other_ursula.start_learning_loop(now=True)
     assert firstula in any_other_ursula.known_nodes
 

--- a/tests/integration/learning/test_learning_upgrade.py
+++ b/tests/integration/learning/test_learning_upgrade.py
@@ -33,7 +33,7 @@ def test_emit_warning_upon_new_version(lonely_ursula_maker, caplog):
                                                        know_each_other=True)
     learner, _bystander = lonely_ursula_maker(quantity=2, domain="no hardcodes")
 
-    learner.learning_domain = "no hardcodes"
+    learner.domain = "no hardcodes"
     learner.remember_node(teacher)
     teacher.remember_node(learner)
     teacher.remember_node(new_node)

--- a/tests/integration/learning/test_learning_versions.py
+++ b/tests/integration/learning/test_learning_versions.py
@@ -101,4 +101,4 @@ def test_deserialize_ursulas_version_2():
         assert version == Ursula.LEARNER_VERSION
 
         resurrected_ursula = Ursula.from_bytes(fossilized_ursula, fail_fast=True)
-        assert TEMPORARY_DOMAIN.encode('utf-8') == resurrected_ursula.domain
+        assert TEMPORARY_DOMAIN == resurrected_ursula.domain

--- a/tests/integration/network/test_treasure_map_integration.py
+++ b/tests/integration/network/test_treasure_map_integration.py
@@ -74,8 +74,8 @@ def test_bob_can_retrieve_the_treasure_map_and_decrypt_it(enacted_federated_poli
     that Bob can retrieve it with only the information about which he is privy pursuant to the PolicyGroup.
     """
     bob = enacted_federated_policy.bob
-    _previous_domain = bob.learning_domain
-    bob.learning_domain = None  # Bob has no knowledge of the network.
+    _previous_domain = bob.domain
+    bob.domain = None  # Bob has no knowledge of the network.
 
     # Of course, in the real world, Bob has sufficient information to reconstitute a PolicyGroup, gleaned, we presume,
     # through a side-channel with Alice.
@@ -88,7 +88,7 @@ def test_bob_can_retrieve_the_treasure_map_and_decrypt_it(enacted_federated_poli
 
     # Bob finds out about one Ursula (in the real world, a seed node, hardcoded based on his learning domain)
     bob.done_seeding = False
-    bob.learning_domain = _previous_domain
+    bob.domain = _previous_domain
 
     # ...and then learns about the rest of the network.
     bob.learn_from_teacher_node(eager=True)

--- a/tests/mock/performance_mocks.py
+++ b/tests/mock/performance_mocks.py
@@ -197,7 +197,7 @@ class NotARestApp:
         if self._actual_rest_app is None:
             self._actual_rest_app, self._datastore = make_rest_app(db_filepath=tempfile.mkdtemp(),
                                                                    this_node=self.this_node,
-                                                                   serving_domain=None)
+                                                                   domain=None)
             _new_view_functions = self._ViewFunctions(self._actual_rest_app.view_functions)
             self._actual_rest_app.view_functions = _new_view_functions
             self._actual_rest_apps.append(

--- a/tests/unit/test_work_tracker_error_handling.py
+++ b/tests/unit/test_work_tracker_error_handling.py
@@ -1,3 +1,20 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 import pytest_twisted
 from twisted.internet import task
 from twisted.internet import threads


### PR DESCRIPTION
Domain "leakage", or nodes saving metadata about nodes from other domains (but never being able to verify them) was still possible because domain-checking only occurred in the high-level APIs (and not, for example, when checking metadata POSTed to the node_metadata_exchange endpoint).  This fixes that (fixes #2417).

**As such, the mechanism by which ibex nodes are leaking into some mainnet fleet states is now disabled.**

Additionally, domains are no longer separated into "serving" or "learning".  Each Learner instance now has exactly one domain, and it is called domain.  Fixes #2356.

*Note: the behavior of `handpicked ursulas` is unchanged.  In other words, it is still possible to explicitly specify an off-domain Ursula during an action that takes `handpicked_ursulas` and use it despite it being on a different domain.*