### PR TITLE
Use an explicit keyword argument in estimateGas

### DIFF
--- a/newsfragments/2543.bugfix.rst
+++ b/newsfragments/2543.bugfix.rst
@@ -1,0 +1,1 @@
+Update the call to ``estimateGas()`` according to the new ``web3`` API

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -501,7 +501,7 @@ class BlockchainInterface:
                 # As web3 buildTransaction() will estimate gas with block identifier "pending" by default,
                 # explicitly estimate gas here with block identifier 'latest' if not otherwise specified
                 # as a pending transaction can cause gas estimation to fail, notably in case of worklock refunds.
-                payload['gas'] = contract_function.estimateGas(payload, 'latest')
+                payload['gas'] = contract_function.estimateGas(payload, block_identifier='latest')
             transaction_dict = contract_function.buildTransaction(payload)
         except (TestTransactionFailed, ValidationError, ValueError) as error:
             # Note: Geth raises ValueError in the same condition that pyevm raises ValidationError here.


### PR DESCRIPTION
This is in the same line as #2366 - probably introduced by someone using an old `web3` version.

Reported on Discord; traceback:
```
Unhandled error during work tracking (#2): 'Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/twisted/internet/base.py", line 1283, in run
    self.mainLoop()
  File "/usr/local/lib/python3.8/site-packages/twisted/internet/base.py", line 1292, in mainLoop
    self.runUntilCurrent()
  File "/usr/local/lib/python3.8/site-packages/twisted/internet/base.py", line 913, in runUntilCurrent
    call.func(*call.args, **call.kw)
  File "/usr/local/lib/python3.8/site-packages/twisted/internet/task.py", line 239, in __call__
    d = defer.maybeDeferred(self.f, *self.a, **self.kw)
--- <exception caught here> ---
  File "/usr/local/lib/python3.8/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
    result = f(*args, **kw)
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/token.py", line 777, in _do_work
    txhash = self.__fire_commitment()
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/token.py", line 784, in __fire_commitment
    txhash = self.worker.commit_to_next_period(fire_and_forget=True)  # < --- blockchain WRITE
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/decorators.py", line 116, in wrapped
    return func(actor, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/decorators.py", line 124, in wrapped
    receipt_or_txhash = actor_method(self, *args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/actors.py", line 1570, in commit_to_next_period
    txhash_or_receipt = self.staking_agent.commit_to_next_period(worker_address=self.__worker_address,
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/decorators.py", line 105, in wrapped
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/agents.py", line 586, in commit_to_next_period
    txhash_or_receipt = self.blockchain.send_transaction(contract_function=contract_function,
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/decorators.py", line 105, in wrapped
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/interfaces.py", line 636, in send_transaction
    transaction = self.build_contract_transaction(contract_function=contract_function,
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/decorators.py", line 105, in wrapped
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/interfaces.py", line 509, in build_contract_transaction
    raise self._handle_failed_transaction(exception=error,
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/interfaces.py", line 421, in _handle_failed_transaction
    raise exception
  File "/usr/local/lib/python3.8/site-packages/nucypher/blockchain/eth/interfaces.py", line 504, in build_contract_transaction
    payload[\'gas\'] = contract_function.estimateGas(payload, \'latest\')
  File "/usr/local/lib/python3.8/site-packages/web3/contract.py", line 1035, in estimateGas
    return estimate_gas_for_function(
  File "/usr/local/lib/python3.8/site-packages/web3/contract.py", line 1618, in estimate_gas_for_function
    return web3.eth.estimateGas(estimate_transaction, block_identifier)
  File "/usr/local/lib/python3.8/site-packages/web3/module.py", line 44, in caller
    result = w3.manager.request_blocking(method_str, params, error_formatters)
  File "/usr/local/lib/python3.8/site-packages/web3/manager.py", line 158, in request_blocking
    raise ValueError(response["error"])
builtins.ValueError: {{\'code\': -32602, \'message\': \'too many arguments, want at most 1\'}}
```