### PR TITLE
[Concept] KFrag Relaying

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1387,11 +1387,12 @@ class BlockchainPolicyAuthor(NucypherTokenActor):
         payload = {**blockchain_payload, **policy_end_time}
         return payload
 
-    def get_stakers_reservoir(self, **options) -> StakersReservoir:
+    def get_stakers_reservoir(self, registry, **options) -> StakersReservoir:
         """
         Get a sampler object containing the currently registered stakers.
         """
-        return self.staking_agent.get_stakers_reservoir(**options)
+        staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)
+        return staking_agent.get_stakers_reservoir(**options)
 
     def create_policy(self, *args, **kwargs):
         """

--- a/nucypher/policy/collections.py
+++ b/nucypher/policy/collections.py
@@ -277,6 +277,7 @@ class SignedTreasureMap(TreasureMap):
                 "Can't cast a DecentralizedTreasureMap to bytes until it has a blockchain signature (otherwise, is it really a 'DecentralizedTreasureMap'?")
         return self._blockchain_signature + super().__bytes__()
 
+
 class WorkOrder:
     class PRETask:
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -353,6 +353,12 @@ def blockchain_alice(alice_blockchain_test_config, testerchain):
     yield alice
     alice.disenchant()
 
+@pytest.fixture(scope="module")
+def another_blockchain_alice(alice_blockchain_test_config, testerchain):
+    alice = alice_blockchain_test_config.produce()
+    yield alice
+    alice.disenchant()
+
 
 @pytest.fixture(scope="module")
 def federated_bob(bob_federated_test_config):


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
3

**What this does:**

- Supports alice relaying pre-generated KFrags
- Changes the signature of `Alice.grant` to accept `policy_encrypting_key` and `kfrags`
- Moves KFrag validity check to just before re-encryption
- New test demonstrating KFrag relaying

**Why it's needed:**

Promotes additional flexibility and use cases of NuCypher PRE
