### PR TITLE
Fix incorrect use of `genesis_seconds_per_period` instead of `seconds_per_period`

### DIFF
--- a/newsfragments/2646.bugfix.rst
+++ b/newsfragments/2646.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed incorrect use of genesis value for ``seconds_per_period`` when estimating block number based on period number - applies to prometheus metrics collection and ``nucypher status events``.

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -190,7 +190,7 @@ def events(general_config, registry_options, contract_name, from_block, to_block
         staking_agent = ContractAgency.get_agent(StakingEscrowAgent, registry=registry)
         current_period = staking_agent.get_current_period()
         from_block = estimate_block_number_for_period(period=current_period,
-                                                      seconds_per_period=staking_agent.staking_parameters()[0],
+                                                      seconds_per_period=staking_agent.staking_parameters()[1],
                                                       latest_block=last_block)
     if to_block is None:
         to_block = 'latest'

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -369,7 +369,7 @@ class CommitmentMadeEventMetricsCollector(EventMetricsCollector):
             # - commitment made during current period for next period
             block_number_for_previous_period = estimate_block_number_for_period(
                 period=previous_period,
-                seconds_per_period=self.contract_agent.staking_parameters()[0],
+                seconds_per_period=self.contract_agent.staking_parameters()[1],
                 latest_block=latest_block)
 
             events_throttler = ContractEventsThrottler(agent=self.contract_agent,


### PR DESCRIPTION
**Type of PR:**
Bugfix


**Required reviews:** 
1

**What this does:**
The value at index 0 within staking parameters is the `genesis_seconds_per_period` (60 * 60 * 24). This caused the estimation of block number of a period to be incorrect causing weird behaviour for both `nucypher status events`, and prometheus metrics collection (`CommitmentMade` event).

**Issues fixed/closed:**
Fixes #2641 

Also encountered similar error as #2641 when running `nucypher status events`:

```bash
$ nucypher status events --contract-name StakingEscrow --event-name CommitmentMade --event-filter staker=<staker_address> --provider <provider> --network mainnet
...
 File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.7/site-packages/web3/manager.py", line 158, in request_blocking
    raise ValueError(response["error"])
ValueError: {'code': -32600, 'message': 'quantity values must start with 0x'}
```

**Why it's needed:**
Because of the period migration the value for `seconds_per_period` needed to be used instead of `genesis_seconds_per_period`.

**Notes for reviewers:**

1. Run `nucypher status events --contract-name StakingEscrow --event-name CommitmentMade --event-filter staker=<staker_address> --provider <provider> --network mainnet`
2. Run an ursula with prometheus metrics collection enabled (Already tested by @KPrasch )