### PR TITLE
Add newsfragment for PR #2346.

### DIFF
--- a/newsfragments/2346.doc.rst
+++ b/newsfragments/2346.doc.rst
@@ -1,0 +1,1 @@
+Document usage of hardware wallets for signing.


### PR DESCRIPTION
Just realized that #2346 was from some time ago and wasn't rebased before getting merged. Therefore, it didn't include a newsfragment for the release notes.