### PR TITLE
Fallback chain of teacher nodes

### DIFF
--- a/newsfragments/2657.feature.rst
+++ b/newsfragments/2657.feature.rst
@@ -1,1 +1,1 @@
-Adds "https://closest-seed.nucypher.network" as a fallback teacher node for mainnet.
+Adds "https://closest-seed.nucypher.network" and "https://mainnet.nucypher.network" as a fallback teacher nodes for mainnet.

--- a/newsfragments/2657.feature.rst
+++ b/newsfragments/2657.feature.rst
@@ -1,1 +1,1 @@
-Adds "https://closest-seed.nucypher.network" as a new teacher node for mainnet.
+Adds "https://closest-seed.nucypher.network" as a fallback teacher node for mainnet.

--- a/newsfragments/2657.feature.rst
+++ b/newsfragments/2657.feature.rst
@@ -1,0 +1,1 @@
+Adds "https://closest-seed.nucypher.network" as a new teacher node for mainnet.

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -94,7 +94,7 @@ from nucypher.datastore.datastore import DatastoreTransactionError, RecordNotFou
 from nucypher.datastore.queries import find_expired_policies, find_expired_treasure_maps
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
-from nucypher.network.nodes import NodeSprout, Teacher
+from nucypher.network.nodes import NodeSprout, TEACHER_NODES, Teacher
 from nucypher.network.protocols import InterfaceInfo, parse_node_uri
 from nucypher.network.server import ProxyRESTServer, TLSHostingPower, make_rest_app
 from nucypher.network.trackers import AvailabilityTracker
@@ -1451,7 +1451,7 @@ class Ursula(Teacher, Character, Worker):
     def seednode_for_network(cls, network: str) -> 'Ursula':
         """Returns a default seednode ursula for a given network."""
         try:
-            url = RestMiddleware.TEACHER_NODES[network][0]
+            url = TEACHER_NODES[network][0]
         except KeyError:
             raise ValueError(f'"{network}" is not a known network.')
         except IndexError:

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -146,7 +146,10 @@ class RestMiddleware:
     _client_class = NucypherMiddlewareClient
 
     TEACHER_NODES = {
-        NetworksInventory.MAINNET: ('https://seeds.nucypher.network:9151',),
+        NetworksInventory.MAINNET: (
+            'https://seeds.nucypher.network:9151',
+            'https://closest-seed.nucypher.network:9151',
+        ),
         NetworksInventory.LYNX: ('https://lynx.nucypher.network:9151',),
         NetworksInventory.IBEX: ('https://ibex.nucypher.network:9151',),
     }

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -145,15 +145,6 @@ class RestMiddleware:
 
     _client_class = NucypherMiddlewareClient
 
-    TEACHER_NODES = {
-        NetworksInventory.MAINNET: (
-            'https://seeds.nucypher.network:9151',
-            'https://closest-seed.nucypher.network:9151',
-        ),
-        NetworksInventory.LYNX: ('https://lynx.nucypher.network:9151',),
-        NetworksInventory.IBEX: ('https://ibex.nucypher.network:9151',),
-    }
-
     class UnexpectedResponse(Exception):
         def __init__(self, message, status, *args, **kwargs):
             super().__init__(message, *args, **kwargs)

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -24,11 +24,21 @@ from typing import Iterable, List, Set, Tuple, Union
 
 import maya
 import requests
-from bytestring_splitter import BytestringSplitter, BytestringSplittingError, PartiallyKwargifiedBytes, \
+from bytestring_splitter import (
+    BytestringSplitter,
+    PartiallyKwargifiedBytes,
     VariableLengthBytestring
+)
 from constant_sorrow import constant_or_bytes
-from constant_sorrow.constants import (CERTIFICATE_NOT_SAVED, FLEET_STATES_MATCH, NOT_SIGNED, NO_KNOWN_NODES,
-                                       NO_STORAGE_AVAILIBLE, RELAX, UNKNOWN_VERSION)
+from constant_sorrow.constants import (
+    CERTIFICATE_NOT_SAVED,
+    FLEET_STATES_MATCH,
+    NOT_SIGNED,
+    NO_KNOWN_NODES,
+    NO_STORAGE_AVAILIBLE,
+    RELAX,
+    UNKNOWN_VERSION
+)
 from cryptography.x509 import Certificate
 from eth_utils import to_checksum_address
 from requests.exceptions import SSLError

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -35,7 +35,7 @@ from constant_sorrow.constants import (
     FLEET_STATES_MATCH,
     NOT_SIGNED,
     NO_KNOWN_NODES,
-    NO_STORAGE_AVAILIBLE,
+    NO_STORAGE_AVAILABLE,
     RELAX,
     UNKNOWN_VERSION
 )
@@ -255,7 +255,7 @@ class Learner:
         if not node_storage:
             node_storage = self.__DEFAULT_NODE_STORAGE(federated_only=self.federated_only)
         self.node_storage = node_storage
-        if save_metadata and node_storage is NO_STORAGE_AVAILIBLE:
+        if save_metadata and node_storage is NO_STORAGE_AVAILABLE:
             raise ValueError("Cannot save nodes without a configured node storage")
 
         from nucypher.characters.lawful import Ursula

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -67,8 +67,9 @@ from nucypher.utilities.logging import Logger
 
 TEACHER_NODES = {
     NetworksInventory.MAINNET: (
-        'https://seeds.nucypher.network:9151',
         'https://closest-seed.nucypher.network:9151',
+        'https://seeds.nucypher.network',
+        'https://mainnet.nucypher.network:9151',
     ),
     NetworksInventory.LYNX: ('https://lynx.nucypher.network:9151',),
     NetworksInventory.IBEX: ('https://ibex.nucypher.network:9151',),

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -114,14 +114,15 @@ def get_external_ip_from_default_teacher(network: str,
                                          log: Logger = IP_DETECTION_LOGGER
                                          ) -> Union[str, None]:
 
-    # Prevents circular import
+    # Prevents circular imports
     from nucypher.characters.lawful import Ursula
+    from nucypher.network.nodes import TEACHER_NODES
 
     if federated_only and registry:
         raise ValueError('Federated mode must not be true if registry is provided.')
     base_error = 'Cannot determine IP using default teacher'
     try:
-        top_teacher_url = RestMiddleware.TEACHER_NODES[network][0]
+        top_teacher_url = TEACHER_NODES[network][0]
     except IndexError:
         log.debug(f'{base_error}: No teacher available for network "{network}".')
         return

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -134,26 +134,26 @@ def get_external_ip_from_default_teacher(network: str,
     Ursula.set_federated_mode(federated_only)
     #####
 
-    teacher = None
+    external_ip = None
     for teacher_uri in TEACHER_NODES[network]:
         try:
             teacher = Ursula.from_teacher_uri(teacher_uri=teacher_uri,
                                               federated_only=federated_only,
                                               min_stake=0)  # TODO: Handle customized min stake here.
+            # TODO: Pass registry here to verify stake (not essential here since it's a hardcoded node)
+            external_ip = _request_from_node(teacher=teacher)
             # Found a reachable teacher, return from loop
-            break
+            if external_ip:
+                break
         except NodeSeemsToBeDown:
             # Teacher is unreachable, try next one
             continue
 
-    if not teacher:
-        # No reachable teacher found, return early
+    if not external_ip:
         log.debug(f'{base_error}: No teacher available for network "{network}".')
         return
 
-    # TODO: Pass registry here to verify stake (not essential here since it's a hardcoded node)
-    result = _request_from_node(teacher=teacher)
-    return result
+    return external_ip
 
 
 def get_external_ip_from_known_nodes(known_nodes: FleetSensor,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1035,4 +1035,4 @@ def stakeholder_configuration_file_location(custom_filepath):
 @pytest.fixture(autouse=True)
 def mock_teacher_nodes(mocker):
     mock_nodes = tuple(u.rest_url() for u in MOCK_KNOWN_URSULAS_CACHE.values())[0:2]
-    mocker.patch.dict(TEACHER_NODES, {TEMPORARY_DOMAIN: mock_nodes})
+    mocker.patch.dict(TEACHER_NODES, {TEMPORARY_DOMAIN: mock_nodes}, clear=True)

--- a/tests/metrics/grant_availability.py
+++ b/tests/metrics/grant_availability.py
@@ -18,6 +18,8 @@
 """
 from pathlib import Path
 
+from nucypher.network.nodes import TEACHER_NODES
+
 """
 WARNING: This script makes automatic transactions.
 Do not use this script unless you know what you
@@ -67,7 +69,7 @@ except KeyError:
 # Alice Configuration
 DOMAIN: str = 'mainnet'  # ibex
 DEFAULT_SEEDNODE_URIS: List[str] = [
-    *RestMiddleware.TEACHER_NODES[DOMAIN],
+    *TEACHER_NODES[DOMAIN],
 ]
 INSECURE_PASSWORD: str = "METRICS_INSECURE_DEVELOPMENT_PASSWORD"
 TEMP_ALICE_DIR: str = Path('/', 'tmp', 'grant-metrics')

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -79,7 +79,7 @@ def mock_client(mocker):
 @pytest.fixture(autouse=True)
 def mock_default_teachers(mocker):
     teachers = {MOCK_NETWORK: (MOCK_IP_ADDRESS, )}
-    mocker.patch.dict(TEACHER_NODES, teachers)
+    mocker.patch.dict(TEACHER_NODES, teachers, clear=True)
 
 
 def test_get_external_ip_from_centralized_source(mock_requests):

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -20,7 +20,8 @@ import pytest
 from nucypher.acumen.perception import FleetSensor
 from nucypher.characters.lawful import Ursula
 from nucypher.network.exceptions import NodeSeemsToBeDown
-from nucypher.network.middleware import RestMiddleware, NucypherMiddlewareClient
+from nucypher.network.middleware import NucypherMiddlewareClient
+from nucypher.network.nodes import TEACHER_NODES
 from nucypher.utilities.networking import (
     determine_external_ip_address,
     get_external_ip_from_centralized_source,
@@ -30,7 +31,6 @@ from nucypher.utilities.networking import (
     UnknownIPAddress
 )
 from tests.constants import MOCK_IP_ADDRESS
-
 
 MOCK_NETWORK = 'holodeck'
 
@@ -79,7 +79,7 @@ def mock_client(mocker):
 @pytest.fixture(autouse=True)
 def mock_default_teachers(mocker):
     teachers = {MOCK_NETWORK: (MOCK_IP_ADDRESS, )}
-    mocker.patch.dict(RestMiddleware.TEACHER_NODES, teachers)
+    mocker.patch.dict(TEACHER_NODES, teachers)
 
 
 def test_get_external_ip_from_centralized_source(mock_requests):
@@ -140,7 +140,7 @@ def test_get_external_ip_from_known_nodes_client(mocker, mock_client):
 
     # Setup HTTP Client
     mocker.patch.object(Ursula, 'from_teacher_uri', return_value=Dummy('0xdeadpork'))
-    teacher_uri = RestMiddleware.TEACHER_NODES[MOCK_NETWORK][0]
+    teacher_uri = TEACHER_NODES[MOCK_NETWORK][0]
 
     get_external_ip_from_known_nodes(known_nodes=sensor, sample_size=sample_size)
     assert mock_client.call_count == 1  # first node responded
@@ -161,7 +161,7 @@ def test_get_external_ip_default_teacher_unreachable(mocker):
 def test_get_external_ip_from_default_teacher(mocker, mock_client, mock_requests):
 
     mock_client.return_value = Dummy.GoodResponse
-    teacher_uri = RestMiddleware.TEACHER_NODES[MOCK_NETWORK][0]
+    teacher_uri = TEACHER_NODES[MOCK_NETWORK][0]
     mocker.patch.object(Ursula, 'from_teacher_uri', return_value=Dummy('0xdeadbeef'))
 
     # "Success"

--- a/tests/utils/middleware.py
+++ b/tests/utils/middleware.py
@@ -96,16 +96,6 @@ class MockRestMiddleware(RestMiddleware):
     class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
         pass
 
-    class TEACHER_NODES:
-
-        @classmethod
-        def get(_cls, item, _default):
-            if item is TEMPORARY_DOMAIN:
-                nodes = tuple(u.rest_url() for u in MOCK_KNOWN_URSULAS_CACHE.values())[0:2]
-            else:
-                nodes = tuple()
-            return nodes
-
     def get_certificate(self, host, port, timeout=3, retry_attempts: int = 3, retry_rate: int = 2,
                         current_attempt: int = 0):
         ursula = self.client._get_ursula_by_port(port)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
- Adds `https://closest-seed.nucypher.network` and `https://mainnet.nucypher.network:9151` nodes to `TEACHER_NODES`
- Moves `TEACHER_NODES` from `RestMiddleware` to `nodes.py`
- Adds some tests to confirm the correctness of using `TEACHER_NODES` as a fallback when local node storage is empty. 

**Issues fixed/closed:**
- Fixes #2481 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
