### PR TITLE
Added an exists check for the user cache folder

### DIFF
--- a/examples/run_demo_ursula_fleet.py
+++ b/examples/run_demo_ursula_fleet.py
@@ -38,10 +38,13 @@ def spin_up_federated_ursulas(quantity: int = FLEET_POPULATION):
     # Ports
     starting_port = DEMO_NODE_STARTING_PORT
     ports = list(map(str, range(starting_port, starting_port + quantity)))
-
+    sage_dir = str(Path(APP_DIR.user_cache_dir) / 'sage.db')
     ursulas = []
 
-    sage = ursula_maker(rest_port=ports[0], db_filepath=str(Path(APP_DIR.user_cache_dir) / 'sage.db'))
+    if not os.path.exists(sage_dir):
+        os.makedirs(sage_dir)
+
+    sage = ursula_maker(rest_port=ports[0], db_filepath=sage_dir)
 
     ursulas.append(sage)
     for index, port in enumerate(ports[1:]):


### PR DESCRIPTION
This is necessary for the run_demo_ursula_fleet.py script in the
examples folder. It's frustrating for new users to follow documentation
and have an error like this pop up. Additionally, the error made it
seem like sage.db is a file. Because there is a product called sage.db,
this caused even more confusion. Now the correct folder is created if
it does not already exist.

**Type of PR:**
- [ X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Added an exists check for the user cache folder

**Why it's needed:**
This is necessary for the run_demo_ursula_fleet.py script in the examples folder. 
It's frustrating for new users to follow documentation and have an error like this pop up.

**Notes for reviewers:**
This is a fairly straightforward review. Without the cache folder check, the demo file will not run if the cache folder is not there, and the resultant error can be confusing for users.