### PR TITLE
Improve handling of incorrect password via software signer

### DIFF
--- a/newsfragments/2451.misc.rst
+++ b/newsfragments/2451.misc.rst
@@ -1,0 +1,1 @@
+Supplies `AccessDenied` exception class for better incorrect password handling.

--- a/nucypher/blockchain/eth/signers/base.py
+++ b/nucypher/blockchain/eth/signers/base.py
@@ -49,6 +49,9 @@ class Signer(ABC):
             self.message = f'Unknown account {account}.'
             super().__init__(self.message)
 
+    class AccessDenied(SignerError):
+        """Raised when ACCESS DENIED"""
+
     @classmethod
     @abstractmethod
     def uri_scheme(cls) -> str:

--- a/nucypher/blockchain/eth/signers/software.py
+++ b/nucypher/blockchain/eth/signers/software.py
@@ -356,7 +356,7 @@ class KeystoreSigner(Signer):
         the keystore instance is decryption is successful.
         """
         if not password:
-            # It is possible that password is None here passed form the above layer,
+            # It is possible that password is None here passed from the above layer
             # causing Account.decrypt to crash, expecting a value for password.
             raise self.AccessDenied('No password supplied to unlock account.')
 
@@ -369,7 +369,7 @@ class KeystoreSigner(Signer):
                 signing_key = Account.from_key(Account.decrypt(key_metadata, password))
                 self.__signers[account] = signing_key
             except ValueError as e:
-                raise self.AccessDenied("Invalid or incorrect signer password") from e
+                raise self.AccessDenied("Invalid or incorrect signer password.") from e
         return True
 
     @validate_checksum_address

--- a/nucypher/blockchain/eth/signers/software.py
+++ b/nucypher/blockchain/eth/signers/software.py
@@ -355,16 +355,17 @@ class KeystoreSigner(Signer):
         Decrypt the signing material from the key metadata file and cache it on
         the keystore instance is decryption is successful.
         """
+        if not password:
+            # It is possible that password is None here passed form the above layer,
+            # causing Account.decrypt to crash, expecting a value for password.
+            raise self.AccessDenied('No password supplied to unlock account.')
+
         if not self.__signers.get(account):
             try:
                 key_metadata = self.__keys[account]
-            except ValueError:
-                return False  # Decryption Failed
             except KeyError:
                 raise self.UnknownAccount(account=account)
             try:
-                # TODO: It is possible that password is None here passed form the above leayer,
-                #       causing Account.decrypt to crash, expecting a value for password.
                 signing_key = Account.from_key(Account.decrypt(key_metadata, password))
                 self.__signers[account] = signing_key
             except ValueError as e:

--- a/nucypher/blockchain/eth/signers/software.py
+++ b/nucypher/blockchain/eth/signers/software.py
@@ -362,11 +362,13 @@ class KeystoreSigner(Signer):
                 return False  # Decryption Failed
             except KeyError:
                 raise self.UnknownAccount(account=account)
-            else:
+            try:
                 # TODO: It is possible that password is None here passed form the above leayer,
                 #       causing Account.decrypt to crash, expecting a value for password.
                 signing_key = Account.from_key(Account.decrypt(key_metadata, password))
                 self.__signers[account] = signing_key
+            except ValueError as e:
+                raise self.AccessDenied("Invalid or incorrect signer password") from e
         return True
 
     @validate_checksum_address

--- a/tests/integration/blockchain/test_keystore_signer_filesystem_integration.py
+++ b/tests/integration/blockchain/test_keystore_signer_filesystem_integration.py
@@ -86,6 +86,7 @@ def unknown_address():
     address = Account.create().address
     return address
 
+
 def test_invalid_keystore(tmp_path):
     with pytest.raises(Signer.InvalidSignerURI) as e:
         Signer.from_signer_uri(uri=f'keystore:{tmp_path/"nonexistent"}', testnet=True)
@@ -168,6 +169,9 @@ def test_keystore_locking(mock_account, good_signer, unknown_address):
 
     with pytest.raises(Signer.UnknownAccount):
         good_signer.unlock_account(account=unknown_address, password=INSECURE_DEVELOPMENT_PASSWORD)
+
+    with pytest.raises(Signer.AccessDenied, match='No password supplied to unlock account.'):
+        good_signer.unlock_account(account=mock_account.address, password=None)
 
     successful_unlock = good_signer.unlock_account(account=mock_account.address, password=INSECURE_DEVELOPMENT_PASSWORD)
     assert successful_unlock


### PR DESCRIPTION
Gives CLI users an `AccessDenied` exception instead of `MACMismatch` on incorrect password