### PR TITLE
Provide required info for nucypher-monitor without unnecessarily maturing sprouts

### DIFF
--- a/newsfragments/2709.bugfix.rst
+++ b/newsfragments/2709.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a performance regression in ``FleetSensor`` where nodes were matured prematurely (pun not intended)

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -269,7 +269,7 @@ class FleetSensor:
             # Replace the existing object with a newer object, even if they're equal
             # (this object can be mutated externally).
             # This behavior is supposed to be consistent with that of the node storage
-            # (where a newer obhect with the same `checksum_address` replaces an older one).
+            # (where a newer object with the same `checksum_address` replaces an older one).
             if node in self._nodes_to_add:
                 self._nodes_to_add.remove(node)
             self._nodes_to_add.add(node)

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -150,7 +150,6 @@ class FleetState:
             nodes_to_add_dict = {node.checksum_address: node for node in nodes_to_add}
             for checksum_address in diff.nodes_updated:
                 new_node = nodes_to_add_dict[checksum_address]
-                new_node.mature()
                 nodes[checksum_address] = new_node
             for checksum_address in diff.nodes_removed:
                 del nodes[checksum_address]

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -266,6 +266,12 @@ class FleetSensor:
     def record_node(self, node: 'Ursula'):
 
         if node.domain == self._domain:
+            # Replace the existing object with a newer object, even if they're equal
+            # (this object can be mutated externally).
+            # This behavior is supposed to be consistent with that of the node storage
+            # (where a newer obhect with the same `checksum_address` replaces an older one).
+            if node in self._nodes_to_add:
+                self._nodes_to_add.remove(node)
             self._nodes_to_add.add(node)
 
             if self._auto_update_state:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -133,6 +133,9 @@ class NodeSprout(PartiallyKwargifiedBytes):
             self._nickname = Nickname.from_seed(self.checksum_address)
         return self._nickname
 
+    def rest_url(self):
+        return self.rest_interface.uri
+
     def mature(self):
         if self._is_finishing:
             return self._finishing_mutex.get()

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -93,7 +93,11 @@ class NodeSprout(PartiallyKwargifiedBytes):
         self._finishing_mutex = Queue()
 
     def __eq__(self, other):
-        return isinstance(other, NodeSprout) and self._checksum_address == other._checksum_address
+        try:
+            other_stamp = other.stamp
+        except (AttributeError, NoSigningPower):
+            return False
+        return bytes(self.stamp) == bytes(other_stamp)
 
     def __hash__(self):
         if not self._hash:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -100,10 +100,7 @@ class NodeSprout(PartiallyKwargifiedBytes):
         return bytes(self.stamp) == bytes(other_stamp)
 
     def __hash__(self):
-        if not self._hash:
-            self._hash = int.from_bytes(self.public_address,
-                                        byteorder="big")  # stop-propagation logic (ie, only propagate verified, staked nodes) keeps this unique and BFT.
-        return self._hash
+        return int.from_bytes(bytes(self.stamp), byteorder="big")
 
     def __repr__(self):
         if not self._repr:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -92,6 +92,9 @@ class NodeSprout(PartiallyKwargifiedBytes):
         self._is_finishing = False
         self._finishing_mutex = Queue()
 
+    def __eq__(self, other):
+        return isinstance(other, NodeSprout) and self._checksum_address == other._checksum_address
+
     def __hash__(self):
         if not self._hash:
             self._hash = int.from_bytes(self.public_address,


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
Removes a `mature()` call that was introduced in https://github.com/nucypher/nucypher/pull/2574/commits/50da675692fba33ab76ece5c4a5da86fd7549ce6 for the purposes of `nucypher-monitor`. The only thing it needs that a sprout doesn't have is `rest_url`, and we can provide that.

Additional changes were necessary to allow some tests to pass, since they now got a mix of `Ursula` and `NodeSprout` objects:
- `NodeSprout.__eq__` added (identical to `Character.__eq__`, comparing stamps)
- `NodeSprout.__hash__` was changed to conform to `__eq__` (and to `Character.__hash__`), that is taking the hash of a stamp.
