### PR TITLE
Fix failing CI test

### DIFF
--- a/nucypher/cli/painting/help.py
+++ b/nucypher/cli/painting/help.py
@@ -21,6 +21,7 @@ import maya
 from nucypher.blockchain.eth.sol.__conf__ import SOLIDITY_COMPILER_VERSION
 from nucypher.characters.banners import NUCYPHER_BANNER
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, USER_LOG_DIR, END_OF_POLICIES_PROBATIONARY_PERIOD
+from constant_sorrow.constants import NO_KEYRING_ATTACHED
 
 
 def echo_version(ctx, param, value):
@@ -55,10 +56,15 @@ def paint_new_installation_help(emitter, new_configuration, filepath):
     character_config_class = new_configuration.__class__
     character_name = character_config_class.NAME.lower()
 
+    if new_configuration.keyring != NO_KEYRING_ATTACHED:
+        maybe_public_key = bytes(new_configuration.keyring.signing_public_key).hex()
+    else:
+        maybe_public_key = "(no keyring attached)"
+
     emitter.message(f"Generated keyring", color='green')
     emitter.message(f"""
     
-Public key (stamp):   {bytes(new_configuration.keyring.signing_public_key).hex()}
+Public key (stamp):   {maybe_public_key}
 Path to keyring: {new_configuration.keyring_root}
 
 - You can share your public key with anyone. Others need it to interact with you.


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- Fixes a failing test, introduced by [this change](https://github.com/nucypher/nucypher/commit/5575c2c1358ffce4cba9bf4a3a41b2dbf68924ca#diff-fcfc8064edaf99ec15716f2b8442c9fb87175511312cffd8bed5aa5752f1684dR61-R63)


**Notes for reviewers:**
- Is it ok for the keyring to **not** be attached at this point? This is underlying cause of the error 