### PR TITLE
Deprecates manual worker commitment via CLI

### DIFF
--- a/newsfragments/2507.removal.rst
+++ b/newsfragments/2507.removal.rst
@@ -1,0 +1,1 @@
+Deprecated manual worker commitments using the CLI.

--- a/nucypher/cli/processes.py
+++ b/nucypher/cli/processes.py
@@ -47,7 +47,7 @@ class UrsulaCommandProtocol(LineReceiver):
         # Expose Ursula functional entry points
         self.__commands = {
 
-             # Help
+            # Help
             '?': self.paintHelp,
             'help': self.paintHelp,
 
@@ -55,9 +55,6 @@ class UrsulaCommandProtocol(LineReceiver):
             'status': self.paintStatus,
             'known_nodes': self.paintKnownNodes,
             'fleet_state': self.paintFleetState,
-
-            # Blockchain Control
-            'commit_next': self.commit_to_next_period,  # hidden
 
             # Learning Control
             'cycle_teacher': self.cycle_teacher,
@@ -69,6 +66,8 @@ class UrsulaCommandProtocol(LineReceiver):
 
         }
 
+        self._hidden_commands = ('?',)
+
     @property
     def commands(self):
         return self.__commands.keys()
@@ -79,7 +78,7 @@ class UrsulaCommandProtocol(LineReceiver):
         """
         self.emitter.echo("\nUrsula Command Help\n===================\n")
         for command, func in self.__commands.items():
-            if command not in ('?', 'commit_next'):
+            if command not in self._hidden_commands:
                 try:
                     self.emitter.echo(f'{command}\n{"-"*len(command)}\n{func.__doc__.lstrip()}')
                 except AttributeError:
@@ -165,12 +164,6 @@ class UrsulaCommandProtocol(LineReceiver):
         Manually stop the attached Ursula's node learning protocol.
         """
         return self.ursula.stop_learning_loop()
-
-    def commit_to_next_period(self):
-        """
-        manually make a commitment to the next period
-        """
-        return self.ursula.commit_to_next_period(fire_and_forget=False)
 
     def stop(self):
         """

--- a/tests/acceptance/cli/ursula/test_ursula_command.py
+++ b/tests/acceptance/cli/ursula/test_ursula_command.py
@@ -75,15 +75,14 @@ def test_ursula_command_help(protocol, ursula):
         protocol.lineReceived(line=b'bananas')
 
     commands = protocol.commands
-    hidden_commands = ['?', 'commit_next']
-    commands = list(set(commands) - set(hidden_commands))
+    commands = list(set(commands) - set(protocol._hidden_commands))
 
     # Ensure all commands are in the help text
     result = out.getvalue()
     assert "Invalid input" in result
     for command in commands:
         assert command in result, '{} is missing from help text'.format(command)
-    for command in hidden_commands:
+    for command in protocol._hidden_commands:
         assert command not in result, f'Hidden command {command} in help text'
 
     # Try again with valid 'help' command
@@ -94,7 +93,7 @@ def test_ursula_command_help(protocol, ursula):
     assert "Invalid input" not in result
     for command in commands:
         assert command in result, '{} is missing from help text'.format(command)
-    for command in hidden_commands:
+    for command in protocol._hidden_commands:
         assert command not in result, f'Hidden command {command} in help text'
 
     # Blank lines are OK!


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other (Deprecation)

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Deprecates CLI commands for manually committing to next period.

**Why it's needed:**

Configurable maximum gas price for workers provides a mitigation that supersedes the ability to manually commit.  While it has served it's purpose, Exposing `commit_to_next_period` as a CLI command is a proverbial "foot gun" that allows users to damage the health of the network. It's removal is part of guiding the codebase and node operators to use other tactics to manage gas costs while still providing a high level of grant availability.

Tangentially related to project https://github.com/nucypher/nucypher/projects/13