### PR TITLE
Add timestamp column to csv output

### DIFF
--- a/newsfragments/2680.feature.rst
+++ b/newsfragments/2680.feature.rst
@@ -1,1 +1,1 @@
-Added timestamp column to csv output of "nucypher status events" command.
+Added timestamp and date columns to csv output of "nucypher status events" command.

--- a/newsfragments/2680.feature.rst
+++ b/newsfragments/2680.feature.rst
@@ -1,0 +1,1 @@
+Added timestamp column to csv output of "nucypher status events" command.

--- a/nucypher/blockchain/eth/events.py
+++ b/nucypher/blockchain/eth/events.py
@@ -34,7 +34,7 @@ class EventRecord:
         except BlockchainInterfaceFactory.NoRegisteredInterfaces:
             self.timestamp = None
         else:
-            self.timestamp = blockchain.client.w3.eth.getBlock(self.block_number)['timestamp'],
+            self.timestamp = blockchain.client.w3.eth.getBlock(self.block_number)['timestamp']
 
     def __repr__(self):
         pairs_to_show = dict(self.args.items())

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -53,6 +53,7 @@ def write_events_to_csv_file(csv_file: str,
             event_row['event_name'] = event_name
             event_row['block_number'] = event_record.block_number
             event_row['timestamp'] = event_record.timestamp
+            event_row['date'] = maya.MayaDT(event_record.timestamp).iso8601()
             event_row.update(dict(event_record.args.items()))
             if events_writer is None:
                 events_writer = csv.DictWriter(events_file, fieldnames=event_row.keys())

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -52,7 +52,7 @@ def write_events_to_csv_file(csv_file: str,
             event_row = OrderedDict()
             event_row['event_name'] = event_name
             event_row['block_number'] = event_record.block_number
-            event_row['timestamp'] = event_record.timestamp
+            event_row['unix_timestamp'] = event_record.timestamp
             event_row['date'] = maya.MayaDT(event_record.timestamp).iso8601()
             event_row.update(dict(event_record.args.items()))
             if events_writer is None:

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -52,6 +52,7 @@ def write_events_to_csv_file(csv_file: str,
             event_row = OrderedDict()
             event_row['event_name'] = event_name
             event_row['block_number'] = event_record.block_number
+            event_row['timestamp'] = event_record.timestamp
             event_row.update(dict(event_record.args.items()))
             if events_writer is None:
                 events_writer = csv.DictWriter(events_file, fieldnames=event_row.keys())

--- a/tests/acceptance/cli/test_status.py
+++ b/tests/acceptance/cli/test_status.py
@@ -205,13 +205,13 @@ def test_nucypher_status_events(click_runner, testerchain, agency_local_registry
         line_count = 0
         for row in csv_reader:
             if line_count == 0:
-                assert ",".join(row) == 'event_name,block_number,staker,period,value'  # specific to CommitmentMade
+                assert ",".join(row) == 'event_name,block_number,unix_timestamp,date,staker,period,value'  # specific to CommitmentMade
             else:
                 row_data = f'{row}'
                 assert row[0] == 'CommitmentMade', row_data
-                # skip block number
-                assert row[2] == first_staker.checksum_address, row_data
-                assert row[3] == f'{committed_period}', row_data
+                # skip block_number, unix_timestamp, date
+                assert row[4] == first_staker.checksum_address, row_data
+                assert row[5] == f'{committed_period}', row_data
                 # skip value
             line_count += 1
         assert line_count == 2, 'column names and single event row in csv file'


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Adds  timestamp and date columns to csv output of "nucypher status events" command

**Issues fixed/closed:**
- Fixes #2652

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
- Originally marked as a bug, but IMHO it's an addition to an existing feature.
- Example output:
```
event_name,block_number,unix_timestamp,date,staker,period,value
Minted,8494719,1619655297,2021-04-29T00:14:57Z,0xf2C45287139C6839215F0FfC0759777FFE734fAa,9372,593704596220612940690
```