### PR TITLE
Fix bug with merged sub-stake and migration (when last period is 1)

### DIFF
--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -1253,6 +1253,9 @@ contract StakingEscrow is Issuer, IERC900History {
             // sub-stake has fixed last period
             if (subStake.lastPeriod != 0) {
                 subStake.lastPeriod = recalculatePeriod(subStake.lastPeriod);
+                if (subStake.lastPeriod == 0) {
+                    subStake.lastPeriod = 1;
+                }
                 subStake.unlockingDuration = 0;
             // sub-stake has no fixed ending but possible that with new period length will have
             } else {


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix

**Required reviews:** 
- [X] 3

**What this does:**
Fix small bug when inactive sub-stake become active for current period only after migration. It leads to lock tokens (without reward) when it should not
