### PR TITLE
Enable eager worker commitment during startup

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1302,7 +1302,7 @@ class Ursula(Teacher, Character, Worker):
                 self.block_until_ready()
             self.stakes.checksum_address = self.checksum_address
             self.stakes.refresh()
-            self.work_tracker.start(commit_now=eager)  # requirement_func=self._availability_tracker.status)  # TODO: #2277
+            self.work_tracker.start(commit_now=True)  # requirement_func=self._availability_tracker.status)  # TODO: #2277
             if emitter:
                 emitter.message(f"✓ Work Tracking", color='green')
 


### PR DESCRIPTION
**Type of PR:**
Reconfiguration

**Required reviews:** 
3

**What this does:**
Worker nodes perform a worker commitment in the middle of service startup.

**Why it's needed:**
Improves UX when restarting a node with a pending commitment close to period advancement.

**Notes for reviewers:**
A disadvantage here is that the nodes services have not fully started, and the transaction is extremely eager.  This may encourage bad behaviors by essentially introducing a CLI command for "manual commitments".


![Screenshot from 2021-03-09 09-59-57](https://user-images.githubusercontent.com/679404/110516276-3cf89e00-80be-11eb-87ea-7607cee44695.png)

