### PR TITLE
Cleaned up each DB on shutdown, and removed reactor.run to give user console control

### DIFF
--- a/examples/run_demo_ursula_fleet.py
+++ b/examples/run_demo_ursula_fleet.py
@@ -20,6 +20,9 @@ import shutil
 from functools import partial
 from pathlib import Path
 
+from twisted.internet import reactor
+from contextlib import suppress
+
 from nucypher.characters.lawful import Ursula
 from nucypher.config.constants import APP_DIR, TEMPORARY_DOMAIN
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
@@ -63,17 +66,11 @@ def spin_up_federated_ursulas(quantity: int = FLEET_POPULATION):
         print(f"{u}: {deployer._listening_message()}")
 
     try:
-        while True:
-            input("'Ctl + C' to quit\r\n")
+        reactor.run()
     finally:
-        last_u = None
         for u in ursulas:
-            shutil.rmtree(u.datastore.db_path)
-            last_u = u
-
-        # This kills the whole process.
-        # TODO: Is there a graceful way to shut each Ursula down?
-        last_u.get_deployer().stop()
+            with suppress(FileNotFoundError):
+                shutil.rmtree(u.datastore.db_path)
 
 
 if __name__ == "__main__":

--- a/examples/run_demo_ursula_fleet.py
+++ b/examples/run_demo_ursula_fleet.py
@@ -47,12 +47,11 @@ def spin_up_federated_ursulas(quantity: int = FLEET_POPULATION):
 
     ursulas.append(sage)
     for index, port in enumerate(ports[1:]):
-        db = f"{USER_CACHE / port}.db"
         u = ursula_maker(
             rest_port=port,
             seed_nodes=[sage.seed_node_metadata()],
             start_learning_now=True,
-            db_filepath=db,
+            db_filepath=f"{USER_CACHE / port}.db",
         )
         ursulas.append(u)
 

--- a/newsfragments/2681.bugfix.rst
+++ b/newsfragments/2681.bugfix.rst
@@ -1,0 +1,1 @@
+examples/run_demo_ursula_fleet.py - Clean up each DB on shutdown, and removed reactor.run to give user console control

--- a/newsfragments/2681.bugfix.rst
+++ b/newsfragments/2681.bugfix.rst
@@ -1,1 +1,1 @@
-examples/run_demo_ursula_fleet.py - Clean up each DB on shutdown, and removed reactor.run to give user console control
+examples/run_demo_ursula_fleet.py - Clean up each DB on shutdown.


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Removed reactor.run in the demo fleet script because it was stealing console input from the user
- cleaned up the temp db files

**Issues fixed/closed:**
- Fixes #2232

**Why it's needed:**
This is just a simple db clean up for the fleet demo in the example scripts
Removed `reactor.run` because it steals console input from the user
