### PR TITLE
Stop the threadpool when all the worker results are processed

### DIFF
--- a/newsfragments/2557.bugfix.rst
+++ b/newsfragments/2557.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent process hanging in the cases when the main thread finishes before the treasure map publisher

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -326,7 +326,7 @@ class Policy(ABC):
 
         if len(accepted_arrangements) < self.n:
 
-            rejected_proposals = "\n".join(f"{address}: {exception}" for address, exception in failures.items())
+            rejected_proposals = "\n".join(f"{address}: {value}" for address, (type_, value, traceback) in failures.items())
 
             self.log.debug(
                 "Could not find enough Ursulas to accept proposals.\n"

--- a/nucypher/utilities/concurrency.py
+++ b/nucypher/utilities/concurrency.py
@@ -32,9 +32,9 @@ class Success:
 
 
 class Failure:
-    def __init__(self, value, exception):
+    def __init__(self, value, exc_info):
         self.value = value
-        self.exception = exception
+        self.exc_info = exc_info
 
 
 class Cancelled(Exception):
@@ -246,7 +246,7 @@ class WorkerPool:
         except Cancelled as e:
             self._result_queue.put(e)
         except BaseException as e:
-            self._result_queue.put(Failure(value, str(e)))
+            self._result_queue.put(Failure(value, sys.exc_info()))
 
     def _process_results(self):
         """
@@ -273,7 +273,7 @@ class WorkerPool:
                         self._target_value.set(self.get_successes())
                 if isinstance(result, Failure):
                     with self._results_lock:
-                        self._failures[result.value] = result.exception
+                        self._failures[result.value] = result.exc_info
 
             if producer_stopped and self._finished_tasks == self._started_tasks:
                 self.cancel() # to cancel the timeout thread

--- a/nucypher/utilities/concurrency.py
+++ b/nucypher/utilities/concurrency.py
@@ -29,6 +29,7 @@ class Success:
         self.value = value
         self.result = result
 
+
 class Failure:
     def __init__(self, value, exception):
         self.value = value
@@ -39,10 +40,10 @@ class Cancelled(Exception):
     pass
 
 
-class SetOnce:
+class Future:
     """
-    A convenience wrapper for a value that can be set once (which can be waited on),
-    and cannot be overwritten (unless cleared).
+    A simplified future object. Can be set to some value (all further sets are ignored),
+    can be waited on.
     """
 
     def __init__(self):
@@ -58,13 +59,6 @@ class SetOnce:
 
     def is_set(self):
         return self._set_event.is_set()
-
-    def get_and_clear(self):
-        with self._lock:
-            value = self._value
-            self._value = None
-            self._set_event.clear()
-            return value
 
     def get(self):
         self._set_event.wait()
@@ -120,8 +114,8 @@ class WorkerPool:
 
         self._cancel_event = Event()
         self._result_queue = Queue()
-        self._target_value = SetOnce()
-        self._unexpected_error = SetOnce()
+        self._target_value = Future()
+        self._unexpected_error = Future()
         self._results_lock = Lock()
         self._threadpool_stop_lock = Lock()
         self._threadpool_stopped = False

--- a/tests/acceptance/utilities/test_concurrency.py
+++ b/tests/acceptance/utilities/test_concurrency.py
@@ -318,14 +318,14 @@ def test_buggy_factory_raises_on_block():
 
     pool.start()
     time.sleep(2) # wait for the stagger timeout to finish
-    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+    with pytest.raises(Exception, match="Buggy factory"):
         pool.block_until_target_successes()
     # Further calls to `block_until_target_successes()` or `join()` don't throw the error.
-    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+    with pytest.raises(Exception, match="Buggy factory"):
         pool.block_until_target_successes()
     pool.cancel()
 
-    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+    with pytest.raises(Exception, match="Buggy factory"):
         pool.join()
 
 
@@ -344,7 +344,7 @@ def test_buggy_factory_raises_on_join():
 
     pool.start()
     pool.cancel()
-    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+    with pytest.raises(Exception, match="Buggy factory"):
         pool.join()
-    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+    with pytest.raises(Exception, match="Buggy factory"):
         pool.join()

--- a/tests/acceptance/utilities/test_concurrency.py
+++ b/tests/acceptance/utilities/test_concurrency.py
@@ -300,7 +300,7 @@ class BuggyFactory:
             raise Exception("Buggy factory")
 
 
-def test_buggy_factory_raises_on_block(join_worker_pool):
+def test_buggy_factory_raises_on_block():
     """
     Tests that if there is an exception thrown in the value factory,
     it is caught in the first call to `block_until_target_successes()`.
@@ -315,19 +315,21 @@ def test_buggy_factory_raises_on_block(join_worker_pool):
     # Non-zero stagger timeout to make BuggyFactory raise its error only in 1.5s,
     # So that we got enough successes for `block_until_target_successes()`.
     pool = WorkerPool(worker, factory, target_successes=10, timeout=10, threadpool_size=10, stagger_timeout=1.5)
-    join_worker_pool(pool)
 
     pool.start()
     time.sleep(2) # wait for the stagger timeout to finish
     with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
         pool.block_until_target_successes()
     # Further calls to `block_until_target_successes()` or `join()` don't throw the error.
-    pool.block_until_target_successes()
+    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+        pool.block_until_target_successes()
     pool.cancel()
-    pool.join()
+
+    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+        pool.join()
 
 
-def test_buggy_factory_raises_on_join(join_worker_pool):
+def test_buggy_factory_raises_on_join():
     """
     Tests that if there is an exception thrown in the value factory,
     it is caught in the first call to `join()`.
@@ -339,10 +341,10 @@ def test_buggy_factory_raises_on_join(join_worker_pool):
 
     factory = BuggyFactory(list(outcomes))
     pool = WorkerPool(worker, factory, target_successes=10, timeout=10, threadpool_size=10)
-    join_worker_pool(pool)
 
     pool.start()
     pool.cancel()
     with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
         pool.join()
-    pool.join()
+    with pytest.raises(RuntimeError, match="Unexpected error in the producer thread"):
+        pool.join()


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 2

**What this does:**
Currently if the main thread stops before `TreasureMapPublisher` finishes distributing treasure maps (e.g. in a CLI granting situation), the process hangs indefinitely. It happens because if `WorkerPool.join()` is never called, the thread pool is still active and waiting for workers to be enqueued. 

In this PR, we stop the thread pool explicitly when all the worker results are processed, so it is guaranteed to be empty and to not receive any more `callInThread()` calls. 

It also makes the logic more strict:
- disallows races in `_threadpool.stop()`
- makes sure `join()` waits for all threads to finish for all callers, not just for the first one
- in case of an unexpected error in the producer thread, raises the error for all `join()` and `block()` callers, not just the first one
