### PR TITLE
Fix prometheus tests that should not be run unless prometheus is installed - it is an optional dependency

### DIFF
--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -19,6 +19,7 @@ from nucypher.blockchain.eth.utils import estimate_block_number_for_period
 
 try:
     from prometheus_client import Gauge, Enum, Counter, Info, Histogram, Summary
+    from prometheus_client.registry import CollectorRegistry
 except ImportError:
     raise ImportError('"prometheus_client" must be installed - run "pip install nucypher[ursula]" and try again.')
 
@@ -31,8 +32,6 @@ from nucypher.blockchain.eth.agents import ContractAgency, PolicyManagerAgent, S
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.datastore.queries import get_policy_arrangements, get_work_orders
-
-from prometheus_client.registry import CollectorRegistry
 
 from typing import Dict, Union
 

--- a/tests/unit/test_prometheus.py
+++ b/tests/unit/test_prometheus.py
@@ -24,25 +24,36 @@ import unittest
 from unittest.mock import Mock
 
 import pytest
-from prometheus_client import (
-    CollectorRegistry,
-    Counter,
-    Enum,
-    Gauge,
-    Histogram,
-    Info,
-    Metric,
-    Summary
-)
-from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp
-
-from nucypher.utilities.prometheus.collector import BaseMetricsCollector, MetricsCollector
-from nucypher.utilities.prometheus.metrics import JSONMetricsResource
-from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
 
 TEST_PREFIX = 'test_prefix'
 
+try:
+    # all prometheus related imports
+    from prometheus_client import (
+        CollectorRegistry,
+        Counter,
+        Enum,
+        Gauge,
+        Histogram,
+        Info,
+        Metric,
+        Summary
+    )
 
+    from prometheus_client.core import GaugeHistogramMetricFamily, Timestamp
+
+    # include dependencies that have sub-dependencies on prometheus
+    from nucypher.utilities.prometheus.collector import BaseMetricsCollector, MetricsCollector
+    from nucypher.utilities.prometheus.metrics import JSONMetricsResource
+    from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
+
+    # flag to skip tests
+    PROMETHEUS_INSTALLED = True
+except ImportError:
+    PROMETHEUS_INSTALLED = False
+
+
+@pytest.mark.skipif(condition=(not PROMETHEUS_INSTALLED), reason="prometheus_client is required for test")
 def test_prometheus_metrics_config():
     port = 2020
 
@@ -79,6 +90,7 @@ def test_prometheus_metrics_config():
     assert prometheus_config.start_now
 
 
+@pytest.mark.skipif(condition=(not PROMETHEUS_INSTALLED), reason="prometheus_client is required for test")
 def test_base_metrics_collector():
     class TestBastMetricsCollector(BaseMetricsCollector):
         def __init__(self):
@@ -104,6 +116,7 @@ def test_base_metrics_collector():
     assert collector.collect_internal_run
 
 
+@pytest.mark.skipif(condition=(not PROMETHEUS_INSTALLED), reason="prometheus_client is required for test")
 class TestGenerateJSON(unittest.TestCase):
     def setUp(self):
         self.registry = CollectorRegistry()


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3
 
**What this does:**
Prometheus unit and acceptance tests are only run when prometheus is installed.

**Why it's needed:**
Unit test / acceptance test suite fails if `prometheus_client` dependency is not installed. Seems like tests are run on circle ci.

**Notes for reviewers:**
Is this the best strategy?
