### PR TITLE
[WIP] Persistent TLS certificates; Simplify Ursula Initialization 

### DIFF
--- a/nucypher/blockchain/__init__.py
+++ b/nucypher/blockchain/__init__.py
@@ -14,3 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
+
+NO_BLOCKCHAIN_CONNECTION.bool_value(False)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1437,8 +1437,6 @@ class Worker(NucypherTokenActor):
                  is_me: bool,
                  work_tracker: WorkTracker = None,
                  worker_address: str = None,
-                 commit_now: bool = False,
-                 block_until_ready: bool = True,
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -1461,13 +1459,8 @@ class Worker(NucypherTokenActor):
         self.__uptime_period = WORKER_NOT_RUNNING
 
         if is_me:
-            if block_until_ready:
-                # Workers cannot be started before bonding.
-                self.block_until_ready()
             self.stakes = StakeList(registry=self.registry, checksum_address=self.checksum_address)
-            self.stakes.refresh()
             self.work_tracker = work_tracker or WorkTracker(worker=self)
-            self.work_tracker.start(commit_now=commit_now)
 
     def block_until_ready(self, poll_rate: int = None, timeout: int = None, feedback_rate: int = None):
         """
@@ -1486,7 +1479,6 @@ class Worker(NucypherTokenActor):
         last_provided_feedback = start
 
         emitter = StdoutEmitter()
-        emitter.message("Qualifying worker", color='yellow')
 
         funded, bonded = False, False
         while True:
@@ -1507,7 +1499,7 @@ class Worker(NucypherTokenActor):
 
             # Success and Escape
             if staking_address != NULL_ADDRESS and ether_balance:
-                self._checksum_address = staking_address
+                self.checksum_address = staking_address
 
                 # TODO: #1823 - Workaround for new nickname every restart
                 self.nickname = Nickname.from_seed(self.checksum_address)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1500,7 +1500,6 @@ class Worker(NucypherTokenActor):
             # Success and Escape
             if staking_address != NULL_ADDRESS and ether_balance:
                 self.checksum_address = staking_address
-
                 # TODO: #1823 - Workaround for new nickname every restart
                 self.nickname = Nickname.from_seed(self.checksum_address)
                 break

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -791,7 +791,7 @@ class StakeList(UserList):
     @validate_checksum_address
     def __init__(self,
                  registry: BaseContractRegistry,
-                 checksum_address: str = None,
+                 checksum_address: str = None,  # allow for lazy setting
                  *args, **kwargs):
 
         super().__init__(*args, **kwargs)
@@ -805,9 +805,8 @@ class StakeList(UserList):
 
         # "load-in":  Read on-chain stakes
         # Allow stake tracker to be initialized as an empty collection.
-        if checksum_address:
-            if not is_checksum_address(checksum_address):
-                raise ValueError(f'{checksum_address} is not a valid EIP-55 checksum address')
+        if checksum_address and not is_checksum_address(checksum_address):
+            raise ValueError(f'{checksum_address} is not a valid EIP-55 checksum address')
         self.checksum_address = checksum_address
         self.__updated = None
 

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -110,10 +110,12 @@ class Character(Learner):
         """
 
         #
-        # Operating Mode
+        # Prologue of the federation
         #
 
+        # FIXME: excuse me... can I speak to the manager?
         if is_me:
+            # If this is a federated-is_me-character, assume everyone else is too.
             self._set_known_node_class(known_node_class, federated_only)
         else:
             # What an awful hack.  The last convulsions of #466.  # TODO: Anything else.
@@ -124,6 +126,8 @@ class Character(Learner):
             if registry or provider_uri:
                 raise ValueError(f"Cannot init federated-only character with {registry or provider_uri}.")
         self.federated_only: bool = federated_only
+
+        ##########################################
 
         #
         # Keys & Powers
@@ -148,10 +152,8 @@ class Character(Learner):
         else:
             self._crypto_power = CryptoPower(power_ups=self._default_crypto_powerups)
 
-
-
         #
-        # Self-Character
+        # Self
         #
 
         if is_me:
@@ -209,32 +211,7 @@ class Character(Learner):
             self.network_middleware = STRANGER
             self.checksum_address = checksum_address
 
-
-        #
-        # Nicknames
-        #
-
-        # TODO: The heck is happening in this block?!?
-
-        if not self.checksum_address and not self.federated_only and not is_me:
-            # Sometimes we don't care about the nickname.  For example, if Alice is granting to Bob, she usually
-            # doesn't know or care about his wallet.  Maybe this needs to change?
-            # Currently, if this is a stranger and there's no blockchain connection, we assign NO_NICKNAME:
-            self.nickname = NO_NICKNAME
-        else:
-            try:
-                if not self.checksum_address:
-                    self.nickname = NO_NICKNAME
-                else:
-                    # This can call _set_checksum_address.
-                    self.nickname = Nickname.from_seed(self.checksum_address)
-            except SigningPower.not_found_error:
-                if self.federated_only:
-                    self.nickname = NO_NICKNAME
-                else:
-                    raise
-
-        # Fleet state
+        self.__setup_nickname(is_me=is_me)
         if is_me:
             self.known_nodes.record_fleet_state()
 
@@ -262,6 +239,25 @@ class Character(Learner):
         except (NoSigningPower, TypeError):  # TODO: ....yeah?  We can probably do better for a repr here.
             r = f"({self.__class__.__name__})⇀{self.nickname}↽"
         return r
+
+    def __setup_nickname(self, is_me: bool):
+        if not self.checksum_address and not self.federated_only and not is_me:
+            # Sometimes we don't care about the nickname.  For example, if Alice is granting to Bob, she usually
+            # doesn't know or care about his wallet.  Maybe this needs to change?
+            # Currently, if this is a stranger and there's no blockchain connection, we assign NO_NICKNAME:
+            self.nickname = NO_NICKNAME
+        else:
+            try:
+                if not self.checksum_address:
+                    self.nickname = NO_NICKNAME
+                else:
+                    # This can call _set_checksum_address.
+                    self.nickname = Nickname.from_seed(self.checksum_address)
+            except SigningPower.not_found_error:
+                if self.federated_only:
+                    self.nickname = NO_NICKNAME
+                else:
+                    raise
 
     @property
     def name(self):

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -128,17 +128,9 @@ class Character(Learner):
         #
 
         # Derive powers from keyring
-        if keyring_root and keyring:
-            if keyring_root != keyring.keyring_root:
-                raise ValueError("Inconsistent keyring root directory path")
-        if keyring:
-            keyring_root, checksum_address = keyring.keyring_root, keyring.checksum_address
-            crypto_power_ups = list()
-            for power_up in self._default_crypto_powerups:
-                power = keyring.derive_crypto_power(power_class=power_up)
-                crypto_power_ups.append(power)
         self.keyring_root = keyring_root
         self.keyring = keyring
+        self.derive_powers()  # depends on keyring and keyring_root being set
 
         if crypto_power and crypto_power_ups:
             raise ValueError("Pass crypto_power or crypto_power_ups (or neither), but not both.")
@@ -261,6 +253,19 @@ class Character(Learner):
         except (NoSigningPower, TypeError):  # TODO: ....yeah?  We can probably do better for a repr here.
             r = f"({self.__class__.__name__})⇀{self.nickname}↽"
         return r
+
+    def derive_powers(self):
+        if self.keyring_root and self.keyring:
+            if self.keyring_root != self.keyring.keyring_root:
+                raise ValueError("Inconsistent keyring root directory path")
+
+        if self.keyring:
+            # FIXME
+            # keyring_root, checksum_address = self.keyring.keyring_root, self.keyring.checksum_address
+            crypto_power_ups = list()
+            for power_up in self._default_crypto_powerups:
+                power = self.keyring.derive_crypto_power(power_class=power_up)
+                crypto_power_ups.append(power)
 
     @property
     def name(self):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -37,10 +37,10 @@ from constant_sorrow.constants import (
     STRANGER_ALICE,
     UNKNOWN_VERSION,
     READY,
-    INVALIDATED
+    INVALIDATED,
+    NOT_SIGNED
 )
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurve
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate, NameOID, load_pem_x509_certificate
 from datetime import datetime
@@ -52,6 +52,7 @@ from json.decoder import JSONDecodeError
 from queue import Queue
 from random import shuffle
 from twisted.internet import reactor, stdio, threads
+from twisted.internet.defer import Deferred
 from twisted.internet.task import LoopingCall
 from twisted.logger import Logger
 from typing import Dict, Iterable, List, Tuple, Union, Optional, Sequence, Set
@@ -69,7 +70,7 @@ from nucypher.blockchain.eth.constants import ETH_ADDRESS_BYTE_LENGTH
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.signers.software import Web3Signer
-from nucypher.blockchain.eth.token import WorkTracker
+from nucypher.blockchain.eth.token import WorkTracker, StakeList
 from nucypher.characters.banners import ALICE_BANNER, BOB_BANNER, ENRICO_BANNER, URSULA_BANNER
 from nucypher.characters.base import Character, Learner
 from nucypher.characters.control.controllers import WebController
@@ -1012,15 +1013,14 @@ class Bob(Character):
 
 
 class Ursula(Teacher, Character, Worker):
+
     banner = URSULA_BANNER
     _alice_class = Alice
 
-    # TODO: Maybe this wants to be a registry, so that, for example,  NRN
-    # TODO: TLSHostingPower still can enjoy default status, but on a different class  NRN
     _default_crypto_powerups = [
         SigningPower,
         DecryptingPower,
-        TLSHostingPower
+        # TLSHostingPower  # Still considered a default for Ursula, but needs the host context
     ]
 
     _pruning_interval = 60  # seconds
@@ -1039,56 +1039,37 @@ class Ursula(Teacher, Character, Worker):
                  # Ursula
                  rest_host: str,
                  rest_port: int,
-                 domain: str = None,  # For now, serving and learning domain will be the same.
+                 domain: str,
+                 is_me: bool = True,
+
                  certificate: Certificate = None,
                  certificate_filepath: str = None,
+
                  db_filepath: str = None,
-                 is_me: bool = True,
                  interface_signature=None,
                  timestamp=None,
-                 availability_check: bool = False,
-                 prune_datastore: bool = True,
+                 availability_check: bool = False,  # TODO: Remove from init
 
                  # Blockchain
-                 decentralized_identity_evidence: bytes = constants.NOT_SIGNED,
                  checksum_address: str = None,
                  worker_address: str = None,  # TODO: deprecate, and rename to "checksum_address"
-                 block_until_ready: bool = True,
-                 # TODO: Must be true in order to set staker address - Allow for manual staker addr to be passed too!
-                 work_tracker: WorkTracker = None,
-                 commit_now: bool = True,
                  client_password: str = None,
+                 decentralized_identity_evidence=NOT_SIGNED,
 
                  # Character
                  abort_on_learning_error: bool = False,
                  federated_only: bool = False,
-                 start_learning_now: bool = None,
                  crypto_power=None,
-                 tls_curve: EllipticCurve = None,
-                 known_nodes: Iterable = None,
+                 known_nodes: Iterable[Teacher] = None,
 
                  **character_kwargs
                  ) -> None:
 
-        #
-        # Character
-        #
-
-        if domain is None:
-            # TODO: Move defaults to configuration, Off character.
-            from nucypher.config.node import CharacterConfiguration
-            domain = CharacterConfiguration.DEFAULT_DOMAIN
-
-        if is_me:
-            # If we're federated only, we assume that all other nodes in our domain are as well.
-            self.set_federated_mode(federated_only)
 
         Character.__init__(self,
                            is_me=is_me,
                            checksum_address=checksum_address,
-                           start_learning_now=start_learning_now,
-                           federated_only=self._federated_only_instances,
-                           # TODO: 'Ursula' object has no attribute '_federated_only_instances' if an is_me Ursula is not inited prior to this moment  NRN
+                           federated_only=federated_only,
                            crypto_power=crypto_power,
                            abort_on_learning_error=abort_on_learning_error,
                            known_nodes=known_nodes,
@@ -1096,115 +1077,68 @@ class Ursula(Teacher, Character, Worker):
                            known_node_class=Ursula,
                            **character_kwargs)
 
+        # excuse me... can I speak to the manager?
         if is_me:
-            # Learner
-            self._start_learning_now = start_learning_now
 
-            # Self-Health Checks
+            # Operating Mode
+            self.known_node_class.set_federated_mode(federated_only)
+
+            # Health Checks
             self._availability_check = availability_check
             self._availability_tracker = AvailabilityTracker(ursula=self)
 
             # Datastore Pruning
-            self.__pruning_task = None
-            self._prune_datastore = prune_datastore
+            self.__pruning_task: Union[Deferred, None] = None
             self._datastore_pruning_task = LoopingCall(f=self.__prune_datastore)
 
-        #
-        # Ursula the Decentralized Worker (Self)
-        #
+            # Decentralized Worker
+            if not federated_only:
 
-        if is_me and not federated_only:  # TODO: #429
+                # Prepare a TransactingPower from worker node's transacting keys
+                transacting_power = TransactingPower(account=worker_address,
+                                                     password=client_password,
+                                                     signer=self.signer,
+                                                     cache=True)
+                self.transacting_power = transacting_power
+                self._crypto_power.consume_power_up(transacting_power)
+                self._checksum_address = transacting_power.account
 
-            # Prepare a TransactingPower from worker node's transacting keys
-            _transacting_power = TransactingPower(account=worker_address,
-                                                  password=client_password,
-                                                  signer=self.signer,
-                                                  cache=True)
-
-            self.transacting_power = _transacting_power
-            self._crypto_power.consume_power_up(_transacting_power)
-            self._set_checksum_address(checksum_address)
-
-            # Use this power to substantiate the stamp
-            self.substantiate_stamp()
-            self.log.debug(
-                f"Created decentralized identity evidence: {self.decentralized_identity_evidence[:10].hex()}")
-            decentralized_identity_evidence = self.decentralized_identity_evidence
-
-            try:
-                Worker.__init__(self,
-                                is_me=is_me,
-                                registry=self.registry,
-                                checksum_address=checksum_address,
-                                worker_address=worker_address,
-                                work_tracker=work_tracker,
-                                commit_now=commit_now,
-                                block_until_ready=block_until_ready)
-            except (Exception, self.WorkerError):  # FIXME
-                # TODO: Do not announce self to "other nodes" until this init is finished.
-                # It's not possible to finish constructing this node.
-                self.stop(halt_reactor=False)
-                raise
-
-        if not crypto_power or (TLSHostingPower not in crypto_power):  # FIXME: Is this line relevant?
-
-            if is_me:
-                self.suspicious_activities_witnessed = {'vladimirs': [],
-                                                        'bad_treasure_maps': [],
-                                                        'freeriders': []}
-
-                # REST Server (Ephemeral Self-Ursula)
-                rest_app, datastore = make_rest_app(
-                    this_node=self,
-                    db_filepath=db_filepath,
-                    domain=domain,
-                )
+                # Use this power to substantiate the stamp
+                self.__substantiate_stamp()
+                decentralized_identity_evidence = self.__decentralized_identity_evidence
 
                 try:
-                    # Restored from private keys
-                    tls_hosting_power = self._crypto_power.power_ups(TLSHostingPower)
-                except TLSHostingPower.not_found_error:
-                    # "Dev Mode" - Generate ephemeral private Keys
-                    tls_hosting_keypair = HostingKeypair(curve=tls_curve,
-                                                         host=rest_host,
-                                                         checksum_address=self.checksum_address)
-                    tls_hosting_power = TLSHostingPower(keypair=tls_hosting_keypair, host=rest_host)
+                    Worker.__init__(self,
+                                    is_me=is_me,
+                                    registry=self.registry,
+                                    checksum_address=checksum_address,
+                                    worker_address=worker_address)
+                except (Exception, self.WorkerError):
+                    # TODO: Do not announce self to "other nodes" until this init is finished.
+                    # It's not possible to finish constructing this node.
+                    self.stop(halt_reactor=False)
+                    raise
 
+            self.rest_server = self._make_local_server(host=rest_host,
+                                                       port=rest_port,
+                                                       db_filepath=db_filepath,
+                                                       domain=domain)
 
-                self.rest_server = ProxyRESTServer(rest_host=rest_host, rest_port=rest_port,
-                                                   rest_app=rest_app, datastore=datastore,
-                                                   hosting_power=tls_hosting_power)
+            # Self-signed TLS certificate of self for Teacher.__init__
+            certificate_filepath = self._crypto_power.power_ups(TLSHostingPower).keypair.certificate_filepath
+            certificate = self._crypto_power.power_ups(TLSHostingPower).keypair.certificate
 
-            else:
+            # Initial Impression
+            self.known_nodes.record_fleet_state(additional_nodes_to_track=[self])
+            message = "THIS IS YOU: {}: {}".format(self.__class__.__name__, self)
+            self.log.info(message)
+            self.log.info(self.banner.format(self.nickname))
 
-                # FEEL LIKE A STRANGER
+        else:
+            # Stranger HTTP Server
+            self.rest_server = ProxyRESTServer(rest_host=rest_host, rest_port=rest_port)
 
-                # TLSHostingPower
-                if certificate or certificate_filepath:
-                    tls_hosting_power = TLSHostingPower(host=rest_host,
-                                                        public_certificate_filepath=certificate_filepath,
-                                                        public_certificate=certificate)
-                else:
-                    tls_hosting_keypair = HostingKeypair(curve=tls_curve, host=rest_host, generate_certificate=False)
-                    tls_hosting_power = TLSHostingPower(host=rest_host, keypair=tls_hosting_keypair)
-
-                # REST Server
-                # Unless the caller passed a crypto power we'll make our own TLSHostingPower for this stranger.
-                self.rest_server = ProxyRESTServer(
-                    rest_host=rest_host,
-                    rest_port=rest_port,
-                    hosting_power=tls_hosting_power
-                )
-
-            # OK - Now we have a ProxyRestServer and a TLSHostingPower for some Ursula
-            self._crypto_power.consume_power_up(tls_hosting_power)  # Consume!
-
-        #
-        # Teacher (Verifiable Node)
-        #
-
-        certificate_filepath = self._crypto_power.power_ups(TLSHostingPower).keypair.certificate_filepath
-        certificate = self._crypto_power.power_ups(TLSHostingPower).keypair.certificate
+        # Teacher (All Modes)
         Teacher.__init__(self,
                          domain=domain,
                          certificate=certificate,
@@ -1213,25 +1147,42 @@ class Ursula(Teacher, Character, Worker):
                          timestamp=timestamp,
                          decentralized_identity_evidence=decentralized_identity_evidence)
 
-        if is_me:
-            self.known_nodes.record_fleet_state(additional_nodes_to_track=[self])  # Initial Impression
+    def __get_hosting_power(self, host: str) -> TLSHostingPower:
+        try:
+            # Pre-existing or injected power
+            tls_hosting_power = self._crypto_power.power_ups(TLSHostingPower)
+        except TLSHostingPower.not_found_error:
+            if self.keyring:
+                # Restore from TLS private key on-disk
+                tls_hosting_power = self.keyring.derive_crypto_power(TLSHostingPower, host=host)
+            else:
+                # Generate ephemeral private key ("Dev Mode")
+                tls_hosting_keypair = HostingKeypair(host=host, checksum_address=self.checksum_address)
+                tls_hosting_power = TLSHostingPower(keypair=tls_hosting_keypair, host=host)
 
-            message = "THIS IS YOU: {}: {}".format(self.__class__.__name__, self)
-            self.log.info(message)
-            self.log.info(self.banner.format(self.nickname))
-        else:
-            message = "Initialized Stranger {} | {}".format(self.__class__.__name__, self)
-            self.log.debug(message)
+        self._crypto_power.consume_power_up(tls_hosting_power)  # Consume!
+        return tls_hosting_power
 
-    def derive_powers(self):
-        if self.keyring_root and self.keyring:
-            if self.keyring_root != self.keyring.keyring_root:
-                raise ValueError("Inconsistent keyring root directory path")
-        if self.keyring:
-            crypto_power_ups = list()
-            for power_up in self._default_crypto_powerups:
-                power = self.keyring.derive_crypto_power(power_class=power_up, host=self.interface.host)
-                crypto_power_ups.append(power)
+    def _make_local_server(self, host, port, domain, db_filepath) -> ProxyRESTServer:
+        rest_app, datastore = make_rest_app(
+            this_node=self,
+            db_filepath=db_filepath,
+            domain=domain,
+        )
+        rest_server = ProxyRESTServer(rest_host=host,
+                                      rest_port=port,
+                                      rest_app=rest_app,
+                                      datastore=datastore,
+                                      hosting_power=self.__get_hosting_power(host=host))
+        return rest_server
+
+    def __substantiate_stamp(self):
+        transacting_power = self._crypto_power.power_ups(TransactingPower)
+        signature = transacting_power.sign_message(message=bytes(self.stamp))
+        self.__decentralized_identity_evidence = signature
+        self.__worker_address = transacting_power.account
+        message = f"Created decentralized identity evidence: {self.__decentralized_identity_evidence[:10].hex()}"
+        self.log.debug(message)
 
     def __prune_datastore(self) -> None:
         """Deletes all expired arrangements, kfrags, and treasure maps in the datastore."""
@@ -1275,17 +1226,24 @@ class Ursula(Teacher, Character, Worker):
     def run(self,
             emitter: StdoutEmitter = None,
             discovery: bool = True,  # TODO: see below
-            availability: bool = True,
+            availability: bool = False,
             worker: bool = True,
             pruning: bool = True,
             interactive: bool = False,
             hendrix: bool = True,
             start_reactor: bool = True,
             prometheus_config: 'PrometheusMetricsConfig' = None,
-            preflight: bool = True
+            preflight: bool = True,
+            block_until_ready: bool = True,
+            eager: bool = False
             ) -> None:
 
         """Schedule and start select ursula services, then optionally start the reactor."""
+
+        # Connect to Provider
+        if not self.federated_only:
+            if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=self.provider_uri):
+                BlockchainInterfaceFactory.initialize_interface(provider_uri=self.provider_uri)
 
         if preflight:
             self.__preflight()
@@ -1298,23 +1256,27 @@ class Ursula(Teacher, Character, Worker):
             emitter.message(f"Starting services", color='yellow')
 
         if pruning:
-            self.__pruning_task = self._datastore_pruning_task.start(interval=self._pruning_interval, now=True)
+            self.__pruning_task = self._datastore_pruning_task.start(interval=self._pruning_interval, now=eager)
             if emitter:
                 emitter.message(f"✓ Database Pruning", color='green')
 
-        # TODO: Startup node discovery here with the rest of Ursula's services.
-        # if discovery and not self.lonely:
-        #     self.start_learning_loop(now=self._start_learning_now)
-        #     if emitter:
-        #         emitter.message(f"✓ Node Discovery - {self.domain}", color='green')
+        if discovery and not self.lonely:
+            self.start_learning_loop(now=eager)
+            if emitter:
+                emitter.message(f"✓ Node Discovery ({self.domain.capitalize()})", color='green')
 
-        if self._availability_check and availability:
-            self._availability_tracker.start(now=False)  # wait...
+        if self._availability_check or availability:
+            self._availability_tracker.start(now=eager)
             if emitter:
                 emitter.message(f"✓ Availability Checks", color='green')
 
         if worker and not self.federated_only:
-            self.work_tracker.start(commit_now=True)  # requirement_func=self._availability_tracker.status)  # TODO: #2277
+            if block_until_ready:
+                # Sets (staker's) checksum address; Prevent worker startup before bonding
+                self.block_until_ready()
+            self.stakes.checksum_address = self.checksum_address
+            self.stakes.refresh()
+            self.work_tracker.start(commit_now=eager)  # requirement_func=self._availability_tracker.status)  # TODO: #2277
             if emitter:
                 emitter.message(f"✓ Work Tracking", color='green')
 
@@ -1407,17 +1369,11 @@ class Ursula(Teacher, Character, Worker):
         deployer = self._crypto_power.power_ups(TLSHostingPower).get_deployer(rest_app=self.rest_app, port=port)
         return deployer
 
-    def rest_server_certificate(self):
-        return self._crypto_power.power_ups(TLSHostingPower).keypair.certificate
-
     def __bytes__(self):
 
         version = self.TEACHER_VERSION.to_bytes(2, "big")
         interface_info = VariableLengthBytestring(bytes(self.rest_interface))
-
-        certificate = self.rest_server_certificate()
-        cert_vbytes = VariableLengthBytestring(certificate.public_bytes(Encoding.PEM))
-
+        certificate_vbytes = VariableLengthBytestring(self.certificate.public_bytes(Encoding.PEM))
         as_bytes = bytes().join((version,
                                  self.canonical_public_address,
                                  bytes(VariableLengthBytestring(self.domain.encode('utf-8'))),
@@ -1426,7 +1382,7 @@ class Ursula(Teacher, Character, Worker):
                                  bytes(VariableLengthBytestring(self.decentralized_identity_evidence)),  # FIXME: Fixed length doesn't work with federated
                                  bytes(self.public_keys(SigningPower)),
                                  bytes(self.public_keys(DecryptingPower)),
-                                 bytes(cert_vbytes),
+                                 bytes(certificate_vbytes),  # TLSHostingPower
                                  bytes(interface_info))
                                 )
         return as_bytes

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1146,10 +1146,9 @@ class Ursula(Teacher, Character, Worker):
                 self.stop(halt_reactor=False)
                 raise
 
-        if not crypto_power or (TLSHostingPower not in crypto_power):
+        if not crypto_power or (TLSHostingPower not in crypto_power):  # FIXME: Is this line relevant?
 
             if is_me:
-
                 self.suspicious_activities_witnessed = {'vladimirs': [],
                                                         'bad_treasure_maps': [],
                                                         'freeriders': []}
@@ -1161,11 +1160,15 @@ class Ursula(Teacher, Character, Worker):
                     domain=domain,
                 )
 
-                # TLSHostingPower (Ephemeral Powers and Private Keys)
-                tls_hosting_keypair = HostingKeypair(curve=tls_curve,
-                                                     host=rest_host,
-                                                     checksum_address=self.checksum_address)
-                tls_hosting_power = TLSHostingPower(keypair=tls_hosting_keypair, host=rest_host)
+                try:
+                    # Restored from private keys
+                    tls_hosting_power = self._crypto_power.power_ups(TLSHostingPower)
+                except TLSHostingPower.not_found_error:
+                    # "Dev Mode" - Generate ephemeral private Keys
+                    tls_hosting_keypair = HostingKeypair(curve=tls_curve,
+                                                         host=rest_host,
+                                                         checksum_address=self.checksum_address)
+                    tls_hosting_power = TLSHostingPower(keypair=tls_hosting_keypair, host=rest_host)
 
 
                 self.rest_server = ProxyRESTServer(rest_host=rest_host, rest_port=rest_port,
@@ -1173,6 +1176,8 @@ class Ursula(Teacher, Character, Worker):
                                                    hosting_power=tls_hosting_power)
 
             else:
+
+                # FEEL LIKE A STRANGER
 
                 # TLSHostingPower
                 if certificate or certificate_filepath:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1016,8 +1016,12 @@ class Ursula(Teacher, Character, Worker):
     _alice_class = Alice
 
     # TODO: Maybe this wants to be a registry, so that, for example,  NRN
-    # TLSHostingPower still can enjoy default status, but on a different class  NRN
-    _default_crypto_powerups = [SigningPower, DecryptingPower]
+    # TODO: TLSHostingPower still can enjoy default status, but on a different class  NRN
+    _default_crypto_powerups = [
+        SigningPower,
+        DecryptingPower,
+        TLSHostingPower
+    ]
 
     _pruning_interval = 60  # seconds
 
@@ -1144,11 +1148,8 @@ class Ursula(Teacher, Character, Worker):
 
         if not crypto_power or (TLSHostingPower not in crypto_power):
 
-            #
-            # Development Ursula
-            #
-
             if is_me:
+
                 self.suspicious_activities_witnessed = {'vladimirs': [],
                                                         'bad_treasure_maps': [],
                                                         'freeriders': []}
@@ -1161,16 +1162,15 @@ class Ursula(Teacher, Character, Worker):
                 )
 
                 # TLSHostingPower (Ephemeral Powers and Private Keys)
-                tls_hosting_keypair = HostingKeypair(curve=tls_curve, host=rest_host,
+                tls_hosting_keypair = HostingKeypair(curve=tls_curve,
+                                                     host=rest_host,
                                                      checksum_address=self.checksum_address)
                 tls_hosting_power = TLSHostingPower(keypair=tls_hosting_keypair, host=rest_host)
+
+
                 self.rest_server = ProxyRESTServer(rest_host=rest_host, rest_port=rest_port,
                                                    rest_app=rest_app, datastore=datastore,
                                                    hosting_power=tls_hosting_power)
-
-            #
-            # Stranger-Ursula
-            #
 
             else:
 
@@ -1217,6 +1217,16 @@ class Ursula(Teacher, Character, Worker):
         else:
             message = "Initialized Stranger {} | {}".format(self.__class__.__name__, self)
             self.log.debug(message)
+
+    def derive_powers(self):
+        if self.keyring_root and self.keyring:
+            if self.keyring_root != self.keyring.keyring_root:
+                raise ValueError("Inconsistent keyring root directory path")
+        if self.keyring:
+            crypto_power_ups = list()
+            for power_up in self._default_crypto_powerups:
+                power = self.keyring.derive_crypto_power(power_class=power_up, host=self.interface.host)
+                crypto_power_ups.append(power)
 
     def __prune_datastore(self) -> None:
         """Deletes all expired arrangements, kfrags, and treasure maps in the datastore."""

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1157,10 +1157,11 @@ class Ursula(Teacher, Character, Worker):
                 tls_hosting_power = self.keyring.derive_crypto_power(TLSHostingPower, host=host)
             else:
                 # Generate ephemeral private key ("Dev Mode")
-                tls_hosting_keypair = HostingKeypair(host=host, checksum_address=self.checksum_address)
+                tls_hosting_keypair = HostingKeypair(host=host,
+                                                     checksum_address=self.checksum_address,
+                                                     generate_certificate=True)
                 tls_hosting_power = TLSHostingPower(keypair=tls_hosting_keypair, host=host)
-
-        self._crypto_power.consume_power_up(tls_hosting_power)  # Consume!
+            self._crypto_power.consume_power_up(tls_hosting_power)  # Consume!
         return tls_hosting_power
 
     def _make_local_server(self, host, port, domain, db_filepath) -> ProxyRESTServer:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1077,7 +1077,6 @@ class Ursula(Teacher, Character, Worker):
                            known_node_class=Ursula,
                            **character_kwargs)
 
-        # excuse me... can I speak to the manager?
         if is_me:
 
             # Operating Mode
@@ -1288,7 +1287,6 @@ class Ursula(Teacher, Character, Worker):
         if prometheus_config:
             # Locally scoped to prevent import without prometheus explicitly installed
             from nucypher.utilities.prometheus.metrics import start_prometheus_exporter
-            # TODO: Integrate with Hendrix TLS Deploy?
             start_prometheus_exporter(ursula=self, prometheus_config=prometheus_config)
             if emitter:
                 emitter.message(f"✓ Prometheus Exporter", color='green')
@@ -1318,7 +1316,7 @@ class Ursula(Teacher, Character, Worker):
                     emitter.message(f"{e.__class__.__name__} {e}", color='red', bold=True)
                 raise  # Crash :-(
 
-        elif start_reactor:  # ... without hendrix
+        if start_reactor:  # ... without hendrix
             reactor.run()  # <--- Blocking Call (Reactor)
 
     def stop(self, halt_reactor: bool = False) -> None:

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -80,7 +80,6 @@ class Vladimir(Ursula):
                        db_filepath=db_filepath,
                        domain=TEMPORARY_DOMAIN,
                        block_until_ready=False,
-                       commit_now=False,
                        rest_host=target_ursula.rest_interface.host,
                        rest_port=target_ursula.rest_interface.port,
                        certificate=target_ursula.rest_server_certificate(),

--- a/nucypher/config/__init__.py
+++ b/nucypher/config/__init__.py
@@ -14,3 +14,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
+from constant_sorrow.constants import NO_KEYRING_ATTACHED
+
+NO_KEYRING_ATTACHED.bool_value(False)

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -122,6 +122,14 @@ class UrsulaConfiguration(CharacterConfiguration):
 
         return ursula
 
+    def derive_node_power_ups(self):
+        power_ups = list()
+        if self.is_me and not self.dev_mode:
+            for power_class in self.CHARACTER_CLASS._default_crypto_powerups:
+                power_up = self.keyring.derive_crypto_power(power_class, host=self.rest_host)
+                power_ups.append(power_up)
+        return power_ups
+
     def attach_keyring(self, checksum_address: str = None, *args, **kwargs) -> None:
         if self.federated_only:
             account = checksum_address or self.checksum_address

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -371,7 +371,7 @@ class NucypherKeyring:
         # Public
         self.__root_pub_keypath = pub_root_key_path or __default_key_filepaths['root_pub']
         self.__signing_pub_keypath = pub_signing_key_path or __default_key_filepaths['signing_pub']
-        self.__tls_certificate = tls_certificate_path or __default_key_filepaths['tls_certificate']
+        self.__tls_certificate_path = tls_certificate_path or __default_key_filepaths['tls_certificate']
 
         # Set Initial State
         self.__derived_key_material = KEYRING_LOCKED
@@ -400,7 +400,7 @@ class NucypherKeyring:
 
     @property
     def certificate_filepath(self) -> str:
-        return self.__tls_certificate
+        return self.__tls_certificate_path
 
     @property
     def keyring_root(self) -> str:
@@ -496,7 +496,11 @@ class NucypherKeyring:
                     raise ValueError('Host is required to derive a TLSHostingPower')
                 pem = _read_keyfile(keypath=path, deserializer=None)
                 private_key = load_pem_private_key(data=pem, password=self.__derived_key_material)
-                keypair = HostingKeypair(private_key=private_key, checksum_address=self.checksum_address, host=host)
+                keypair = HostingKeypair(host=host,
+                                         private_key=private_key,
+                                         checksum_address=self.checksum_address,
+                                         generate_certificate=False,
+                                         certificate_filepath=self.__tls_certificate_path)
                 new_cryptopower = TLSHostingPower(keypair=keypair, host=host)
 
             else:

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -114,8 +114,8 @@ def _read_keyfile(keypath: str,
     with open(keypath, 'rb') as keyfile:
         key_data = keyfile.read()
         if deserializer:
-            key_metadata = deserializer(key_data)
-    return key_metadata
+            key_data = deserializer(key_data)
+    return key_data
 
 
 def _write_private_keyfile(keypath: str,

--- a/nucypher/config/keyring.py
+++ b/nucypher/config/keyring.py
@@ -39,7 +39,7 @@ from eth_keys import KeyAPI as EthKeyAPI
 from eth_utils import to_checksum_address
 from nacl.exceptions import CryptoError
 from nacl.secret import SecretBox
-from typing import Callable, ClassVar, Dict, List, Tuple, Union
+from typing import Callable, ClassVar, Dict, List, Tuple, Union, Optional
 from umbral.keys import UmbralKeyingMaterial, UmbralPrivateKey, UmbralPublicKey, derive_key_from_password
 
 from nucypher.crypto.keypairs import HostingKeypair
@@ -472,13 +472,11 @@ class NucypherKeyring:
         return self.is_unlocked
 
     @unlock_required
-    def derive_crypto_power(self, power_class: ClassVar, host = None) -> Union[KeyPairBasedPower, DerivedKeyBasedPower]:
+    def derive_crypto_power(self, power_class: ClassVar, host: Optional[str] = None) -> Union[KeyPairBasedPower, DerivedKeyBasedPower]:
         """
         Takes either a SigningPower or a DecryptingPower and returns
         either a SigningPower or DecryptingPower with the coinciding
         private key.
-
-        TODO: Derive a key from the root_key.
         """
         # Keypair-Based
         if issubclass(power_class, KeyPairBasedPower):
@@ -487,28 +485,24 @@ class NucypherKeyring:
                      DecryptingPower: self.__root_keypath,
                      TLSHostingPower: self.__tls_keypath}
 
-            path = codex[power_class]
             try:
-                if power_class is TLSHostingPower:  # TODO: something more elegant
-                    if not host:
-                        raise ValueError('Host is required to derive a TLSHostingPower')
-                    pem = _read_keyfile(keypath=path, deserializer=None)
-                    privkey = load_pem_private_key(data=pem, password=self.__derived_key_material)
-
-                    keypair: HostingKeypair
-                    keypair = power_class._keypair_class(private_key=privkey,
-                                                         checksum_address=self.checksum_address,
-                                                         host=host)
-                    new_cryptopower = power_class(keypair=keypair, host=host)
-
-                else:
-                    privkey = self.__decrypt_keyfile(key_path=path)
-                    keypair = power_class._keypair_class(privkey)
-                    new_cryptopower = power_class(keypair=keypair)
-
+                path = codex[power_class]
             except KeyError:
                 failure_message = "{} is an invalid type for deriving a CryptoPower".format(power_class.__name__)
                 raise TypeError(failure_message)
+
+            if power_class is TLSHostingPower:  # TODO: something more elegant
+                if not host:
+                    raise ValueError('Host is required to derive a TLSHostingPower')
+                pem = _read_keyfile(keypath=path, deserializer=None)
+                private_key = load_pem_private_key(data=pem, password=self.__derived_key_material)
+                keypair = HostingKeypair(private_key=private_key, checksum_address=self.checksum_address, host=host)
+                new_cryptopower = TLSHostingPower(keypair=keypair, host=host)
+
+            else:
+                privkey = self.__decrypt_keyfile(key_path=path)
+                keypair = power_class._keypair_class(privkey)
+                new_cryptopower = power_class(keypair=keypair)
 
         # Derived
         elif issubclass(power_class, DerivedKeyBasedPower):

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -74,11 +74,11 @@ class CharacterConfiguration(BaseConfiguration):
     _CONFIG_FIELDS = ('config_root',
                       'poa',
                       'light',
-                      'provider_uri',
                       'registry_filepath',
                       'gas_strategy',
                       'max_gas_price',  # gwei
-                      'signer_uri')
+                      'signer_uri'
+                      )
 
     def __init__(self,
 
@@ -409,7 +409,6 @@ class CharacterConfiguration(BaseConfiguration):
             # Identity
             federated_only=self.federated_only,
             checksum_address=self.checksum_address,
-            keyring_root=self.keyring_root,
 
             # Behavior
             domain=self.domain,
@@ -455,6 +454,7 @@ class CharacterConfiguration(BaseConfiguration):
         payload.update(dict(network_middleware=self.network_middleware or self.DEFAULT_NETWORK_MIDDLEWARE(),
                             known_nodes=self.known_nodes,
                             node_storage=self.node_storage,
+                            keyring=self.keyring,
                             crypto_power_ups=self.derive_node_power_ups()))
 
         return payload

--- a/nucypher/config/node.py
+++ b/nucypher/config/node.py
@@ -456,6 +456,7 @@ class CharacterConfiguration(BaseConfiguration):
                             known_nodes=self.known_nodes,
                             node_storage=self.node_storage,
                             crypto_power_ups=self.derive_node_power_ups()))
+
         return payload
 
     def generate_filepath(self, filepath: str = None, modifier: str = None, override: bool = False) -> str:

--- a/nucypher/crypto/api.py
+++ b/nucypher/crypto/api.py
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-from random import SystemRandom
+
 
 import datetime
 import sha3
@@ -33,6 +33,7 @@ from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_utils import is_checksum_address, to_checksum_address
 from ipaddress import IPv4Address
+from random import SystemRandom
 from typing import Tuple
 from umbral import pre
 from umbral.keys import UmbralPrivateKey, UmbralPublicKey
@@ -42,6 +43,7 @@ from nucypher.crypto.constants import SHA256
 from nucypher.crypto.kits import UmbralMessageKit
 
 SYSTEM_RAND = SystemRandom()
+_TLS_CURVE = ec.SECP384R1
 
 
 class InvalidNodeCertificate(RuntimeError):
@@ -176,19 +178,17 @@ def verify_ecdsa(message: bytes,
 
 
 def __generate_self_signed_certificate(host: str,
-                                       curve: EllipticCurve,
+                                       curve: EllipticCurve = _TLS_CURVE,
                                        private_key: _EllipticCurvePrivateKey = None,
-                                       days_valid: int = 365,
+                                       days_valid: int = 365,  # TODO: Until end of stake / when to renew?
                                        checksum_address: str = None
                                        ) -> Tuple[Certificate, _EllipticCurvePrivateKey]:
 
     if not private_key:
         private_key = ec.generate_private_key(curve, default_backend())
-
     public_key = private_key.public_key()
 
     now = datetime.datetime.utcnow()
-
     fields = [
         x509.NameAttribute(NameOID.COMMON_NAME, host),
     ]

--- a/nucypher/crypto/keypairs.py
+++ b/nucypher/crypto/keypairs.py
@@ -149,10 +149,12 @@ class HostingKeypair(Keypair):
                  private_key: Union[UmbralPrivateKey, UmbralPublicKey] = None,
                  certificate=None,
                  certificate_filepath: str = None,
-                 generate_certificate=True,
+                 generate_certificate=False,
                  ) -> None:
 
-        if private_key and certificate_filepath:
+        if private_key:
+            if not certificate_filepath:
+                raise ValueError('public certificate required to load a hosting keypair.')
             from nucypher.config.keyring import _read_tls_public_certificate
             certificate = _read_tls_public_certificate(filepath=certificate_filepath)
             super().__init__(private_key=private_key)
@@ -189,8 +191,7 @@ class HostingKeypair(Keypair):
                                 key=self._privkey,
                                 cert=X509.from_cryptography(self.certificate),
                                 context_factory=ExistingKeyTLSContextFactory,
-                                context_factory_kwargs={"curve_name": _TLS_CURVE.name,
-                                                        "sslmethod": TLSv1_2_METHOD},
+                                context_factory_kwargs={"curve_name": _TLS_CURVE.name, "sslmethod": TLSv1_2_METHOD},
                                 options={
                                     "wsgi": rest_app,
                                     "https_port": port,

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -213,6 +213,8 @@ class Learner:
 
         self.log = Logger("learning-loop")  # type: Logger
 
+        self.suspicious_activities_witnessed = defaultdict(list)  # TODO: Combine with buckets / node labeling
+
         self.learning_deferred = Deferred()
         self.domain = domain
         if not self.federated_only:
@@ -256,7 +258,7 @@ class Learner:
                 self.unresponsive_startup_nodes.append(node)
 
         self.teacher_nodes = deque()
-        self._current_teacher_node = None  # type: Teacher
+        self._current_teacher_node = None  # type: Union[Teacher, None]
         self._learning_task = task.LoopingCall(self.keep_learning_about_nodes)
 
         if self._DEBUG_MODE:
@@ -1008,20 +1010,12 @@ class Teacher:
         cls._cert_store_function = node_storage_function
 
     def mature(self, *args, **kwargs):
-        """
-        This is the most mature form, so we do nothing.
-        """
+        """This is the most mature form, so we do nothing."""
         return self
 
     @classmethod
     def set_federated_mode(cls, federated_only: bool):
         cls._federated_only_instances = federated_only
-
-    @classmethod
-    def from_tls_hosting_power(cls, tls_hosting_power: TLSHostingPower, *args, **kwargs) -> 'Teacher':
-        certificate_filepath = tls_hosting_power.keypair.certificate_filepath
-        certificate = tls_hosting_power.keypair.certificate
-        return cls(certificate=certificate, certificate_filepath=certificate_filepath, *args, **kwargs)
 
     #
     # Known Nodes
@@ -1255,12 +1249,6 @@ class Teacher:
             self.__worker_address = recover_address_eip_191(message=bytes(self.stamp),
                                                             signature=self.decentralized_identity_evidence)
         return self.__worker_address
-
-    def substantiate_stamp(self):
-        transacting_power = self._crypto_power.power_ups(TransactingPower)
-        signature = transacting_power.sign_message(message=bytes(self.stamp))
-        self.__decentralized_identity_evidence = signature
-        self.__worker_address = transacting_power.account
 
     #
     # Interface

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -170,7 +170,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
     def all_known_nodes():
         headers = {'Content-Type': 'application/octet-stream'}
         if this_node._learning_deferred is not RELAX and not this_node._learning_task.running:
-            # TODO: Is this every something we don't want to do?
+            # Learn when learned about
             this_node.start_learning_loop()
 
         if this_node.known_nodes.checksum is NO_KNOWN_NODES:

--- a/tests/acceptance/blockchain/actors/test_staker.py
+++ b/tests/acceptance/blockchain/actors/test_staker.py
@@ -293,7 +293,6 @@ def test_staker_collects_staking_reward(testerchain,
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[worker_address],
-                                        commit_now=False,
                                         registry=test_registry).pop()
 
     # ...mint few tokens...
@@ -338,7 +337,6 @@ def test_staker_manages_winding_down(testerchain,
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[staker.worker_address],
-                                        commit_now=False,
                                         registry=test_registry).pop()
 
     # Unlock

--- a/tests/acceptance/blockchain/actors/test_worker.py
+++ b/tests/acceptance/blockchain/actors/test_worker.py
@@ -66,8 +66,9 @@ def test_worker_auto_commitments(mocker,
     ursula = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[worker_address],
-                                        commit_now=True,
                                         registry=test_registry).pop()
+
+    ursula.run()  # start services
 
     initial_period = staker.staking_agent.get_current_period()
 
@@ -134,6 +135,8 @@ def test_worker_auto_commitments(mocker,
 
     # Ursula commits on startup
     d = threads.deferToThread(start)
+    d.addCallback(advance_one_cycle)
+
     d.addCallback(verify_confirmed)
     d.addCallback(check_pending_commitments(1))
     d.addCallback(advance_one_cycle)

--- a/tests/acceptance/blockchain/actors/test_worker.py
+++ b/tests/acceptance/blockchain/actors/test_worker.py
@@ -68,7 +68,7 @@ def test_worker_auto_commitments(mocker,
                                         workers_addresses=[worker_address],
                                         registry=test_registry).pop()
 
-    ursula.run()  # start services
+    ursula.run(preflight=False, start_reactor=False)  # "start" services
 
     initial_period = staker.staking_agent.get_current_period()
 

--- a/tests/acceptance/characters/test_stakeholder.py
+++ b/tests/acceptance/characters/test_stakeholder.py
@@ -126,7 +126,6 @@ def test_collect_inflation_rewards(software_stakeholder, manual_worker, testerch
     worker = Worker(is_me=True,
                     worker_address=manual_worker,
                     checksum_address=stake.staker_address,
-                    commit_now=False,
                     registry=test_registry)
 
     mock_transacting_power_activation(account=manual_worker, password=INSECURE_DEVELOPMENT_PASSWORD)

--- a/tests/acceptance/characters/test_ursula_prepares_to_act_as_worker.py
+++ b/tests/acceptance/characters/test_ursula_prepares_to_act_as_worker.py
@@ -33,8 +33,7 @@ from tests.utils.ursula import make_decentralized_ursulas
 def test_stakers_bond_to_ursulas(testerchain, test_registry, stakers, ursula_decentralized_test_config):
     ursulas = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                          stakers_addresses=testerchain.stakers_accounts,
-                                         workers_addresses=testerchain.ursulas_accounts,
-                                         commit_now=False)
+                                         workers_addresses=testerchain.ursulas_accounts)
 
     assert len(ursulas) == len(stakers)
     for ursula in ursulas:
@@ -78,7 +77,7 @@ def test_vladimir_cannot_verify_interface_with_ursulas_signing_key(blockchain_ur
     vladimir = Vladimir.from_target_ursula(his_target, claim_signing_key=True)
 
     # Vladimir can substantiate the stamp using his own ether address...
-    vladimir.substantiate_stamp()
+    vladimir.__substantiate_stamp()
     vladimir.validate_worker = lambda: True
     vladimir.validate_worker()  # lol
 
@@ -102,7 +101,7 @@ def test_vladimir_invalidity_without_stake(testerchain, blockchain_ursulas, bloc
     message = vladimir._signable_interface_info_message()
     signature = vladimir._crypto_power.power_ups(SigningPower).sign(vladimir.timestamp_bytes() + message)
     vladimir._Teacher__interface_signature = signature
-    vladimir.substantiate_stamp()
+    vladimir.__substantiate_stamp()
 
     # However, the actual handshake proves him wrong.
     with pytest.raises(vladimir.InvalidNode):
@@ -120,7 +119,7 @@ def test_vladimir_uses_his_own_signing_key(blockchain_alice, blockchain_ursulas)
     message = vladimir._signable_interface_info_message()
     signature = vladimir._crypto_power.power_ups(SigningPower).sign(vladimir.timestamp_bytes() + message)
     vladimir._Teacher__interface_signature = signature
-    vladimir.substantiate_stamp()
+    vladimir.__substantiate_stamp()
 
     vladimir._worker_is_bonded_to_staker = lambda: True
     vladimir._staker_is_really_staking = lambda: True

--- a/tests/acceptance/cli/ursula/test_local_keystore_integration.py
+++ b/tests/acceptance/cli/ursula/test_local_keystore_integration.py
@@ -146,7 +146,6 @@ def test_ursula_and_local_keystore_signer_integration(click_runner,
     # Produce an Ursula with a Keystore signer correctly derived from the signer URI, and don't do anything else!
     mocker.patch.object(StakeList, 'refresh', autospec=True)
     ursula = ursula_config.produce(client_password=password,
-                                   commit_now=False,
                                    block_until_ready=False)
 
     try:

--- a/tests/acceptance/learning/test_fault_tolerance.py
+++ b/tests/acceptance/learning/test_fault_tolerance.py
@@ -116,7 +116,6 @@ def test_invalid_workers_tolerance(testerchain,
                                     worker_address=testerchain.unassigned_accounts[-1],
                                     ursula_config=ursula_decentralized_test_config,
                                     blockchain=testerchain,
-                                    commit_now=True,
                                     ursulas_to_learn_about=None)
 
     # Since we made a commitment, we need to advance one period

--- a/tests/acceptance/network/test_network_actors.py
+++ b/tests/acceptance/network/test_network_actors.py
@@ -136,7 +136,7 @@ def test_alice_refuses_to_make_arrangement_unless_ursula_is_valid(blockchain_ali
     message = vladimir._signable_interface_info_message()
     signature = vladimir._crypto_power.power_ups(SigningPower).sign(message)
 
-    vladimir.substantiate_stamp()
+    vladimir.__substantiate_stamp()
     vladimir._Teacher__interface_signature = signature
     vladimir.node_storage.store_node_certificate(certificate=target.certificate)
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -690,8 +690,7 @@ def blockchain_ursulas(testerchain, stakers, ursula_decentralized_test_config):
 
     _ursulas = make_decentralized_ursulas(ursula_config=ursula_decentralized_test_config,
                                           stakers_addresses=testerchain.stakers_accounts,
-                                          workers_addresses=testerchain.ursulas_accounts,
-                                          commit_now=True)
+                                          workers_addresses=testerchain.ursulas_accounts)
     for u in _ursulas:
         u.synchronous_query_timeout = .01  # We expect to never have to wait for content that is actually on-chain during tests.
     testerchain.time_travel(periods=1)

--- a/tests/integration/cli/test_ursula_local_keystore_cli_functionality.py
+++ b/tests/integration/cli/test_ursula_local_keystore_cli_functionality.py
@@ -100,8 +100,7 @@ def test_ursula_init_with_local_keystore_signer(click_runner,
 
     # Produce an ursula with a Keystore signer correctly derived from the signer URI, and dont do anything else!
     mocker.patch.object(StakeList, 'refresh', autospec=True)
-    ursula = ursula_config.produce(client_password=password,
-                                   block_until_ready=False)
+    ursula = ursula_config.produce(client_password=password)
 
     # Verify the keystore path is still preserved
     assert isinstance(ursula.signer, KeystoreSigner)

--- a/tests/integration/cli/test_ursula_local_keystore_cli_functionality.py
+++ b/tests/integration/cli/test_ursula_local_keystore_cli_functionality.py
@@ -90,7 +90,7 @@ def test_ursula_init_with_local_keystore_signer(click_runner,
             "Keystore URI was not correctly included in configuration file"
 
     # Recreate a configuration with the signer URI preserved
-    ursula_config = UrsulaConfiguration.from_configuration_file(custom_config_filepath)
+    ursula_config = UrsulaConfiguration.from_configuration_file(custom_config_filepath, config_root=custom_filepath)
     assert ursula_config.signer_uri == mock_signer_uri
 
     # Mock decryption of web3 client keyring

--- a/tests/integration/config/test_character_configuration.py
+++ b/tests/integration/config/test_character_configuration.py
@@ -85,7 +85,6 @@ def test_federated_development_character_configurations(character, configuration
     assert TEMPORARY_DOMAIN == thing_one.domain
 
     # Node Storage
-    assert configuration.TEMP_CONFIGURATION_DIR_PREFIX in thing_one.keyring_root
     assert isinstance(thing_one.node_storage, ForgetfulNodeStorage)
     assert ':memory:' in thing_one.node_storage._name
 
@@ -172,7 +171,6 @@ def test_ursula_development_configuration(federated_only=True):
     assert port == UrsulaConfiguration.DEFAULT_DEVELOPMENT_REST_PORT
     assert tempfile.gettempdir() in ursula_one.datastore.db_path
     assert ursula_one.certificate_filepath is CERTIFICATE_NOT_SAVED
-    assert UrsulaConfiguration.TEMP_CONFIGURATION_DIR_PREFIX in ursula_one.keyring_root
     assert isinstance(ursula_one.node_storage, ForgetfulNodeStorage)
     assert ':memory:' in ursula_one.node_storage._name
 

--- a/tests/integration/config/test_configuration_persistence.py
+++ b/tests/integration/config/test_configuration_persistence.py
@@ -29,8 +29,9 @@ from tests.utils.middleware import MockRestMiddleware
 
 def test_alices_powers_are_persistent(federated_ursulas, tmpdir):
     # Create a non-learning AliceConfiguration
+    config_root = os.path.join(tmpdir, 'nucypher-custom-alice-config')
     alice_config = AliceConfiguration(
-        config_root=os.path.join(tmpdir, 'nucypher-custom-alice-config'),
+        config_root=config_root,
         network_middleware=MockRestMiddleware(),
         domain=TEMPORARY_DOMAIN,
         start_learning_now=False,
@@ -94,6 +95,7 @@ def test_alices_powers_are_persistent(federated_ursulas, tmpdir):
         network_middleware=MockRestMiddleware(),
         known_nodes=federated_ursulas,
         start_learning_now=False,
+        config_root=config_root
     )
 
     # Alice unlocks her restored keyring from disk

--- a/tests/integration/config/test_keyring_integration.py
+++ b/tests/integration/config/test_keyring_integration.py
@@ -14,6 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 import pytest
 import tempfile
 from constant_sorrow.constants import FEDERATED_ADDRESS
@@ -21,6 +23,7 @@ from umbral.keys import UmbralPrivateKey
 from umbral.signing import Signer
 
 from nucypher.characters.lawful import Alice, Bob, Ursula
+from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.config.keyring import NucypherKeyring
 from nucypher.crypto.powers import DecryptingPower, DelegatingPower
 from tests.constants import INSECURE_DEVELOPMENT_PASSWORD
@@ -71,11 +74,17 @@ def test_characters_use_keyring(tmpdir):
         checksum_address=FEDERATED_ADDRESS,
         password=INSECURE_DEVELOPMENT_PASSWORD,
         encrypting=True,
-        rest=False,
+        rest=True,
+        host='127.0.0.1',
         keyring_root=tmpdir)
     keyring.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
-    a = Alice(federated_only=True, start_learning_now=False, keyring=keyring)
+    alice = Alice(federated_only=True, start_learning_now=False, keyring=keyring)
     Bob(federated_only=True, start_learning_now=False, keyring=keyring)
-    Ursula(federated_only=True, start_learning_now=False, keyring=keyring,
-           rest_host='127.0.0.1', rest_port=12345, db_filepath=tempfile.mkdtemp())
-    a.disenchant()  # To stop Alice's publication threadpool.  TODO: Maybe only start it at first enactment?
+    Ursula(federated_only=True,
+           start_learning_now=False,
+           keyring=keyring,
+           rest_host='127.0.0.1',
+           rest_port=12345,
+           db_filepath=tempfile.mkdtemp(),
+           domain=TEMPORARY_DOMAIN)
+    alice.disenchant()  # To stop Alice's publication threadpool.  TODO: Maybe only start it at first enactment?

--- a/tests/integration/config/test_storages.py
+++ b/tests/integration/config/test_storages.py
@@ -20,9 +20,9 @@ import pytest
 import tempfile
 
 from nucypher.characters.lawful import Ursula
+from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.config.storages import ForgetfulNodeStorage, NodeStorage, TemporaryFileBasedNodeStorage
 from nucypher.network.nodes import Learner
-
 from tests.utils.ursula import MOCK_URSULA_STARTING_PORT
 
 ADDITIONAL_NODES_TO_LEARN_ABOUT = 10
@@ -36,7 +36,8 @@ class BaseTestNodeStorageBackends:
         node = Ursula(rest_host='127.0.0.1',
                       rest_port=MOCK_URSULA_STARTING_PORT,
                       db_filepath=MOCK_URSULA_DB_FILEPATH,
-                      federated_only=True)
+                      federated_only=True,
+                      domain=TEMPORARY_DOMAIN)
         yield node
 
     character_class = Ursula
@@ -55,8 +56,11 @@ class BaseTestNodeStorageBackends:
         # Save more nodes
         all_known_nodes = set()
         for port in range(MOCK_URSULA_STARTING_PORT, MOCK_URSULA_STARTING_PORT + ADDITIONAL_NODES_TO_LEARN_ABOUT):
-            node = Ursula(rest_host='127.0.0.1', db_filepath=MOCK_URSULA_DB_FILEPATH, rest_port=port,
-                          federated_only=True)
+            node = Ursula(rest_host='127.0.0.1',
+                          db_filepath=MOCK_URSULA_DB_FILEPATH,
+                          rest_port=port,
+                          federated_only=True,
+                          domain=TEMPORARY_DOMAIN)
             node_storage.store_node_metadata(node=node)
             all_known_nodes.add(node)
 

--- a/tests/unit/config/test_keyring.py
+++ b/tests/unit/config/test_keyring.py
@@ -1,0 +1,51 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from nucypher.config.keyring import _assemble_key_data, _PrivateKeySerializer, _generate_tls_keys, \
+    _TLSPrivateKeySerializer
+
+
+def test_private_key_serialization():
+    key_data = _assemble_key_data(key_data=b'peanuts, get your peanuts',
+                                  master_salt=b'sea salt',
+                                  wrap_salt=b'red salt')
+    key_bytes = _PrivateKeySerializer.serialize(key_data)
+    deserialized_key_data = _PrivateKeySerializer.deserialize(key_bytes)
+
+    assert key_data == deserialized_key_data
+
+
+def test_tls_private_key_serialization():
+    host = '127.0.0.1'
+    checksum_address = '0xdeadbeef'
+    curve = ec.SECP384R1
+
+    private_key, _ = _generate_tls_keys(host=host,
+                                        checksum_address=checksum_address,
+                                        curve=curve)
+    password = b'serialize_deserialized'
+    key_bytes = _TLSPrivateKeySerializer.serialize(private_key, password=password)
+    deserialized_private_key = _TLSPrivateKeySerializer.deserialize(key_bytes, password=password)
+
+    assert private_key.private_numbers() == deserialized_private_key.private_numbers()
+
+    # just to be certain that a different key doesn't have the same private numbers
+    other_private_key, _ = _generate_tls_keys(host=host,
+                                              checksum_address=checksum_address,
+                                              curve=curve)
+    assert other_private_key.private_numbers() != deserialized_private_key.private_numbers()

--- a/tests/utils/ursula.py
+++ b/tests/utils/ursula.py
@@ -98,7 +98,6 @@ def make_federated_ursulas(ursula_config: UrsulaConfiguration,
 def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
                                stakers_addresses: Iterable[str],
                                workers_addresses: Iterable[str],
-                               commit_now: bool = True,
                                **ursula_overrides) -> List[Ursula]:
 
     if not MOCK_KNOWN_URSULAS_CACHE:
@@ -114,7 +113,6 @@ def make_decentralized_ursulas(ursula_config: UrsulaConfiguration,
                                        worker_address=worker_address,
                                        db_filepath=MOCK_DB,
                                        rest_port=port + 100,
-                                       commit_now=commit_now,
                                        **ursula_overrides)
 
         ursulas.append(ursula)
@@ -131,7 +129,6 @@ def make_ursula_for_staker(staker: Staker,
                            blockchain: BlockchainInterface,
                            ursula_config: UrsulaConfiguration,
                            ursulas_to_learn_about: Optional[List[Ursula]] = None,
-                           commit_now: bool = True,
                            **ursula_overrides) -> Ursula:
 
     # Assign worker to this staker
@@ -141,7 +138,6 @@ def make_ursula_for_staker(staker: Staker,
                                         blockchain=blockchain,
                                         stakers_addresses=[staker.checksum_address],
                                         workers_addresses=[worker_address],
-                                        commit_now=commit_now,
                                         **ursula_overrides).pop()
 
     for ursula_to_learn_about in (ursulas_to_learn_about or []):


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other - (Code Quality)

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**

- Bugfix: Ensure that persistent public TLS certificates are used for worker servers
- Ensure that persistent powers are derived from keyrings
- Reduce and simplify internals of Ursula's construction

**Issues fixed/closed:**

TBD

**Why it's needed:**

- Improves node availability: Allows public TLS certificates to be properly reused for connection handshakes
- Preserves browser security exceptions :tada: 
- Better readability and maintainability for characters

**Notes for reviewers:**

- Currently This PR is conceptual and will be subjected to a reset and history rework
- May introduce new side-effects:  When do certificates need to be recreated or renewed?  
  - IP address changes
  - Certificate Expiration 
- How/when to force re-validation and download a fresh copy of a certificate from a peer 

**Co-Authorship**

Co-Authored-By: vepkenez <gdamon@gmail.com>
Co-Authored-By: Derek Pierre <derek.pierre@gmail.com>