### PR TITLE
Improve 'nucypher status events' to allow event filtering

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -109,6 +109,7 @@ Whitepapers
 
    references/pip-installation
    references/cli_reference
+   references/network_events
    references/signers
    references/environment_variables
    references/networks

--- a/docs/source/references/cli_reference.rst
+++ b/docs/source/references/cli_reference.rst
@@ -139,7 +139,7 @@ Manage stakes and other staker-related operations.
 +----------------------+-------------------------------------------------------------------------------+
 |  ``remove-unused``   | Remove unused stake                                                           |
 +----------------------+-------------------------------------------------------------------------------+
-|  ``events``          | View blockchain events associated with a staker                               |
+|  ``events``          | View StakingEscrow blockchain events associated with a staker                 |
 +----------------------+-------------------------------------------------------------------------------+
 
 **Stake Command Options**

--- a/docs/source/references/network_events.rst
+++ b/docs/source/references/network_events.rst
@@ -1,0 +1,200 @@
+Network Events
+==============
+
+When there is an interaction with NuCypher smart contracts, various on-chain events are emitted. These events are
+defined in the :doc:`Contracts API </contracts_api/index>`, and they are queryable via the ``nucypher status events``
+CLI command, and allows for any NuCypher Network event to be queried.
+
+
+Querying Events
+---------------
+
+Since the number of events returned may be large, by default the query is limited to events within block numbers for the
+current period. However, this is configurable using the ``--from-block`` option.
+
+.. important::
+
+    Depending on the Ethereum provider being used, the number of results a query is allowed to return may be limited.
+    For example, on Infura this limit is currently 10,000.
+
+
+For a full list of CLI options, run:
+
+.. code::
+
+    $ nucypher status events --help
+
+
+For example, to view the staking rewards received by all Stakers in the current period, run:
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name StakingEscrow --event-name Minted
+
+    Reading Latest Chaindata...
+    Retrieving events from block 11916688 to latest
+
+    --------- StakingEscrow Events ---------
+
+    Minted:
+      - (EventRecord) staker: <STAKER_ADDRESS 1>, period: 18681, value: 1234567890123456789012, block_number: 11916689
+      - (EventRecord) staker: <STAKER ADDRESS 2>, period: 18681, value: 1234567890123456789012, block_number: 11916692
+      - (EventRecord) staker: <STAKER ADDRESS 3>, period: 18681, value: 1234567890123456789012, block_number: 11916692
+      - (EventRecord) staker: <STAKER ADDRESS 4>, period: 18681, value: 1234567890123456789012, block_number: 11916692
+      ...
+
+The value ``1234567890123456789012`` is in NuNits and equates to approximately 1234.57 NU (1 NU = 10\ :sup:`18` NuNits).
+
+
+To view the staking rewards received by all Stakers from block number ``11916685`` to ``11916688``, run:
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name StakingEscrow --event-name Minted --from-block 11916685 --to-block 11916688
+
+    Reading Latest Chaindata...
+    Retrieving events from block 11916685 to 11916688
+
+    --------- StakingEscrow Events ---------
+
+    Minted:
+      - (EventRecord) staker: <STAKER_ADDRESS 1>, period: 18681, value: 1234567890123456789012, block_number: 11916687
+      - (EventRecord) staker: <STAKER_ADDRESS 2>, period: 18681, value: 1234567890123456789012, block_number: 11916687
+      - (EventRecord) staker: <STAKER_ADDRESS 3>, period: 18681, value: 1234567890123456789012, block_number: 11916687
+      - (EventRecord) staker: <STAKER ADDRESS 4>, period: 18681, value: 1234567890123456789012, block_number: 11916687
+      ...
+
+
+To view every PolicyManager smart contract event thus far, run:
+
+.. code::
+
+    $  nucypher status events --provider <PROVIDER URI> --contract-name PolicyManager --from-block 0
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- PolicyManager Events ---------
+
+    ArrangementRevoked:
+    FeeRateRangeSet:
+      - (EventRecord) sender: 0xb6bfF48574B722F3BFf0C29c9e1b631dD19c1A93, min: 50000000000, defaultValue: 50000000000, max: 500000000000, block_number: 11057893
+    MinFeeRateSet:
+      - (EventRecord) node: 0xd4CA3a2F1046B845Aad5fe16211fd1686421e175, value: 500000000000, block_number: 11466651
+    OwnershipTransferred:
+      - (EventRecord) previousOwner: 0x0000000000000000000000000000000000000000, newOwner: 0xebA17F35955E057a8d2e74bD4638528851d8E063, block_number: 10763539
+      - (EventRecord) previousOwner: 0xebA17F35955E057a8d2e74bD4638528851d8E063, newOwner: 0xb6bfF48574B722F3BFf0C29c9e1b631dD19c1A93, block_number: 11057541
+    ...
+
+
+Event Filters
+-------------
+
+To aid with query limits and more specific queries, events can be filtered using the ``--event-filter``
+option. Multiple ``--event-filter`` options can be defined, but note that only properties classified
+as ``indexed`` in the event's solidity definition can be used as a filter.
+
+For example, to view all of the commitments ever made by the Worker associated with a specific Staker run:
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name StakingEscrow --event-name CommitmentMade --event-filter staker=<STAKING_ADDRESS> --from-block 0
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- StakingEscrow Events ---------
+
+    CommitmentMade:
+      - (EventRecord) staker: <STAKER_ADDRESS>, period: 18551, value: 1234567890123456789012, block_number: 11057641
+      - (EventRecord) staker: <STAKER_ADDRESS>, period: 18552, value: 1234567890123456789012, block_number: 11063640
+      - (EventRecord) staker: <STAKER_ADDRESS>, period: 18553, value: 1234567890123456789012, block_number: 11070103
+      - (EventRecord) staker: <STAKER_ADDRESS>, period: 18554, value: 1234567890123456789012, block_number: 11076964
+      ...
+
+To view the commitment made by the Worker associated with a specific Staker in period 18552, run:
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name StakingEscrow --event-name CommitmentMade --event-filter staker=<STAKING_ADDRESS> --event-filter period=18552 --from-block 0
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- StakingEscrow Events ---------
+
+    CommitmentMade:
+      - (EventRecord) staker: <STAKER_ADDRESS>, period: 18552, value: 1234567890123456789012, block_number: 11063640
+
+
+CSV Output
+----------
+
+CLI output can be cumbersome when trying to generate insights and correlate different events. Instead, the event
+data can be written to a CSV file using either of the following command-line options:
+
+* ``--csv`` - flag to write event information to default CSV files in the current directory with default filenames
+* ``--csv-file <FILEPATH>`` - write event information to a specific CSV file at the provided filepath
+
+
+For example,
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name PolicyManager --event-name PolicyCreated --from-block 0 --csv
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- PolicyManager Events ---------
+
+    PolicyManager::PolicyCreated events written to PolicyManager_PolicyCreated_2021-02-24_20-02-32.csv
+
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name PolicyManager --event-name PolicyCreated --from-block 0 --csv-file ~/Policy_Events.csv
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- PolicyManager Events ---------
+
+    PolicyManager::PolicyCreated events written to /<HOME DIRECTORY>/Policy_Events.csv
+
+
+To write every PolicyManager smart contract events thus far to corresponding CSV files, run:
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name PolicyManager --from-block 0 --csv
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- PolicyManager Events ---------
+
+    No PolicyManager::ArrangementRevoked events found
+    PolicyManager::FeeRateRangeSet events written to PolicyManager_FeeRateRangeSet_2021-02-24_20-47-00.csv
+    PolicyManager::MinFeeRateSet events written to PolicyManager_MinFeeRateSet_2021-02-24_20-47-01.csv
+    PolicyManager::OwnershipTransferred events written to PolicyManager_OwnershipTransferred_2021-02-24_20-47-01.csv
+    PolicyManager::PolicyCreated events written to PolicyManager_PolicyCreated_2021-02-24_20-47-01.csv
+    No PolicyManager::PolicyRevoked events found
+    No PolicyManager::RefundForArrangement events found
+    No PolicyManager::RefundForPolicy events found
+    PolicyManager::StateVerified events written to PolicyManager_StateVerified_2021-02-24_20-47-06.csv
+    PolicyManager::UpgradeFinished events written to PolicyManager_UpgradeFinished_2021-02-24_20-47-06.csv
+    PolicyManager::Withdrawn events written to PolicyManager_Withdrawn_2021-02-24_20-47-06.csv
+
+
+.. note::
+
+    If there were no events found, a CSV file is not written to.
+
+
+.. important::
+
+    When using the ``--csv-file`` option, since different events can have different
+    properties, the ``--event-name`` and ``--contract-name`` options must be specified. If querying for multiple
+    events at the same time i.e. running the command without ``--event-name``, the ``--csv`` option can be used
+    to generate separate default filenames for the different events.

--- a/docs/source/references/network_events.rst
+++ b/docs/source/references/network_events.rst
@@ -163,7 +163,7 @@ For example,
     PolicyManager::PolicyCreated events written to /<HOME DIRECTORY>/Policy_Events.csv
 
 
-To write every PolicyManager smart contract events thus far to corresponding CSV files, run:
+To write every PolicyManager smart contract event thus far to corresponding CSV files, run:
 
 .. code::
 
@@ -185,6 +185,39 @@ To write every PolicyManager smart contract events thus far to corresponding CSV
     PolicyManager::StateVerified events written to PolicyManager_StateVerified_2021-02-24_20-47-06.csv
     PolicyManager::UpgradeFinished events written to PolicyManager_UpgradeFinished_2021-02-24_20-47-06.csv
     PolicyManager::Withdrawn events written to PolicyManager_Withdrawn_2021-02-24_20-47-06.csv
+
+
+To write StakingEscrow events for a specific Staker for the current period to corresponding CSV files, run:
+
+.. code::
+
+    $ nucypher status events --provider <PROVIDER URI> --contract-name StakingEscrow --event-filter staker=<STAKING_ADDRESS> --csv
+
+    Reading Latest Chaindata...
+    Retrieving events from block 11929449 to latest
+
+    --------- StakingEscrow Events ---------
+
+    StakingEscrow::CommitmentMade events written to StakingEscrow_CommitmentMade_2021-02-26_00-11-53.csv
+    No StakingEscrow::Deposited events found
+    No StakingEscrow::Divided events found
+    No StakingEscrow::Donated events found
+    No StakingEscrow::Initialized events found
+    No StakingEscrow::Locked events found
+    StakingEscrow::Merged events written to StakingEscrow_Merged_2021-02-26_00-12-27.csv
+    StakingEscrow::Minted events written to StakingEscrow_Minted_2021-02-26_00-12-29.csv
+    No StakingEscrow::OwnershipTransferred events found
+    No StakingEscrow::Prolonged events found
+    No StakingEscrow::ReStakeLocked events found
+    No StakingEscrow::ReStakeSet events found
+    No StakingEscrow::Slashed events found
+    No StakingEscrow::SnapshotSet events found
+    No StakingEscrow::StateVerified events found
+    No StakingEscrow::UpgradeFinished events found
+    No StakingEscrow::WindDownSet events found
+    No StakingEscrow::Withdrawn events found
+    No StakingEscrow::WorkMeasurementSet events found
+    No StakingEscrow::WorkerBonded events found
 
 
 .. note::

--- a/docs/source/staking/stake_management.rst
+++ b/docs/source/staking/stake_management.rst
@@ -269,21 +269,45 @@ staking compensation if you use a hardware wallet.
           make sure to call ``nucypher stake mint`` first to ensure the last reward is included
 
 
-View Staker Blockchain Events
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _staker_blockchain_events:
+
+Query Staker Blockchain Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 As the Staker and its associated Worker interact with the StakingEscrow smart contract, various on-chain events
 are emitted. These events are outlined :doc:`here </contracts_api/main/StakingEscrow>`, and are made accessible via the
 ``nucypher stake events`` CLI command.
 
+
+.. note::
+
+    This command is limited to events from the StakingEscrow smart contract and the Staker address associated with
+    the Staker's configuration file. For generic and network-wide event queries,
+    see :doc:`/references/network_events`.
+
+
 For simple Staker accounting, events such as ``CommitmentMade``, ``Withdrawn``, and ``Minted`` can
 be used. The output of each can be correlated using the period number.
 
-For example, to view all of the staking rewards received by a specific Staker thus far, run:
+By default, the query is performed from block number 0 i.e. from the genesis of the blockchain. This can be modified
+using the ``--from-block`` option.
+
+
+For a full list of CLI options, run:
+
+.. code::
+
+    $ nucypher stake events --help
+
+
+For example, to view all of the staking rewards received by the Staker thus far, run:
 
 .. code::
 
     $ nucypher stake events --staking-address <STAKER ADDRESS> --provider <PROVIDER URI> --event-name Minted
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
 
     --------- StakingEscrow Events ---------
 
@@ -294,10 +318,34 @@ For example, to view all of the staking rewards received by a specific Staker th
 
 ``1234567890123456789012`` is in NuNits and equates to approximately 1234.57 NU (1 NU = 10\ :sup:`18` NuNits).
 
+
+To view staking rewards received by the Staker from block number 11070000 to block number 11916688, run:
+
+.. code::
+
+    $ nucypher stake events --staking-address <STAKER ADDRESS> --provider <PROVIDER URI> --event-name Minted --from-block 11070000 --to-block 11916688
+
+    Reading Latest Chaindata...
+    Retrieving events from block 11070000 to 11916688
+
+    --------- StakingEscrow Events ---------
+
+    Minted:
+      - (EventRecord) staker: <STAKER ADDRESS>, period: 18551, value: 1234567890123456789012, block_number: 11070103
+      - (EventRecord) staker: <STAKER ADDRESS>, period: 18552, value: 1234567890123456789012, block_number: 11076964
+      ...
+
+
+.. important::
+
+    Depending on the Ethereum provider being used, the number of results a query is allowed to return may be limited.
+    For example, on Infura this limit is currently 10,000.
+
+
 To aid with management of this information, instead of outputting the information to the CLI, the event data can
 be written to a CSV file using either of the following command-line options:
 
-* ``--csv`` - flag to write event information to a CSV file with a default filename in the current directory
+* ``--csv`` - flag to write event information to a CSV file in the current directory with a default filename
 * ``--csv-file <FILEPATH>`` - write event information to a CSV file at the provided filepath
 
 For example,
@@ -306,10 +354,21 @@ For example,
 
     $ nucypher stake events --staking-address <STAKER ADDRESS> --provider <PROVIDER URI> --event-name Minted --csv
 
-    StakingEscrow::Minted events written to ./Minted_2021-02-09_15-23-25.csv
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- StakingEscrow Events ---------
+
+    StakingEscrow::Minted events written to StakingEscrow_Minted_2021-02-09_15-23-25.csv
+
 
 .. code::
 
     $ nucypher stake events --staking-address <STAKER ADDRESS> --provider <PROVIDER URI> --event-name Minted --csv-file ~/Minted_Events.csv
+
+    Reading Latest Chaindata...
+    Retrieving events from block 0 to latest
+
+    --------- StakingEscrow Events ---------
 
     StakingEscrow::Minted events written to /<HOME DIRECTORY>/Minted_Events.csv

--- a/newsfragments/2573.feature.rst
+++ b/newsfragments/2573.feature.rst
@@ -1,0 +1,1 @@
+`nucypher status events` can now use event filters and be output to a csv file for simpler accounting.

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -15,14 +15,12 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 from decimal import Decimal
-from pathlib import Path
 
 import click
 from web3 import Web3
 
 from nucypher.blockchain.eth.actors import StakeHolder
 from nucypher.blockchain.eth.constants import MAX_UINT16
-from nucypher.blockchain.eth.events import EventRecord
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory, BlockchainInterface
 from nucypher.blockchain.eth.registry import IndividualAllocationRegistry
 from nucypher.blockchain.eth.signers import TrezorSigner
@@ -91,7 +89,7 @@ from nucypher.cli.literature import (
     CONFIRM_ENABLE_SNAPSHOTS,
     CONFIRM_STAKE_USE_UNLOCKED,
     CONFIRM_REMOVE_SUBSTAKE,
-    SUCCESSFUL_STAKE_REMOVAL, CONFIRM_OVERWRITE_EVENTS_CSV_FILE
+    SUCCESSFUL_STAKE_REMOVAL
 )
 from nucypher.cli.options import (
     group_options,
@@ -123,9 +121,9 @@ from nucypher.cli.types import (
     GWEI,
     DecimalRange
 )
-from nucypher.cli.utils import setup_emitter
+from nucypher.cli.utils import setup_emitter, retrieve_events
 from nucypher.config.characters import StakeHolderConfiguration
-from nucypher.utilities.events import write_events_to_csv_file, generate_events_csv_file
+from nucypher.utilities.events import generate_events_csv_file
 from nucypher.utilities.gas_strategies import construct_fixed_price_gas_strategy
 
 option_csv = click.option('--csv', help="Write event data to a CSV file using a default filename in the current directory",
@@ -1288,26 +1286,32 @@ def preallocation(general_config: GroupGeneralConfig,
 @group_staker_options
 @option_config_file
 @option_event_name
-@option_from_block
+@option_from_block  # defaults to 0
 @option_to_block
 @option_csv
 @option_csv_file
 @group_general_config
-def events(general_config, staker_options, config_file, from_block, to_block, event_name, csv, csv_file):
-    """View blockchain events associated with a staker"""
+def events(general_config, staker_options, config_file, event_name, from_block, to_block, csv, csv_file):
+    """View StakingEscrow blockchain events associated with a staker"""
 
     # Setup
     emitter = setup_emitter(general_config)
 
     if not event_name:
-        raise click.BadOptionUsage(message='You must specify an event name with --event-name')
-        # TODO: Doesn't work for the moment
-        # event_names = STAKEHOLDER.staking_agent.events.names
-        # events = [STAKEHOLDER.staking_agent.contract.events[e] for e in event_names]
-        # events = [e for e in events if 'staker' in e.argument_names]
+        raise click.BadOptionUsage(option_name='--event-name',
+                                   message='You must specify an event name with --event-name')
     if csv and csv_file:
-        emitter.echo(f'Pass either --csv or --csv-file, not both.', color='red')
-        raise click.Abort()
+        raise click.BadOptionUsage(option_name='--event-filter',
+                                   message=f'Pass either --csv or --csv-file, not both.')
+
+    if to_block is None:
+        to_block = 'latest'
+    else:
+        # validate block range
+        if from_block > to_block:
+            raise click.BadOptionUsage(option_name='--to-block, --from-block',
+                                       message=f'Invalid block range provided, '
+                                               f'from-block ({from_block}) > to-block ({to_block})')
 
     STAKEHOLDER = staker_options.create_character(emitter, config_file)
     _client_account, staking_address = select_client_account_for_staking(
@@ -1316,37 +1320,27 @@ def events(general_config, staker_options, config_file, from_block, to_block, ev
         staking_address=staker_options.staking_address,
         individual_allocation=STAKEHOLDER.individual_allocation,
         force=True)
-    if to_block is None:
-        to_block = 'latest'
 
     argument_filters = {'staker': staking_address}
     agent = STAKEHOLDER.staking_agent
-    emitter.echo(f"Obtaining events from block {from_block} to {to_block}")
-    if csv or csv_file:
-        csv_output_file = csv_file
+    contract_name = agent.contract_name
+
+    csv_output_file = csv_file
+    if csv or csv_output_file:
         if not csv_output_file:
             # use default file path if not specified
-            csv_output_file = generate_events_csv_file(event_name)
+            csv_output_file = generate_events_csv_file(contract_name=contract_name, event_name=event_name)
 
-        if Path(csv_output_file).exists():
-            click.confirm(CONFIRM_OVERWRITE_EVENTS_CSV_FILE.format(csv_file=csv_output_file), abort=True)
-        write_events_to_csv_file(csv_file=csv_output_file,
-                                 agent=agent,
-                                 event_name=event_name,
-                                 from_block=from_block,
-                                 to_block=to_block,
-                                 argument_filters=argument_filters)
-        emitter.echo(f"\n{agent.contract_name}::{event_name} events written to {csv_output_file}",
-                     bold=True,
-                     color='green')
-    else:
-        event_type = agent.contract.events[event_name]
-        title = f" {agent.contract_name} Events ".center(40, "-")
-        emitter.echo(f"\n{title}\n", bold=True, color='green')
-        emitter.echo(f"{event_type.event_name}:", bold=True, color='yellow')
-        entries = event_type.getLogs(fromBlock=from_block, toBlock=to_block, argument_filters=argument_filters)
-        for event_record in entries:
-            emitter.echo(f"  - {EventRecord(event_record)}")
+    emitter.echo(f"Retrieving events from block {from_block} to {to_block}")
+    title = f" {contract_name} Events ".center(40, "-")
+    emitter.echo(f"\n{title}\n", bold=True, color='green')
+    retrieve_events(emitter=emitter,
+                    agent=agent,
+                    event_name=event_name,
+                    from_block=from_block,
+                    to_block=to_block,
+                    argument_filters=argument_filters,
+                    csv_output_file=csv_output_file)
 
 
 @stake.command('set-min-rate')

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -18,7 +18,6 @@ from decimal import Decimal
 from pathlib import Path
 
 import click
-import maya
 from web3 import Web3
 
 from nucypher.blockchain.eth.actors import StakeHolder
@@ -126,7 +125,7 @@ from nucypher.cli.types import (
 )
 from nucypher.cli.utils import setup_emitter
 from nucypher.config.characters import StakeHolderConfiguration
-from nucypher.utilities.events import write_events_to_csv_file
+from nucypher.utilities.events import write_events_to_csv_file, generate_events_csv_file
 from nucypher.utilities.gas_strategies import construct_fixed_price_gas_strategy
 
 option_csv = click.option('--csv', help="Write event data to a CSV file using a default filename in the current directory",
@@ -1315,7 +1314,7 @@ def events(general_config, staker_options, config_file, event_name, csv, csv_fil
         csv_output_file = csv_file
         if not csv_output_file:
             # use default file path if not specified
-            csv_output_file = f'./{event_name}_{maya.now().datetime().strftime("%Y-%m-%d_%H-%M-%S")}.csv'
+            csv_output_file = generate_events_csv_file(event_name)
 
         if Path(csv_output_file).exists():
             click.confirm(CONFIRM_OVERWRITE_EVENTS_CSV_FILE.format(csv_file=csv_output_file), abort=True)

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -40,12 +40,15 @@ from nucypher.cli.options import (
 )
 from nucypher.cli.painting.staking import paint_fee_rate_range
 from nucypher.cli.painting.status import paint_contract_status, paint_locked_tokens_status, paint_stakers
-from nucypher.cli.utils import connect_to_blockchain, get_registry, setup_emitter, retrieve_events
-from nucypher.config.constants import NUCYPHER_ENVVAR_PROVIDER_URI
-from nucypher.utilities.events import (
-    generate_events_csv_file,
+from nucypher.cli.utils import (
+    connect_to_blockchain,
+    get_registry,
+    setup_emitter,
+    retrieve_events,
     parse_event_filters_into_argument_filters
 )
+from nucypher.config.constants import NUCYPHER_ENVVAR_PROVIDER_URI
+from nucypher.utilities.events import generate_events_csv_file
 
 
 class RegistryOptions:

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -183,8 +183,14 @@ def events(general_config, registry_options, contract_name, from_block, to_block
     # csv output file
     csv_output_file = csv_file
     if csv or csv_output_file:
+        if csv and csv_file:
+            raise click.BadOptionUsage(option_name='--event-filter',
+                                       message=f'Pass either --csv or --csv-file, not both.')
+
         # ensure that event name is specified - different events would have different columns in the csv file
         if not event_name:
+            # TODO consider a single csv that just gets appended to for each event
+            #  (including headers) - report-type functionality, see #2561
             raise click.BadOptionUsage(option_name='--csv, --csv-file, --event-name',
                                        message='Event name must be specified to output events to csv file')
         if not csv_output_file:

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -16,6 +16,7 @@
 """
 
 import os
+from pathlib import Path
 
 import click
 
@@ -24,9 +25,11 @@ from nucypher.blockchain.eth.constants import (
     POLICY_MANAGER_CONTRACT_NAME,
     STAKING_ESCROW_CONTRACT_NAME
 )
+from nucypher.blockchain.eth.events import EventRecord
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.blockchain.eth.utils import estimate_block_number_for_period
 from nucypher.cli.config import group_general_config
+from nucypher.cli.literature import CONFIRM_OVERWRITE_EVENTS_CSV_FILE
 from nucypher.cli.options import (
     group_options,
     option_contract_name,
@@ -42,6 +45,11 @@ from nucypher.cli.painting.staking import paint_fee_rate_range
 from nucypher.cli.painting.status import paint_contract_status, paint_locked_tokens_status, paint_stakers
 from nucypher.cli.utils import connect_to_blockchain, get_registry, setup_emitter
 from nucypher.config.constants import NUCYPHER_ENVVAR_PROVIDER_URI
+from nucypher.utilities.events import (
+    generate_events_csv_file,
+    write_events_to_csv_file,
+    parse_event_filters_into_argument_filters
+)
 
 
 class RegistryOptions:
@@ -70,6 +78,19 @@ group_registry_options = group_options(
     network=option_network(default=NetworksInventory.DEFAULT, validate=True),  # TODO: See 2214
     provider_uri=option_provider_uri(default=os.environ.get(NUCYPHER_ENVVAR_PROVIDER_URI)),
 )
+
+option_csv = click.option('--csv',
+                          help="Write event data to a CSV file using a default filename in the current directory",
+                          default=False,
+                          is_flag=True)
+option_csv_file = click.option('--csv-file',
+                               help="Write event data to the CSV file at specified filepath",
+                               type=click.Path(dir_okay=False))
+option_event_filters = click.option('--event-filter', '-f', 'event_filters',
+                                    help="Event filter of the form <name>=<value>",
+                                    multiple=True,
+                                    type=click.STRING,
+                                    default=[])
 
 
 @click.group()
@@ -114,11 +135,13 @@ def locked_tokens(general_config, registry_options, periods):
 @group_general_config
 @option_contract_name(required=False)
 @option_event_name
-@click.option('--from-block', help="Collect events from this block number", type=click.INT)
-@click.option('--to-block', help="Collect events until this block number", type=click.INT)
+@click.option('--from-block', help="Collect events from this block number; current block number by default", type=click.INT)
+@click.option('--to-block', help="Collect events until this block number; latest block number by default", type=click.INT)
+@option_csv
+@option_csv_file
+@option_event_filters
 # TODO: Add options for number of periods in the past (default current period), or range of blocks
-# TODO: Add way to input additional event filters? (e.g., staker, etc)
-def events(general_config, registry_options, contract_name, from_block, to_block, event_name):
+def events(general_config, registry_options, contract_name, from_block, to_block, event_name, csv, csv_file, event_filters):
     """Show events associated to NuCypher contracts."""
 
     emitter, registry, blockchain = registry_options.setup(general_config=general_config)
@@ -140,18 +163,55 @@ def events(general_config, registry_options, contract_name, from_block, to_block
     if to_block is None:
         to_block = 'latest'
 
+    # event argument filters
+    argument_filters = None
+    if event_filters:
+        try:
+            argument_filters = parse_event_filters_into_argument_filters(event_filters)
+        except ValueError as e:
+            raise click.BadOptionUsage(option_name='--event-filter',
+                                       message=f'Event filter must be specified as name-value pairs of '
+                                               f'the form `<name>=<value>` - {str(e)}')
+
+    # csv output file
+    csv_output_file = csv_file
+    if csv or csv_output_file:
+        # ensure that event name is specified - different events would have different columns in the csv file
+        if not event_name:
+            raise click.BadOptionUsage(option_name='--csv, --csv-file, --event-name',
+                                       message='Event name must be specified to output events to csv file')
+        if not csv_output_file:
+            csv_output_file = generate_events_csv_file(event_name)  # output to one file - use generic name
+
+        if Path(csv_output_file).exists():
+            click.confirm(CONFIRM_OVERWRITE_EVENTS_CSV_FILE.format(csv_file=csv_output_file), abort=True)
+
     # TODO: additional input validation for block numbers
     emitter.echo(f"Showing events from block {from_block} to {to_block}")
     for contract_name in contract_names:
-        title = f" {contract_name} Events ".center(40, "-")
-        emitter.echo(f"\n{title}\n", bold=True, color='green')
         agent = ContractAgency.get_agent_by_contract_name(contract_name, registry)
         names = agent.events.names if not event_name else [event_name]
-        for name in names:
-            emitter.echo(f"{name}:", bold=True, color='yellow')
-            event_method = agent.events[name]
-            for event_record in event_method(from_block=from_block, to_block=to_block):
-                emitter.echo(f"  - {event_record}")
+        if csv_output_file:
+            # csv output
+            for name in names:
+                write_events_to_csv_file(csv_file=csv_output_file,
+                                         agent=agent,
+                                         event_name=name,
+                                         to_block=to_block,
+                                         from_block=from_block,
+                                         argument_filters=argument_filters)
+                emitter.echo(f"\n{contract_name}::{name} events written to {csv_output_file}",
+                             bold=True,
+                             color='green')
+        else:
+            title = f" {contract_name} Events ".center(40, "-")
+            emitter.echo(f"\n{title}\n", bold=True, color='green')
+            for name in names:
+                emitter.echo(f"{name}:", bold=True, color='yellow')
+                event_method = agent.contract.events[name]
+                entries = event_method.getLogs(fromBlock=from_block, toBlock=to_block, argument_filters=argument_filters)
+                for event_record in entries:
+                    emitter.echo(f"  - {EventRecord(event_record)}")
 
 
 @status.command(name='fee-range')

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -92,6 +92,13 @@ option_event_filters = click.option('--event-filter', '-f', 'event_filters',
                                     type=click.STRING,
                                     default=[])
 
+option_from_block = click.option('--from-block',
+                                 help="Collect events from this block number; defaults to the block number of current period",
+                                 type=click.INT)
+option_to_block = click.option('--to-block',
+                               help="Collect events until this block number; defaults to 'latest' block number",
+                               type=click.INT)
+
 
 @click.group()
 def status():
@@ -135,8 +142,8 @@ def locked_tokens(general_config, registry_options, periods):
 @group_general_config
 @option_contract_name(required=False)
 @option_event_name
-@click.option('--from-block', help="Collect events from this block number; current block number by default", type=click.INT)
-@click.option('--to-block', help="Collect events until this block number; latest block number by default", type=click.INT)
+@option_from_block
+@option_to_block
 @option_csv
 @option_csv_file
 @option_event_filters
@@ -187,7 +194,7 @@ def events(general_config, registry_options, contract_name, from_block, to_block
             click.confirm(CONFIRM_OVERWRITE_EVENTS_CSV_FILE.format(csv_file=csv_output_file), abort=True)
 
     # TODO: additional input validation for block numbers
-    emitter.echo(f"Showing events from block {from_block} to {to_block}")
+    emitter.echo(f"Obtaining events from block {from_block} to {to_block}")
     for contract_name in contract_names:
         agent = ContractAgency.get_agent_by_contract_name(contract_name, registry)
         names = agent.events.names if not event_name else [event_name]

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -125,7 +125,7 @@ See https://docs.nucypher.com/en/latest/staking/running_a_worker.html
 #
 # Events
 #
-CONFIRM_OVERWRITE_EVENTS_CSV_FILE = "\nOverwrite existing CSV file - {csv_file}?"
+CONFIRM_OVERWRITE_EVENTS_CSV_FILE = "\nOverwrite existing CSV events file - {csv_file}?"
 
 #
 # Minting

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -125,7 +125,7 @@ See https://docs.nucypher.com/en/latest/staking/running_a_worker.html
 #
 # Events
 #
-CONFIRM_OVERWRITE_EVENTS_CSV_FILE = "\nOverwrite existing CSV events file - {csv_file}?"
+CONFIRM_OVERWRITE_EVENTS_CSV_FILE = "Overwrite existing CSV events file - {csv_file}?"
 
 #
 # Minting

--- a/nucypher/cli/utils.py
+++ b/nucypher/cli/utils.py
@@ -20,7 +20,7 @@ import os
 import shutil
 from distutils.util import strtobool
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import click
 from constant_sorrow.constants import NO_CONTROL_PROTOCOL
@@ -227,6 +227,20 @@ def deployer_pre_launch_warnings(emitter: StdoutEmitter, etherscan: bool, hw_wal
         emitter.echo(ETHERSCAN_FLAG_DISABLED_WARNING, color='yellow')
 
 
+def parse_event_filters_into_argument_filters(event_filters: Tuple) -> Dict:
+    argument_filters = dict()
+    for event_filter in event_filters:
+        event_filter_split = event_filter.split('=')
+        if len(event_filter_split) != 2:
+            raise ValueError(f"Invalid filter format: {event_filter}")
+        key = event_filter_split[0]
+        value = event_filter_split[1]
+        if value.isnumeric():
+            value = int(value)
+        argument_filters[key] = value
+    return argument_filters
+
+
 def retrieve_events(emitter: StdoutEmitter,
                     agent: EthereumContractAgent,
                     event_name: str,
@@ -248,7 +262,7 @@ def retrieve_events(emitter: StdoutEmitter,
                          bold=True,
                          color='green')
         else:
-            emitter.echo(f'No {event_name} events found', color='yellow')
+            emitter.echo(f'No {agent.contract_name}::{event_name} events found', color='yellow')
     else:
         event = agent.contract.events[event_name]
         emitter.echo(f"{event_name}:", bold=True, color='yellow')

--- a/nucypher/cli/utils.py
+++ b/nucypher/cli/utils.py
@@ -227,7 +227,12 @@ def deployer_pre_launch_warnings(emitter: StdoutEmitter, etherscan: bool, hw_wal
         emitter.echo(ETHERSCAN_FLAG_DISABLED_WARNING, color='yellow')
 
 
-def parse_event_filters_into_argument_filters(event_filters: Tuple) -> Dict:
+def parse_event_filters_into_argument_filters(event_filters: Tuple[str]) -> Dict:
+    """
+    Converts tuple of entries of the form <filter_name>=<filter_value> into a dict
+    of filter_name (key) -> filter_value (value) entries. Filter values can only be strings, but if the filter
+    value can be converted to an int, then it is converted, otherwise it remains a string.
+    """
     argument_filters = dict()
     for event_filter in event_filters:
         event_filter_split = event_filter.split('=')
@@ -235,6 +240,7 @@ def parse_event_filters_into_argument_filters(event_filters: Tuple) -> Dict:
             raise ValueError(f"Invalid filter format: {event_filter}")
         key = event_filter_split[0]
         value = event_filter_split[1]
+        # events are only indexed by string or int values
         if value.isnumeric():
             value = int(value)
         argument_filters[key] = value
@@ -247,7 +253,7 @@ def retrieve_events(emitter: StdoutEmitter,
                     from_block: BlockIdentifier,
                     to_block: BlockIdentifier,
                     argument_filters: Dict,
-                    csv_output_file: Optional[str] = None):
+                    csv_output_file: Optional[str] = None) -> None:
     if csv_output_file:
         if Path(csv_output_file).exists():
             click.confirm(CONFIRM_OVERWRITE_EVENTS_CSV_FILE.format(csv_file=csv_output_file), abort=True)

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -16,7 +16,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 import csv
 from collections import OrderedDict
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional
 
 import maya
 from web3.types import BlockIdentifier
@@ -28,20 +28,6 @@ from nucypher.blockchain.eth.events import EventRecord
 def generate_events_csv_file(contract_name: str, event_name: str) -> str:
     csv_output_file = f'{contract_name}_{event_name}_{maya.now().datetime().strftime("%Y-%m-%d_%H-%M-%S")}.csv'
     return csv_output_file
-
-
-def parse_event_filters_into_argument_filters(event_filters: Tuple) -> Dict:
-    argument_filters = dict()
-    for event_filter in event_filters:
-        event_filter_split = event_filter.split('=')
-        if len(event_filter_split) != 2:
-            raise ValueError(f"Invalid filter format: {event_filter}")
-        key = event_filter_split[0]
-        value = event_filter_split[1]
-        if value.isnumeric():
-            value = int(value)
-        argument_filters[key] = value
-    return argument_filters
 
 
 def write_events_to_csv_file(csv_file: str,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

`nucypher status events` command can now:
* output to csv file using `--csv` or `--csv-file`
* accept 1 or more event filters in the form `--event-filter name=value`, for example you can filter by staker address.


**Issues fixed/closed:**
> - Fixes #...

Related to #2548 , #2561 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

This allows for ease of accounting based on events emitted by smart contracts.

For example
```
$ nucypher status events --contract-name StakingEscrow  --provider <provider> --event-filter staker=<staker_address>  --from-block 0 --to-block 11876507 --csv --event-name Minted
```
**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

* Try `nucypher stake events` and `nucypher status events` commands
* Proofread docs