### PR TITLE
Initial implementation of native support for Ledger Nano hardware signer

### DIFF
--- a/nucypher/blockchain/eth/signers/__init__.py
+++ b/nucypher/blockchain/eth/signers/__init__.py
@@ -17,11 +17,12 @@
 
 from nucypher.blockchain.eth.signers.base import Signer
 from nucypher.blockchain.eth.signers.software import ClefSigner, KeystoreSigner
-from nucypher.blockchain.eth.signers.hardware import TrezorSigner
+from nucypher.blockchain.eth.signers.hardware import TrezorSigner, LedgerSigner
 
 
 Signer._SIGNERS = {
     ClefSigner.uri_scheme(): ClefSigner,
     KeystoreSigner.uri_scheme(): KeystoreSigner,
-    TrezorSigner.uri_scheme(): TrezorSigner
+    TrezorSigner.uri_scheme(): TrezorSigner,
+    LedgerSigner.uri_scheme(): LedgerSigner,
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ ipfshttpclient==0.7.0a1; python_full_version >= '3.5.4' and python_full_version 
 itsdangerous==1.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 jinja2==2.11.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 jsonschema==3.2.0
+ledgereth==0.1.3
 libusb1==1.9.1
 lmdb==1.0.0
 lru-dict==1.1.6


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Adds a new hardware signer `LedgerSigner` supporting Ledger Nano devices.

**Why it's needed:**
Using Ledger wallets with clef is a complete PITA - this make it much simpler.

**Notes for reviewers:**
- This uses [ledgereth](https://github.com/mikeshultz/ledger-eth-lib) which is an MIT licensed wrapper around [ledgerblue](https://github.com/LedgerHQ/blue-loader-python)
- All development/testing done on Linux/x86_64 using Ledger Nano X with latest firmware and ethereum app
- Tested with CLI tools in production/mainnet, querying commands but transactions only to the point of rejecting on the ledger
- Not clear to me if multiple ledgers attached to the computer will work (as the device handle is buried in the APIs)
- Signed transactions are older style (i.e. v=27/28) and not EIP-155 style (which the existing Trezor signer makes a big deal of requiring); likely can be implemented but ledgereth may require root canal surgery to do so
- Testnet accounts (i.e. with derivation paths beginning 44'/1'/...) required changing implementation global variables in ledgereth; this should ideally either be fixed upstream (it is an alpha project) or ledgereth should be forked / replaced
- Observations from testing with `nucypher stake restake`:
  - Two ledger signers get created as the account list is iterated twice which doesn't happen with `nucypher stake list`
  - If `--hw-wallet` is not specified, the CLI asks for a wallet unlock passwork which seems silly as the implementation of Signer.is_device() always returns true (i.e. the signer module knows if it's a hardware wallet or not, so another CLI option to tell it what it is is unnecessary, unless I'm missing some strange use case here).
 - Error/exception handling - not sure what the appropriate exceptions signers should through to allow for good UX without hiding details; as usual various stuff comes out of ledger blue, ledgereth does some exception mapping itself and so at the signer level it's a bit hodge podge - needs polish