### PR TITLE
Cache Alice's transacting power for later activation

### DIFF
--- a/newsfragments/2555.bugfix.rst
+++ b/newsfragments/2555.bugfix.rst
@@ -1,0 +1,1 @@
+Cache Alice's transacting power for later activation.

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -164,12 +164,12 @@ class Alice(Character, BlockchainPolicyAuthor):
 
         if is_me and not federated_only:  # TODO: #289
             blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=self.provider_uri)
-            transacting_power = TransactingPower(account=self.checksum_address,
-                                                 password=client_password,
-                                                 cache=cache_password,
-                                                 signer=signer or Web3Signer(blockchain.client))
+            self.transacting_power = TransactingPower(account=self.checksum_address,
+                                                      password=client_password,
+                                                      cache=cache_password,
+                                                      signer=signer or Web3Signer(blockchain.client))
 
-            self._crypto_power.consume_power_up(transacting_power)
+            self._crypto_power.consume_power_up(self.transacting_power)
             BlockchainPolicyAuthor.__init__(self,
                                             registry=self.registry,
                                             rate=rate,


### PR DESCRIPTION
**Type of PR:**
Bugfix

**Required reviews:** 
1

**Why it's needed:**
Provides a handle for `Alice` signers to be used while sharing a blockchain connection with other character in-scope.