### PR TITLE
Include relock of docs-requirements.txt in the relock_dependencies script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ smoke-test: clean
 
 lock: clean
     # Relock dependencies
-	scripts/installation/relock_dependencies.sh
+	scripts/dependencies/relock_dependencies.sh
 
 env: lock
     # Relock dependencies and generate a pipenv virtualenv from the result

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -403,6 +403,14 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
+                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.3.0"
+        },
         "incremental": {
             "hashes": [
                 "sha256:717e12246dddf231a349175f48d74d93e2897244939173b01974ab6661406b9f",
@@ -1153,6 +1161,7 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "tzlocal": {
@@ -1251,6 +1260,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.0.1"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.0"
         },
         "zope.interface": {
             "hashes": [
@@ -1461,11 +1478,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:6eea89b655917b500437e9668e4a12eabdcf00229a0df1762aabd692ef9b746b",
-                "sha256:befa4d101f91bad1b632df4308ec64555db684c360bd7d2130b4807d49ce86b8"
+                "sha256:42dbefd8d9e2576c496ed0059f3103dcef7125b9ce16f9d5f9c834aed44a1dac",
+                "sha256:867ec3dfb126aac0f8296b19fb63b8c4a399f32b4b6fafe84c4b10af5fa9f7b5"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==3.1.11"
+            "version": "==3.1.12"
         },
         "greenlet": {
             "hashes": [
@@ -1492,11 +1509,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:37990720e2894f99aee6ee870805190b772fa7d88478a3388aa100dece7dbeb1",
-                "sha256:c343282d67ee0efe5bdc2181e642941ffaf3a3c720d95b11c3e8c0a11d60325e"
+                "sha256:36a4d5587c34193125d654b61bf9284e24a227d1edd339c49143378658a10c7d",
+                "sha256:e91111f2f01abf2566041c4c86366aa7f08bfd5b3d858cc77a545fcf67df335e"
             ],
             "index": "pypi",
-            "version": "==5.47.0"
+            "version": "==5.49.0"
         },
         "identify": {
             "hashes": [
@@ -1513,6 +1530,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:5c5a2720817414a6c41f0a49993908068243ae02c1635a228126519b509c8aed",
+                "sha256:bf792d480abbd5eda85794e4afb09dd538393f7d6e6ffef6e9f03d2014cf9450"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.3.0"
         },
         "iniconfig": {
             "hashes": [
@@ -1789,6 +1814,7 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
+            "markers": "python_version < '3.8' and python_version < '3.8'",
             "version": "==3.7.4.3"
         },
         "urllib3": {
@@ -1806,6 +1832,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.2.2"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.0"
         }
     }
 }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,11 +12,12 @@ distlib==0.3.1
 execnet==1.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 filelock==3.0.12
 gitdb==4.0.5; python_version >= '3.4'
-gitpython==3.1.11; python_version >= '3.4'
+gitpython==3.1.12; python_version >= '3.4'
 greenlet==0.4.17
-hypothesis==5.47.0
+hypothesis==5.49.0
 identify==1.5.11; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==3.3.0; python_version < '3.8'
 iniconfig==1.1.1
 mypy-extensions==0.4.3
 mypy==0.790
@@ -45,6 +46,7 @@ sortedcontainers==2.3.0
 stevedore==3.3.0; python_version >= '3.6'
 toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 typed-ast==1.4.2
-typing-extensions==3.7.4.3
+typing-extensions==3.7.4.3; python_version < '3.8' and python_version < '3.8'
 urllib3==1.26.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
 virtualenv==20.2.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+zipp==3.4.0; python_version >= '3.6'

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,22 +1,41 @@
 -i https://pypi.python.org/simple
 alabaster==0.7.12
+apipkg==1.5; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+attrs==20.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+autosemver==0.5.5
 babel==2.9.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 certifi==2020.12.5
 chardet==4.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 click==7.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+coverage==5.3.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
 docutils==0.16; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+dulwich==0.19.16
+execnet==1.7.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+git+git://github.com/inspirehep/jsonschema2rst.git@d211d9709046431a6b6a4594c97c22d8713d854b#egg=jsonschema2rst
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 imagesize==1.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==3.3.0; python_version < '3.8' and python_version < '3.8'
 incremental==17.5.0
+iniconfig==1.1.1
+isort==5.7.0; python_version >= '3.6' and python_version < '4'
 jinja2==2.11.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-git+git://github.com/inspirehep/jsonschema2rst@d211d9709046431a6b6a4594c97c22d8713d854b#egg=jsonschema2rst
 markupsafe==1.1.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-py-solc-x==0.10.1
+mock==4.0.3; python_version >= '3.6'
 packaging==20.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pep8==1.7.1
+pluggy==0.13.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+py-solc-x==0.10.1
+py==1.10.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pygments==2.7.3; python_version >= '3.5'
 pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
+pytest-cache==1.0
+pytest-cov==2.10.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+pytest-pep8==1.0.6
+pytest==6.2.1; python_version >= '3.6'
 pytz==2020.5
+pyyaml==5.3.1
 requests==2.25.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+semantic-version==2.8.5; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 snowballstemmer==2.0.0
 sphinx-rtd-theme==0.5.1
 sphinx==3.0.1
@@ -26,6 +45,8 @@ sphinxcontrib-htmlhelp==1.0.3; python_version >= '3.5'
 sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
 sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.4; python_version >= '3.5'
-toml==0.10.2
+toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 towncrier==19.2.0
+typing-extensions==3.7.4.3; python_version < '3.8'
 urllib3==1.26.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+zipp==3.4.0; python_version >= '3.6'

--- a/newsfragments/2510.misc.rst
+++ b/newsfragments/2510.misc.rst
@@ -1,0 +1,1 @@
+Ensure that documentation dependencies are updated when standard/development dependencies are updated.

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ hexbytes==0.2.1; python_version >= '3.6' and python_version < '4'
 humanize==3.2.0; python_version >= '3.6'
 hyperlink==20.0.1
 idna==2.10; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+importlib-metadata==3.3.0; python_version < '3.8'
 incremental==17.5.0
 ipfshttpclient==0.7.0a1; python_full_version >= '3.5.4' and python_full_version not in '3.6.0, 3.6.1, 3.7.0, 3.7.1'
 itsdangerous==1.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
@@ -94,7 +95,7 @@ trezor==0.12.2
 trie==2.0.0a5; python_version >= '3.6' and python_version < '4'
 twisted==20.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 txaio==20.12.1; python_version >= '3.6'
-typing-extensions==3.7.4.3
+typing-extensions==3.7.4.3; python_version < '3.8' and python_version < '3.8'
 tzlocal==2.1
 umbral==0.1.3a2
 urllib3==1.26.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
@@ -103,4 +104,5 @@ watchdog==1.0.2; python_version >= '3.6'
 web3==5.12.3
 websockets==8.1; python_full_version >= '3.6.1'
 werkzeug==1.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+zipp==3.4.0; python_version >= '3.6'
 zope.interface==5.2.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/scripts/dependencies/docs/Pipfile
+++ b/scripts/dependencies/docs/Pipfile
@@ -1,0 +1,14 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[requires]
+python_version = "3"
+
+[packages]
+jsonschema2rst = {git = "git://github.com/inspirehep/jsonschema2rst.git", editable = false, ref="d211d9709046431a6b6a4594c97c22d8713d854b"}
+py-solc-x = "==0.10.1"
+sphinx = "==3.0.1"
+sphinx_rtd_theme = "*"
+towncrier = "*"

--- a/scripts/dependencies/relock_dependencies.sh
+++ b/scripts/dependencies/relock_dependencies.sh
@@ -9,12 +9,20 @@ pipenv --rm
 rm -f Pipfile.lock
 rm -f $PREFIX.txt
 rm -f dev-$PREFIX.txt
+rm -f docs-$PREFIX.txt
 
 echo "Removing pip and pipenv system cache..."
 rm -r ~/.cache/pip ~/.cache/pipenv
 
 # start enforcing failures
 set -e
+
+echo "Building Documentation Requirements"
+pushd ./scripts/dependencies/docs
+pipenv lock --clear --pre --requirements --no-header > ../../../docs-$PREFIX.txt
+rm -f Pipfile.lock
+pipenv --rm
+popd
 
 echo "Building Development Requirements"
 pipenv lock --clear --pre --requirements --dev-only --no-header > dev-$PREFIX.txt


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

Relock `doc-requirements.txt` as part of the `relock_dependencies.sh` script

**Issues fixed/closed:**
> - Fixes #...

Fixes #2495 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

Prevent RTD build failures (eg. https://readthedocs.org/projects/nucypher/builds/12688734/) due to mismatched dependency versions in docs-requirements.txt, when `requirements.txt` and `dev-requirements.txt` dependencies are updated.


**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

* Focus on logic/strategy followed in `relock_dependencies.sh`. We have to maintain a Pipfile for the docs requirements
* At least one other person should run the relock script (preferably on Linux, since I tested on Mac)
