### PR TITLE
Release note github action should handle multiple newsfragment files.

### DIFF
--- a/.github/workflows/pr_release_note_entry.yml
+++ b/.github/workflows/pr_release_note_entry.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          test -f ${{ github.workspace }}/newsfragments/${{ github.event.number }}.*
+          ls -l ${{ github.workspace }}/newsfragments/${{ github.event.number }}.*.rst


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [] 3

**What this does:**
Our existing github action doesn't handle multiple PR newsfragments for the same PR (eg. feature, and bugfix). This is seen in #2617 .

Since the github action is mostly internal, I won't add a newsfragment for this PR i.e. the action will fail for this PR (oh the irony!)

**Why it's needed:**
Sometimes a PR solves multiple types of issues and necessitates multiple newsfragments of different types.

--

Adding here for posterity. When testing GitHub Actions, use the `act` command from  'act' command by installing https://github.com/nektos/act.

For PR testing use the following steps:
1. Run Docker Desktop
2. Get any previous PR data - `curl -X GET https://api.github.com/repos/nucypher/nucypher/pulls/PR_NUMBER > OUTPUT_FILE`
3. Run `act pull_request --eventpath OUTPUT_FILE`
4. Test various scenarios by adding/renaming/copying & pasting newsfragment files - the action only cares about existence, not content of newsfragment files.