### PR TITLE
Example granting script for python API docs

### DIFF
--- a/docs/source/application_development/getting_started.rst
+++ b/docs/source/application_development/getting_started.rst
@@ -261,12 +261,12 @@ software wallet and an existing keyring:
 
 
     # Restore Existing NuCypher Keyring
-    keyring = NucypherKeyring(account='0xdeadbeef')
+    keyring = NucypherKeyring(account='0x287A817426DD1AE78ea23e9918e2273b6733a43D')
     keyring.unlock('KEYRING PASSWORD')
 
     # Ethereum Software Wallet
-    wallet = Signer.from_signer_uri("keystore:///home/user/.ethereum/keystore/UTC--2021...')
-    wallet.unlock_account('0xdeadbeef', 'SOFTWARE WALLET PASSWORD')
+    wallet = Signer.from_signer_uri("keystore:///home/user/.ethereum/goerli/keystore/UTC--2021...0278ad02...')
+    wallet.unlock_account('0x287A817426DD1AE78ea23e9918e2273b6733a43D', 'SOFTWARE WALLET PASSWORD')
 
     # Make Alice
     alice = Alice(

--- a/docs/source/application_development/getting_started.rst
+++ b/docs/source/application_development/getting_started.rst
@@ -181,7 +181,7 @@ After generating a keyring, any future usage can decrypt the keys from the disk:
    from nucypher.characters.lawful import Alice, Ursula
 
    # Instantiate a default peer (optional)
-   ursula = Ursula.from_seed_and_stake_info(seed_uri=<SEEDNODE URI>)
+   ursula = Ursula.from_seed_and_stake_info(seed_uri='https://lynx.nucypher.network:9151')
 
    # Instantiate Alice
    alice = Alice(
@@ -271,8 +271,8 @@ software wallet and an existing keyring:
     # Make Alice
     alice = Alice(
         domain='lynx',  # testnet
-        keyring=keyring,
         provider_uri='GOERLI RPC ENDPOINT',
+        keyring=keyring,
         signer=wallet,
     )
 
@@ -343,7 +343,7 @@ Bob's setup is similar to Alice's above.
    # alice_verifying_key = <Side Channel>
 
    # Everyone!
-   ursula = Ursula.from_seed_and_stake_info(seed_uri=<SEEDNODE URI>)
+   ursula = Ursula.from_seed_and_stake_info(seed_uri='https://lynx.nucypher.network:9151')
    alice = Alice.from_public_keys(verifying_key=alice_verifying_key)
    enrico = Enrico(policy_encrypting_key=policy_encrypting_key)
 

--- a/docs/source/staking/best_practices.rst
+++ b/docs/source/staking/best_practices.rst
@@ -72,7 +72,7 @@ Datastore diligence can be exercised by maintain regular backups of the worker's
 
         $ nucypher --config-path
 
-    The worker database and peer metadata can be
+    The worker database and peer metadata can be found in the nucypher configuration root
 
     .. code-block:: bash
 

--- a/newsfragments/2554.doc.rst
+++ b/newsfragments/2554.doc.rst
@@ -1,0 +1,1 @@
+Expands example granting script for Alice using the python API.

--- a/newsfragments/2554.doc.rst
+++ b/newsfragments/2554.doc.rst
@@ -1,1 +1,1 @@
-Expands example granting script for Alice using the python API.
+Expands Alice grant example using the python API.


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**

- Includes missing `rate` parameter from `Alice.grant` in docs.
- Expands example granting script for Alice using the python API.
- Consistently use a single ethereum address in documentation code samples.

**Why it's needed:**
Help application developers get on-board and integrate more easily.
