### PR TITLE
Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,19 +11,15 @@
 
 **What this does:**
 > High-level idea of the changes introduced in this PR. 
-> List relevant API changes (if any).
+> List relevant API changes (if any), as well as related PRs and issues.
 
 **Issues fixed/closed:**
-
 > - Fixes #...
 
 **Why it's needed:**
-> Explain how this PR fits in the greater context of the NuCypher Network, 
-> so it's justified why this PR (and reviewing it) is necessary.
-
-**Does this PR address a `nucypher/productdev` issue?**   Yes/No
+> Explain how this PR fits in the greater context of the NuCypher Network.
+> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!
 
 **Notes for reviewers:**
-
 > What should reviewers focus on? 
 > Is there a particular commit/function/section of your PR that requires more attention from reviewers?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,27 @@
-**Type of PR**: Bugfix / Feature / Docs / Other
+**Type of PR:**
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Other
 
-**Required reviews**: 1 / 2 / 3
+**Required reviews:** 
+- [ ] 1
+- [ ] 2
+- [X] 3
 
-**What does this PR do? Why is it needed?**
+**What this does:**
+> High-level idea of the changes introduced in this PR. 
+> List relevant API changes (if any).
 
-> Try to answer both questions, when possible. 
-> The second one is often not obvious and can help the team to prioritize.
+**Issues fixed/closed:**
 
-**Which issues(s) does this PR fix?**
+> - Fixes #...
 
-> Fixes #...
+**Why it's needed:**
+> Explain how this PR fits in the greater context of the NuCypher Network, 
+> so it's justified why this PR (and reviewing it) is necessary.
+
+**Does this PR address a `nucypher/productdev` issue?**   Yes/No
 
 **Notes for reviewers:**
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+**Type of PR**: Bugfix / Feature / Docs / Other
+
+**Required reviews**: 1 / 2 / 3
+
+**What does this PR do? Why is it needed?**
+
+> Try to answer both questions, when possible. 
+> The second one is often not obvious and can help the team to prioritize.
+
+**Which issues(s) does this PR fix?**
+
+> Fixes #...
+
+**Notes for reviewers:**
+
+> What should reviewers focus on? 
+> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

--- a/newsfragments/2476.misc.rst
+++ b/newsfragments/2476.misc.rst
@@ -1,0 +1,1 @@
+Introduce a template to describe Pull Requests.


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
This PR introduces a simple GH template for pull requests, with the goal that all PRs from now on have some common information. 

**Issues fixed/closed:**
None

**Why it's needed:**
We need a way to harmonize the description of the PRs, especially, to facilitate the reviewers' work, and hopefully, improve efficiency of the review process.

**Does this PR address a `nucypher/productdev` issue?**  No

**Notes for reviewers:**
* The "Why it's needed" section is a way to link the PR description with high-level team-wide goals that can help justify why this PR (and reviewing this PR) is necessary.
* The "required reviews" part is just a personal idea. My thought here is that this is an aspect self-assessed by the PR author, as in practice many PRs don't need 3 reviews; there are also some controversial PRs that may be good to have more than 3 reviews.
