### PR TITLE
fix: broken link to contributing docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,1 +1,1 @@
-docs/source/guides/contribution_guide.rst
+docs/source/support/contribution.rst

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ NuCypher is a community-driven project and we're very open to outside contributi
 All our development discussions happen in our [Discord server](https://discord.gg/7rmXa3S), where we're happy to answer technical questions, discuss feature requests,
 and accept bug reports.
 
-If you're interested in contributing code, please check out our [Contribution Guide](https://docs.nucypher.com/en/latest/guides/contribution_guide.html)
+If you're interested in contributing code, please check out our [Contribution Guide](https://docs.nucypher.com/en/latest/support/contribution.html)
 and browse our [Open Issues](https://github.com/nucypher/nucypher/issues) for potential areas to contribute.
 
 Get up and running quickly by using our [docker development setup](dev/docker/README.md)


### PR DESCRIPTION
This commit fixes the symlink to the Contributing file. It also
fixes the broken/stale link to the contributing docs on the
README.

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
This commit fixes the symlink to the Contributing file. It also
fixes the broken/stale link to the contributing docs on the
README.