### PR TITLE
Update requirements for documentation build to fix failing RTD build

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -15,7 +15,7 @@ py-solc-x==0.10.1
 packaging==20.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pygments==2.7.3; python_version >= '3.5'
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
-pytz==2020.4
+pytz==2020.5
 requests==2.25.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 snowballstemmer==2.0.0
 sphinx-rtd-theme==0.5.1

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,32 +1,31 @@
 -i https://pypi.python.org/simple
 alabaster==0.7.12
-babel==2.8.0
-certifi==2020.6.20
-chardet==3.0.4
-click==7.1.2
-docutils==0.16
-idna==2.10
-imagesize==1.2.0
+babel==2.9.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+certifi==2020.12.5
+chardet==4.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+click==7.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+docutils==0.16; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+imagesize==1.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 incremental==17.5.0
-jinja2==2.11.2
+jinja2==2.11.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 git+git://github.com/inspirehep/jsonschema2rst@d211d9709046431a6b6a4594c97c22d8713d854b#egg=jsonschema2rst
-markupsafe==1.1.1
+markupsafe==1.1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 py-solc-x==0.10.1
-packaging==20.4
-pygments==2.7.1
-pyparsing==2.4.7
-pytz==2020.1
-requests==2.24.0
-six==1.15.0
+packaging==20.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pygments==2.7.3; python_version >= '3.5'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
+pytz==2020.4
+requests==2.25.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 snowballstemmer==2.0.0
-sphinx-rtd-theme==0.5.0
+sphinx-rtd-theme==0.5.1
 sphinx==3.0.1
-sphinxcontrib-applehelp==1.0.2
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==1.0.3
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.4
-toml==0.10.1
+sphinxcontrib-applehelp==1.0.2; python_version >= '3.5'
+sphinxcontrib-devhelp==1.0.2; python_version >= '3.5'
+sphinxcontrib-htmlhelp==1.0.3; python_version >= '3.5'
+sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
+sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
+sphinxcontrib-serializinghtml==1.1.4; python_version >= '3.5'
+toml==0.10.2
 towncrier==19.2.0
-urllib3==1.25.10
+urllib3==1.26.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'

--- a/newsfragments/2496.misc.rst
+++ b/newsfragments/2496.misc.rst
@@ -1,0 +1,1 @@
+Fixed failing readthedocs build due to dependency mismatches in docs requirements.


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [x] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

Fixes the failing readthedocs build. As part of the relock of dependencies, the docs-requirements.txt dependencies need to be update as well. Long term we need to make this process better - the docs-requirements.txt should be updated as part of the relock dependencies script.

**Issues fixed/closed:**
> - Fixes #...

Related to #2440, #2498
Follow-up issue filed https://github.com/nucypher/nucypher/issues/2495.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

Failing RTD build - https://readthedocs.org/projects/nucypher/builds/12688734/

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Just a second pair of eyes really.
