### PR TITLE
[Hotfix] Fixes account selection with ambiguous source.

### DIFF
--- a/newsfragments/2615.bugfix.rst
+++ b/newsfragments/2615.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes ethereum account selection with ambiguous source in CLI.

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -106,7 +106,8 @@ def select_client_account(emitter,
         # Connect to the blockchain in order to select an account
         if not BlockchainInterfaceFactory.is_interface_initialized(provider_uri=provider_uri):
             BlockchainInterfaceFactory.initialize_interface(provider_uri=provider_uri, poa=poa, emitter=emitter)
-        signer_uri = provider_uri
+        if not signer_uri:
+            signer_uri = provider_uri
 
     blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=provider_uri)
 


### PR DESCRIPTION
**Type of PR:**
Bugfix

**Required reviews:** 
1

**What this does:**
> Fixes `Not ETH accounts found` when using `--signer` and `--provider` flags together.
