### PR TITLE
Fix ReactorNotRestartable exception after receiving SIGINT

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1354,7 +1354,7 @@ class Ursula(Teacher, Character, Worker):
                     emitter.message(f"{e.__class__.__name__} {e}", color='red', bold=True)
                 raise  # Crash :-(
 
-        if start_reactor:  # ... without hendrix
+        elif start_reactor:  # ... without hendrix
             reactor.run()  # <--- Blocking Call (Reactor)
 
     def stop(self, halt_reactor: bool = False) -> None:


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- Fixes second exception thrown when killing the node with CTRL+C

**Issues fixed/closed:**
- Refers #2608

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- It only partly fixes #2608, but it's something
- IMHO not worthy of newsfragment