### PR TITLE
Improve logic for updating configuration file

### DIFF
--- a/newsfragments/2660.bugfix.rst
+++ b/newsfragments/2660.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed inability to update ursula configuration file due to the keyring not being instantiated - updated logic no longer needs keyring to be instantiated.

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -295,7 +295,7 @@ class BaseConfiguration(ABC):
                                  f"Expected version {cls.VERSION}; Got version {version}")
         return deserialized_payload
 
-    def update(self, filepath: str = None, modifier: str = None, **updates) -> None:
+    def update(self, filepath: str = None, **updates) -> None:
         for field, value in updates.items():
             try:
                 getattr(self, field)
@@ -303,7 +303,8 @@ class BaseConfiguration(ABC):
                 raise self.ConfigurationError(f"Cannot update '{field}'. It is an invalid configuration field.")
             else:
                 setattr(self, field, value)
-        self.to_configuration_file(filepath=filepath, modifier=modifier, override=True)
+        # just write the configuration file, file exists and we are overriding
+        self._write_configuration_file(filepath=filepath, override=True)
 
 
 class CharacterConfiguration(BaseConfiguration):
@@ -552,7 +553,8 @@ class CharacterConfiguration(BaseConfiguration):
 
         Warning: This method allows mutation and may result in an inconsistent configuration.
         """
-        return super().update(modifier=self.checksum_address, filepath=self.config_file_location, **kwargs)
+        # config file should exist and we we override -> no need for modifier
+        return super().update(filepath=self.config_file_location, **kwargs)
 
     @classmethod
     def generate(cls, password: str, *args, **kwargs):


### PR DESCRIPTION
 No need to use modifiers when updating since the configuration file already exists, and it will be overwritten.

**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

No reason to care about modifiers when updating a configuration file.

**Issues fixed/closed:**

Fixes #2659 
