### PR TITLE
Implicitly remove whitespaces from character nicknames

### DIFF
--- a/newsfragments/2672.feature.rst
+++ b/newsfragments/2672.feature.rst
@@ -1,0 +1,1 @@
+Whitespaces in character nicknames are now implicitly replaced with an underscore ("_").

--- a/nucypher/policy/identity.py
+++ b/nucypher/policy/identity.py
@@ -23,7 +23,6 @@ from typing import Union, Optional, Dict, Callable
 import base64
 import constant_sorrow
 import hashlib
-import maya
 import os
 from bytestring_splitter import VariableLengthBytestring, BytestringKwargifier
 from constant_sorrow.constants import ALICE, BOB, NO_SIGNATURE
@@ -34,7 +33,6 @@ from nucypher.characters.base import Character
 from nucypher.characters.lawful import Alice, Bob
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
 from nucypher.crypto.powers import SigningPower, DecryptingPower
-from nucypher.policy.collections import SignedTreasureMap
 
 
 class Card:
@@ -270,6 +268,7 @@ class Card:
             return self.__nickname.decode()
 
     def set_nickname(self, nickname: str) -> None:
+        nickname = nickname.replace(' ', '_')
         if len(nickname.encode()) > self.__MAX_NICKNAME_SIZE:
             raise ValueError(f'New nickname exceeds maximum size ({self.__MAX_NICKNAME_SIZE} bytes)')
         self.__nickname = nickname.encode()

--- a/tests/unit/test_card.py
+++ b/tests/unit/test_card.py
@@ -67,12 +67,13 @@ def test_character_card(character_class, capsys):
 
     # nicknames
     original_checksum = character_card.id
-    nickname = 'Wilson'
+    nickname = 'Wilson the Great'
+    expected_nickname = nickname.replace(' ', '_')
     character_card.set_nickname(nickname)
     restored = Card.from_bytes(bytes(character_card))
     restored_checksum = restored.id
-    assert restored.nickname == nickname
+    assert restored.nickname == expected_nickname
     assert original_checksum == restored_checksum == same_card.id
 
     # filepath with nickname
-    assert f'{nickname}.{character_card.id.hex()}' in str(character_card.filepath)
+    assert f'{expected_nickname}.{character_card.id.hex()}' in str(character_card.filepath)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- When saving a character card, `--nickname My Nickname` will result in `My_Nickname` character nickname.

**Issues fixed/closed:**
 - Fixes #2465

**Why it's needed:**
- It's a missing piece of nickname validation.

**Notes for reviewers:**
- May break existing character cards of relationship between nickname and card filenames.
