### PR TITLE
Handle ambiguous card nickname in lookup

### DIFF
--- a/nucypher/policy/identity.py
+++ b/nucypher/policy/identity.py
@@ -311,7 +311,7 @@ class Card:
         except ValueError:
             nickname = identifier
         filenames = [f for f in os.listdir(Card.CARD_DIR) if nickname.lower() in f.lower()]
-        if len(filenames) == 0:
+        if not filenames:
             raise cls.UnknownCard(f'Unknown card nickname or ID "{nickname}".')
         elif len(filenames) == 1:
             filename = filenames[0]

--- a/nucypher/policy/identity.py
+++ b/nucypher/policy/identity.py
@@ -310,11 +310,13 @@ class Card:
             nickname, _id = identifier.split(cls.__DELIMITER)
         except ValueError:
             nickname = identifier
-        for filename in os.listdir(Card.CARD_DIR):
-            if nickname.lower() in filename.lower():
-                break
-        else:
+        filenames = [f for f in os.listdir(Card.CARD_DIR) if nickname.lower() in f.lower()]
+        if len(filenames) == 0:
             raise cls.UnknownCard(f'Unknown card nickname or ID "{nickname}".')
+        elif len(filenames) == 1:
+            filename = filenames[0]
+        else:
+            raise ValueError(f'Ambiguous card nickname: {nickname}. Try using card ID instead.')
         filepath = card_dir / filename
         return filepath
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other - UX

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- Previously, when restoring cards we would pick the first matching filename
- Now, we throw an error if the given nickname was ambiguous

Example:
```bash
$ ls ~/.local/share/nucypher/cards 
test-nickname.0x8fe7f7811e.card
test-nickname.0xb9d0b18089.card

## Before

$ nucypher alice grant --bob test-nickname
# Silently picks Bob from test-nickname.0x8fe7f7811e.card

## After

$ nucypher alice grant --bob test-nickname
# ...
ValueError: Ambiguous card nickname: test-nickname. Try using ID instead.

$ nucypher alice grant --bob 0xb9d0b18089
# Picks Bob from test-nickname.0xb9d0b18089.card
```

**Issues fixed/closed:**
- Fixes: #2464

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
