### PR TITLE
IP address checks on worker startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ docs/source/api/
 docs/source/contracts_api/
 
 tests/unit/.hypothesis/
+.hypothesis/

--- a/deploy/ansible/worker/include/run_ursula.yml
+++ b/deploy/ansible/worker/include/run_ursula.yml
@@ -133,5 +133,5 @@
       become: yes
       wait_for:
         path: "/var/lib/docker/containers/{{ursula_container_name['stdout']}}/{{ursula_container_name['stdout']}}-json.log"
-        search_regex: "Awaiting worker qualification"
+        search_regex: "External IP matches configuration"
         timeout: 30

--- a/dev/docker/8-federated-ursulas.yml
+++ b/dev/docker/8-federated-ursulas.yml
@@ -38,7 +38,7 @@ services:
     image: dev:nucypher
     depends_on:
       - ursula1
-    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.2 --rest-port 11500 --teacher 172.28.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.28.1.2 --rest-port 11500 --teacher 172.28.1.1:11500 
     networks:
       nucypher_net:
         ipv4_address: 172.28.1.2
@@ -121,6 +121,7 @@ services:
       nucypher_net:
         ipv4_address: 172.28.1.8
     container_name: ursula8
+
 networks:
   nucypher_net:
     ipam:

--- a/newsfragments/2462.feature.rst
+++ b/newsfragments/2462.feature.rst
@@ -1,0 +1,1 @@
+Compare Ursula IP address with configuration values on startup to help ensure node availability.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -15,6 +15,7 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 import csv
 import json
 import os
@@ -1486,9 +1487,7 @@ class Worker(NucypherTokenActor):
         last_provided_feedback = start
 
         emitter = StdoutEmitter()
-        message = f"Awaiting worker qualification\n" \
-                  f"Startup will resume when {self.__worker_address} is funded and bonded to a staking account."
-        emitter.message(message, color='yellow')
+        emitter.message("Qualifying worker", color='yellow')
 
         funded, bonded = False, False
         while True:
@@ -1500,12 +1499,12 @@ class Worker(NucypherTokenActor):
             # Bonding
             if (not bonded) and (staking_address != NULL_ADDRESS):
                 bonded = True
-                emitter.message(f"✓ Worker is bonded to ({staking_address})!", color='green', bold=True)
+                emitter.message(f"✓ Worker is bonded to {staking_address}", color='green')
 
             # Balance
             if ether_balance and (not funded):
                 funded, balance = True, Web3.fromWei(ether_balance, 'ether')
-                emitter.message(f"✓ Worker is funded with {balance} ETH!", color='green', bold=True)
+                emitter.message(f"✓ Worker is funded with {balance} ETH", color='green')
 
             # Success and Escape
             if staking_address != NULL_ADDRESS and ether_balance:
@@ -1524,7 +1523,8 @@ class Worker(NucypherTokenActor):
                         waiting_for = "bonding and funding"
                     else:
                         waiting_for = "bonding" if not bonded else "funding"
-                    emitter.message(f"ⓘ  Worker not fully started - awaiting {waiting_for} ...", color='blue', bold=True)
+                    message = f"ⓘ  Worker startup is paused. Waiting for {waiting_for} ..."
+                    emitter.message(message, color='blue', bold=True)
                     last_provided_feedback = now
 
             # Crash on Timeout
@@ -1541,8 +1541,6 @@ class Worker(NucypherTokenActor):
 
             # Increment
             time.sleep(poll_rate)
-
-        emitter.message("✓ Worker settings confirmed", color='green')
 
     @property
     def eth_balance(self) -> Decimal:

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1437,7 +1437,7 @@ class Worker(NucypherTokenActor):
                  is_me: bool,
                  work_tracker: WorkTracker = None,
                  worker_address: str = None,
-                 start_working_now: bool = True,
+                 commit_now: bool = False,
                  block_until_ready: bool = True,
                  *args, **kwargs):
 
@@ -1467,8 +1467,7 @@ class Worker(NucypherTokenActor):
             self.stakes = StakeList(registry=self.registry, checksum_address=self.checksum_address)
             self.stakes.refresh()
             self.work_tracker = work_tracker or WorkTracker(worker=self)
-            if start_working_now:
-                self.work_tracker.start(act_now=start_working_now)
+            self.work_tracker.start(commit_now=commit_now)
 
     def block_until_ready(self, poll_rate: int = None, timeout: int = None, feedback_rate: int = None):
         """

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1459,15 +1459,14 @@ class Worker(NucypherTokenActor):
         self.__start_time = WORKER_NOT_RUNNING
         self.__uptime_period = WORKER_NOT_RUNNING
 
-        # Workers cannot be started without being assigned a stake first.
         if is_me:
             if block_until_ready:
+                # Workers cannot be started before bonding.
                 self.block_until_ready()
-
+            self.stakes = StakeList(registry=self.registry, checksum_address=self.checksum_address)
+            self.stakes.refresh()
+            self.work_tracker = work_tracker or WorkTracker(worker=self)
             if start_working_now:
-                self.stakes = StakeList(registry=self.registry, checksum_address=self.checksum_address)
-                self.stakes.refresh()
-                self.work_tracker = work_tracker or WorkTracker(worker=self)
                 self.work_tracker.start(act_now=start_working_now)
 
     def block_until_ready(self, poll_rate: int = None, timeout: int = None, feedback_rate: int = None):

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1719,18 +1719,20 @@ class ContractAgency:
         if not issubclass(agent_class, EthereumContractAgent):
             raise TypeError(f"Only agent subclasses can be used from the agency.")
 
+        registry_id = None
         if not registry:
             if len(cls.__agents) == 1:
-                _registry_id = list(cls.__agents.keys()).pop()
+                registry_id = list(cls.__agents.keys()).pop()
             else:
                 raise ValueError("Need to specify a registry in order to get an agent from the ContractAgency")
 
+        registry_id = registry_id or registry.id
         try:
-            return cast(Agent, cls.__agents[registry.id][agent_class])
+            return cast(Agent, cls.__agents[registry_id][agent_class])
         except KeyError:
             agent = cast(Agent, agent_class(registry=registry, provider_uri=provider_uri))
-            cls.__agents[registry.id] = cls.__agents.get(registry.id, dict())
-            cls.__agents[registry.id][agent_class] = agent
+            cls.__agents[registry_id] = cls.__agents.get(registry_id, dict())
+            cls.__agents[registry_id][agent_class] = agent
             return agent
 
     @staticmethod

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -1719,14 +1719,13 @@ class ContractAgency:
         if not issubclass(agent_class, EthereumContractAgent):
             raise TypeError(f"Only agent subclasses can be used from the agency.")
 
-        registry_id = None
         if not registry:
             if len(cls.__agents) == 1:
                 registry_id = list(cls.__agents.keys()).pop()
             else:
                 raise ValueError("Need to specify a registry in order to get an agent from the ContractAgency")
-
-        registry_id = registry_id or registry.id
+        else:
+            registry_id = registry.id
         try:
             return cast(Agent, cls.__agents[registry_id][agent_class])
         except KeyError:

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -628,9 +628,9 @@ class WorkTracker:
             # the effect of this is that we get one immediate retry.
             # After that, the random_interval will be honored until
             # success is achieved
-            act_now = self._consecutive_fails < 1
+            commit_now = self._consecutive_fails < 1
             self._consecutive_fails += 1
-            self.start(act_now=act_now)
+            self.start(commit_now=commit_now)
 
 
     def __work_requirement_is_satisfied(self) -> bool:

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -585,7 +585,7 @@ class WorkTracker:
             self._tracking_task.stop()
             self.log.info(f"STOPPED WORK TRACKING")
 
-    def start(self, act_now: bool = True, requirement_func: Callable = None, force: bool = False) -> None:
+    def start(self, commit_now: bool = True, requirement_func: Callable = None, force: bool = False) -> None:
         """
         High-level stake tracking initialization, this function aims
         to be safely called at any time - For example, it is okay to call
@@ -602,8 +602,8 @@ class WorkTracker:
         self.__uptime_period = self.staking_agent.get_current_period()
         self.__current_period = self.__uptime_period
 
-        self.log.info(f"START WORK TRACKING (immediate action: {act_now})")
-        d = self._tracking_task.start(interval=self.random_interval(fails=self._consecutive_fails), now=act_now)
+        self.log.info(f"START WORK TRACKING (immediate action: {commit_now})")
+        d = self._tracking_task.start(interval=self.random_interval(fails=self._consecutive_fails), now=commit_now)
         d.addErrback(self.handle_working_errors)
 
     def _crash_gracefully(self, failure=None) -> None:

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -104,6 +104,8 @@ class Character(Learner):
 
         #
         # Operating Mode
+        #
+
         if hasattr(self, '_interface_class'):  # TODO: have argument about meaning of 'lawful'
             #                                         and whether maybe only Lawful characters have an interface
             self.interface = self._interface_class(character=self)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1057,7 +1057,7 @@ class Ursula(Teacher, Character, Worker):
                  block_until_ready: bool = True,
                  # TODO: Must be true in order to set staker address - Allow for manual staker addr to be passed too!
                  work_tracker: WorkTracker = None,
-                 start_working_now: bool = False,
+                 commit_now: bool = True,
                  client_password: str = None,
 
                  # Character
@@ -1139,7 +1139,7 @@ class Ursula(Teacher, Character, Worker):
                                 checksum_address=checksum_address,
                                 worker_address=worker_address,
                                 work_tracker=work_tracker,
-                                start_working_now=start_working_now,
+                                commit_now=commit_now,
                                 block_until_ready=block_until_ready)
             except (Exception, self.WorkerError):  # FIXME
                 # TODO: Do not announce self to "other nodes" until this init is finished.
@@ -1296,7 +1296,7 @@ class Ursula(Teacher, Character, Worker):
                 emitter.message(f"✓ Availability Checks", color='green')
 
         if worker and not self.federated_only:
-            self.work_tracker.start(act_now=True)  # requirement_func=self._availability_tracker.status)  # TODO: #2277
+            self.work_tracker.start(commit_now=True)  # requirement_func=self._availability_tracker.status)  # TODO: #2277
             if emitter:
                 emitter.message(f"✓ Work Tracking", color='green')
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1284,8 +1284,7 @@ class Ursula(Teacher, Character, Worker):
             if emitter:
                 emitter.message(f"✓ Database Pruning", color='green')
 
-        # TODO: block until specific nodes are known here?
-        if discovery:
+        if discovery and not self.lonely:
             self.start_learning_loop(now=self._start_learning_now)
             if emitter:
                 emitter.message(f"✓ Node Discovery - {self.domain}", color='green')

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1277,18 +1277,18 @@ class Ursula(Teacher, Character, Worker):
         #
 
         if emitter:
-            emitter.message(f"Starting services...", color='yellow')
+            emitter.message(f"Starting services", color='yellow')
 
         if pruning:
             self.__pruning_task = self._datastore_pruning_task.start(interval=self._pruning_interval, now=True)
             if emitter:
-                emitter.message(f"✓ Database pruning", color='green')
+                emitter.message(f"✓ Database Pruning", color='green')
 
         # TODO: block until specific nodes are known here?
-        # if learning:  # TODO: Include learning startup here with the rest of the services?
-        #     self.start_learning_loop(now=self._start_learning_now)
-        #     if emitter:
-        #         emitter.message(f"✓ Node Discovery ({','.join(self.domain)})", color='green')
+        if discovery:
+            self.start_learning_loop(now=self._start_learning_now)
+            if emitter:
+                emitter.message(f"✓ Node Discovery - {self.domain}", color='green')
 
         if self._availability_check and availability:
             self._availability_tracker.start(now=False)  # wait...
@@ -1316,9 +1316,8 @@ class Ursula(Teacher, Character, Worker):
             stdio.StandardIO(UrsulaCommandProtocol(ursula=self, emitter=emitter))
 
         if hendrix:
-
             if emitter:
-                emitter.message(f"Starting Ursula on {self.rest_interface}", color='green', bold=True)
+                emitter.message(f"✓ Rest Server https://{self.rest_interface}", color='green')
 
             deployer = self.get_deployer()
             deployer.addServices()

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1057,7 +1057,7 @@ class Ursula(Teacher, Character, Worker):
                  block_until_ready: bool = True,
                  # TODO: Must be true in order to set staker address - Allow for manual staker addr to be passed too!
                  work_tracker: WorkTracker = None,
-                 start_working_now: bool = True,
+                 start_working_now: bool = False,
                  client_password: str = None,
 
                  # Character
@@ -1260,14 +1260,14 @@ class Ursula(Teacher, Character, Worker):
 
     def run(self,
             emitter: StdoutEmitter = None,
-            hendrix: bool = True,
-            learning: bool = True,
+            discovery: bool = True,
             availability: bool = True,
             worker: bool = True,
             pruning: bool = True,
             interactive: bool = False,
+            hendrix: bool = True,
             start_reactor: bool = True,
-            prometheus_config: 'PrometheusMetricsConfig' = None,
+            prometheus_config: 'PrometheusMetricsConfig' = None
             ) -> None:
 
         """Schedule and start select ursula services, then optionally start the reactor."""

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1284,10 +1284,11 @@ class Ursula(Teacher, Character, Worker):
             if emitter:
                 emitter.message(f"✓ Database Pruning", color='green')
 
-        if discovery and not self.lonely:
-            self.start_learning_loop(now=self._start_learning_now)
-            if emitter:
-                emitter.message(f"✓ Node Discovery - {self.domain}", color='green')
+        # TODO: Startup node discovery here with the rest of Ursula's services.
+        # if discovery and not self.lonely:
+        #     self.start_learning_loop(now=self._start_learning_now)
+        #     if emitter:
+        #         emitter.message(f"✓ Node Discovery - {self.domain}", color='green')
 
         if self._availability_check and availability:
             self._availability_tracker.start(now=False)  # wait...

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1270,12 +1270,14 @@ class Ursula(Teacher, Character, Worker):
             interactive: bool = False,
             hendrix: bool = True,
             start_reactor: bool = True,
-            prometheus_config: 'PrometheusMetricsConfig' = None
+            prometheus_config: 'PrometheusMetricsConfig' = None,
+            preflight: bool = True
             ) -> None:
 
         """Schedule and start select ursula services, then optionally start the reactor."""
 
-        self.__preflight()
+        if preflight:
+            self.__preflight()
 
         #
         # Async loops ordered by schedule priority

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -80,7 +80,7 @@ class Vladimir(Ursula):
                        db_filepath=db_filepath,
                        domain=TEMPORARY_DOMAIN,
                        block_until_ready=False,
-                       start_working_now=False,
+                       commit_now=False,
                        rest_host=target_ursula.rest_interface.host,
                        rest_port=target_ursula.rest_interface.port,
                        certificate=target_ursula.rest_server_certificate(),

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -160,10 +160,11 @@ def perform_ip_checkup(emitter: StdoutEmitter, ursula: Ursula, force: bool = Fal
         return  # TODO: crash, or not to crash... that is the question
     ip_mismatch = external_ip != ursula.rest_interface.host
     if ip_mismatch and not force:
-        error = f'External IP address ({external_ip}) does not match configuration ({ursula.rest_interface.host})' \
-                f"\nRun 'nucypher ursula config ip' to reconfigure the IP address then try " \
-                f"again or use --no-ip-checkup to bypass this check."
-        emitter.error(error)
+        error = f'\nX External IP address ({external_ip}) does not match configuration ({ursula.rest_interface.host}).\n'
+        hint = f"Run 'nucypher ursula config ip-address' to reconfigure the IP address then try " \
+               f"again or use --no-ip-checkup to bypass this check.\n"
+        emitter.message(error, color='red')
+        emitter.message(hint, color='yellow')
         raise click.Abort()
     else:
         emitter.message('✓ External IP matches configuration', 'green')

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -162,7 +162,7 @@ def perform_ip_checkup(emitter: StdoutEmitter, ursula: Ursula, force: bool = Fal
     if ip_mismatch and not force:
         error = f'\nX External IP address ({external_ip}) does not match configuration ({ursula.rest_interface.host}).\n'
         hint = f"Run 'nucypher ursula config ip-address' to reconfigure the IP address then try " \
-               f"again or use --no-ip-checkup to bypass this check.\n"
+               f"again or use --no-ip-checkup to bypass this check (not recommended).\n"
         emitter.message(error, color='red')
         emitter.message(hint, color='yellow')
         raise click.Abort()

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -57,7 +57,7 @@ def get_or_update_configuration(emitter: StdoutEmitter,
                                 updates: Optional[dict] = None) -> None:
     """
     Utility for writing updates to an existing configuration file then displaying the result.
-    If the config file is invalid, trey very hard to display the problem.  If there are no updates,
+    If the config file is invalid, try very hard to display the problem.  If there are no updates,
     the config file will be displayed without changes.
     """
     try:

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -148,7 +148,7 @@ def collect_worker_ip_address(emitter: StdoutEmitter, network: str, force: bool 
     return ip
 
 
-def perform_ip_checkup(emitter: StdoutEmitter, ursula: Ursula, force: bool = False) -> None:
+def perform_startup_ip_check(emitter: StdoutEmitter, ursula: Ursula, force: bool = False) -> None:
     """
     Used on ursula startup to determine if the external
     IP address is consistent with the configuration's values.

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -121,7 +121,7 @@ def handle_invalid_configuration_file(emitter: StdoutEmitter,
 
 def collect_external_ip_address(emitter: StdoutEmitter, network: str, force: bool = False) -> str:
 
-    # From environment variable
+    # From environment variable  # TODO: remove this environment variable?
     ip = os.environ.get(NUCYPHER_ENVVAR_WORKER_IP_ADDRESS)
     if ip:
         message = f'Using IP address from {NUCYPHER_ENVVAR_WORKER_IP_ADDRESS} environment variable'
@@ -143,7 +143,6 @@ def collect_external_ip_address(emitter: StdoutEmitter, network: str, force: boo
         if not click.confirm(CONFIRM_URSULA_IPV4_ADDRESS.format(rest_host=ip)):
             ip = click.prompt(COLLECT_URSULA_IPV4_ADDRESS, type=IPV4_ADDRESS)
 
-    emitter.message(f'Configured IP address {ip}')
     return ip
 
 

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -14,6 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 from decimal import Decimal
 
 import click
@@ -35,7 +37,8 @@ from nucypher.cli.actions.confirm import (
     confirm_enable_restaking_lock,
     confirm_enable_winding_down,
     confirm_large_stake,
-    confirm_staged_stake, confirm_disable_snapshots
+    confirm_staged_stake,
+    confirm_disable_snapshots
 )
 from nucypher.cli.actions.select import select_client_account_for_staking, select_stake
 from nucypher.cli.config import group_general_config, GroupGeneralConfig
@@ -67,13 +70,32 @@ from nucypher.cli.literature import (
     SUCCESSFUL_SET_MIN_POLICY_RATE,
     SUCCESSFUL_STAKE_DIVIDE,
     SUCCESSFUL_STAKE_PROLONG,
-    SUCCESSFUL_WORKER_BONDING, NO_MINTABLE_PERIODS, STILL_LOCKED_TOKENS, CONFIRM_MINTING, SUCCESSFUL_MINTING,
-    CONFIRM_COLLECTING_WITHOUT_MINTING, NO_TOKENS_TO_WITHDRAW, NO_FEE_TO_WITHDRAW, CONFIRM_INCREASING_STAKE,
-    PROMPT_STAKE_INCREASE_VALUE, SUCCESSFUL_STAKE_INCREASE, INSUFFICIENT_BALANCE_TO_INCREASE, MAXIMUM_STAKE_REACHED,
-    INSUFFICIENT_BALANCE_TO_CREATE, PROMPT_STAKE_CREATE_VALUE, PROMPT_STAKE_CREATE_LOCK_PERIODS,
-    ONLY_DISPLAYING_MERGEABLE_STAKES_NOTE, CONFIRM_MERGE, SUCCESSFUL_STAKES_MERGE, SUCCESSFUL_ENABLE_SNAPSHOTS,
-    SUCCESSFUL_DISABLE_SNAPSHOTS, CONFIRM_ENABLE_SNAPSHOTS,
-    CONFIRM_STAKE_USE_UNLOCKED, CONFIRM_REMOVE_SUBSTAKE, SUCCESSFUL_STAKE_REMOVAL)
+    SUCCESSFUL_WORKER_BONDING,
+    NO_MINTABLE_PERIODS,
+    STILL_LOCKED_TOKENS,
+    CONFIRM_MINTING,
+    SUCCESSFUL_MINTING,
+    CONFIRM_COLLECTING_WITHOUT_MINTING,
+    NO_TOKENS_TO_WITHDRAW,
+    NO_FEE_TO_WITHDRAW,
+    CONFIRM_INCREASING_STAKE,
+    PROMPT_STAKE_INCREASE_VALUE,
+    SUCCESSFUL_STAKE_INCREASE,
+    INSUFFICIENT_BALANCE_TO_INCREASE,
+    MAXIMUM_STAKE_REACHED,
+    INSUFFICIENT_BALANCE_TO_CREATE,
+    PROMPT_STAKE_CREATE_VALUE,
+    PROMPT_STAKE_CREATE_LOCK_PERIODS,
+    ONLY_DISPLAYING_MERGEABLE_STAKES_NOTE,
+    CONFIRM_MERGE,
+    SUCCESSFUL_STAKES_MERGE,
+    SUCCESSFUL_ENABLE_SNAPSHOTS,
+    SUCCESSFUL_DISABLE_SNAPSHOTS,
+    CONFIRM_ENABLE_SNAPSHOTS,
+    CONFIRM_STAKE_USE_UNLOCKED,
+    CONFIRM_REMOVE_SUBSTAKE,
+    SUCCESSFUL_STAKE_REMOVAL
+)
 from nucypher.cli.options import (
     group_options,
     option_config_file,
@@ -102,7 +124,8 @@ from nucypher.cli.types import (
     EIP55_CHECKSUM_ADDRESS,
     EXISTING_READABLE_FILE,
     GWEI,
-    DecimalRange)
+    DecimalRange
+)
 from nucypher.cli.utils import setup_emitter
 from nucypher.config.characters import StakeHolderConfiguration
 from nucypher.utilities.gas_strategies import construct_fixed_price_gas_strategy

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -387,7 +387,8 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
         URSULA.run(emitter=emitter,
                    start_reactor=not dry_run,
                    interactive=interactive,
-                   prometheus_config=prometheus_config)
+                   prometheus_config=prometheus_config,
+                   preflight=not dev_mode)
     finally:
         if dry_run:
             URSULA.stop()

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -359,6 +359,7 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
     dev_mode = character_options.config_options.dev
 
     if prometheus and not metrics_port:
+        # Require metrics port when using prometheus
         raise click.BadOptionUsage(option_name='metrics-port',
                                    message='--metrics-port is required when using --prometheus')
 
@@ -371,7 +372,6 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
 
     prometheus_config: 'PrometheusMetricsConfig' = None
     if prometheus and not dev_mode:
-        # ensure metrics port is provided
         # Locally scoped to prevent import without prometheus explicitly installed
         from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
         prometheus_config = PrometheusMetricsConfig(port=metrics_port,
@@ -386,8 +386,6 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
     if ip_checkup and not dev_mode:
         perform_startup_ip_check(emitter=emitter, ursula=URSULA, force=force)
 
-    # TODO: should we just not call run at all for "dry_run"
-    # RE: That might make the some tests less accurate
     try:
         URSULA.run(emitter=emitter,
                    start_reactor=not dry_run,

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -409,16 +409,21 @@ def save_metadata(general_config, character_options, config_file):
 
 
 @ursula.command()
+@click.argument('action', required=False)
 @group_config_options
 @option_config_file
 @group_general_config
-def config(general_config, config_options, config_file):
+@option_force
+def config(general_config, config_options, config_file, force, action):
     """View and optionally update the Ursula node's configuration."""
     emitter = setup_emitter(general_config, config_options.worker_address)
     if not config_file:
         config_file = select_config_file(emitter=emitter,
                                          checksum_address=config_options.worker_address,
                                          config_class=UrsulaConfiguration)
+    if action == 'ip-address':
+        rest_host = collect_external_ip_address(emitter=emitter, network=config_options.domain, force=force)
+        config_options.rest_host = rest_host
     updates = config_options.get_updates()
     get_or_update_configuration(emitter=emitter,
                                 config_class=UrsulaConfiguration,

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -17,17 +17,15 @@
 
 
 import click
-import os
 
 from nucypher.blockchain.eth.signers.software import ClefSigner
 from nucypher.cli.actions.auth import get_client_password, get_nucypher_password
 from nucypher.cli.actions.configure import (
     destroy_configuration,
     handle_missing_configuration_file,
-    get_or_update_configuration
+    get_or_update_configuration, configure_external_ip_address
 )
-from nucypher.cli.actions.configure import forget as forget_nodes
-from nucypher.cli.actions.configure import perform_ip_checkup
+from nucypher.cli.actions.configure import forget as forget_nodes, perform_ip_checkup
 from nucypher.cli.actions.select import (
     select_client_account,
     select_config_file,
@@ -66,11 +64,9 @@ from nucypher.cli.utils import make_cli_character, setup_emitter
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_WORKER_ETH_PASSWORD,
-    NUCYPHER_ENVVAR_WORKER_IP_ADDRESS,
     TEMPORARY_DOMAIN
 )
 from nucypher.config.keyring import NucypherKeyring
-from nucypher.utilities.networking import determine_external_ip_address
 
 
 class UrsulaConfigOptions:
@@ -179,14 +175,12 @@ class UrsulaConfigOptions:
                                                        signer_uri=self.signer_uri)
 
         # Resolve rest host
-        rest_host = self.rest_host
-        if not rest_host:
-            rest_host = os.environ.get(NUCYPHER_ENVVAR_WORKER_IP_ADDRESS,
-                                       determine_external_ip_address(emitter, force=force))
+        if not self.rest_host:
+            self.rest_host = configure_external_ip_address(emitter, network=self.domain, force=force)
 
         return UrsulaConfiguration.generate(password=get_nucypher_password(confirm=True),
                                             config_root=config_root,
-                                            rest_host=rest_host,
+                                            rest_host=self.rest_host,
                                             rest_port=self.rest_port,
                                             db_filepath=self.db_filepath,
                                             domain=self.domain,
@@ -300,9 +294,7 @@ def ursula():
 @option_config_root
 @group_general_config
 def init(general_config, config_options, force, config_root):
-    """
-    Create a new Ursula node configuration.
-    """
+    """Create a new Ursula node configuration."""
     emitter = setup_emitter(general_config, config_options.worker_address)
     _pre_launch_warnings(emitter, dev=None, force=force)
     if not config_root:
@@ -319,9 +311,7 @@ def init(general_config, config_options, force, config_root):
 @option_force
 @group_general_config
 def destroy(general_config, config_options, config_file, force):
-    """
-    Delete Ursula node configuration.
-    """
+    """Delete Ursula node configuration."""
     emitter = setup_emitter(general_config, config_options.worker_address)
     _pre_launch_warnings(emitter, dev=config_options.dev, force=force)
     if not config_file:

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -18,8 +18,10 @@
 
 import click
 
+from nucypher.blockchain.economics import EconomicsFactory
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.blockchain.eth.signers.software import ClefSigner
+from nucypher.blockchain.eth.utils import datetime_at_period
 from nucypher.cli.actions.auth import get_client_password, get_nucypher_password
 from nucypher.cli.actions.configure import (
     destroy_configuration,
@@ -34,7 +36,9 @@ from nucypher.cli.config import group_general_config
 from nucypher.cli.literature import (
     DEVELOPMENT_MODE_WARNING,
     FORCE_MODE_WARNING,
-    SUCCESSFUL_MANUALLY_SAVE_METADATA
+    SUCCESSFUL_MANUALLY_SAVE_METADATA,
+    SUCCESSFUL_CONFIRM_ACTIVITY,
+    CONFIRMING_ACTIVITY_NOW
 )
 from nucypher.cli.options import (
     group_options,
@@ -57,6 +61,7 @@ from nucypher.cli.options import (
     option_max_gas_price
 )
 from nucypher.cli.painting.help import paint_new_installation_help
+from nucypher.cli.painting.transactions import paint_receipt_summary
 from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, NETWORK_PORT, WORKER_IP
 from nucypher.cli.utils import make_cli_character, setup_emitter
 from nucypher.config.characters import UrsulaConfiguration

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -357,6 +357,7 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
     worker_address = character_options.config_options.worker_address
     emitter = setup_emitter(general_config)
     dev_mode = character_options.config_options.dev
+    lonely = character_options.config_options.lonely
 
     if prometheus and not metrics_port:
         # Require metrics port when using prometheus
@@ -383,7 +384,9 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
                                                                config_file=config_file,
                                                                json_ipc=general_config.json_ipc)
 
-    if ip_checkup and not dev_mode:
+
+    if ip_checkup and not (dev_mode or lonely):
+        # Always skip startup IP checks for dev and lonely modes.
         perform_startup_ip_check(emitter=emitter, ursula=URSULA, force=force)
 
     try:

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -381,7 +381,7 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
                                                                json_ipc=general_config.json_ipc)
 
     if ip_checkup and not dev_mode:
-        perform_ip_checkup(emitter=emitter, ursula_config=URSULA, force=force)
+        perform_ip_checkup(emitter=emitter, ursula=URSULA, force=force)
 
     # TODO: should we just not call run at all for "dry_run"
     # RE: That might make the some tests less accurate

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -27,12 +27,8 @@ from nucypher.cli.actions.configure import (
     get_or_update_configuration,
     collect_worker_ip_address
 )
-from nucypher.cli.actions.configure import forget as forget_nodes, perform_ip_checkup
-from nucypher.cli.actions.select import (
-    select_client_account,
-    select_config_file,
-    select_network
-)
+from nucypher.cli.actions.configure import forget as forget_nodes, perform_startup_ip_check
+from nucypher.cli.actions.select import select_client_account, select_config_file, select_network
 from nucypher.cli.commands.deploy import option_gas_strategy
 from nucypher.cli.config import group_general_config
 from nucypher.cli.literature import (
@@ -383,7 +379,7 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
                                                                json_ipc=general_config.json_ipc)
 
     if ip_checkup and not dev_mode:
-        perform_ip_checkup(emitter=emitter, ursula=URSULA, force=force)
+        perform_startup_ip_check(emitter=emitter, ursula=URSULA, force=force)
 
     # TODO: should we just not call run at all for "dry_run"
     # RE: That might make the some tests less accurate

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -388,8 +388,6 @@ START_LOADING_SEEDNODES = "Connecting to preferred teacher nodes..."
 
 UNREADABLE_SEEDNODE_ADVISORY = "Failed to connect to teacher: {uri}"
 
-FORCE_DETECT_URSULA_IP_WARNING = "WARNING: --force is set, using auto-detected IP '{rest_host}'"
-
 NO_DOMAIN_PEERS = "WARNING: No Peers Available for domain: {domain}"
 
 SEEDNODE_NOT_STAKING_WARNING = "Teacher ({uri}) is not actively staking, skipping"

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -377,7 +377,7 @@ DECRYPTING_CHARACTER_KEYRING = 'Authenticating {name}'
 
 CONFIRM_URSULA_IPV4_ADDRESS = "Detected IPv4 address ({rest_host}) - Is this the public-facing address of Ursula?"
 
-COLLECT_URSULA_IPV4_ADDRESS = "Enter Ursula's public-facing IPv4 address:"
+COLLECT_URSULA_IPV4_ADDRESS = "Enter Ursula's public-facing IPv4 address"
 
 
 #

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -26,6 +26,7 @@ from nucypher.blockchain.economics import StandardTokenEconomics
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.blockchain.eth.token import NU
+from nucypher.utilities.networking import validate_worker_ip, InvalidWorkerIP
 
 
 class ChecksumAddress(click.ParamType):
@@ -46,10 +47,22 @@ class IPv4Address(click.ParamType):
     def convert(self, value, param, ctx):
         try:
             _address = ip_address(value)
-        except ValueError as e:
+        except ValueError:
             self.fail("Invalid IP Address")
         else:
             return value
+
+
+class WorkerIPAddress(IPv4Address):
+    name = 'worker_ip'
+
+    def convert(self, value, param, ctx):
+        _ip = super().convert(value, param, ctx)
+        try:
+            validate_worker_ip(worker_ip=_ip)
+        except InvalidWorkerIP as e:
+            self.fail(str(e))
+        return value
 
 
 class DecimalType(click.ParamType):
@@ -136,6 +149,7 @@ EXISTING_READABLE_FILE = click.Path(exists=True, dir_okay=False, file_okay=True,
 # Network
 NETWORK_PORT = click.IntRange(min=0, max=65535, clamp=False)
 IPV4_ADDRESS = IPv4Address()
+WORKER_IP = WorkerIPAddress()
 
 GAS_STRATEGY_CHOICES = click.Choice(list(BlockchainInterface.GAS_STRATEGIES.keys()))
 UMBRAL_PUBLIC_KEY_HEX = UmbralPublicKeyHex()

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -39,7 +39,6 @@ class UrsulaConfiguration(CharacterConfiguration):
     CHARACTER_CLASS = Ursula
     NAME = CHARACTER_CLASS.__name__.lower()
 
-    DEFAULT_REST_HOST = '127.0.0.1'
     DEFAULT_REST_PORT = 9151
     DEFAULT_DEVELOPMENT_REST_PORT = 10151
     __DEFAULT_TLS_CURVE = ec.SECP384R1
@@ -48,10 +47,10 @@ class UrsulaConfiguration(CharacterConfiguration):
     LOCAL_SIGNERS_ALLOWED = True
 
     def __init__(self,
+                 rest_host: str,
                  worker_address: str = None,
                  dev_mode: bool = False,
                  db_filepath: str = None,
-                 rest_host: str = None,
                  rest_port: int = None,
                  tls_curve: EllipticCurve = None,
                  certificate: Certificate = None,
@@ -64,7 +63,7 @@ class UrsulaConfiguration(CharacterConfiguration):
             else:
                 rest_port = self.DEFAULT_REST_PORT
         self.rest_port = rest_port
-        self.rest_host = rest_host or self.DEFAULT_REST_HOST
+        self.rest_host = rest_host
         self.tls_curve = tls_curve or self.__DEFAULT_TLS_CURVE
         self.certificate = certificate
         self.db_filepath = db_filepath or UNINITIALIZED_CONFIGURATION

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -40,14 +40,15 @@ class UrsulaConfiguration(CharacterConfiguration):
     NAME = CHARACTER_CLASS.__name__.lower()
 
     DEFAULT_REST_PORT = 9151
+    DEFAULT_DEVELOPMENT_REST_HOST = '127.0.0.1'
     DEFAULT_DEVELOPMENT_REST_PORT = 10151
     __DEFAULT_TLS_CURVE = ec.SECP384R1
-    DEFAULT_DB_NAME = '{}.db'.format(NAME)
+    DEFAULT_DB_NAME = f'{NAME}.db'
     DEFAULT_AVAILABILITY_CHECKS = False
     LOCAL_SIGNERS_ALLOWED = True
 
     def __init__(self,
-                 rest_host: str,
+                 rest_host: str = None,
                  worker_address: str = None,
                  dev_mode: bool = False,
                  db_filepath: str = None,
@@ -57,11 +58,16 @@ class UrsulaConfiguration(CharacterConfiguration):
                  availability_check: bool = None,
                  *args, **kwargs) -> None:
 
-        if not rest_port:
-            if dev_mode:
+        if dev_mode:
+            rest_host = self.DEFAULT_DEVELOPMENT_REST_HOST
+            if not rest_port:
                 rest_port = self.DEFAULT_DEVELOPMENT_REST_PORT
-            else:
+        else:
+            if not rest_host:
+                raise ValueError('rest_host is required for live workers.')
+            if not rest_port:
                 rest_port = self.DEFAULT_REST_PORT
+
         self.rest_port = rest_port
         self.rest_host = rest_host
         self.tls_curve = tls_curve or self.__DEFAULT_TLS_CURVE

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -59,7 +59,7 @@ class UrsulaConfiguration(CharacterConfiguration):
                  *args, **kwargs) -> None:
 
         if dev_mode:
-            rest_host = self.DEFAULT_DEVELOPMENT_REST_HOST
+            rest_host = rest_host or self.DEFAULT_DEVELOPMENT_REST_HOST
             if not rest_port:
                 rest_port = self.DEFAULT_DEVELOPMENT_REST_PORT
         else:

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -286,7 +286,3 @@ class RestMiddleware:
                                        params=params)
 
         return response
-
-    def ping(self, node):
-        response = self.client.get(node_or_sprout=node, path=f"ping", timeout=2)
-        return response

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -287,3 +287,7 @@ class RestMiddleware:
                                        params=params)
 
         return response
+
+    def ping(self, node):
+        response = self.client.get(node_or_sprout=node, path=f"ping", timeout=2)
+        return response

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -36,7 +36,6 @@ class NucypherMiddlewareClient:
     library = requests
     timeout = 1.2
 
-
     def __init__(self, registry=None, *args, **kwargs):
         self.registry = registry
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -245,8 +245,7 @@ class Learner:
 
         from nucypher.characters.lawful import Ursula
         self.node_class = node_class or Ursula
-        self.node_class.set_cert_storage_function(
-            node_storage.store_node_certificate)  # TODO: Fix this temporary workaround for on-disk cert storage.  #1481
+        self.node_class.set_cert_storage_function(node_storage.store_node_certificate)  # TODO: Fix this temporary workaround for on-disk cert storage.  #1481
 
         known_nodes = known_nodes or tuple()
         self.unresponsive_startup_nodes = list()  # TODO: Buckets - Attempt to use these again later  #567

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -385,11 +385,10 @@ class Learner:
         with suppress(KeyError):
             already_known_node = self.known_nodes[node.checksum_address]
             if not node.timestamp > already_known_node.timestamp:
-                # self.log.debug("Skipping already known node {}".format(already_known_node))  # FIXME: ""OMG, enough with the learning already!" – @vepkenez  (#1712)
                 # This node is already known.  We can safely return.
                 return False
 
-        self.known_nodes[node.checksum_address] = node
+        self.known_nodes[node.checksum_address] = node  # FIXME - dont always remember nodes, bucket them.
 
         if self.save_metadata:
             self.node_storage.store_node_metadata(node=node)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -113,20 +113,15 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
 
     @rest_app.route("/public_information")
     def public_information():
-        """
-        REST endpoint for public keys and address.
-        """
-        response = Response(
-            response=bytes(this_node),
-            mimetype='application/octet-stream')
-
+        """REST endpoint for public keys and address."""
+        response = Response(response=bytes(this_node), mimetype='application/octet-stream')
         return response
 
     @rest_app.route("/ping", methods=['GET', 'POST'])
     def ping():
         """
-        GET: Asks this node: "What is my IP address"
-        POST: Asks this node: "Can you access my public information endpoint"?
+        GET: Asks this node: "What is my IP address?"
+        POST: Asks this node: "Can you access my public information endpoint?"
         """
 
         if request.method == 'GET':
@@ -145,7 +140,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
             # Compare requester and posted Ursula information
             request_address = request.environ['REMOTE_ADDR']
             if request_address != initiator_address:
-                return Response({'error': 'Suspicious origin address'}, status=400)
+                return Response({'error': 'Origin address mismatch'}, status=400)
 
             #
             # Make a Sandwich

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -125,7 +125,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
         """
 
         if request.method == 'GET':
-            requester_ip_address = request.environ['REMOTE_ADDR']
+            requester_ip_address = request.remote_addr
             return Response(requester_ip_address, status=200)
 
         elif request.method == 'POST':
@@ -138,9 +138,10 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
                 initiator_address, initiator_port = tuple(requesting_ursula.rest_interface)
 
             # Compare requester and posted Ursula information
-            request_address = request.environ['REMOTE_ADDR']
+            request_address = request.remote_addr
             if request_address != initiator_address:
-                return Response({'error': 'Origin address mismatch'}, status=400)
+                message = f'Origin address mismatch: Request origin is {request_address} but metadata claims {initiator_address}.'
+                return Response({'error': message}, status=400)
 
             #
             # Make a Sandwich

--- a/nucypher/utilities/clouddeploy.py
+++ b/nucypher/utilities/clouddeploy.py
@@ -171,7 +171,7 @@ class BaseCloudNodeConfigurator:
                  stakeholder_config_path,
                  blockchain_provider=None,
                  nucypher_image=None,
-                 seed_network=False,
+                 seed_network=None,
                  sentry_dsn=None,
                  profile=None,
                  pre_config=False,

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -59,19 +59,12 @@ def get_external_ip_from_default_teacher(network: str, federated_only: bool = Fa
     except (KeyError, IndexError):
         # unknown network or no default teachers available
         return  # just move on.
-
     teacher = Ursula.from_teacher_uri(teacher_uri=top_teacher_url,
                                       federated_only=federated_only,
                                       min_stake=StandardTokenEconomics._default_minimum_allowed_locked)
-
-    # host, port = teacher.rest_interface.host, teacher.rest_interface.port
-    # certificate = teacher.network_middleware.get_certificate(host=host, port=port)
-    # local_node_storage = LocalFileBasedNodeStorage()
-    # certificate_filepath = local_node_storage.store_node_certificate(certificate=certificate)
     response = teacher.network_middleware.ping()
     if response.status_code == 200:
         return response.text
-    breakpoint()
 
 
 def get_external_ip_from_known_nodes(known_nodes, sample_size: int = 3):

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -14,6 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 import random
 
 import requests
@@ -47,7 +49,7 @@ def get_external_ip_from_url_source(url: str) -> Union[str, None]:
 
 def get_external_ip_from_default_teacher(network: str) -> Union[str, None]:
     try:
-        endpoint = f'{RestMiddleware.TEACHER_NODES[network]}/ping'
+        endpoint = f'{RestMiddleware.TEACHER_NODES[network]}/ping'  # TODO: use client
     except KeyError:  # unknown network name
         return
     ip = get_external_ip_from_url_source(url=endpoint)

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-
+import random
 
 import requests
 from requests.exceptions import RequestException, HTTPError
@@ -46,9 +46,20 @@ def get_external_ip_from_url_source(url: str) -> Union[str, None]:
 
 
 def get_external_ip_from_default_teacher(network: str) -> Union[str, None]:
-    endpoint = f'{RestMiddleware.TEACHER_NODES[network]}/ping'
+    try:
+        endpoint = f'{RestMiddleware.TEACHER_NODES[network]}/ping'
+    except KeyError:  # unknown network name
+        return
     ip = get_external_ip_from_url_source(url=endpoint)
     return ip
+
+
+def get_external_ip_from_known_nodes(known_nodes, sample_size: int = 3):
+    sample = random.sample(known_nodes, sample_size)
+    for node in sample:
+        ip = get_external_ip_from_url_source(url=node.rest_url())
+        if ip:
+            return ip
 
 
 def get_external_ip_from_centralized_source() -> str:
@@ -57,15 +68,19 @@ def get_external_ip_from_centralized_source() -> str:
     return ip
 
 
-def determine_external_ip_address(network: str) -> str:
+def determine_external_ip_address(network: str, known_nodes = None) -> str:
     """
     Attempts to automatically get the external IP from the default teacher.
     If the request fails, it falls back to a centralized service.  If the IP address cannot be determined
     for any reason UnknownIPAddress is raised.
     """
-    rest_host = get_external_ip_from_default_teacher(network=network)
-    if not rest_host:  # fallback
+    rest_host = None
+    if known_nodes:  # primary
+        rest_host = get_external_ip_from_known_nodes(known_nodes=known_nodes)
+    if not rest_host:  # fallback 1
+        rest_host = get_external_ip_from_default_teacher(network=network)
+    if not rest_host:  # fallback 2
         rest_host = get_external_ip_from_centralized_source()
-    if not rest_host:  # fallback failure
+    if not rest_host:  # complete cascading failure
         raise UnknownIPAddress('External IP address detection failed')
     return rest_host

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -139,8 +139,8 @@ def get_external_ip_from_known_nodes(known_nodes: FleetSensor,
     for node in sample:
         ip = __request(url=node.rest_url())
         if ip:
-            log.info(f'Fetched external IP address from randomly selected known node(s).')
-    return ip
+            log.info(f'Fetched external IP address ({ip}) from randomly selected known node(s).')
+            return ip
 
 
 def get_external_ip_from_centralized_source(log: Logger = IP_DETECTION_LOGGER) -> Union[str, None]:
@@ -148,7 +148,7 @@ def get_external_ip_from_centralized_source(log: Logger = IP_DETECTION_LOGGER) -
     endpoint = 'https://ifconfig.me/'
     ip = __request(url=endpoint)
     if ip:
-        log.info(f'Fetched external IP address from centralized source ({endpoint}).')
+        log.info(f'Fetched external IP address ({ip}) from centralized source ({endpoint}).')
     return ip
 
 

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -15,11 +15,16 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
+from ipaddress import ip_address
+
 import random
 import requests
 from requests.exceptions import RequestException, HTTPError
 from typing import Union
 
+from nucypher.blockchain.eth.registry import BaseContractRegistry, InMemoryContractRegistry
+from nucypher.acumen.perception import FleetSensor
 from nucypher.characters.lawful import Ursula
 from nucypher.network.middleware import RestMiddleware, NucypherMiddlewareClient
 from nucypher.utilities.logging import Logger
@@ -37,9 +42,15 @@ RequestErrors = (
     HTTPError
 )
 
+IP_DETECTION_LOGGER = Logger('external-ip-detection')
 
-def get_external_ip_from_url_source(url: str, certificate=None) -> Union[str, None]:
-    """Certificate is needed if the remote URL source is self-signed."""
+
+def __request(url: str, certificate=None) -> Union[str, None]:
+    """
+    Utility function to send a GET request to a URL returning it's
+    text content or None, suppressing all errors. Certificate is
+    needed if the remote URL source is self-signed.
+    """
     try:
         # 'None' or 'True' will verify self-signed certificates
         response = requests.get(url, verify=certificate)
@@ -51,60 +62,94 @@ def get_external_ip_from_url_source(url: str, certificate=None) -> Union[str, No
 
 def get_external_ip_from_default_teacher(network: str,
                                          federated_only: bool = False,
-                                         log=None
+                                         log: Logger = IP_DETECTION_LOGGER,
+                                         registry: BaseContractRegistry = None
                                          ) -> Union[str, None]:
-    if not log:
-        log = Logger('whoami')
-
+    if federated_only and registry:
+        raise ValueError('Federated mode must not be true if registry is provided.')
+    base_error = 'Cannot determine IP using default teacher'
     try:
         top_teacher_url = RestMiddleware.TEACHER_NODES[network][0]
-    except (KeyError, IndexError):
-        # unknown network or no default teachers available
-        return  # just move on.
+    except IndexError:
+        log.debug(f'{base_error}: No teacher available for network "{network}".')
+        return
+    except KeyError:
+        log.debug(f'{base_error}: Unknown network "{network}".')
+        return
+    if not registry:
+        # Registry is needed to perform on-chain staking verification.
+        registry = InMemoryContractRegistry.from_latest_publication(network=network)
     teacher = Ursula.from_teacher_uri(teacher_uri=top_teacher_url,
+                                      registry=registry,
                                       federated_only=federated_only,
-                                      min_stake=0)  # TODO: Handle (more than) min stake here
-
+                                      min_stake=0)  # TODO: Handle customized min stake here.
     client = NucypherMiddlewareClient()
-    response = client.get(node_or_sprout=teacher, path=f"ping", timeout=2)  # TLS certificate login within
+    try:
+        response = client.get(node_or_sprout=teacher, path=f"ping", timeout=2)  # TLS certificate logic within
+    except RestMiddleware.UnexpectedResponse:
+        # 404, 405, 500, All server response codes handled by will be caught here.
+        return  # Default teacher does not support this request - just move on.
     if response.status_code == 200:
-        log.info(f'Fetched external IP address from default teacher ({top_teacher_url}).')
-        return response.text
+        try:
+            ip = str(ip_address(response.text))
+        except ValueError:
+            error = f'Default teacher at {top_teacher_url} returned an invalid IP response; Got {response.text}'
+            raise UnknownIPAddress(error)
+        log.info(f'Fetched external IP address from default teacher ({top_teacher_url} reported {ip}).')
+        return ip
 
 
-def get_external_ip_from_known_nodes(known_nodes, sample_size: int = 3, log: Logger = None):
-    if not log:
-        log = Logger('whoami')
+def get_external_ip_from_known_nodes(known_nodes: FleetSensor,
+                                     sample_size: int = 3,
+                                     log: Logger = IP_DETECTION_LOGGER
+                                     ) -> Union[str, None]:
+    """
+    Randomly select a sample of peers to determine the external IP address
+    of this host. The first node to reply successfully will be used.
+    # TODO: Parallelize the requests and compare results.
+    """
+    ip = None
     sample = random.sample(known_nodes, sample_size)
     for node in sample:
-        ip = get_external_ip_from_url_source(url=node.rest_url())
+        ip = __request(url=node.rest_url())
         if ip:
             log.info(f'Fetched external IP address from randomly selected known node(s).')
-            return ip
-
-
-def get_external_ip_from_centralized_source(log: Logger = None) -> str:
-    endpoint = 'https://ifconfig.me/'
-    ip = get_external_ip_from_url_source(url=endpoint)
-    if not log:
-        log = Logger('whoami')
-    log.info(f'Fetched external IP address from centralized source ({endpoint}).')
     return ip
 
 
-def determine_external_ip_address(network: str, known_nodes=None) -> str:
+def get_external_ip_from_centralized_source(log: Logger = IP_DETECTION_LOGGER) -> Union[str, None]:
+    """Use hardcoded URL to determine the external IP address of this host."""
+    endpoint = 'https://ifconfig.me/'
+    ip = __request(url=endpoint)
+    if ip:
+        log.info(f'Fetched external IP address from centralized source ({endpoint}).')
+    return ip
+
+
+def determine_external_ip_address(network: str, known_nodes: FleetSensor = None) -> str:
     """
-    Attempts to automatically get the external IP from the default teacher.
-    If the request fails, it falls back to a centralized service.  If the IP address cannot be determined
-    for any reason UnknownIPAddress is raised.
+    Attempts to automatically determine the external IP in the following priority:
+    1. Randomly Selected Known Nodes
+    2. The Default Teacher URI from RestMiddleware
+    3. A centralized IP address service
+
+    If the IP address cannot be determined for any reason UnknownIPAddress is raised.
     """
     rest_host = None
-    if known_nodes:  # primary
+
+    # primary source
+    if known_nodes:
         rest_host = get_external_ip_from_known_nodes(known_nodes=known_nodes)
-    if not rest_host:  # fallback 1
+
+    # fallback 1
+    if not rest_host:
         rest_host = get_external_ip_from_default_teacher(network=network)
-    if not rest_host:  # fallback 2
+
+    # fallback 2
+    if not rest_host:
         rest_host = get_external_ip_from_centralized_source()
-    if not rest_host:  # complete cascading failure
+
+    # complete failure!
+    if not rest_host:
         raise UnknownIPAddress('External IP address detection failed')
     return rest_host

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -119,7 +119,7 @@ def get_external_ip_from_default_teacher(network: str,
         except ValueError:
             error = f'Default teacher at {top_teacher_url} returned an invalid IP response; Got {response.text}'
             raise UnknownIPAddress(error)
-        log.info(f'Fetched external IP address from default teacher ({top_teacher_url} reported {ip}).')
+        log.info(f'Fetched external IP address ({ip}) from default teacher ({top_teacher_url}).')
         return ip
     else:
         log.debug(f'Failed to get external IP from teacher node ({response.status_code})')

--- a/scripts/circle/docker-compose.yml
+++ b/scripts/circle/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - 11500
     image: circle:nucypher
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.1 --rest-port 11500 --lonely --disable-availability-check
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.1 --rest-port 11500 --lonely --disable-availability-check --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.1
@@ -32,7 +32,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.2 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.2 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.2
@@ -43,7 +43,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.3 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.3 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.3
@@ -54,7 +54,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.4 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.4 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.4
@@ -65,7 +65,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.5 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.5 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.5
@@ -76,7 +76,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.6 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.6 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.6
@@ -87,7 +87,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.7 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.7 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.7
@@ -98,7 +98,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.8 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.8 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.8
@@ -109,7 +109,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.9 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.9 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.9
@@ -120,7 +120,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.10 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.10 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.10
@@ -131,7 +131,7 @@ services:
     image: circle:nucypher
     depends_on:
       - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.11 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.11 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.11
@@ -141,8 +141,8 @@ services:
       - 11500
     image: circle:nucypher
     depends_on:
-      - circleursula1
-    command: nucypher  ursula run --dev --federated-only --rest-host 172.29.1.12 --rest-port 11500 --disable-availability-check --teacher 172.29.1.1:11500
+      - circleursula11
+    command: nucypher ursula run --dev --federated-only --rest-host 172.29.1.12 --rest-port 11500 --teacher 172.29.1.1:11500 --no-ip-checkup
     networks:
       nucypher_circle_net:
         ipv4_address: 172.29.1.12

--- a/tests/acceptance/blockchain/actors/test_staker.py
+++ b/tests/acceptance/blockchain/actors/test_staker.py
@@ -293,7 +293,7 @@ def test_staker_collects_staking_reward(testerchain,
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[worker_address],
-                                        commit_to_next_period=False,
+                                        commit_now=False,
                                         registry=test_registry).pop()
 
     # ...mint few tokens...
@@ -338,7 +338,7 @@ def test_staker_manages_winding_down(testerchain,
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[staker.worker_address],
-                                        commit_to_next_period=False,
+                                        commit_now=False,
                                         registry=test_registry).pop()
 
     # Unlock

--- a/tests/acceptance/blockchain/actors/test_worker.py
+++ b/tests/acceptance/blockchain/actors/test_worker.py
@@ -14,6 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 import pytest_twisted
 from twisted.internet import threads
 from twisted.internet.task import Clock
@@ -64,7 +66,7 @@ def test_worker_auto_commitments(mocker,
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[worker_address],
-                                        commit_to_next_period=False,  # FIXME: 2424 - It commits anyway
+                                        commit_now=True,
                                         registry=test_registry).pop()
 
     initial_period = staker.staking_agent.get_current_period()

--- a/tests/acceptance/characters/test_stakeholder.py
+++ b/tests/acceptance/characters/test_stakeholder.py
@@ -126,7 +126,7 @@ def test_collect_inflation_rewards(software_stakeholder, manual_worker, testerch
     worker = Worker(is_me=True,
                     worker_address=manual_worker,
                     checksum_address=stake.staker_address,
-                    start_working_now=False,
+                    commit_now=False,
                     registry=test_registry)
 
     mock_transacting_power_activation(account=manual_worker, password=INSECURE_DEVELOPMENT_PASSWORD)

--- a/tests/acceptance/characters/test_ursula_prepares_to_act_as_worker.py
+++ b/tests/acceptance/characters/test_ursula_prepares_to_act_as_worker.py
@@ -34,7 +34,7 @@ def test_stakers_bond_to_ursulas(testerchain, test_registry, stakers, ursula_dec
     ursulas = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                          stakers_addresses=testerchain.stakers_accounts,
                                          workers_addresses=testerchain.ursulas_accounts,
-                                         commit_to_next_period=False)
+                                         commit_now=False)
 
     assert len(ursulas) == len(stakers)
     for ursula in ursulas:

--- a/tests/acceptance/cli/test_cli_config.py
+++ b/tests/acceptance/cli/test_cli_config.py
@@ -27,7 +27,7 @@ from nucypher.config.constants import NUCYPHER_ENVVAR_KEYRING_PASSWORD, NUCYPHER
     TEMPORARY_DOMAIN
 from tests.constants import (FAKE_PASSWORD_CONFIRMED, INSECURE_DEVELOPMENT_PASSWORD, MOCK_CUSTOM_INSTALLATION_PATH,
                              MOCK_IP_ADDRESS,
-                             TEST_PROVIDER_URI)
+                             TEST_PROVIDER_URI, YES)
 
 CONFIG_CLASSES = (AliceConfiguration, BobConfiguration, UrsulaConfiguration)
 
@@ -51,7 +51,7 @@ def test_initialize_via_cli(config_class, custom_filepath, click_runner, monkeyp
 
     result = click_runner.invoke(nucypher_cli,
                                  init_args,
-                                 input=FAKE_PASSWORD_CONFIRMED,
+                                 input=FAKE_PASSWORD_CONFIRMED + YES,
                                  catch_exceptions=False,
                                  env=ENV)
     assert result.exit_code == 0, result.output

--- a/tests/acceptance/cli/ursula/test_federated_ursula.py
+++ b/tests/acceptance/cli/ursula/test_federated_ursula.py
@@ -148,9 +148,8 @@ def test_run_federated_ursula_from_config_file(custom_filepath, click_runner):
                                  catch_exceptions=False)
 
     # CLI Output
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
     assert 'Federated' in result.output, 'WARNING: Federated ursula is not running in federated mode'
-    # assert 'Connecting' in result.output
     assert 'Running' in result.output
     assert "'help' or '?'" in result.output
 

--- a/tests/acceptance/cli/ursula/test_local_keystore_integration.py
+++ b/tests/acceptance/cli/ursula/test_local_keystore_integration.py
@@ -146,7 +146,7 @@ def test_ursula_and_local_keystore_signer_integration(click_runner,
     # Produce an Ursula with a Keystore signer correctly derived from the signer URI, and don't do anything else!
     mocker.patch.object(StakeList, 'refresh', autospec=True)
     ursula = ursula_config.produce(client_password=password,
-                                   start_working_now=False,
+                                   commit_now=False,
                                    block_until_ready=False)
 
     try:

--- a/tests/acceptance/cli/ursula/test_run_ursula.py
+++ b/tests/acceptance/cli/ursula/test_run_ursula.py
@@ -50,8 +50,10 @@ def test_missing_configuration_file(default_filepath_mock, click_runner):
 
 
 def test_ursula_startup_ip_checkup(click_runner, mocker):
+    target = 'nucypher.cli.actions.configure.determine_external_ip_address'
+
     # Patch the get_external_ip call
-    mocker.patch.object(utilities.networking, 'get_external_ip_from_default_teacher', return_value=MOCK_IP_ADDRESS)
+    mocker.patch(target, return_value=MOCK_IP_ADDRESS)
     mocker.patch.object(UrsulaConfiguration, 'to_configuration_file', return_value=None)
 
     args = ('ursula', 'init', '--federated-only', '--network', TEMPORARY_DOMAIN)
@@ -63,10 +65,9 @@ def test_ursula_startup_ip_checkup(click_runner, mocker):
     args = ('ursula', 'init', '--federated-only', '--network', TEMPORARY_DOMAIN, '--force')
     result = click_runner.invoke(nucypher_cli, args, catch_exceptions=False, input=FAKE_PASSWORD_CONFIRMED)
     assert result.exit_code == 0
-    assert MOCK_IP_ADDRESS in result.output
 
     # Patch get_external_ip call to error output
-    mocker.patch.object(utilities.networking, 'get_external_ip_from_default_teacher', side_effect=UnknownIPAddress)
+    mocker.patch(target, side_effect=UnknownIPAddress)
     args = ('ursula', 'init', '--federated-only', '--network', TEMPORARY_DOMAIN, '--force')
     result = click_runner.invoke(nucypher_cli, args, catch_exceptions=True, input=FAKE_PASSWORD_CONFIRMED)
     assert result.exit_code == 1, result.output
@@ -151,7 +152,7 @@ def test_federated_ursula_learns_via_cli(click_runner, federated_ursulas):
     result = d.result
 
     assert result.exit_code == 0
-    assert "Starting Ursula" in result.output
+    assert "Starting services" in result.output
     assert f"127.0.0.1:{deploy_port}" in result.output
 
     reserved_ports = (UrsulaConfiguration.DEFAULT_REST_PORT, UrsulaConfiguration.DEFAULT_DEVELOPMENT_REST_PORT)

--- a/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
+++ b/tests/acceptance/cli/ursula/test_stake_via_allocation_contract.py
@@ -524,7 +524,7 @@ def test_collect_rewards_integration(click_runner,
                     registry=agency_local_registry,
                     rest_host='127.0.0.1',
                     rest_port=ursula_port,
-                    start_working_now=False,
+                    commit_now=False,
                     network_middleware=MockRestMiddleware(),
                     db_filepath=tempfile.mkdtemp(),
                     domain=TEMPORARY_DOMAIN)

--- a/tests/acceptance/learning/test_fault_tolerance.py
+++ b/tests/acceptance/learning/test_fault_tolerance.py
@@ -116,7 +116,7 @@ def test_invalid_workers_tolerance(testerchain,
                                     worker_address=testerchain.unassigned_accounts[-1],
                                     ursula_config=ursula_decentralized_test_config,
                                     blockchain=testerchain,
-                                    commit_to_next_period=True,
+                                    commit_now=True,
                                     ursulas_to_learn_about=None)
 
     # Since we made a commitment, we need to advance one period

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,7 +185,14 @@ def check_character_state_after_test(request):
             tracker.work_tracker.stop()
 
 
+
 @pytest.fixture(scope='session', autouse=True)
 def mock_datastore(monkeysession):
     monkeysession.setattr(lmdb, 'open', mock_lmdb_open)
     yield
+    
+
+def mock_get_external_ip_from_url_source(session_mocker):
+    """Prevent tests from making a call to third party external networks"""
+    target = 'nucypher.utilities.networking.get_external_ip_from_centralized_source'
+    session_mocker.patch(target, return_value=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,6 @@ WebEmitter._crash_on_error_default = True
 LOCK_FUNCTION = TransactingPower.lock_account
 TransactingPower.lock_account = lambda *a, **k: True
 
-# Disable any hardcoded preferred teachers during tests.
-TEACHER_NODES = dict()
-
 # Prevent halting the reactor via health checks during tests
 AvailabilityTracker._halt_reactor = lambda *a, **kw: True
 
@@ -146,7 +143,7 @@ def pytest_collection_modifyitems(config, items):
     GlobalLoggerSettings.start_json_file_logging()
 
 
-# global_mutable_where_everybody = defaultdict(list)
+# global_mutable_where_everybody = defaultdict(list)  # TODO: cleanup
 
 @pytest.fixture(scope='module', autouse=True)
 def check_character_state_after_test(request):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Learner
 from nucypher.network.trackers import AvailabilityTracker
 from nucypher.utilities.logging import GlobalLoggerSettings
-from tests.constants import INSECURE_DEVELOPMENT_PASSWORD
+from tests.constants import INSECURE_DEVELOPMENT_PASSWORD, MOCK_IP_ADDRESS
 from tests.mock.datastore import mock_lmdb_open
 
 # Crash on server error by default
@@ -186,13 +186,15 @@ def check_character_state_after_test(request):
 
 
 
+
 @pytest.fixture(scope='session', autouse=True)
 def mock_datastore(monkeysession):
     monkeysession.setattr(lmdb, 'open', mock_lmdb_open)
     yield
     
 
+
+@pytest.fixture(scope='session', autouse=True)
 def mock_get_external_ip_from_url_source(session_mocker):
-    """Prevent tests from making a call to third party external networks"""
-    target = 'nucypher.utilities.networking.get_external_ip_from_centralized_source'
-    session_mocker.patch(target, return_value=None)
+    target = 'nucypher.cli.actions.configure.determine_external_ip_address'
+    session_mocker.patch(target, return_value=MOCK_IP_ADDRESS)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -686,7 +686,7 @@ def blockchain_ursulas(testerchain, stakers, ursula_decentralized_test_config):
     _ursulas = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                           stakers_addresses=testerchain.stakers_accounts,
                                           workers_addresses=testerchain.ursulas_accounts,
-                                          commit_to_next_period=True)
+                                          commit_now=True)
     for u in _ursulas:
         u.synchronous_query_timeout = .01  # We expect to never have to wait for content that is actually on-chain during tests.
     testerchain.time_travel(periods=1)

--- a/tests/integration/config/test_character_configuration.py
+++ b/tests/integration/config/test_character_configuration.py
@@ -20,6 +20,7 @@ import pytest
 import tempfile
 from constant_sorrow.constants import CERTIFICATE_NOT_SAVED, NO_KEYRING_ATTACHED
 
+from tests.constants import MOCK_IP_ADDRESS
 from nucypher.blockchain.eth.actors import StakeHolder
 from nucypher.characters.chaotic import Felix
 from nucypher.characters.lawful import Alice, Bob, Ursula
@@ -54,7 +55,11 @@ all_configurations = tuple(configurations + blockchain_only_configurations)
 @pytest.mark.parametrize("character,configuration", characters_and_configurations)
 def test_federated_development_character_configurations(character, configuration):
 
-    config = configuration(dev_mode=True, federated_only=True, lonely=True, domain=TEMPORARY_DOMAIN)
+    config = configuration(dev_mode=True,
+                           federated_only=True,
+                           lonely=True,
+                           domain=TEMPORARY_DOMAIN)
+
     assert config.is_me is True
     assert config.dev_mode is True
     assert config.keyring == NO_KEYRING_ATTACHED
@@ -116,6 +121,11 @@ def test_default_character_configuration_preservation(configuration_class, teste
     if configuration_class == StakeHolderConfiguration:
         # special case for defaults
         character_config = StakeHolderConfiguration(provider_uri=testerchain.provider_uri, domain=network)
+
+    elif configuration_class == UrsulaConfiguration:
+        # special case for rest_host & dev mode
+        character_config = configuration_class(checksum_address=fake_address, domain=network, rest_host=MOCK_IP_ADDRESS)
+
     else:
         character_config = configuration_class(checksum_address=fake_address, domain=network)
 

--- a/tests/unit/test_work_tracker_error_handling.py
+++ b/tests/unit/test_work_tracker_error_handling.py
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-
+import pytest
 import pytest_twisted
 from twisted.internet import task
 from twisted.internet import threads
@@ -167,6 +167,7 @@ class WorkTrackerThatFailsFor12HoursThenSucceeds(WorkTrackerArbitraryFailureCond
         return cls.INTERVAL_FLOOR
 
 
+@pytest.mark.skip('Damon ... send help')
 @pytest_twisted.inlineCallbacks
 def test_worker_rate_limiting():
     """

--- a/tests/unit/test_work_tracker_error_handling.py
+++ b/tests/unit/test_work_tracker_error_handling.py
@@ -14,6 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 import pytest
 import pytest_twisted
 from twisted.internet import task
@@ -167,7 +169,6 @@ class WorkTrackerThatFailsFor12HoursThenSucceeds(WorkTrackerArbitraryFailureCond
         return cls.INTERVAL_FLOOR
 
 
-@pytest.mark.skip('Damon ... send help')
 @pytest_twisted.inlineCallbacks
 def test_worker_rate_limiting():
     """

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -67,7 +67,7 @@ def assemble(federated: bool,
 
 def make_ursula_test_configuration(rest_port: int = MOCK_URSULA_STARTING_PORT, **assemble_kwargs) -> UrsulaConfiguration:
     test_params = assemble(**assemble_kwargs)
-    ursula_config = UrsulaConfiguration(**test_params, rest_host=MOCK_IP_ADDRESS, rest_port=rest_port)
+    ursula_config = UrsulaConfiguration(**test_params, rest_port=rest_port)
     return ursula_config
 
 

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -17,6 +17,7 @@
 
 from typing import List
 
+from tests.constants import MOCK_IP_ADDRESS
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.characters.lawful import Ursula
 from nucypher.config.characters import AliceConfiguration, BobConfiguration, UrsulaConfiguration
@@ -66,7 +67,7 @@ def assemble(federated: bool,
 
 def make_ursula_test_configuration(rest_port: int = MOCK_URSULA_STARTING_PORT, **assemble_kwargs) -> UrsulaConfiguration:
     test_params = assemble(**assemble_kwargs)
-    ursula_config = UrsulaConfiguration(**test_params, rest_port=rest_port)
+    ursula_config = UrsulaConfiguration(**test_params, rest_host=MOCK_IP_ADDRESS, rest_port=rest_port)
     return ursula_config
 
 

--- a/tests/utils/ursula.py
+++ b/tests/utils/ursula.py
@@ -98,7 +98,7 @@ def make_federated_ursulas(ursula_config: UrsulaConfiguration,
 def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
                                stakers_addresses: Iterable[str],
                                workers_addresses: Iterable[str],
-                               commit_to_next_period: bool = False,
+                               commit_now: bool = True,
                                **ursula_overrides) -> List[Ursula]:
 
     if not MOCK_KNOWN_URSULAS_CACHE:
@@ -114,17 +114,12 @@ def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
                                        worker_address=worker_address,
                                        db_filepath=MOCK_DB,
                                        rest_port=port + 100,
-                                       # start_working_now=commit_to_next_period,  # FIXME: 2424
+                                       commit_now=commit_now,
                                        **ursula_overrides)
-        if commit_to_next_period:  # FIXME: 2424
-            # TODO: Is _crypto_power trying to be public?  Or is there a way to expose *something* public about TransactingPower?
-            # Do we need to revisit the concept of "public material"?  Or does this rightly belong as a method?
-            tx_power = ursula._crypto_power.power_ups(TransactingPower)
-            tx_power.activate()
-            ursula.commit_to_next_period()
 
         ursulas.append(ursula)
-        # Store this Ursula in our global cache.
+
+        # Store this Ursula in our global testing cache.
         port = ursula.rest_interface.port
         MOCK_KNOWN_URSULAS_CACHE[port] = ursula
 
@@ -136,7 +131,7 @@ def make_ursula_for_staker(staker: Staker,
                            blockchain: BlockchainInterface,
                            ursula_config: UrsulaConfiguration,
                            ursulas_to_learn_about: Optional[List[Ursula]] = None,
-                           commit_to_next_period: bool = False,
+                           commit_now: bool = True,
                            **ursula_overrides) -> Ursula:
 
     # Assign worker to this staker
@@ -146,7 +141,7 @@ def make_ursula_for_staker(staker: Staker,
                                         blockchain=blockchain,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[worker_address],
-                                        commit_to_next_period=commit_to_next_period,
+                                        commit_now=commit_now,
                                         **ursula_overrides).pop()
 
     for ursula_to_learn_about in (ursulas_to_learn_about or []):


### PR DESCRIPTION
**Type of PR:**

Bugfix & Feature

**Required reviews:** 

3

**What this does:**

- Validate Worker IP address on startup
- Attempts to determine the external IP by asking Ursulas with fallbacks a centralized HTTP service and manual entry
- Introduces a new click type `WorkerIP(IPV4Address)`
- More networking utility functions used by both the Character API and the CLI
- Introduces `Ursula.__preflight` which can be used to optionally enforce character-level startup self-validation
- Prohibits reserved IP address from being used to run ursula (`--dev` mode can still use `127.0.0.1`)
- `UrsulaConfiguration` now requires a `rest_host` when not in `dev_mode`

**Issues fixed/closed:**
* Closes #2311 - Improves qualification of nodes on startup
* Closes #2424
* Closes #2306 
* Scratches the surface of #2277 

**Why it's needed:**

* Part of https://github.com/nucypher/nucypher/projects/13
* Running Ursula with the correct IP address is critial for discoverability by other actors and the availability of Grant and Retrieve.
  This PR resolves a facused subset of issues pertaining to worker availability.

**Notes for reviewers:**

Ibex testnet example of startup IP check:

![Screenshot from 2020-12-11 18-16-52](https://user-images.githubusercontent.com/679404/101970079-13be9380-3bdd-11eb-8185-188ae222792a.png)

