### PR TITLE
Help nucypher-monitor get the info it needs

### DIFF
--- a/newsfragments/2574.misc.rst
+++ b/newsfragments/2574.misc.rst
@@ -1,0 +1,1 @@
+Adjust ``Ursula.status_info()`` API to make it easier for ``nucypher-monitor`` to collect data.

--- a/nucypher/acumen/nicknames.py
+++ b/nucypher/acumen/nicknames.py
@@ -105,6 +105,7 @@ class Nickname:
 
     def to_json(self):
         return dict(text=self._text,
+                    icon=self.icon,
                     characters=[character.to_json() for character in self.characters])
 
     def __str__(self):

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -19,7 +19,7 @@
 import random
 import weakref
 from collections.abc import KeysView
-from typing import Optional, Dict, Iterable, List, Tuple, NamedTuple, Union
+from typing import Optional, Dict, Iterable, List, Tuple, NamedTuple, Union, Any
 
 import binascii
 import itertools
@@ -423,7 +423,7 @@ class RemoteUrsulaStatus(NamedTuple):
     recorded_fleet_state: Optional[ArchivedFleetState]
     last_learned_from: Optional[maya.MayaDT]
 
-    def to_json(self):
+    def to_json(self) -> Dict[str, Any]:
         if self.recorded_fleet_state is None:
             recorded_fleet_state_json = None
         else:

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -400,10 +400,12 @@ class FleetSensor:
 
         recorded_fleet_state = self._remote_states.get(node.checksum_address, None)
         last_learned_from = self._remote_last_seen.get(node.checksum_address, None)
+        worker_address = node.worker_address if node.verified_node else None
 
-        return RemoteUrsulaStatus(nickname=node.nickname,
+        return RemoteUrsulaStatus(verified=node.verified_node,
+                                  nickname=node.nickname,
                                   staker_address=node.checksum_address,
-                                  worker_address=node.worker_address,
+                                  worker_address=worker_address,
                                   rest_url=node.rest_url(),
                                   timestamp=node.timestamp,
                                   last_learned_from=last_learned_from,
@@ -412,9 +414,10 @@ class FleetSensor:
 
 
 class RemoteUrsulaStatus(NamedTuple):
+    verified: bool
     nickname: Nickname
     staker_address: ChecksumAddress
-    worker_address: str
+    worker_address: Optional[ChecksumAddress]
     rest_url: str
     timestamp: maya.MayaDT
     recorded_fleet_state: Optional[ArchivedFleetState]
@@ -429,7 +432,8 @@ class RemoteUrsulaStatus(NamedTuple):
             last_learned_from_json = None
         else:
             last_learned_from_json = last_learned_from.iso8601()
-        return dict(nickname=self.nickname.to_json(),
+        return dict(verified=self.verified,
+                    nickname=self.nickname.to_json(),
                     staker_address=self.staker_address,
                     worker_address=self.worker_address,
                     rest_url=self.rest_url,

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -32,13 +32,12 @@ from nucypher.utilities.logging import Logger
 from .nicknames import Nickname
 
 
-class ArchivedFleetState:
+class ArchivedFleetState(NamedTuple):
 
-    def __init__(self, checksum: str, nickname: Nickname, timestamp: maya.MayaDT, population: int):
-        self.checksum = checksum
-        self.nickname = nickname
-        self.timestamp = timestamp
-        self.population = population
+    checksum: ChecksumAddress
+    nickname: Nickname
+    timestamp: maya.MayaDT
+    population: int
 
     def to_json(self):
         return dict(checksum=self.checksum,

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -111,8 +111,8 @@ class FleetState:
         for node in nodes_to_add:
             if node.checksum_address in nodes_to_remove:
                 continue
-            if (    node.checksum_address not in self._nodes
-                    or bytes(self._nodes[node.checksum_address]) != bytes(node)):
+            unknown = node.checksum_address not in self._nodes
+            if unknown or bytes(self._nodes[node.checksum_address]) != bytes(node):
                 nodes_updated.append(node.checksum_address)
 
         nodes_removed = []
@@ -328,13 +328,18 @@ class FleetSensor:
     def values(self):
         return self._current_state.values()
 
-    def latest_states(self, quantity: int) -> List[ArchivedFleetState]:
+    def latest_state(self) -> ArchivedFleetState:
+        # `_archived_states` is never empty, one state is created in the constructor
+        return self._archived_states[-1]
+
+    def previous_states(self, quantity: int) -> List[ArchivedFleetState]:
         """
-        Returns at most ``quantity`` latest archived states (including the current one),
+        Returns at most ``quantity`` latest archived states (*not* including the current one),
         in chronological order.
         """
-        latest = self._archived_states[-min(len(self._archived_states), quantity):]
-        return latest
+        # `_archived_states` is never empty, one state is created in the constructor
+        previous_states_num = min(len(self._archived_states) - 1, quantity)
+        return self._archived_states[-previous_states_num-1:-1]
 
     def addresses(self):
         return self._current_state.addresses()

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -149,7 +149,9 @@ class FleetState:
             nodes = dict(self._nodes)
             nodes_to_add_dict = {node.checksum_address: node for node in nodes_to_add}
             for checksum_address in diff.nodes_updated:
-                nodes[checksum_address] = nodes_to_add_dict[checksum_address]
+                new_node = nodes_to_add_dict[checksum_address]
+                new_node.mature()
+                nodes[checksum_address] = new_node
             for checksum_address in diff.nodes_removed:
                 del nodes[checksum_address]
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1740,10 +1740,8 @@ class Ursula(Teacher, Character, Worker):
         domain = self.domain
         version = nucypher.__version__
 
-        latest_states = self.known_nodes.latest_states(5)
-
-        fleet_state = latest_states[-1]
-        previous_fleet_states = [state for state in latest_states[:-1]]
+        fleet_state = self.known_nodes.latest_state()
+        previous_fleet_states = self.known_nodes.previous_states(4)
 
         if not omit_known_nodes:
             known_nodes_info = [self.known_nodes.status_info(node) for node in self.known_nodes]

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -55,7 +55,7 @@ from twisted.internet import reactor, stdio, threads
 from twisted.internet.defer import Deferred
 from twisted.internet.task import LoopingCall
 from twisted.logger import Logger
-from typing import Dict, Iterable, List, NamedTuple, Tuple, Union, Optional, Sequence, Set
+from typing import Dict, Iterable, List, NamedTuple, Tuple, Union, Optional, Sequence, Set, Any
 from umbral import pre
 from umbral.keys import UmbralPublicKey
 from umbral.kfrags import KFrag
@@ -1169,9 +1169,6 @@ class Ursula(Teacher, Character, Worker):
                          timestamp=timestamp,
                          decentralized_identity_evidence=decentralized_identity_evidence)
 
-        # Only non-None when is_me=False (that is, for remote nodes).
-        self._recorded_fleet_state: Optional[ArchivedFleetState] = None
-
     def __get_hosting_power(self, host: str) -> TLSHostingPower:
         try:
             # Pre-existing or injected power
@@ -1738,7 +1735,7 @@ class Ursula(Teacher, Character, Worker):
         # ... and finally returns all the re-encrypted bytes
         return cfrag_byte_stream
 
-    def status_info(self, omit_known_nodes=False) -> 'LocalUrsulaStatus':
+    def status_info(self, omit_known_nodes: bool = False) -> 'LocalUrsulaStatus':
 
         domain = self.domain
         version = nucypher.__version__
@@ -1778,7 +1775,7 @@ class LocalUrsulaStatus(NamedTuple):
     previous_fleet_states: List[ArchivedFleetState]
     known_nodes: Optional[List[RemoteUrsulaStatus]]
 
-    def to_json(self):
+    def to_json(self) -> Dict[str, Any]:
         if self.known_nodes is None:
             known_nodes_json = None
         else:

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -432,11 +432,10 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
         return_json = request.args.get('json') == 'true'
         omit_known_nodes = request.args.get('omit_known_nodes') == 'true'
 
-        status_info = this_node.status_info(raise_invalid=False,
-                                            omit_known_nodes=omit_known_nodes)
+        status_info = this_node.status_info(omit_known_nodes=omit_known_nodes)
 
         if return_json:
-            return jsonify(status_info)
+            return jsonify(status_info.to_json())
 
         else:
             headers = {"Content-Type": "text/html", "charset": "utf-8"}

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -17,8 +17,8 @@ def contrast_color(color_hex):
         return "white"
 
 def character_span(character):
-    color = character['color_hex']
-    symbol = character['symbol']
+    color = character.color_hex
+    symbol = character.symbol
     return f'<span class="symbol" style="color: {contrast_color(color)}; background-color: {color}">{symbol}</span>'
 %>
 
@@ -26,16 +26,16 @@ def character_span(character):
 %if not state:
 <span style="color: #CCCCCC">&mdash;</span>
 %else:
-<table class="state-info" title="${state['nickname']['text']}">
+<table class="state-info" title="${state.nickname}">
     <tr>
         <td>
             ## Need to compose these spans as strings to avoid introducing whitespaces
-            <span class="state-icon">${"".join(character_span(character) for character in state['nickname']['characters'])}</span>
+            <span class="state-icon">${"".join(character_span(character) for character in state.nickname.characters)}</span>
         </td>
         <td>
-            <span>${state['population']} nodes</span>
+            <span>${state.population} nodes</span>
             <br/>
-            <span class="checksum">${state['checksum'][0:8]}</span>
+            <span class="checksum">${state.checksum[0:8]}</span>
         </td>
     </tr>
 </table>
@@ -49,14 +49,14 @@ def character_span(character):
         <tr>
             <td>
                 ## Need to compose these spans as strings to avoid introducing whitespaces
-                <span class="node-icon">${"".join(character_span(character) for character in node['nickname']['characters'])}</span>
+                <span class="node-icon">${"".join(character_span(character) for character in node.nickname.characters)}</span>
             </td>
             <td>
-                <a href="https://${node['rest_url']}/status">
-                <span class="nickname">${ node['nickname']['text'] }</span>
+                <a href="https://${node.rest_url}/status">
+                <span class="nickname">${ node.nickname }</span>
                 </a>
                 <br/>
-                <span class="checksum">${ node['staker_address'] }</span>
+                <span class="checksum">${ node.staker_address }</span>
             </td>
         </tr>
     </table>
@@ -165,28 +165,28 @@ def character_span(character):
         </tr>
         <tr>
             <td><i>Running:</i></td>
-            <td>v${ status_info['version'] }</td>
+            <td>v${ status_info.version }</td>
         </tr>
         <tr>
             <td><i>Domain:</i></td>
-            <td>${ status_info['domain'] }</td>
+            <td>${ status_info.domain }</td>
         </tr>
         <tr>
             <td><i>Fleet state:</i></td>
-            <td>${fleet_state_icon(status_info['fleet_state'])}</td>
+            <td>${fleet_state_icon(status_info.fleet_state)}</td>
         </tr>
         <tr>
             <td><i>Previous states:</i></td>
             <td>
-                %for state in status_info['previous_fleet_states']:
+                %for state in status_info.previous_fleet_states:
                     ${fleet_state_icon(state)}
                 %endfor
             </td>
         </tr>
     </table>
 
-    %if 'known_nodes' in status_info:
-    <h3>${len(status_info['known_nodes'])} ${"known node" if len(status_info['known_nodes']) == 1 else "known nodes"}:</h3>
+    %if status_info.known_nodes is not None:
+    <h3>${len(status_info.known_nodes)} ${"known node" if len(status_info.known_nodes) == 1 else "known nodes"}:</h3>
 
     <table class="known-nodes">
         <thead>
@@ -196,18 +196,18 @@ def character_span(character):
             <td>Fleet State</td>
         </thead>
         <tbody>
-        %for node in status_info['known_nodes']:
+        %for node in status_info.known_nodes:
             <tr>
                 <td>${node_info(node)}</td>
-                <td>${node['timestamp']}</td>
+                <td>${node.timestamp.iso8601()}</td>
                 <td>
-                %if node['last_learned_from']:
-                ${node['last_learned_from']}
+                %if node.last_learned_from is not None:
+                ${node.last_learned_from.iso8601()}
                 %else:
                 <span style="color: #CCCCCC">&mdash;</span>
                 %endif
                 </td>
-                <td>${fleet_state_icon(node['recorded_fleet_state'])}</td>
+                <td>${fleet_state_icon(node.recorded_fleet_state)}</td>
             </tr>
         %endfor
         </tbody>

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -186,7 +186,12 @@ def character_span(character):
     </table>
 
     %if status_info.known_nodes is not None:
-    <h3>${len(status_info.known_nodes)} ${"known node" if len(status_info.known_nodes) == 1 else "known nodes"}:</h3>
+    <%
+        verified_nodes = [node_status for node_status in status_info.known_nodes if node_status.verified]
+        unverified_nodes = [node_status for node_status in status_info.known_nodes if not node_status.verified]
+    %>
+    %for node_set, qualifier in [(verified_nodes, "verified"), (unverified_nodes, "unverified")]:
+    <h3>${len(node_set)} ${qualifier} ${"node" if len(node_set) == 1 else "nodes"}:</h3>
 
     <table class="known-nodes">
         <thead>
@@ -196,7 +201,7 @@ def character_span(character):
             <td>Fleet State</td>
         </thead>
         <tbody>
-        %for node in status_info.known_nodes:
+        %for node in node_set:
             <tr>
                 <td>${node_info(node)}</td>
                 <td>${node.timestamp.iso8601()}</td>
@@ -212,6 +217,7 @@ def character_span(character):
         %endfor
         </tbody>
     </table>
+    %endfor
     %endif
 </body>
 </html>

--- a/tests/acceptance/characters/test_ursula_web_status.py
+++ b/tests/acceptance/characters/test_ursula_web_status.py
@@ -53,4 +53,4 @@ def test_decentralized_json_status_endpoint(ursula, client, omit_known_nodes):
     assert response.status_code == 200
     json_status = response.get_json()
     status = ursula.status_info(omit_known_nodes=omit_known_nodes)
-    assert json_status == status
+    assert json_status == status.to_json()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -895,6 +895,9 @@ def fleet_of_highperf_mocked_ursulas(ursula_federated_test_config, request):
                 all_ursulas = {u.checksum_address: u for u in _ursulas}
 
                 for ursula in _ursulas:
+                    # FIXME: FleetSensor should not own fully-functional Ursulas.
+                    # It only needs to see whatever public info we can normally get via REST.
+                    # Also sharing mutable Ursulas like that can lead to unpredictable results.
                     ursula.known_nodes.current_state._nodes = all_ursulas
                     ursula.known_nodes.current_state.checksum = b"This is a fleet state checksum..".hex()
     yield _ursulas

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -651,6 +651,9 @@ def blockchain_ursulas(testerchain, stakers, ursula_decentralized_test_config):
     # Bootstrap the network
     for ursula_to_teach in _ursulas:
         for ursula_to_learn_about in _ursulas:
+            # FIXME #2588: FleetSensor should not own fully-functional Ursulas.
+            # It only needs to see whatever public info we can normally get via REST.
+            # Also sharing mutable Ursulas like that can lead to unpredictable results.
             ursula_to_teach.remember_node(ursula_to_learn_about)
 
     _ports_to_remove = [ursula.rest_interface.port for ursula in _ursulas]
@@ -895,7 +898,7 @@ def fleet_of_highperf_mocked_ursulas(ursula_federated_test_config, request):
                 all_ursulas = {u.checksum_address: u for u in _ursulas}
 
                 for ursula in _ursulas:
-                    # FIXME: FleetSensor should not own fully-functional Ursulas.
+                    # FIXME #2588: FleetSensor should not own fully-functional Ursulas.
                     # It only needs to see whatever public info we can normally get via REST.
                     # Also sharing mutable Ursulas like that can lead to unpredictable results.
                     ursula.known_nodes.current_state._nodes = all_ursulas


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 2

**What this does:**
Some adjustments and bugfixes for node and fleet state metadata to help `nucypher-monitor`:
- `FleetSensor.record_fleet_state()` now returns `None` if the fleet state was not updated and the new `ArchivedFleetState` otherwise.
- `Nickname.to_json()` now has an `icon` field (a little redundant, but it is needed often).
- `status_info()` is now a method of `Ursula` instead of `Teacher`. It is used to get the status of the local node. It returns a `LocalUrsulaStatus` object (a namedtuple with a `to_json()` method).
- `FleetSensor.status_info(checksum_or_node)` is used for remote nodes (those from `FleetSensor` itself) and returns a `RemoteUrsulaStatus` object.
- Removed `Learner.last_seen` and keeping track of it in `FleetSensor` instead.

Paired with https://github.com/nucypher/nucypher-monitor/pull/94

