### PR TITLE
Use constant for loopback address

### DIFF
--- a/examples/run_demo_ursula_fleet.py
+++ b/examples/run_demo_ursula_fleet.py
@@ -24,11 +24,12 @@ from twisted.internet import reactor
 
 from nucypher.characters.lawful import Ursula
 from nucypher.config.constants import APP_DIR, TEMPORARY_DOMAIN
+from nucypher.utilities.networking import LOOPBACK_ADDRESS
 
 FLEET_POPULATION = 12
 DEMO_NODE_STARTING_PORT = 11500
 
-ursula_maker = partial(Ursula, rest_host='127.0.0.1',
+ursula_maker = partial(Ursula, rest_host=LOOPBACK_ADDRESS,
                        federated_only=True,
                        domain=TEMPORARY_DOMAIN)
 

--- a/newsfragments/2538.misc.rst
+++ b/newsfragments/2538.misc.rst
@@ -1,0 +1,1 @@
+Use constant for loopback address across the codebase

--- a/newsfragments/2538.misc.rst
+++ b/newsfragments/2538.misc.rst
@@ -1,1 +1,0 @@
-Use constant for loopback address across the codebase

--- a/newsfragments/2629.misc.rst
+++ b/newsfragments/2629.misc.rst
@@ -1,0 +1,1 @@
+Use constant for loopback address across the codebase.

--- a/nucypher/cli/commands/felix.py
+++ b/nucypher/cli/commands/felix.py
@@ -56,6 +56,7 @@ from nucypher.cli.painting.help import paint_new_installation_help
 from nucypher.cli.types import NETWORK_PORT
 from nucypher.config.characters import FelixConfiguration
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, NUCYPHER_ENVVAR_WORKER_ETH_PASSWORD
+from nucypher.utilities.networking import LOOPBACK_ADDRESS
 
 option_port = click.option('--port', help="The host port to run Felix HTTP services on", type=NETWORK_PORT, default=FelixConfiguration.DEFAULT_REST_PORT)
 
@@ -128,7 +129,8 @@ group_config_options = group_options(
     network=option_network(),
     provider_uri=option_provider_uri(),
     signer_uri=option_signer_uri,
-    host=click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING, default='127.0.0.1'),
+    host=click.option('--host', help="The host to run Felix HTTP services on", type=click.STRING,
+                      default=LOOPBACK_ADDRESS),
     db_filepath=option_db_filepath,
     checksum_address=option_checksum_address,
     registry_filepath=option_registry_filepath,

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -32,6 +32,7 @@ from nucypher.config.constants import (
     NUCYPHER_ENVVAR_BOB_ETH_PASSWORD
 )
 from nucypher.config.keyring import NucypherKeyring
+from nucypher.utilities.networking import LOOPBACK_ADDRESS
 
 
 class UrsulaConfiguration(CharacterConfiguration):
@@ -41,7 +42,7 @@ class UrsulaConfiguration(CharacterConfiguration):
     NAME = CHARACTER_CLASS.__name__.lower()
 
     DEFAULT_REST_PORT = 9151
-    DEFAULT_DEVELOPMENT_REST_HOST = '127.0.0.1'
+    DEFAULT_DEVELOPMENT_REST_HOST = LOOPBACK_ADDRESS
     DEFAULT_DEVELOPMENT_REST_PORT = 10151
     DEFAULT_DB_NAME = f'{NAME}.db'
     DEFAULT_AVAILABILITY_CHECKS = False
@@ -255,7 +256,7 @@ class FelixConfiguration(CharacterConfiguration):
     DEFAULT_DB_FILEPATH = os.path.join(DEFAULT_CONFIG_ROOT, DEFAULT_DB_NAME)
     DEFAULT_REST_PORT = 6151
     DEFAULT_LEARNER_PORT = 9151
-    DEFAULT_REST_HOST = '127.0.0.1'
+    DEFAULT_REST_HOST = LOOPBACK_ADDRESS
     __DEFAULT_TLS_CURVE = ec.SECP384R1
 
 

--- a/nucypher/network/protocols.py
+++ b/nucypher/network/protocols.py
@@ -18,6 +18,8 @@ from bytestring_splitter import VariableLengthBytestring
 from eth_utils import is_checksum_address
 from urllib.parse import urlparse
 
+from nucypher.utilities.networking import LOOPBACK_ADDRESS
+
 
 class SuspiciousActivity(RuntimeError):
     """raised when an action appears to amount to malicious conduct."""
@@ -63,7 +65,7 @@ class InterfaceInfo:
     expected_bytes_length = lambda: VariableLengthBytestring
 
     def __init__(self, host, port) -> None:
-        loopback, localhost = '127.0.0.1', 'localhost'
+        loopback, localhost = LOOPBACK_ADDRESS, 'localhost'
         self.host = loopback if host == localhost else host
         self.port = int(port)
 

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -40,7 +40,7 @@ class InvalidWorkerIP(RuntimeError):
 
 CENTRALIZED_IP_ORACLE_URL = 'https://ifconfig.me/'
 
-LOOPBACK_ADDRESS = '127.0.0.1'  # TODO use across code base - #2538
+LOOPBACK_ADDRESS = '127.0.0.1'
 
 RequestErrors = (
     # https://requests.readthedocs.io/en/latest/user/quickstart/#errors-and-exceptions

--- a/scripts/local_fleet/run_single_ursula.py
+++ b/scripts/local_fleet/run_single_ursula.py
@@ -26,6 +26,7 @@ from click.testing import CliRunner
 
 from nucypher.cli.main import nucypher_cli
 from nucypher.exceptions import DevelopmentInstallationRequired
+from nucypher.utilities.networking import LOOPBACK_ADDRESS
 
 try:
     from tests.utils.ursula import select_test_port
@@ -40,7 +41,7 @@ DEMO_FLEET_STARTING_PORT = 11500
 args = ['ursula', 'run',
         '--debug',
         '--federated-only',
-        '--teacher', f'https://127.0.0.1:{DEMO_FLEET_STARTING_PORT}',
+        '--teacher', f'https://{LOOPBACK_ADDRESS}:{DEMO_FLEET_STARTING_PORT}',
         '--rest-port', DEMO_NODE_PORT,
         '--dev'
         ]

--- a/tests/acceptance/cli/ursula/test_run_ursula.py
+++ b/tests/acceptance/cli/ursula/test_run_ursula.py
@@ -30,7 +30,7 @@ from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import NUCYPHER_ENVVAR_KEYRING_PASSWORD, TEMPORARY_DOMAIN
 from nucypher.network.nodes import Teacher
-from nucypher.utilities.networking import UnknownIPAddress
+from nucypher.utilities.networking import LOOPBACK_ADDRESS, UnknownIPAddress
 from tests.constants import (
     FAKE_PASSWORD_CONFIRMED,
     INSECURE_DEVELOPMENT_PASSWORD,
@@ -114,7 +114,7 @@ def test_run_lone_federated_default_development_ursula(click_runner):
     time.sleep(Learner._SHORT_LEARNING_DELAY)
     assert result.exit_code == 0, result.output
     assert "Running" in result.output
-    assert "127.0.0.1:{}".format(deploy_port) in result.output
+    assert f"{LOOPBACK_ADDRESS}:{deploy_port}" in result.output
 
     reserved_ports = (UrsulaConfiguration.DEFAULT_REST_PORT, UrsulaConfiguration.DEFAULT_DEVELOPMENT_REST_PORT)
     assert deploy_port not in reserved_ports
@@ -153,7 +153,7 @@ def test_federated_ursula_learns_via_cli(click_runner, federated_ursulas):
 
     assert result.exit_code == 0
     assert "Starting services" in result.output
-    assert f"127.0.0.1:{deploy_port}" in result.output
+    assert f"{LOOPBACK_ADDRESS}:{deploy_port}" in result.output
 
     reserved_ports = (UrsulaConfiguration.DEFAULT_REST_PORT, UrsulaConfiguration.DEFAULT_DEVELOPMENT_REST_PORT)
     assert deploy_port not in reserved_ports

--- a/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
+++ b/tests/acceptance/cli/ursula/test_stakeholder_and_ursula.py
@@ -37,6 +37,7 @@ from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import StakeHolderConfiguration, UrsulaConfiguration
 from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.utilities.logging import Logger
+from nucypher.utilities.networking import LOOPBACK_ADDRESS
 from tests.constants import (
     FAKE_PASSWORD_CONFIRMED,
     FEE_RATE_RANGE,
@@ -583,7 +584,7 @@ def test_collect_rewards_integration(click_runner,
                     signer=Web3Signer(testerchain.client),
                     worker_address=worker_address,
                     registry=agency_local_registry,
-                    rest_host='127.0.0.1',
+                    rest_host=LOOPBACK_ADDRESS,
                     rest_port=ursula_port,
                     provider_uri=TEST_PROVIDER_URI,
                     network_middleware=MockRestMiddleware(),

--- a/tests/unit/test_web3_clients.py
+++ b/tests/unit/test_web3_clients.py
@@ -24,6 +24,7 @@ from web3 import HTTPProvider, IPCProvider, WebsocketProvider
 from nucypher.blockchain.eth.clients import (GanacheClient, GethClient, InfuraClient, PUBLIC_CHAINS,
                                              ParityClient, AlchemyClient)
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
+from nucypher.utilities.networking import LOOPBACK_ADDRESS
 
 DEFAULT_GAS_PRICE = 42
 GAS_PRICE_FROM_STRATEGY = 1234
@@ -59,7 +60,7 @@ class MockAlchemyProvider:
 
 
 class MockWebSocketProvider:
-    endpoint_uri = 'ws://127.0.0.1:8546'
+    endpoint_uri = f'ws://{LOOPBACK_ADDRESS}:8546'
     clientVersion = 'Geth/v1.8.23-omnibus-2ad89aaa/linux-amd64/go1.11.1'
 
 
@@ -260,7 +261,7 @@ def test_detect_provider_type_https():
 
 
 def test_detect_provider_type_ws():
-    interface = ProviderTypeTestClient(provider_uri='ws://127.0.0.1:8546',
+    interface = ProviderTypeTestClient(provider_uri=f'ws://{LOOPBACK_ADDRESS}:8546',
                                        expected_provider_class=WebsocketProvider,
                                        actual_provider_to_attach=MockWebSocketProvider())
     interface.connect()


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other - (Code Quality)

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- Replaces occurrences of `127.0.0.1` with a `LOOPBACK_ADDRESS` constant.

**Issues fixed/closed:**
- Fixes #2538 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- [One occurrence](https://github.com/nucypher/nucypher/blob/main/scripts/local_fleet/run_local_ursula_fleet.py#L33) of `127.0.0.1` was ignored because it's a script without dependency on the codebase.
