### PR TITLE
Fix failing build_docker job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -754,7 +754,7 @@ jobs:
       - setup_remote_docker
       - restore_cache:
           keys:
-            - v1-{{ .Branch }}
+            - v2-{{ .Branch }}-{{ arch }}
           paths:
             - ~/docker/nucypher.tar
       - run:
@@ -772,7 +772,7 @@ jobs:
             mkdir -p ~/docker
             docker save -o ~/docker/nucypher.tar nucypher/nucypher:circle
       - save_cache:
-          key: v1-{{ .Branch }}-{{ epoch }}
+          key: v2-{{ .Branch }}-{{ arch }}-{{ epoch }}
           paths:
             - ~/docker/nucypher.tar
 
@@ -812,7 +812,7 @@ jobs:
       - setup_remote_docker
       - restore_cache:
           keys:
-            - v1-{{ .Branch }}
+            - v2-{{ .Branch }}-{{ arch }}
           paths:
             - ~/docker/nucypher.tar
       - run:
@@ -836,7 +836,7 @@ jobs:
       - setup_remote_docker
       - restore_cache:
           keys:
-            - v1-{{ .Branch }}
+            - v2-{{ .Branch }}-{{ arch }}
           paths:
             - ~/docker/nucypher.tar
       - run:


### PR DESCRIPTION
I think the problem is that last time we saved the result of the `build_docker` job to cache, we were using the previous CI docker images, which changed in this commit https://github.com/nucypher/nucypher/commit/9d95ce81fe54c2abf5cf7724f753dc7d3447cce1

The problem is that we didn't changed the cache key, and probably the images have changed internally. I verified that simply bumping the cache key works, both for saving and restoring the cache. 

Also added the architecture ID to the cache key, as suggested in https://support.circleci.com/hc/en-us/articles/360004250693-Restoring-cache-fails-with-Permission-Denied-