### PR TITLE
Change nickname delimiter in card filename

### DIFF
--- a/newsfragments/2628.misc.rst
+++ b/newsfragments/2628.misc.rst
@@ -1,0 +1,1 @@
+Change filepath delimiter to dot (".") in Card Storage API

--- a/nucypher/policy/identity.py
+++ b/nucypher/policy/identity.py
@@ -65,7 +65,7 @@ class Card:
     __BASE_PAYLOAD_SIZE = sum(length[1] for length in _bob_specification.values() if isinstance(length[1], int))
     __MAX_CARD_LENGTH = __BASE_PAYLOAD_SIZE + __MAX_NICKNAME_SIZE + 2
     __FILE_EXTENSION = 'card'
-    __DELIMITER = ':'  # delimits nickname from ID
+    __DELIMITER = '.'  # delimits nickname from ID
 
     TRUNCATE = 16
     CARD_DIR = Path(DEFAULT_CONFIG_ROOT) / 'cards'

--- a/tests/unit/test_card.py
+++ b/tests/unit/test_card.py
@@ -17,7 +17,7 @@
 
 import pytest
 
-from nucypher.characters.lawful import Bob, Alice
+from nucypher.characters.lawful import Alice, Bob
 from nucypher.crypto.powers import DecryptingPower, SigningPower
 from nucypher.policy.identity import Card
 from tests.utils.middleware import MockRestMiddleware
@@ -59,6 +59,9 @@ def test_character_card(character_class):
     character_card.to_qr_code()
     # TODO: Examine system output here?
 
+    # filepath without nickname
+    assert character_card.id.hex() in str(character_card.filepath)
+
     # nicknames
     original_checksum = character_card.id
     nickname = 'Wilson'
@@ -67,3 +70,6 @@ def test_character_card(character_class):
     restored_checksum = restored.id
     assert restored.nickname == nickname
     assert original_checksum == restored_checksum == same_card.id
+
+    # filepath with nickname
+    assert f'{nickname}.{character_card.id.hex()}' in str(character_card.filepath)

--- a/tests/unit/test_card.py
+++ b/tests/unit/test_card.py
@@ -24,7 +24,7 @@ from tests.utils.middleware import MockRestMiddleware
 
 
 @pytest.mark.parametrize('character_class', (Bob, Alice))
-def test_character_card(character_class):
+def test_character_card(character_class, capsys):
     character = character_class(federated_only=True,
                                 start_learning_now=False,
                                 network_middleware=MockRestMiddleware())
@@ -57,7 +57,10 @@ def test_character_card(character_class):
 
     # qr code echo
     character_card.to_qr_code()
-    # TODO: Examine system output here?
+    captured = capsys.readouterr()
+    qr_code_padding = '\xa0' * 21  # min length for qr code version 1
+    assert captured.out.startswith(qr_code_padding)
+    assert captured.out.endswith(f'{qr_code_padding}\n')
 
     # filepath without nickname
     assert character_card.id.hex() in str(character_card.filepath)


### PR DESCRIPTION
**Type of PR:**
Other

**Required reviews:** 
1

**What this does:**
- Changes nickname delimiter in card filename from colon `:` to dot `.`.
- Adds a test for a QR code output.

**Issues fixed/closed:**
- Fixes #2471 

**Notes for reviewers:**
- It could break compatibility for existing card files.
