### PR TITLE
cloudworkers: clean disk space more thoroughly, stop containers first

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
+venv
 .env/*
 env/*
 docs/*
 newsfragments/*
 .coverage/*
 .git/*
+.history

--- a/deploy/ansible/worker/include/update_existing_ursula.yml
+++ b/deploy/ansible/worker/include/update_existing_ursula.yml
@@ -6,11 +6,7 @@
 
     - name: Keep disk space clean by pruning unneeded docker debris
       become: yes
-      docker_prune:
-        containers: yes
-        images: yes
-        networks: yes
-        builder_cache: yes
+      shell: docker system prune -af
 
     - name: "pull {{ nucypher_image | default('nucypher/nucypher:latest') }}"
       become: yes
@@ -19,7 +15,6 @@
         source: pull
         force_source: yes
 
-- import_playbook: stop_containers.yml
 - import_playbook: run_geth.yml
   when: node_is_decentralized is not undefined and node_is_decentralized
 - import_playbook: run_ursula.yml

--- a/deploy/ansible/worker/update_remote_workers.yml
+++ b/deploy/ansible/worker/update_remote_workers.yml
@@ -2,6 +2,7 @@
   hosts: "{{ play_hosts }}"
   remote_user: "{{default_user}}"
 
+- import_playbook: include/stop_containers.yml
 - import_playbook: include/update_existing_ursula.yml
 - import_playbook: include/check_running_ursula.yml
 - import_playbook: include/backup_ursula_data.yml

--- a/newsfragments/2618.bugfix.rst
+++ b/newsfragments/2618.bugfix.rst
@@ -1,0 +1,1 @@
+cloudworkers more throughoughly cleans up diskspace before updates.


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Cloudworker configured nodes were still having their disks filled up by logs and old docker images. This PR more forcefully cleans up old junk with no side effects.



