### PR TITLE
acumen bug fix, ansible geth node playbook

### DIFF
--- a/deploy/ansible/worker/geth_inventory.yml
+++ b/deploy/ansible/worker/geth_inventory.yml
@@ -1,0 +1,20 @@
+all:
+  children:
+    nucypher:
+      children:
+        mainnet:
+          children:
+            nodes:
+              vars:
+                network_name: "mainnet"
+                geth_options: "--mainnet"
+                geth_dir: '/home/nucypher/geth/.ethereum/mainnet/'
+                geth_container_geth_datadir: "/root/.ethereum/mainnet"
+                nucypher_container_geth_datadir: "/root/.local/share/geth/.ethereum/mainnet"
+                etherscan_domain: mainnet.etherscan.io
+                ansible_python_interpreter: /usr/bin/python3
+                ansible_connection: ssh
+                ansible_ssh_private_key_file: <PEM FILE HERE>
+              hosts:
+                <IP ADDRESS HERE>:
+                  default_user: ubuntu

--- a/deploy/ansible/worker/include/init_worker.yml
+++ b/deploy/ansible/worker/include/init_worker.yml
@@ -10,19 +10,6 @@
         state: absent
       when: wipe_nucypher_config is not undefined and wipe_nucypher_config
 
-    - name: "create geth directory"
-      become: yes
-      file:
-        path: /home/nucypher/geth/
-        state: directory
-        mode: '0755'
-
-    - name: "pull ethereum/client-go:latest"
-      become: yes
-      docker_image:
-        name: ethereum/client-go:latest
-        source: pull
-
     - name: "create geth keystore directory"
       become: yes
       file:

--- a/deploy/ansible/worker/include/install_geth.yml
+++ b/deploy/ansible/worker/include/install_geth.yml
@@ -1,0 +1,17 @@
+- name: "Setup Ethereum"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+  gather_facts: no
+  tasks:
+    - name: "create geth directory"
+      become: yes
+      file:
+        path: /home/nucypher/geth/
+        state: directory
+        mode: '0755'
+
+    - name: "pull ethereum/client-go:latest"
+      become: yes
+      docker_image:
+        name: ethereum/client-go:latest
+        source: pull

--- a/deploy/ansible/worker/include/install_geth.yml
+++ b/deploy/ansible/worker/include/install_geth.yml
@@ -10,8 +10,8 @@
         state: directory
         mode: '0755'
 
-    - name: "pull ethereum/client-go:latest"
+    - name: "pull ethereum/client-go:stable"
       become: yes
       docker_image:
-        name: ethereum/client-go:latest
+        name: ethereum/client-go:stable
         source: pull

--- a/deploy/ansible/worker/include/run_external_geth.yml
+++ b/deploy/ansible/worker/include/run_external_geth.yml
@@ -10,7 +10,7 @@
         name: geth
         state: started
         restart: yes
-        image: ethereum/client-go:latest
+        image: ethereum/client-go:stable
         restart_policy: "unless-stopped"
         command: "{{geth_options}} --http --http.addr 0.0.0.0 --http.api eth,web3,net --nousb --syncmode fast --rpcvhosts=* --cache 2000"
         volumes:

--- a/deploy/ansible/worker/include/run_external_geth.yml
+++ b/deploy/ansible/worker/include/run_external_geth.yml
@@ -16,7 +16,6 @@
         volumes:
           - /home/nucypher/geth:/root
         ports:
-          - "8545/tcp"
-          - "30303/tcp"
-          - "8546/tcp"
-          - "30303/udp"
+          - "8545:8545/tcp"
+          - "30303:30303"
+          - "8546:8546/tcp"

--- a/deploy/ansible/worker/include/run_external_geth.yml
+++ b/deploy/ansible/worker/include/run_external_geth.yml
@@ -1,0 +1,22 @@
+- name: "Run shared externally available geth node"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+  gather_facts: no
+  tasks:
+
+    - name: "run geth {{geth_options}} forever in the background"
+      become: yes
+      docker_container:
+        name: geth
+        state: started
+        restart: yes
+        image: ethereum/client-go:latest
+        restart_policy: "unless-stopped"
+        command: "{{geth_options}} --http --http.addr 0.0.0.0 --http.api eth,web3,net --nousb --syncmode fast --rpcvhosts=* --cache 2000"
+        volumes:
+          - /home/nucypher/geth:/root
+        ports:
+          - "8545/tcp"
+          - "30303/tcp"
+          - "8546/tcp"
+          - "30303/udp"

--- a/deploy/ansible/worker/setup_remote_workers.yml
+++ b/deploy/ansible/worker/setup_remote_workers.yml
@@ -4,6 +4,7 @@
 
 - import_playbook: include/setup_user.yml
 - import_playbook: include/setup_docker.yml
+- import_playbook: include/install_geth.yml
 - import_playbook: include/init_worker.yml
 - import_playbook: include/run_geth.yml
   when: node_is_decentralized is not undefined and node_is_decentralized

--- a/deploy/ansible/worker/setup_standalone_geth_node.yml
+++ b/deploy/ansible/worker/setup_standalone_geth_node.yml
@@ -1,0 +1,8 @@
+- name: "Setup Remote Geth"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+
+- import_playbook: include/setup_user.yml
+- import_playbook: include/setup_docker.yml
+- import_playbook: include/install_geth.yml
+- import_playbook: include/run_external_geth.yml

--- a/newsfragments/2624.feature.rst
+++ b/newsfragments/2624.feature.rst
@@ -1,0 +1,1 @@
+New standalone geth fullnode anisble playbook.

--- a/newsfragments/2624.feature.rst
+++ b/newsfragments/2624.feature.rst
@@ -1,1 +1,1 @@
-New standalone geth fullnode anisble playbook.
+New standalone geth fullnode ansible playbook.

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -432,11 +432,11 @@ class RemoteUrsulaStatus(NamedTuple):
         if self.recorded_fleet_state is None:
             recorded_fleet_state_json = None
         else:
-            recorded_fleet_state_json = recorded_fleet_state.to_json()
+            recorded_fleet_state_json = self.recorded_fleet_state.to_json()
         if self.last_learned_from is None:
             last_learned_from_json = None
         else:
-            last_learned_from_json = last_learned_from.iso8601()
+            last_learned_from_json = self.last_learned_from.iso8601()
         return dict(verified=self.verified,
                     nickname=self.nickname.to_json(),
                     staker_address=self.staker_address,


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
* Tweaks some existing ansible playbooks for re-usability.
* Creates setup_standalone_geth_node.yml for one line deployment of latest geth on existing VPS.
* fixes https://sentry.io/organizations/nucypher/issues/2269874410

**Why it's needed:**
* Our current Ethereum infrastructure relies on copying and pasting from history of existing node. This formally declares our spec and makes for a simple and reliable way to create new Ethereum nodes.

