### PR TITLE
Check allowance value before transactions

### DIFF
--- a/newsfragments/2673.bugfix.rst
+++ b/newsfragments/2673.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed issues where failing transactions would result in incorrect token allowance and prevent creation of new stakes.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -764,9 +764,7 @@ class Staker(NucypherTokenActor):
 
     def _deposit(self, amount: int, lock_periods: int) -> TxReceipt:
         """Public facing method for token locking."""
-        self.token_agent.approve_transfer(amount=0,
-                                          spender_address=self.staking_agent.contract_address,
-                                          transacting_power=self.transacting_power)
+        self._ensure_allowance_equals(0)
         receipt = self.token_agent.approve_and_call(amount=amount,
                                                     target_address=self.staking_agent.contract_address,
                                                     transacting_power=self.transacting_power,
@@ -790,22 +788,28 @@ class Staker(NucypherTokenActor):
 
     def _deposit_and_increase(self, stake_index: int, amount: int) -> TxReceipt:
         """Public facing method for deposit and increasing stake."""
-        self._ensure_allowance_at_least(amount)
+        self._ensure_allowance_equals(amount)
         receipt = self.staking_agent.deposit_and_increase(transacting_power=self.transacting_power,
                                                           stake_index=stake_index,
                                                           amount=amount)
         return receipt
 
-    def _ensure_allowance_at_least(self, amount):
-        current_allowance = self.token_agent.get_allowance(owner=self.checksum_address,
-                                                           spender=self.staking_agent.contract.address)
+    def _ensure_allowance_equals(self, amount: int):
+        owner = self.checksum_address
+        spender = self.staking_agent.contract.address
+        current_allowance = self.token_agent.get_allowance(owner=owner, spender=spender)
         if amount > current_allowance:
             to_increase = amount - current_allowance
             self.token_agent.increase_allowance(increase=to_increase,
                                                 transacting_power=self.transacting_power,
-                                                spender_address=self.staking_agent.contract.address)
-            self.log.info(
-                f"{self.checksum_address} increased token allowance for spender {self.staking_agent.contract.address} to {amount}")
+                                                spender_address=spender)
+            self.log.info(f"{owner} increased token allowance for spender {spender} to {amount}")
+        elif amount < current_allowance:
+            to_decrease = current_allowance - amount
+            self.token_agent.decrease_allowance(decrease=to_decrease,
+                                                transacting_power=self.transacting_power,
+                                                spender_address=spender)
+            self.log.info(f"{owner} decreased token allowance for spender {spender} to {amount}")
 
     def _lock_and_increase(self, stake_index: int, amount: int) -> TxReceipt:
         """Public facing method for increasing stake."""

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -795,7 +795,7 @@ class Staker(NucypherTokenActor):
         return receipt
 
     def _ensure_allowance_equals(self, amount: int):
-        owner = self.checksum_address
+        owner = self.transacting_power.account
         spender = self.staking_agent.contract.address
         current_allowance = self.token_agent.get_allowance(owner=owner, spender=spender)
         if amount > current_allowance:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -185,6 +185,10 @@ class NucypherTokenAgent(EthereumContractAgent):
                          transacting_power: TransactingPower
                          ) -> TxReceipt:
         """Approve the spender address to transfer an amount of tokens on behalf of the sender address"""
+        current_allowance = self.get_allowance(owner=transacting_power.account, spender=spender_address)
+        if current_allowance != 0:
+            raise self.RequirementError(f"Token allowance for spender {spender_address} must be 0")
+
         payload: TxParams = {'gas': Wei(500_000)}  # TODO #842: gas needed for use with geth! <<<< Is this still open?
         contract_function: ContractFunction = self.contract.functions.approve(spender_address, amount)
         receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
@@ -208,6 +212,10 @@ class NucypherTokenAgent(EthereumContractAgent):
                          call_data: bytes = b'',
                          gas_limit: Optional[Wei] = None
                          ) -> TxReceipt:
+        current_allowance = self.get_allowance(owner=transacting_power.account, spender=target_address)
+        if current_allowance != 0:
+            raise self.RequirementError(f"Token allowance for spender {target_address} must be 0")
+
         payload = None
         if gas_limit:  # TODO: Gas management - #842
             payload = {'gas': gas_limit}

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -179,13 +179,25 @@ class NucypherTokenAgent(EthereumContractAgent):
         return receipt
 
     @contract_api(TRANSACTION)
+    def decrease_allowance(self,
+                           transacting_power: TransactingPower,
+                           spender_address: ChecksumAddress,
+                           decrease: NuNits
+                           ) -> TxReceipt:
+        """Decrease the allowance of a spender address funded by a sender address"""
+        contract_function: ContractFunction = self.contract.functions.increaseAllowance(spender_address, decrease)
+        receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
+                                                              transacting_power=transacting_power)
+        return receipt
+
+    @contract_api(TRANSACTION)
     def approve_transfer(self,
                          amount: NuNits,
                          spender_address: ChecksumAddress,
                          transacting_power: TransactingPower
                          ) -> TxReceipt:
         """Approve the spender address to transfer an amount of tokens on behalf of the sender address"""
-        self._validate_zero_allowance(spender_address, transacting_power)
+        self._validate_zero_allowance(amount, spender_address, transacting_power)
 
         payload: TxParams = {'gas': Wei(500_000)}  # TODO #842: gas needed for use with geth! <<<< Is this still open?
         contract_function: ContractFunction = self.contract.functions.approve(spender_address, amount)
@@ -210,7 +222,7 @@ class NucypherTokenAgent(EthereumContractAgent):
                          call_data: bytes = b'',
                          gas_limit: Optional[Wei] = None
                          ) -> TxReceipt:
-        self._validate_zero_allowance(target_address, transacting_power)
+        self._validate_zero_allowance(amount, target_address, transacting_power)
 
         payload = None
         if gas_limit:  # TODO: Gas management - #842
@@ -221,7 +233,9 @@ class NucypherTokenAgent(EthereumContractAgent):
                                                                                payload=payload)
         return approve_and_call_receipt
 
-    def _validate_zero_allowance(self, target_address, transacting_power):
+    def _validate_zero_allowance(self, amount, target_address, transacting_power):
+        if amount == 0:
+            return
         current_allowance = self.get_allowance(owner=transacting_power.account, spender=target_address)
         if current_allowance != 0:
             raise self.RequirementError(f"Token allowance for spender {target_address} must be 0")

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -185,7 +185,7 @@ class NucypherTokenAgent(EthereumContractAgent):
                            decrease: NuNits
                            ) -> TxReceipt:
         """Decrease the allowance of a spender address funded by a sender address"""
-        contract_function: ContractFunction = self.contract.functions.increaseAllowance(spender_address, decrease)
+        contract_function: ContractFunction = self.contract.functions.decreaseAllowance(spender_address, decrease)
         receipt: TxReceipt = self.blockchain.send_transaction(contract_function=contract_function,
                                                               transacting_power=transacting_power)
         return receipt

--- a/tests/acceptance/blockchain/actors/test_staker.py
+++ b/tests/acceptance/blockchain/actors/test_staker.py
@@ -25,7 +25,7 @@ from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.blockchain.eth.token import NU, Stake
 from nucypher.blockchain.eth.utils import datetime_at_period
 from nucypher.crypto.powers import TransactingPower
-from tests.constants import FEE_RATE_RANGE, INSECURE_DEVELOPMENT_PASSWORD, DEVELOPMENT_TOKEN_AIRDROP_AMOUNT
+from tests.constants import FEE_RATE_RANGE, DEVELOPMENT_TOKEN_AIRDROP_AMOUNT
 from tests.utils.blockchain import token_airdrop
 from tests.utils.ursula import make_decentralized_ursulas
 

--- a/tests/acceptance/blockchain/actors/test_staker.py
+++ b/tests/acceptance/blockchain/actors/test_staker.py
@@ -36,6 +36,9 @@ def test_staker_locking_tokens(testerchain, agency, staker, token_economics, tes
 
     assert NU(token_economics.minimum_allowed_locked, 'NuNit') < staker.token_balance, "Insufficient staker balance"
 
+    # Make sure staking handles existing token allowance
+    staker.token_agent.approve_transfer(1000000000, staking_agent.contract_address, staker.transacting_power)
+
     staker.initialize_stake(amount=NU(token_economics.minimum_allowed_locked, 'NuNit'),
                             # Lock the minimum amount of tokens
                             lock_periods=token_economics.minimum_locked_periods)

--- a/tests/integration/cli/test_stake_cli_functionality.py
+++ b/tests/integration/cli/test_stake_cli_functionality.py
@@ -987,11 +987,12 @@ def test_create_interactive(click_runner,
     mock_staking_agent.get_all_stakes.assert_called()
     mock_staking_agent.get_current_period.assert_called()
     mock_refresh_stakes.assert_called()
+    mock_token_agent.get_allowance.assert_called()
     mock_token_agent.approve_and_call.assert_called_with(amount=value.to_nunits(),
                                                          target_address=mock_staking_agent.contract_address,
                                                          transacting_power=surrogate_transacting_power,
                                                          call_data=Web3.toBytes(lock_periods))
-    mock_token_agent.assert_only_transactions([mock_token_agent.approve_and_call])
+    mock_token_agent.assert_only_transactions([mock_token_agent.increase_allowance, mock_token_agent.approve_and_call])
     mock_staking_agent.assert_no_transactions()
 
 
@@ -1048,11 +1049,12 @@ def test_create_non_interactive(click_runner,
     mock_staking_agent.get_all_stakes.assert_called()
     mock_staking_agent.get_current_period.assert_called()
     mock_refresh_stakes.assert_called()
+    mock_token_agent.get_allowance.assert_called()
     mock_token_agent.approve_and_call.assert_called_once_with(amount=value.to_nunits(),
                                                               target_address=mock_staking_agent.contract_address,
                                                               transacting_power=surrogate_transacting_power,
                                                               call_data=Web3.toBytes(lock_periods))
-    mock_token_agent.assert_only_transactions([mock_token_agent.approve_and_call])
+    mock_token_agent.assert_only_transactions([mock_token_agent.increase_allowance, mock_token_agent.approve_and_call])
     mock_staking_agent.assert_no_transactions()
 
 

--- a/tests/integration/cli/test_stake_cli_functionality.py
+++ b/tests/integration/cli/test_stake_cli_functionality.py
@@ -987,12 +987,11 @@ def test_create_interactive(click_runner,
     mock_staking_agent.get_all_stakes.assert_called()
     mock_staking_agent.get_current_period.assert_called()
     mock_refresh_stakes.assert_called()
-    mock_token_agent.get_allowance.assert_called()
     mock_token_agent.approve_and_call.assert_called_with(amount=value.to_nunits(),
                                                          target_address=mock_staking_agent.contract_address,
                                                          transacting_power=surrogate_transacting_power,
                                                          call_data=Web3.toBytes(lock_periods))
-    mock_token_agent.assert_only_transactions([mock_token_agent.increase_allowance, mock_token_agent.approve_and_call])
+    mock_token_agent.assert_only_transactions([mock_token_agent.decrease_allowance, mock_token_agent.approve_and_call])
     mock_staking_agent.assert_no_transactions()
 
 
@@ -1054,7 +1053,7 @@ def test_create_non_interactive(click_runner,
                                                               target_address=mock_staking_agent.contract_address,
                                                               transacting_power=surrogate_transacting_power,
                                                               call_data=Web3.toBytes(lock_periods))
-    mock_token_agent.assert_only_transactions([mock_token_agent.increase_allowance, mock_token_agent.approve_and_call])
+    mock_token_agent.assert_only_transactions([mock_token_agent.decrease_allowance, mock_token_agent.approve_and_call])
     mock_staking_agent.assert_no_transactions()
 
 


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Updates token allowance when needed for `depositAndIncrease()` transaction
- Raises error if token allowance is not 0 prior to `approve()` and `approveAndCall()` tranasctions

**Issues fixed/closed:**
- Fixes #2636 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
