### PR TITLE
Fixed blocking call waiting for number of known nodes which could infinite loop

### DIFF
--- a/newsfragments/2534.bugfix.rst
+++ b/newsfragments/2534.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed infinite loop during learning when timing out but known nodes exceeds target.

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -610,6 +610,7 @@ class Learner:
             elapsed = (round_finish - start).seconds
             if elapsed > timeout:
                 if len(self.known_nodes) >= number_of_nodes_to_know:  # Last chance!
+                    self.log.info(f"Learned about enough nodes after {rounds_undertaken} rounds.")
                     return True
                 if not self._learning_task.running:
                     raise RuntimeError("Learning loop is not running.  Start it with start_learning().")

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -610,7 +610,7 @@ class Learner:
             elapsed = (round_finish - start).seconds
             if elapsed > timeout:
                 if len(self.known_nodes) >= number_of_nodes_to_know:  # Last chance!
-                    continue
+                    return True
                 if not self._learning_task.running:
                     raise RuntimeError("Learning loop is not running.  Start it with start_learning().")
                 elif not reactor.running and not learn_on_this_thread:

--- a/tests/metrics/grant_availability.py
+++ b/tests/metrics/grant_availability.py
@@ -37,7 +37,7 @@ from umbral.keys import UmbralPrivateKey
 from web3.main import Web3
 from web3.types import Wei
 
-from network.middleware import RestMiddleware
+from nucypher.network.middleware import RestMiddleware
 from nucypher.characters.lawful import Bob, Ursula, Alice
 from nucypher.config.characters import AliceConfiguration
 from nucypher.policy.policies import Policy


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

Exit while loop when blocking until number nodes exceeds requirement. This caused an infinite loop while timing out when learning - exhibited for Alice.

Side fix for invalid import in grant_availability script which was used for testing when bug was discovered.

**Issues fixed/closed:**
> - Fixes #...

Closes #2487 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
