### PR TITLE
When rendering /status, don't fail, but log on StampNotSigned

### DIFF
--- a/newsfragments/2515.bugfix.rst
+++ b/newsfragments/2515.bugfix.rst
@@ -1,0 +1,1 @@
+Gentler handling of unsigned stamps from stranger Ursulas on status endpoint

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1331,10 +1331,15 @@ class Teacher:
             address_first6=self.checksum_address[2:8]
         )
 
-    def known_nodes_details(self) -> dict:
+    def known_nodes_details(self, raise_invalid=True) -> dict:
         abridged_nodes = {}
         for checksum_address, node in self.known_nodes._nodes.items():
-            abridged_nodes[checksum_address] = self.node_details(node=node)
+            try:
+                abridged_nodes[checksum_address] = self.node_details(node=node)
+            except self.StampNotSigned:
+                if raise_invalid:
+                    raise
+                self.log.error(f"encountered unsigned stamp for node with checksum: {checksum_address}")
         return abridged_nodes
 
     @staticmethod
@@ -1367,11 +1372,11 @@ class Teacher:
                    }
         return payload
 
-    def abridged_node_details(self) -> dict:
+    def abridged_node_details(self, raise_invalid=True) -> dict:
         """Self-Reporting"""
         payload = self.node_details(node=self)
         states = self.known_nodes.abridged_states_dict()
-        known = self.known_nodes_details()
+        known = self.known_nodes_details(raise_invalid=raise_invalid)
         payload.update({'states': states, 'known_nodes': known})
         if not self.federated_only:
             payload.update({

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -421,7 +421,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
     @rest_app.route('/status/', methods=['GET'])
     def status():
         if request.args.get('json'):
-            payload = this_node.abridged_node_details()
+            payload = this_node.abridged_node_details(raise_invalid=False)
             response = jsonify(payload)
             return response
 


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Allows for a gentler handling of UnsignedStamps only when in the context of reading known nodes while rendering ursula's /status endpoint

Resolves https://sentry.io/organizations/nucypher/issues/2134995939/?project=1480080&query=is%3Aunresolved
Fixes the /status?json=1 which is currently broken network wide.

**Notes for reviewers:**
This will not affect https://github.com/nucypher/nucypher/issues/1698 or any of the related issues as it only will change anything when called from /status

I have already tested this on several NuCo nodes over the period of 2021-01-01 to 2021-01-10 or so
