### PR TITLE
Allow Porter to launch with TLS

### DIFF
--- a/nucypher/cli/commands/alice.py
+++ b/nucypher/cli/commands/alice.py
@@ -362,7 +362,7 @@ def run(general_config, character_options, config_file, controller_port, dry_run
             controller = ALICE.make_web_controller(crash_on_error=general_config.debug)
             ALICE.log.info('Starting HTTP Character Web Controller')
             emitter.message(f'Running HTTP Alice Controller at http://localhost:{controller_port}')
-            return controller.start(http_port=controller_port, dry_run=dry_run)
+            return controller.start(port=controller_port, dry_run=dry_run)
 
     # Handle Crash
     except Exception as e:

--- a/nucypher/cli/commands/bob.py
+++ b/nucypher/cli/commands/bob.py
@@ -265,7 +265,7 @@ def run(general_config, character_options, config_file, controller_port, dry_run
     # Start Controller
     controller = BOB.make_web_controller(crash_on_error=general_config.debug)
     BOB.log.info('Starting HTTP Character Web Controller')
-    return controller.start(http_port=controller_port, dry_run=dry_run)
+    return controller.start(port=controller_port, dry_run=dry_run)
 
 
 @bob.command()

--- a/nucypher/cli/commands/enrico.py
+++ b/nucypher/cli/commands/enrico.py
@@ -53,7 +53,7 @@ def run(general_config, policy_encrypting_key, dry_run, http_port):
 
     ENRICO.log.info('Starting HTTP Character Web Controller')
     controller = ENRICO.make_web_controller()
-    return controller.start(http_port=http_port, dry_run=dry_run)
+    return controller.start(port=http_port, dry_run=dry_run)
 
 
 @enrico.command()

--- a/nucypher/cli/commands/porter.py
+++ b/nucypher/cli/commands/porter.py
@@ -94,7 +94,7 @@ def exec_work_order(general_config, porter_uri, ursula, work_order):
 @option_registry_filepath
 @option_min_stake
 @click.option('--http-port', help="Porter HTTP/HTTPS port for JSON endpoint", type=NETWORK_PORT, default=Porter.DEFAULT_PORT)
-@click.option('--certificate-filepath', help="Pre-signed TLS certificate filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
+@click.option('--tls-certificate-filepath', help="Pre-signed TLS certificate filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
 @click.option('--tls-key-filepath', help="TLS private key filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
 @click.option('--dry-run', '-x', help="Execute normally without actually starting Porter", is_flag=True)
 @click.option('--eager', help="Start learning and scraping the network before starting up other services", is_flag=True, default=True)
@@ -106,7 +106,7 @@ def run(general_config,
         registry_filepath,
         min_stake,
         http_port,
-        certificate_filepath,
+        tls_certificate_filepath,
         tls_key_filepath,
         dry_run,
         eager):
@@ -158,8 +158,8 @@ def run(general_config,
         return
 
     # HTTP/HTTPS
-    if bool(tls_key_filepath) ^ bool(certificate_filepath):
-        raise click.BadOptionUsage(option_name='--tls-key-filepath, --certificate-filepath',
+    if bool(tls_key_filepath) ^ bool(tls_certificate_filepath):
+        raise click.BadOptionUsage(option_name='--tls-key-filepath, --tls-certificate-filepath',
                                    message=BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED)
 
     emitter.message(f"Network: {PORTER.domain.capitalize()}", color='green')
@@ -167,10 +167,10 @@ def run(general_config,
         emitter.message(f"Provider: {provider_uri}", color='green')
 
     controller = PORTER.make_web_controller(crash_on_error=False)
-    http_scheme = "https" if tls_key_filepath and certificate_filepath else "http"
+    http_scheme = "https" if tls_key_filepath and tls_certificate_filepath else "http"
     message = PORTER_RUN_MESSAGE.format(http_scheme=http_scheme, http_port=http_port)
     emitter.message(message, color='green', bold=True)
     return controller.start(port=http_port,
                             tls_key_filepath=tls_key_filepath,
-                            certificate_filepath=certificate_filepath,
+                            tls_certificate_filepath=tls_certificate_filepath,
                             dry_run=dry_run)

--- a/nucypher/cli/commands/porter.py
+++ b/nucypher/cli/commands/porter.py
@@ -14,6 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+from pathlib import Path
+
 import click
 
 from nucypher.blockchain.eth.networks import NetworksInventory
@@ -90,7 +92,9 @@ def exec_work_order(general_config, porter_uri, ursula, work_order):
 @option_teacher_uri
 @option_registry_filepath
 @option_min_stake
-@click.option('--http-port', help="Porter HTTP port for JSON endpoint", type=NETWORK_PORT, default=Porter.DEFAULT_PORTER_HTTP_PORT)
+@click.option('--http-port', help="Porter HTTP/HTTPS port for JSON endpoint", type=NETWORK_PORT, default=Porter.DEFAULT_PORT)
+@click.option('--certificate-filepath', help="Pre-signed TLS certificate filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
+@click.option('--tls-key-filepath', help="TLS private key filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
 @click.option('--dry-run', '-x', help="Execute normally without actually starting Porter", is_flag=True)
 @click.option('--eager', help="Start learning and scraping the network before starting up other services", is_flag=True, default=True)
 def run(general_config,
@@ -101,6 +105,8 @@ def run(general_config,
         registry_filepath,
         min_stake,
         http_port,
+        certificate_filepath,
+        tls_key_filepath,
         dry_run,
         eager):
     """Start Porter's Web controller."""
@@ -149,12 +155,21 @@ def run(general_config,
         rpc_controller.start()
         return
 
-    # HTTP
+    # HTTP/HTTPS
+    if bool(tls_key_filepath) ^ bool(certificate_filepath):
+        raise click.BadOptionUsage(option_name='--tls-key-filepath, --certificate-filepath',
+                                   message='both --tls-key-filepath and --certificate-filepath must be specified to '
+                                           'launch porter with TLS; only one specified')
+
     emitter.message(f"Network: {PORTER.domain.capitalize()}", color='green')
     if not federated_only:
         emitter.message(f"Provider: {provider_uri}", color='green')
 
     controller = PORTER.make_web_controller(crash_on_error=False)
-    message = f"Running Porter Web Controller at http://127.0.0.1:{http_port}"
+    http_scheme = "https" if tls_key_filepath and certificate_filepath else "http"
+    message = f"Running Porter Web Controller at {http_scheme}://127.0.0.1:{http_port}"
     emitter.message(message, color='green', bold=True)
-    return controller.start(http_port=http_port, dry_run=dry_run)
+    return controller.start(port=http_port,
+                            tls_key_filepath=tls_key_filepath,
+                            certificate_filepath=certificate_filepath,
+                            dry_run=dry_run)

--- a/nucypher/cli/commands/porter.py
+++ b/nucypher/cli/commands/porter.py
@@ -21,6 +21,7 @@ import click
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.config import group_general_config
+from nucypher.cli.literature import BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED, PORTER_RUN_MESSAGE
 from nucypher.cli.options import (
     option_network,
     option_provider_uri,
@@ -131,6 +132,7 @@ def run(general_config,
             raise click.BadOptionUsage(option_name='--provider',
                                        message="--provider is required for decentralized porter.")
         if not network:
+            # should never happen - network defaults to 'mainnet' if not specified
             raise click.BadOptionUsage(option_name='--network',
                                        message="--network is required for decentralized porter.")
 
@@ -158,8 +160,7 @@ def run(general_config,
     # HTTP/HTTPS
     if bool(tls_key_filepath) ^ bool(certificate_filepath):
         raise click.BadOptionUsage(option_name='--tls-key-filepath, --certificate-filepath',
-                                   message='both --tls-key-filepath and --certificate-filepath must be specified to '
-                                           'launch porter with TLS; only one specified')
+                                   message=BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED)
 
     emitter.message(f"Network: {PORTER.domain.capitalize()}", color='green')
     if not federated_only:
@@ -167,7 +168,7 @@ def run(general_config,
 
     controller = PORTER.make_web_controller(crash_on_error=False)
     http_scheme = "https" if tls_key_filepath and certificate_filepath else "http"
-    message = f"Running Porter Web Controller at {http_scheme}://127.0.0.1:{http_port}"
+    message = PORTER_RUN_MESSAGE.format(http_scheme=http_scheme, http_port=http_port)
     emitter.message(message, color='green', bold=True)
     return controller.start(port=http_port,
                             tls_key_filepath=tls_key_filepath,

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -684,3 +684,12 @@ CONFIRMING_ACTIVITY_NOW = "Making a commitment to period {committed_period}"
 SUCCESSFUL_CONFIRM_ACTIVITY = '\nCommitment was made to period #{committed_period} (starting at {date})'
 
 SUCCESSFUL_MANUALLY_SAVE_METADATA = "Successfully saved node metadata to {metadata_path}."
+
+
+#
+# Porter
+#
+
+PORTER_RUN_MESSAGE = "Running Porter Web Controller at {http_scheme}://127.0.0.1:{http_port}"
+
+BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED = "Both --tls-key-filepath and --certificate-filepath must be provided to launch porter with TLS; only one specified"

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -692,4 +692,4 @@ SUCCESSFUL_MANUALLY_SAVE_METADATA = "Successfully saved node metadata to {metada
 
 PORTER_RUN_MESSAGE = "Running Porter Web Controller at {http_scheme}://127.0.0.1:{http_port}"
 
-BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED = "Both --tls-key-filepath and --certificate-filepath must be provided to launch porter with TLS; only one specified"
+BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED = "Both --tls-key-filepath and --tls-certificate-filepath must be provided to launch porter with TLS; only one specified"

--- a/nucypher/cli/options.py
+++ b/nucypher/cli/options.py
@@ -84,7 +84,7 @@ def option_contract_name(required: bool = False):
 def option_controller_port(default=None):
     return click.option(
         '--controller-port',
-        help="The host port to run Alice HTTP services on",
+        help="The host port to run HTTP services on",
         type=NETWORK_PORT,
         default=default)
 

--- a/nucypher/control/controllers.py
+++ b/nucypher/control/controllers.py
@@ -269,18 +269,17 @@ class WebController(InterfaceControlServer):
     def start(self,
               port: int,
               tls_key_filepath: str = None,
-              certificate_filepath: str = None,
+              tls_certificate_filepath: str = None,
               dry_run: bool = False):
-
-        self.log.info("Starting HTTP/HTTPS Control...")
         if dry_run:
             return
 
-        if tls_key_filepath and certificate_filepath:
+        if tls_key_filepath and tls_certificate_filepath:
+            self.log.info("Starting HTTPS Control...")
             # HTTPS endpoint
             hx_deployer = HendrixDeployTLS(action="start",
                                            key=tls_key_filepath,
-                                           cert=certificate_filepath,
+                                           cert=tls_certificate_filepath,
                                            options={
                                                "wsgi": self._transport,
                                                "https_port": port,
@@ -289,6 +288,7 @@ class WebController(InterfaceControlServer):
         else:
             # HTTP endpoint
             # TODO #845: Make non-blocking web control startup
+            self.log.info("Starting HTTP Control...")
             hx_deployer = HendrixDeploy(action="start",
                                         options={
                                             "wsgi": self._transport,

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -63,7 +63,7 @@ the Pipe for nucypher network operations
     _LONG_LEARNING_DELAY = 30
     _ROUNDS_WITHOUT_NODES_AFTER_WHICH_TO_SLOW_DOWN = 25
 
-    DEFAULT_PORTER_HTTP_PORT = 9155
+    DEFAULT_PORT = 9155
 
     _interface_class = PorterInterface
 
@@ -147,7 +147,7 @@ the Pipe for nucypher network operations
                                                         port=ursula.rest_interface.port)
 
             return Porter.UrsulaInfo(checksum_address=ursula_checksum,
-                                     uri=f"https://{ursula.rest_interface.host}:{ursula.rest_interface.port}",
+                                     uri=f"{ursula.rest_interface.formal_uri}",
                                      encrypting_key=ursula.public_keys(DecryptingPower))
 
         self.block_until_number_of_known_nodes_is(quantity, learn_on_this_thread=True, eager=True)

--- a/tests/acceptance/cli/test_porter.py
+++ b/tests/acceptance/cli/test_porter.py
@@ -1,0 +1,252 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nucypher.characters.lawful import Ursula
+from nucypher.cli.literature import PORTER_RUN_MESSAGE, BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED
+from nucypher.cli.main import nucypher_cli
+from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.utilities.porter.porter import Porter
+from tests.constants import TEST_PROVIDER_URI
+from tests.utils.ursula import select_test_port
+
+
+@pytest.fixture(scope="function")
+def federated_teacher_uri(mocker, federated_ursulas):
+    teacher = list(federated_ursulas)[0]
+    teacher_uri = teacher.seed_node_metadata(as_teacher_uri=True)
+    mocker.patch.object(Ursula, 'from_teacher_uri', return_value=teacher)
+    yield teacher_uri
+
+
+@pytest.fixture(scope="function")
+def blockchain_teacher_uri(mocker, blockchain_ursulas):
+    teacher = list(blockchain_ursulas)[0]
+    teacher_uri = teacher.seed_node_metadata(as_teacher_uri=True)
+    mocker.patch.object(Ursula, 'from_teacher_uri', return_value=teacher)
+    yield teacher_uri
+
+
+def test_federated_porter_cli_run_simple(click_runner, federated_ursulas, federated_teacher_uri):
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    output = result.output
+    assert f"Network: {TEMPORARY_DOMAIN}" in output
+    assert PORTER_RUN_MESSAGE.format(http_scheme="http", http_port=Porter.DEFAULT_PORT) in output
+
+    # Non-default port
+    non_default_port = select_test_port()
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--http-port', non_default_port,
+                          '--teacher', federated_teacher_uri)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    output = result.output
+    assert f"Network: {TEMPORARY_DOMAIN}" in output
+    assert PORTER_RUN_MESSAGE.format(http_scheme="http", http_port=non_default_port) in output
+
+
+def test_federated_porter_cli_run_teacher_must_be_provided(click_runner, federated_ursulas):
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only')
+
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert f"--teacher is required" in result.output
+
+
+def test_federated_porter_cli_run_tls_filepath_and_certificate(click_runner,
+                                                               federated_ursulas,
+                                                               tempfile_path,
+                                                               temp_dir_path,
+                                                               federated_teacher_uri):
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri,
+                          '--tls-key-filepath', tempfile_path)  # only tls-key provided
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code != 0  # both --tls-key-filepath and --certificate-filepath must be provided for TLS
+    assert BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
+
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri,
+                          '--certificate-filepath', tempfile_path)  # only certificate provided
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code != 0  # both --tls-key-filepath and --certificate-filepath must be provided for TLS
+    assert BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
+
+    #
+    # tls-key and certificate filepaths must exist
+    #
+    assert Path(tempfile_path).exists()  # temp file exists
+
+    non_existent_path = (Path(temp_dir_path) / 'non_existent_file')
+    assert not non_existent_path.exists()
+    # tls-key-filepath does not exist
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri,
+                          '--certificate-filepath', tempfile_path,
+                          '--tls-key-filepath', str(non_existent_path.absolute()))
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code != 0
+    output = result.output
+    assert f"'--tls-key-filepath': File '{non_existent_path.absolute()}' does not exist" in output
+
+    # certificate-filepath does not exist
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri,
+                          '--certificate-filepath', str(non_existent_path.absolute()),
+                          '--tls-key-filepath', tempfile_path)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code != 0
+    output = result.output
+    assert f"'--certificate-filepath': File '{non_existent_path.absolute()}' does not exist" in output
+
+
+def test_federated_cli_run_https(click_runner, federated_ursulas, temp_dir_path, federated_teacher_uri):
+    tls_key_path = Path(temp_dir_path) / 'key.pem'
+    _write_random_data(tls_key_path)
+    certificate_file_path = Path(temp_dir_path) / 'fullchain.pem'
+    _write_random_data(certificate_file_path)
+
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri,
+                          '--tls-key-filepath', tls_key_path,
+                          '--certificate-filepath', certificate_file_path)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
+
+
+def test_blockchain_porter_cli_run_simple(click_runner,
+                                          blockchain_ursulas,
+                                          testerchain,
+                                          agency_local_registry,
+                                          blockchain_teacher_uri):
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--network', TEMPORARY_DOMAIN,
+                          '--provider', TEST_PROVIDER_URI,
+                          '--registry-filepath', agency_local_registry.filepath,
+                          '--teacher', blockchain_teacher_uri)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    output = result.output
+    assert f"Network: {TEMPORARY_DOMAIN}" in output
+    assert f"Provider: {TEST_PROVIDER_URI}" in output
+    assert PORTER_RUN_MESSAGE.format(http_scheme="http", http_port=Porter.DEFAULT_PORT) in output
+
+    # Non-default port
+    non_default_port = select_test_port()
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--network', TEMPORARY_DOMAIN,
+                          '--provider', TEST_PROVIDER_URI,
+                          '--registry-filepath', agency_local_registry.filepath,
+                          '--http-port', non_default_port,
+                          '--teacher', blockchain_teacher_uri)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    output = result.output
+    assert f"Network: {TEMPORARY_DOMAIN}" in output
+    assert f"Provider: {TEST_PROVIDER_URI}" in output
+    assert PORTER_RUN_MESSAGE.format(http_scheme="http", http_port=non_default_port) in output
+
+
+def test_blockchain_porter_cli_run_provider_required(click_runner,
+                                                     blockchain_ursulas,
+                                                     testerchain,
+                                                     agency_local_registry,
+                                                     blockchain_teacher_uri):
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--network', TEMPORARY_DOMAIN,
+                          '--registry-filepath', agency_local_registry.filepath,
+                          '--teacher', blockchain_teacher_uri)
+
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+
+    assert result.exit_code != 0
+    assert "--provider is required" in result.output
+
+
+def test_blockchain_porter_cli_run_network_defaults_to_mainnet(click_runner,
+                                                               blockchain_ursulas,
+                                                               testerchain,
+                                                               agency_local_registry,
+                                                               blockchain_teacher_uri):
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--provider', TEST_PROVIDER_URI,
+                          '--registry-filepath', agency_local_registry.filepath,
+                          '--teacher', blockchain_teacher_uri)
+
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+
+    assert result.exit_code != 0
+    # there is no 'mainnet' network for decentralized testing
+    assert "'mainnet' is not a NuCypher Network" in result.output
+
+
+def test_blockchain_porter_cli_run_https(click_runner,
+                                         blockchain_ursulas,
+                                         testerchain,
+                                         agency_local_registry,
+                                         temp_dir_path,
+                                         blockchain_teacher_uri):
+    tls_key_path = Path(temp_dir_path) / 'key.pem'
+    _write_random_data(tls_key_path)
+    certificate_file_path = Path(temp_dir_path) / 'fullchain.pem'
+    _write_random_data(certificate_file_path)
+
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--network', TEMPORARY_DOMAIN,
+                          '--provider', TEST_PROVIDER_URI,
+                          '--registry-filepath', agency_local_registry.filepath,
+                          '--teacher', blockchain_teacher_uri,
+                          '--tls-key-filepath', tls_key_path,
+                          '--certificate-filepath', certificate_file_path)
+
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
+
+
+def _write_random_data(filepath: Path):
+    with filepath.open('wb') as file:
+        file.write(os.urandom(24))

--- a/tests/acceptance/cli/test_porter.py
+++ b/tests/acceptance/cli/test_porter.py
@@ -91,16 +91,16 @@ def test_federated_porter_cli_run_tls_filepath_and_certificate(click_runner,
                           '--teacher', federated_teacher_uri,
                           '--tls-key-filepath', tempfile_path)  # only tls-key provided
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
-    assert result.exit_code != 0  # both --tls-key-filepath and --certificate-filepath must be provided for TLS
+    assert result.exit_code != 0  # both --tls-key-filepath and --tls-certificate-filepath must be provided for TLS
     assert BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
 
     porter_run_command = ('porter', 'run',
                           '--dry-run',
                           '--federated-only',
                           '--teacher', federated_teacher_uri,
-                          '--certificate-filepath', tempfile_path)  # only certificate provided
+                          '--tls-certificate-filepath', tempfile_path)  # only certificate provided
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
-    assert result.exit_code != 0  # both --tls-key-filepath and --certificate-filepath must be provided for TLS
+    assert result.exit_code != 0  # both --tls-key-filepath and --tls-certificate-filepath must be provided for TLS
     assert BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
 
     #
@@ -115,24 +115,24 @@ def test_federated_porter_cli_run_tls_filepath_and_certificate(click_runner,
                           '--dry-run',
                           '--federated-only',
                           '--teacher', federated_teacher_uri,
-                          '--certificate-filepath', tempfile_path,
+                          '--tls-certificate-filepath', tempfile_path,
                           '--tls-key-filepath', str(non_existent_path.absolute()))
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code != 0
     output = result.output
     assert f"'--tls-key-filepath': File '{non_existent_path.absolute()}' does not exist" in output
 
-    # certificate-filepath does not exist
+    # tls-certificate-filepath does not exist
     porter_run_command = ('porter', 'run',
                           '--dry-run',
                           '--federated-only',
                           '--teacher', federated_teacher_uri,
-                          '--certificate-filepath', str(non_existent_path.absolute()),
+                          '--tls-certificate-filepath', str(non_existent_path.absolute()),
                           '--tls-key-filepath', tempfile_path)
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code != 0
     output = result.output
-    assert f"'--certificate-filepath': File '{non_existent_path.absolute()}' does not exist" in output
+    assert f"'--tls-certificate-filepath': File '{non_existent_path.absolute()}' does not exist" in output
 
 
 def test_federated_cli_run_https(click_runner, federated_ursulas, temp_dir_path, federated_teacher_uri):
@@ -146,7 +146,7 @@ def test_federated_cli_run_https(click_runner, federated_ursulas, temp_dir_path,
                           '--federated-only',
                           '--teacher', federated_teacher_uri,
                           '--tls-key-filepath', tls_key_path,
-                          '--certificate-filepath', certificate_file_path)
+                          '--tls-certificate-filepath', certificate_file_path)
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code == 0
     assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
@@ -240,7 +240,7 @@ def test_blockchain_porter_cli_run_https(click_runner,
                           '--registry-filepath', agency_local_registry.filepath,
                           '--teacher', blockchain_teacher_uri,
                           '--tls-key-filepath', tls_key_path,
-                          '--certificate-filepath', certificate_file_path)
+                          '--tls-certificate-filepath', certificate_file_path)
 
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code == 0


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Based over #2717 (which should be reviewed first).

`--tls-key-filepath` and `--certificate-filepath` options can now be provided to `nucypher porter run ... ` for Porter to be launched with TLS i.e. https.

For testing you can create a tls key and certificate for the localhost using the openssl command:
```bash
openssl req -x509 -out fullchain.pem -keyout key.pem \
  -newkey rsa:2048 -nodes -sha256 \
  -subj '/CN=localhost' -extensions EXT -config <( \
   printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
```
