### PR TITLE
Handle period migration in work tracker.

### DIFF
--- a/newsfragments/2607.feature.rst
+++ b/newsfragments/2607.feature.rst
@@ -1,0 +1,1 @@
+Support extended period migration by nodes via work tracker.

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -752,9 +752,15 @@ class WorkTracker:
         # Measure working interval
         interval = onchain_period - self.worker.last_committed_period
         if interval < 0:
-            self.__reset_tracker_state()
-            return  # No need to commit to this period.  Save the gas.
-        if interval > 0:
+            # Handle period migrations
+            last_commitment = self.worker.last_committed_period
+            next_period = onchain_period + 1
+            if last_commitment > next_period:
+                self.log.warn(f"PERIOD MIGRATION DETECTED - proceeding with commitment.")
+            else:
+                self.__reset_tracker_state()
+                return  # No need to commit to this period.  Save the gas.
+        elif interval > 0:
             # TODO: #1516 Follow-up actions for missed commitments
             self.log.warn(f"MISSED COMMITMENTS - {interval} missed staking commitments detected.")
 


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
1

**What this does:**
Handles an edge case in `WorkTracker` during period extension migration.

**Why it's needed:**
Prepares nodes for graceful transition to an extended period duration.

**Notes for reviewers**
This PR is a cherry-pick from #2594 