### PR TITLE
Don't collect prometheus WorkLock metrics when on testnet

### DIFF
--- a/newsfragments/2546.misc.rst
+++ b/newsfragments/2546.misc.rst
@@ -1,0 +1,1 @@
+WorkLock prometheus metrics are only collected on mainnet.

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -14,6 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.exceptions import DevelopmentInstallationRequired
 
 try:
@@ -193,10 +194,6 @@ def create_metrics_collectors(ursula: 'Ursula', metrics_prefix: str) -> List[Met
         collectors.append(WorkerMetricsCollector(worker_address=ursula.worker_address,
                                                  contract_registry=ursula.registry))
 
-        # WorkLock prometheus
-        collectors.append(WorkLockMetricsCollector(staker_address=ursula.checksum_address,
-                                                   contract_registry=ursula.registry))
-
         #
         # Events
         #
@@ -206,15 +203,23 @@ def create_metrics_collectors(ursula: 'Ursula', metrics_prefix: str) -> List[Met
                                                                             metrics_prefix=metrics_prefix)
         collectors.extend(staking_events_collectors)
 
-        # WorkLock Events
-        worklock_events_collectors = create_worklock_events_metric_collectors(ursula=ursula,
-                                                                              metrics_prefix=metrics_prefix)
-        collectors.extend(worklock_events_collectors)
-
         # Policy Events
         policy_events_collectors = create_policy_events_metric_collectors(ursula=ursula,
                                                                           metrics_prefix=metrics_prefix)
         collectors.extend(policy_events_collectors)
+
+        #
+        # WorkLock information - only collected for mainnet
+        #
+        if ursula.domain == NetworksInventory.MAINNET:
+            # WorkLock metrics
+            collectors.append(WorkLockMetricsCollector(staker_address=ursula.checksum_address,
+                                                       contract_registry=ursula.registry))
+
+            # WorkLock Events
+            worklock_events_collectors = create_worklock_events_metric_collectors(ursula=ursula,
+                                                                                  metrics_prefix=metrics_prefix)
+            collectors.extend(worklock_events_collectors)
 
     return collectors
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
> - Fixes #...

Fixes #2545 - change applied for all testnets, not just Lynx.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

WorkLock prometheus metrics are only meaningful on mainnet.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

WorkLock metrics are only collected on mainnet. Is there any reason to collect them on testnet i.e. Ibex?