### PR TITLE
Fixes to unit tests. Fix for #2484

### DIFF
--- a/docs/source/guides/contribution_guide.rst
+++ b/docs/source/guides/contribution_guide.rst
@@ -260,14 +260,14 @@ Issuing a New Release
 1. Decide what part of the version to bump.
 The version string follows the format ``{major}.{minor}.{patch}-{stage}.{devnum}``,
 so the options are ``major``, ``minor``, ``patch``, ``stage``, or ``devnum``.
-We usually issue new releases increasing the ``devnum`` version.
+We usually issue new releases increasing the ``patch`` version.
 
 2. Use the ``make release`` script, specifying the version increment with the ``bump`` parameter.
-For example, for a new ``devnum`` release, we would do:
+For example, for a new ``patch`` release, we would do:
 
 .. code:: bash
 
-  (nucypher)$ make release bump=devnum
+  (nucypher)$ make release bump=patch
 
 3. The previous step triggers the publication webhooks on CircleCI.
 Monitor the triggered deployment build for manual approval.

--- a/docs/source/guides/ethereum_node.rst
+++ b/docs/source/guides/ethereum_node.rst
@@ -163,7 +163,7 @@ Clef is typically installed alongside geth.
 
 .. important::
 
-    Geth version 1.9.0 or higher is required.
+    Geth version 1.9.22 or higher is required.
 
 If you already have geth installed on your system you may already have Clef installed.  To check for an
 existing installation run:

--- a/newsfragments/2484.bugfix.rst
+++ b/newsfragments/2484.bugfix.rst
@@ -1,0 +1,1 @@
+Fix wrong usage of net_version to identify the EthereumClient client chain.

--- a/newsfragments/2533.bugfix.rst
+++ b/newsfragments/2533.bugfix.rst
@@ -1,0 +1,1 @@
+Use eth_chainId instead of net_version to maintain compatibility with geth.

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -15,16 +15,16 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-import maya
 import os
 import time
+from typing import Union
+
 from constant_sorrow.constants import UNKNOWN_DEVELOPMENT_CHAIN_ID
 from cytoolz.dicttoolz import dissoc
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_typing.evm import BlockNumber, ChecksumAddress
 from eth_utils import to_canonical_address, to_checksum_address
-from typing import Union
 from web3 import Web3
 from web3.contract import Contract
 from web3.types import Wei, TxReceipt
@@ -409,8 +409,7 @@ class GethClient(EthereumClient):
 
     @property
     def is_local(self):
-        # TODO: #1505  -- rethink this metaphor
-        return int(self.w3.net.version) not in PUBLIC_CHAINS
+        return self.chain_id not in PUBLIC_CHAINS
 
     @property
     def peers(self):

--- a/tests/mock/interfaces.py
+++ b/tests/mock/interfaces.py
@@ -76,7 +76,7 @@ class MockBlockchain(TesterBlockchain):
     PROVIDER_URI = MOCK_PROVIDER_URI
 
     def __init__(self):
-        super().__init__()
+        super().__init__(compile_now=False)
 
 
 class MockEthereumClient(EthereumClient):

--- a/tests/unit/test_card.py
+++ b/tests/unit/test_card.py
@@ -23,7 +23,6 @@ from nucypher.policy.identity import Card
 from tests.utils.middleware import MockRestMiddleware
 
 
-@pytest.mark.skip('Skip until qrcode module is added as dependency in 2440')
 @pytest.mark.parametrize('character_class', (Bob, Alice))
 def test_character_card(character_class):
     character = character_class(federated_only=True,

--- a/tests/unit/test_web3_clients.py
+++ b/tests/unit/test_web3_clients.py
@@ -179,10 +179,6 @@ class GethClientTestBlockchain(BlockchainInterfaceTestBase):
     def _attach_provider(self, *args, **kwargs) -> None:
         super()._attach_provider(provider=MockGethProvider())
 
-    @property
-    def is_local(self):
-        return int(self.w3.net.version) not in PUBLIC_CHAINS
-
 
 class ParityClientTestInterface(BlockchainInterfaceTestBase):
 

--- a/tests/utils/blockchain.py
+++ b/tests/utils/blockchain.py
@@ -106,6 +106,7 @@ class TesterBlockchain(BlockchainDeployerInterface):
                  light: bool = False,
                  eth_airdrop: bool = False,
                  free_transactions: bool = False,
+                 compile_now: bool = True,
                  *args, **kwargs):
 
         self.free_transactions = free_transactions
@@ -118,7 +119,7 @@ class TesterBlockchain(BlockchainDeployerInterface):
                          *args, **kwargs)
 
         self.log = Logger("test-blockchain")
-        self.connect()
+        self.connect(compile_now=compile_now)
 
         # Generate additional ethereum accounts for testing
         population = test_accounts


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
A small PR with some assorted bugfixes and changes.

- Fixes #2484: We were incorrectly using `net_version` to identify the Ethereum chain in some places. This was found in the short period where geth deprecated said endpoint. In any case, we now use `eth_chainId`.
- Fixes #2531: The MockBlockchain was compiling solidity sources, which is not correct and was making unit tests very slow.
- Unskips card tests
- Adds some minor clarifications to the docs.

**Why it's needed:**
Maintenance.

**Notes for reviewers:**
Nothing.
