### PR TITLE
[Hotfix] Fix Ursulas not starting up when prometheus is enabled

### DIFF
--- a/newsfragments/2589.bugfix.rst
+++ b/newsfragments/2589.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed missing domain parameter causing Ursulas to fail on startup when prometheus is enabled.

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -174,8 +174,9 @@ class BlockchainMetricsCollector(BaseMetricsCollector):
 
 class StakerMetricsCollector(BaseMetricsCollector):
     """Collector for Staker specific metrics."""
-    def __init__(self, staker_address: ChecksumAddress, contract_registry: BaseContractRegistry):
+    def __init__(self, domain: str, staker_address: ChecksumAddress, contract_registry: BaseContractRegistry):
         super().__init__()
+        self.domain = domain
         self.staker_address = staker_address
         self.contract_registry = contract_registry
 
@@ -205,7 +206,9 @@ class StakerMetricsCollector(BaseMetricsCollector):
         self.metrics["current_period_gauge"].set(staking_agent.get_current_period())
 
         # balances
-        nucypher_token_actor = NucypherTokenActor(self.contract_registry, checksum_address=self.staker_address)
+        nucypher_token_actor = NucypherTokenActor(registry=self.contract_registry,
+                                                  domain=self.domain,
+                                                  checksum_address=self.staker_address)
         self.metrics["eth_balance_gauge"].set(nucypher_token_actor.eth_balance)
         self.metrics["token_balance_gauge"].set(int(nucypher_token_actor.token_balance))
 
@@ -228,8 +231,9 @@ class StakerMetricsCollector(BaseMetricsCollector):
 
 class WorkerMetricsCollector(BaseMetricsCollector):
     """Collector for Worker specific metrics."""
-    def __init__(self, worker_address: ChecksumAddress, contract_registry: BaseContractRegistry):
+    def __init__(self, domain: str, worker_address: ChecksumAddress, contract_registry: BaseContractRegistry):
         super().__init__()
+        self.domain = domain
         self.worker_address = worker_address
         self.contract_registry = contract_registry
 
@@ -244,7 +248,9 @@ class WorkerMetricsCollector(BaseMetricsCollector):
         }
 
     def _collect_internal(self) -> None:
-        nucypher_worker_token_actor = NucypherTokenActor(self.contract_registry, checksum_address=self.worker_address)
+        nucypher_worker_token_actor = NucypherTokenActor(registry=self.contract_registry,
+                                                         domain=self.domain,
+                                                         checksum_address=self.worker_address)
         self.metrics["worker_eth_balance_gauge"].set(nucypher_worker_token_actor.eth_balance)
         self.metrics["worker_token_balance_gauge"].set(int(nucypher_worker_token_actor.token_balance))
 

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -187,11 +187,13 @@ def create_metrics_collectors(ursula: 'Ursula', metrics_prefix: str) -> List[Met
         collectors.append(BlockchainMetricsCollector(provider_uri=ursula.provider_uri))
 
         # Staker prometheus
-        collectors.append(StakerMetricsCollector(staker_address=ursula.checksum_address,
+        collectors.append(StakerMetricsCollector(domain=ursula.domain,
+                                                 staker_address=ursula.checksum_address,
                                                  contract_registry=ursula.registry))
 
         # Worker prometheus
-        collectors.append(WorkerMetricsCollector(worker_address=ursula.worker_address,
+        collectors.append(WorkerMetricsCollector(domain=ursula.domain,
+                                                 worker_address=ursula.worker_address,
                                                  contract_registry=ursula.registry))
 
         #


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

Issue observed in v4.7.0.

```
Mar  2 22:24:12 m2-nucypher01 nucypher[31355]: Working ~ Keep Ursula Online!
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]: Unhandled error in Deferred:
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]: Traceback (most recent call last):
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/twisted/internet/base.py", line 1283, in run
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     self.mainLoop()
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/twisted/internet/base.py", line 1292, in mainLoop
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     self.runUntilCurrent()
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/twisted/internet/base.py", line 913, in runUntilCurrent
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     call.func(*call.args, **call.kw)
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/twisted/internet/task.py", line 239, in __call__
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     d = defer.maybeDeferred(self.f, *self.a, **self.kw)
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]: --- <exception caught here> ---
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/twisted/internet/defer.py", line 151, in maybeDeferred
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     result = f(*args, **kw)
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/nucypher/utilities/prometheus/metrics.py", line 148, in collect_prometheus_metrics
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     collector.collect()
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/nucypher/utilities/prometheus/collector.py", line 76, in collect
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     self._collect_internal()
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/nucypher/utilities/prometheus/collector.py", line 208, in _collect_internal
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     nucypher_token_actor = NucypherTokenActor(self.contract_registry, checksum_address=self.staker_address)
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/nucypher/blockchain/eth/actors.py", line 168, in __init__
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     super().__init__(registry=registry, **kwargs)
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/home/nucypher/.local/lib/python3.7/site-packages/nucypher/blockchain/eth/decorators.py", line 71, in wrapped
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     params = inspect.getcallargs(func, *args, **kwargs)
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/usr/lib/python3.7/inspect.py", line 1372, in getcallargs
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     _missing_arguments(f_name, req, True, arg2value)
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:   File "/usr/lib/python3.7/inspect.py", line 1302, in _missing_arguments
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]:     "" if missing == 1 else "s", s))
Mar  2 22:25:42 m2-nucypher01 nucypher[31355]: builtins.TypeError: __init__() missing 1 required positional argument: 'domain'
```

**Issues fixed/closed:**
> - Fixes #...

Fixes #2590 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

Ursulas fail on startup when prometheus is enabled.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Try running an Ursula on Ibex with prometheus enabled - run for more than 90s so that there is 1 metric collection.