### PR TITLE
Remove docs pip extra from setup.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -727,7 +727,7 @@ jobs:
           command: |
             python -m pip install pip==20.2.4
             pip3 --version
-            pip3 install --user .[docs]
+            pip3 install --user -r docs-requirements.txt .
       - run:
           name: Build Sphinx Documentation
           command: make docs

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,6 @@ def read_requirements(path):
 
 
 INSTALL_REQUIRES = read_requirements('requirements.txt')
-DOCS_REQUIRE = read_requirements('docs-requirements.txt')
 DEV_REQUIRES = read_requirements('dev-requirements.txt')
 
 BENCHMARK_REQUIRES = [
@@ -140,10 +139,9 @@ BOB_REQUIRES = ['qrcode']
 EXTRAS = {
 
     # Admin
-    'docs': DOCS_REQUIRE,
-    'dev': DEV_REQUIRES + DOCS_REQUIRE + URSULA_REQUIRES + ALICE_REQUIRES,
+    'dev': DEV_REQUIRES + URSULA_REQUIRES + ALICE_REQUIRES,
     'benchmark': DEV_REQUIRES + BENCHMARK_REQUIRES,
-    'deploy': DOCS_REQUIRE + DEPLOY_REQUIRES,
+    'deploy': DEPLOY_REQUIRES,
 
     # User
     'ursula': URSULA_REQUIRES,


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**

Removes the docs pip extra to allow prevent distributing `jsonschema2rst`

**Issues fixed/closed:**

Closes #2524 