### PR TITLE
Fix missing provider_uri

### DIFF
--- a/examples/finnegans_wake_demo/finnegans-wake-demo-testnet.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo-testnet.py
@@ -69,7 +69,7 @@ TESTNET = 'lynx'
 
 # Then, there was bob. Bob learns about the
 # rest of the network from the seednode.
-bob = Bob(domain=TESTNET)
+bob = Bob(domain=TESTNET, provider_uri=PROVIDER_URI)
 
 # Bob puts his public keys somewhere alice can find them.
 verifying_key = bob.public_keys(SigningPower)
@@ -90,7 +90,7 @@ password = os.environ.get('DEMO_ALICE_PASSWORD') or getpass(f"Enter password to 
 wallet.unlock_account(account=ALICE_ADDRESS, password=password)
 
 # This is Alice.
-alice = Alice(checksum_address=ALICE_ADDRESS, signer=wallet, domain=TESTNET)
+alice = Alice(checksum_address=ALICE_ADDRESS, signer=wallet, domain=TESTNET, provider_uri=PROVIDER_URI)
 
 # Alice puts her public key somewhere for Bob to find later...
 alice_verifying_key = bytes(alice.stamp)

--- a/examples/finnegans_wake_demo/finnegans-wake-demo-testnet.py
+++ b/examples/finnegans_wake_demo/finnegans-wake-demo-testnet.py
@@ -69,7 +69,7 @@ TESTNET = 'lynx'
 
 # Then, there was bob. Bob learns about the
 # rest of the network from the seednode.
-bob = Bob(domain=TESTNET, provider_uri=PROVIDER_URI)
+bob = Bob(domain=TESTNET)
 
 # Bob puts his public keys somewhere alice can find them.
 verifying_key = bob.public_keys(SigningPower)

--- a/newsfragments/2626.bugfix.rst
+++ b/newsfragments/2626.bugfix.rst
@@ -1,0 +1,1 @@
+Bob now accepts provider_uri as an optional parameter

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -84,7 +84,6 @@ class Character(Learner):
                  signer: Signer = None,
                  registry: BaseContractRegistry = None,
                  include_self_in_the_state: bool = False,
-                 is_offchain: bool = False,
                  *args, **kwargs
                  ) -> None:
 
@@ -179,9 +178,7 @@ class Character(Learner):
                 self._stamp = NO_SIGNING_POWER
 
             # Blockchainy
-            if not self.federated_only and not is_offchain:
-                if not provider_uri:
-                    raise ValueError('Provider URI is required to init a decentralized character.')
+            if not self.federated_only:
                 self.provider_uri = provider_uri
 
                 # TODO: Implicit / lazy blockchain connection here?

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -84,6 +84,7 @@ class Character(Learner):
                  signer: Signer = None,
                  registry: BaseContractRegistry = None,
                  include_self_in_the_state: bool = False,
+                 is_offchain: bool = False,
                  *args, **kwargs
                  ) -> None:
 
@@ -178,7 +179,7 @@ class Character(Learner):
                 self._stamp = NO_SIGNING_POWER
 
             # Blockchainy
-            if not self.federated_only:
+            if not self.federated_only and not is_offchain:
                 if not provider_uri:
                     raise ValueError('Provider URI is required to init a decentralized character.')
                 self.provider_uri = provider_uri

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -112,6 +112,7 @@ class Alice(Character, BlockchainPolicyAuthor):
                  # Mode
                  is_me: bool = True,
                  federated_only: bool = False,
+                 provider_uri: str = None,
                  signer=None,
 
                  # Ownership
@@ -156,11 +157,15 @@ class Alice(Character, BlockchainPolicyAuthor):
                            known_node_class=Ursula,
                            is_me=is_me,
                            federated_only=federated_only,
+                           provider_uri=provider_uri,
                            checksum_address=checksum_address,
                            network_middleware=network_middleware,
                            *args, **kwargs)
 
         if is_me and not federated_only:  # TODO: #289
+            if not provider_uri:
+                raise ValueError('Provider URI is required to init a decentralized character.')
+
             blockchain = BlockchainInterfaceFactory.get_interface(provider_uri=self.provider_uri)
             signer = signer or Web3Signer(blockchain.client)  # fallback to web3 provider by default for Alice.
             self.transacting_power = TransactingPower(account=self.checksum_address, signer=signer)
@@ -171,7 +176,6 @@ class Alice(Character, BlockchainPolicyAuthor):
                                             registry=self.registry,
                                             rate=rate,
                                             duration_periods=duration_periods)
-
 
         self.log = Logger(self.__class__.__name__)
         if is_me:
@@ -502,7 +506,6 @@ class Bob(Character):
                            is_me=is_me,
                            known_node_class=Ursula,
                            verify_node_bonding=verify_node_bonding,
-                           is_offchain=provider_uri is None,
                            provider_uri=provider_uri,
                            *args, **kwargs)
 
@@ -1080,6 +1083,7 @@ class Ursula(Teacher, Character, Worker):
                  worker_address: ChecksumAddress = None,  # TODO: deprecate, and rename to "checksum_address"
                  client_password: str = None,
                  decentralized_identity_evidence=NOT_SIGNED,
+                 provider_uri: str = None,
 
                  # Character
                  abort_on_learning_error: bool = False,
@@ -1100,6 +1104,7 @@ class Ursula(Teacher, Character, Worker):
                            domain=domain,
                            known_node_class=Ursula,
                            include_self_in_the_state=True,
+                           provider_uri=provider_uri,
                            **character_kwargs)
 
         if is_me:
@@ -1117,6 +1122,9 @@ class Ursula(Teacher, Character, Worker):
 
             # Decentralized Worker
             if not federated_only:
+
+                if not provider_uri:
+                    raise ValueError('Provider URI is required to init a decentralized character.')
 
                 # TODO: Move to method
                 # Prepare a TransactingPower from worker node's transacting keys

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -495,12 +495,15 @@ class Bob(Character):
                  treasure_maps: Optional[Dict] = None,
                  controller: bool = True,
                  verify_node_bonding: bool = False,
+                 provider_uri: str = None,
                  *args, **kwargs) -> None:
 
         Character.__init__(self,
                            is_me=is_me,
                            known_node_class=Ursula,
                            verify_node_bonding=verify_node_bonding,
+                           is_offchain=provider_uri is None,
+                           provider_uri=provider_uri,
                            *args, **kwargs)
 
         if controller:


### PR DESCRIPTION
**Type of PR:**
Bugfix

**Required reviews:** 
1

**What this does:**
Fixes `ValueError: Provider URI is required to init a decentralized character.` thrown on `Bob()` and `Alice()` constructors.

