### PR TITLE
Fix CI build

### DIFF
--- a/newsfragments/2521.bugfix.rst
+++ b/newsfragments/2521.bugfix.rst
@@ -1,0 +1,1 @@
+Restore the re-raising behavior in ``BlockchainInterface._handle_failed_transaction()``

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -403,17 +403,13 @@ class BlockchainInterface:
         # TODO: #1504 - Additional Handling of validation failures (gas limits, invalid fields, etc.)
         """
 
-        try:
-            response = exception.args[0]
-        except (AttributeError, TypeError):
-            # Python exceptions must have the 'args' attribute which must be a sequence (i.e. indexable)
-            raise ValueError(f'{exception} is not a valid Exception instance')
+        response = exception.args[0]
 
         # Assume this error is formatted as an RPC response
         try:
             code = int(response['code'])
             message = response['message']
-        except (KeyError, ValueError):
+        except Exception:
             # TODO: #1504 - Try even harder to determine if this is insufficient funds causing the issue,
             #               This may be best handled at the agent or actor layer for registry and token interactions.
             # Worst case scenario - raise the exception held in context implicitly


### PR DESCRIPTION
**Type of PR:**
Bugfix

**Required reviews:** 
1

**What this does:**
Fix a bug introduced in #2486. [Example of a failed CI](https://app.circleci.com/pipelines/github/nucypher/nucypher/6922/workflows/86ddb3fc-8793-4899-89e2-7890ee71708c/jobs/118136)

Basically, the code in `_handle_failed_transaction()`
```
        try:
            code = int(response['code'])
            message = response['message']
        except (KeyError, ValueError):
```
May result in a `TypeError` if `response` is not subscriptable. As a result, `TypeError` is raised instead of `exception`, which results in multiple tests failing. 

The PR introduces two changes: 
- Let `response = exception.args[0]` fail naturally. If we're replacing the exception, we may as well know what exactly failed there.
- Catch all `Exception`s in the block above instead of enumerating possible failures. Would be even better to actually check the type of `response`, perhaps?
