### PR TITLE
raise 403 instead of 500 on invalid Alice Signature on kfrag

### DIFF
--- a/newsfragments/2562.feature.rst
+++ b/newsfragments/2562.feature.rst
@@ -1,0 +1,1 @@
+Improved status codes and error messages for various PRE http endpoints

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -258,7 +258,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
         kfrag = KFrag.from_bytes(kfrag_bytes)
 
         if not kfrag.verify(signing_pubkey=alices_verifying_key):
-            raise InvalidSignature("{} is invalid".format(kfrag))
+            return Response(f"Signature on {kfrag} is invalid", status=403)
 
         with datastore.describe(PolicyArrangement, id_as_hex, writeable=True) as policy_arrangement:
             if not policy_arrangement.alice_verifying_key == alice.stamp.as_umbral_pubkey():

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -232,7 +232,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
             cleartext = this_node.verify_from(alice, policy_message_kit, decrypt=True)
         except InvalidSignature:
             # TODO: Perhaps we log this?  Essentially 355.
-            return Response(status_code=400)
+            return Response("Invalid Signature", status_code=400)
 
         if not this_node.federated_only:
             # This splitter probably belongs somewhere canonical.
@@ -246,12 +246,12 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
             except TimeExhausted:
                 # Alice didn't pay.  Return response with that weird status code.
                 this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"No transaction matching {tx}."))
-                return Response(status=402)
+                return Response(f"No paid transaction matching {tx} for this node", status=402)
 
             this_node_has_been_arranged = this_node.checksum_address in arranged_addresses
             if not this_node_has_been_arranged:
                 this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"The transaction {tx} does not list me as a Worker - it lists {arranged_addresses}."))
-                return Response(status=402)
+                return Response(f"No transaction arrangement matching {tx} for this node", status=402)
         else:
             _tx = NO_BLOCKCHAIN_CONNECTION
             kfrag_bytes = cleartext
@@ -262,7 +262,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
 
         with datastore.describe(PolicyArrangement, id_as_hex, writeable=True) as policy_arrangement:
             if not policy_arrangement.alice_verifying_key == alice.stamp.as_umbral_pubkey():
-                raise alice.SuspiciousActivity
+                return Response(f"Policy key does not match Alice stamp.", status=403)
             policy_arrangement.kfrag = kfrag
 
         # TODO: Sign the arrangement here.  #495

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -251,7 +251,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
             this_node_has_been_arranged = this_node.checksum_address in arranged_addresses
             if not this_node_has_been_arranged:
                 this_node.suspicious_activities_witnessed['freeriders'].append((alice, f"The transaction {tx} does not list me as a Worker - it lists {arranged_addresses}."))
-                return Response(f"No transaction arrangement matching {tx} for this node", status=402)
+                return Response(f"This node was not listed as servicing the policy in transaction {tx}", status=402)
         else:
             _tx = NO_BLOCKCHAIN_CONNECTION
             kfrag_bytes = cleartext
@@ -262,7 +262,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
 
         with datastore.describe(PolicyArrangement, id_as_hex, writeable=True) as policy_arrangement:
             if not policy_arrangement.alice_verifying_key == alice.stamp.as_umbral_pubkey():
-                return Response(f"Policy key does not match Alice stamp.", status=403)
+                return Response("Policy arrangement's signing key does not match sender's", status=403)
             policy_arrangement.kfrag = kfrag
 
         # TODO: Sign the arrangement here.  #495


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
500s will not be raised in response to HTTP requests.
Also, 400s all have sensible messages.

**Why it's needed:**
Better http behavior.

