### PR TITLE
Estimate gas with block identifier 'latest'

### DIFF
--- a/newsfragments/2486.bugfix.rst
+++ b/newsfragments/2486.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore pending Ethereum transactions for purposes of gas estimation.

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -409,7 +409,7 @@ class BlockchainInterface:
             code = response['code']
             message = response['message']
 
-        except (ValueError, IndexError, AttributeError):
+        except (ValueError, IndexError, AttributeError, KeyError, TypeError):
             # TODO: #1504 - Try even harder to determine if this is insufficient funds causing the issue,
             #               This may be best handled at the agent or actor layer for registry and token interactions.
             # Worst case scenario - raise the exception held in context implicitly


### PR DESCRIPTION
Running `nucypher worklock refund` fails with "no refund availble" if a pending refund transaction is present in the mempool.
During gas estimation, the pending refund transaction is effectively assumed to have already completed thus causing the attempted refund transaction to fail when estimating gas.

This PR explicitly estimates gas with block identifier set to "latest" which ignores the pending transactions for purposes of gas estimation.

The PR also fixes failed transaction exception handling, where the resulting ValueError had a third unexpected "data" member causing the unpack and assign to two variables statement to fail and throw.

This PR is a bug fix and fairly small in scope - review should hopefully be easy and straightforward.