### PR TITLE
Basic Authentication for Porter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,7 +436,7 @@ commands:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - save_cache:
-          key: pip-v6-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pip-v7-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "~/.local/bin"
             - "~/.local/lib/python3.7/site-packages"
@@ -451,7 +451,7 @@ commands:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: pip-v6-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pip-v7-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - restore_cache:
           key: solc-v2-{{ checksum "nucypher/blockchain/eth/sol/__conf__.py" }}
 

--- a/deploy/docker/porter/Dockerfile
+++ b/deploy/docker/porter/Dockerfile
@@ -1,0 +1,12 @@
+FROM nucypher:latest
+
+# Update
+RUN apt update -y && apt upgrade -y
+
+WORKDIR /code
+COPY . /code
+
+# Porter requirements
+RUN pip3 install .[porter]
+
+CMD ["/bin/bash"]

--- a/deploy/docker/porter/docker-compose.yml
+++ b/deploy/docker/porter/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: nucypher:latest
     build:
       context: ../../..
-      dockerfile: deploy/docker/Dockerfile
+      dockerfile: deploy/docker/porter/Dockerfile
     ports:
       # Default Porter port
       - "80:9155"
@@ -22,16 +22,37 @@ services:
     image: nucypher:latest
     build:
       context: ../../..
-      dockerfile: deploy/docker/Dockerfile
+      dockerfile: deploy/docker/porter/Dockerfile
     ports:
       # Default Porter port
       - "443:9155"
     volumes:
       - .:/code
       - ~/.local/share/nucypher:/nucypher
-      - "${TLS_DIR}:/etc/porter-tls/"
+      - "${TLS_DIR}:/etc/porter/tls/"
     command: [ "nucypher", "porter", "run",
                "--provider", "${WEB3_PROVIDER_URI}",
                "--network", "${NUCYPHER_NETWORK}",
-               "--tls-key-filepath", "/etc/porter-tls/key.pem",
-               "--tls-certificate-filepath", "/etc/porter-tls/cert.pem"]
+               "--tls-key-filepath", "/etc/porter/tls/key.pem",
+               "--tls-certificate-filepath", "/etc/porter/tls/cert.pem"]
+
+  porter-https-auth:
+    restart: on-failure
+    image: nucypher:latest
+    build:
+      context: ../../..
+      dockerfile: deploy/docker/porter/Dockerfile
+    ports:
+      # Default Porter port
+      - "443:9155"
+    volumes:
+      - .:/code
+      - ~/.local/share/nucypher:/nucypher
+      - "${TLS_DIR}:/etc/porter/tls/"
+      - "${HTPASSWD_FILE}:/etc/porter/auth/htpasswd"
+    command: [ "nucypher", "porter", "run",
+               "--provider", "${WEB3_PROVIDER_URI}",
+               "--network", "${NUCYPHER_NETWORK}",
+               "--tls-key-filepath", "/etc/porter/tls/key.pem",
+               "--tls-certificate-filepath", "/etc/porter/tls/cert.pem",
+               "--basic-auth-filepath", "/etc/porter/auth/htpasswd"]

--- a/deploy/docker/porter/docker-compose.yml
+++ b/deploy/docker/porter/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3'
+
+services:
+  porter-http:
+    restart: on-failure
+    image: nucypher:latest
+    build:
+      context: ../../..
+      dockerfile: deploy/docker/Dockerfile
+    ports:
+      # Default Porter port
+      - "80:9155"
+    volumes:
+      - .:/code
+      - ~/.local/share/nucypher:/nucypher
+    command: ["nucypher", "porter", "run",
+              "--provider", "${WEB3_PROVIDER_URI}",
+              "--network", "${NUCYPHER_NETWORK}"]
+
+  porter-https:
+    restart: on-failure
+    image: nucypher:latest
+    build:
+      context: ../../..
+      dockerfile: deploy/docker/Dockerfile
+    ports:
+      # Default Porter port
+      - "443:9155"
+    volumes:
+      - .:/code
+      - ~/.local/share/nucypher:/nucypher
+      - "${TLS_DIR}:/etc/porter-tls/"
+    command: [ "nucypher", "porter", "run",
+               "--provider", "${WEB3_PROVIDER_URI}",
+               "--network", "${NUCYPHER_NETWORK}",
+               "--tls-key-filepath", "/etc/porter-tls/key.pem",
+               "--tls-certificate-filepath", "/etc/porter-tls/cert.pem"]

--- a/nucypher/cli/commands/porter.py
+++ b/nucypher/cli/commands/porter.py
@@ -177,7 +177,7 @@ def run(general_config,
         emitter.message(f"Provider: {provider_uri}", color='green')
 
     if basic_auth_filepath:
-        emitter.message(f"Basic Authentication enabled", color='green')
+        emitter.message("Basic Authentication enabled", color='green')
 
     controller = PORTER.make_web_controller(htpasswd_filepath=basic_auth_filepath, crash_on_error=False)
     http_scheme = "https" if is_https else "http"

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -693,3 +693,5 @@ SUCCESSFUL_MANUALLY_SAVE_METADATA = "Successfully saved node metadata to {metada
 PORTER_RUN_MESSAGE = "Running Porter Web Controller at {http_scheme}://127.0.0.1:{http_port}"
 
 BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED = "Both --tls-key-filepath and --tls-certificate-filepath must be provided to launch porter with TLS; only one specified"
+
+BASIC_AUTH_REQUIRES_HTTPS = "Basic authentication can only be used with HTTPS. --tls-key-filepath and --tls-certificate-filepath must also be provided"

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -19,7 +19,6 @@ from typing import List, Optional, Iterable
 from constant_sorrow.constants import NO_CONTROL_PROTOCOL, NO_BLOCKCHAIN_CONNECTION
 from eth_typing import ChecksumAddress
 from flask import request, Response
-from flask_htpasswd import HtPasswdAuth
 from umbral.keys import UmbralPublicKey
 
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
@@ -208,6 +207,12 @@ the Pipe for nucypher network operations
         # Register Flask Decorator
         porter_flask_control = controller.make_control_transport()
         if htpasswd_filepath:
+            try:
+                from flask_htpasswd import HtPasswdAuth
+            except ImportError:
+                raise ImportError('Porter installation is required for basic authentication '
+                                  '- run "pip install nucypher[porter]" and try again.')
+
             porter_flask_control.config['FLASK_HTPASSWD_PATH'] = htpasswd_filepath
             # ensure basic auth required for all endpoints
             porter_flask_control.config['FLASK_AUTH_ALL'] = True

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -19,6 +19,7 @@ from typing import List, Optional, Iterable
 from constant_sorrow.constants import NO_CONTROL_PROTOCOL, NO_BLOCKCHAIN_CONNECTION
 from eth_typing import ChecksumAddress
 from flask import request, Response
+from flask_htpasswd import HtPasswdAuth
 from umbral.keys import UmbralPublicKey
 
 from nucypher.blockchain.eth.agents import ContractAgency, StakingEscrowAgent
@@ -198,7 +199,7 @@ the Pipe for nucypher network operations
         self.controller = controller
         return controller
 
-    def make_web_controller(self, crash_on_error: bool = False):
+    def make_web_controller(self, crash_on_error: bool = False, htpasswd_filepath: str = None):
         controller = WebController(app_name=self.APP_NAME,
                                    crash_on_error=crash_on_error,
                                    interface=self._interface_class(porter=self))
@@ -206,6 +207,11 @@ the Pipe for nucypher network operations
 
         # Register Flask Decorator
         porter_flask_control = controller.make_control_transport()
+        if htpasswd_filepath:
+            porter_flask_control.config['FLASK_HTPASSWD_PATH'] = htpasswd_filepath
+            # ensure basic auth required for all endpoints
+            porter_flask_control.config['FLASK_AUTH_ALL'] = True
+            _ = HtPasswdAuth(app=porter_flask_control)
 
         #
         # Porter Control HTTP Endpoints

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ PORTER_REQUIRES = ['flask-htpasswd']  # needed for basic authentication
 EXTRAS = {
 
     # Admin
-    'dev': DEV_REQUIRES + URSULA_REQUIRES + ALICE_REQUIRES,
+    'dev': DEV_REQUIRES + URSULA_REQUIRES + ALICE_REQUIRES + PORTER_REQUIRES,
     'benchmark': DEV_REQUIRES + BENCHMARK_REQUIRES,
     'deploy': DEPLOY_REQUIRES,
 

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,7 @@ DEPLOY_REQUIRES = [
 URSULA_REQUIRES = ['prometheus_client', 'sentry-sdk']  # TODO: Consider renaming to 'monitor', etc.
 ALICE_REQUIRES = ['qrcode']
 BOB_REQUIRES = ['qrcode']
+PORTER_REQUIRES = ['flask-htpasswd']  # needed for basic authentication
 
 EXTRAS = {
 
@@ -146,7 +147,8 @@ EXTRAS = {
     # User
     'ursula': URSULA_REQUIRES,
     'alice': ALICE_REQUIRES,
-    'bob': BOB_REQUIRES
+    'bob': BOB_REQUIRES,
+    'porter': PORTER_REQUIRES
 }
 
 

--- a/tests/acceptance/porter/control/conftest.py
+++ b/tests/acceptance/porter/control/conftest.py
@@ -27,6 +27,12 @@ def blockchain_porter_web_controller(blockchain_porter):
     yield web_controller.test_client()
 
 
+@pytest.fixture(scope='module')
+def blockchain_porter_basic_auth_web_controller(blockchain_porter, basic_auth_file):
+    web_controller = blockchain_porter.make_web_controller(crash_on_error=True, htpasswd_filepath=basic_auth_file)
+    yield web_controller.test_client()
+
+
 #
 # RPC
 #

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -23,6 +23,7 @@ import shutil
 import tempfile
 from datetime import datetime, timedelta
 from functools import partial
+from pathlib import Path
 from typing import Callable, Tuple
 
 import maya
@@ -1066,3 +1067,16 @@ def stakeholder_configuration_file_location(custom_filepath):
 def mock_teacher_nodes(mocker):
     mock_nodes = tuple(u.rest_url() for u in MOCK_KNOWN_URSULAS_CACHE.values())[0:2]
     mocker.patch.dict(TEACHER_NODES, {TEMPORARY_DOMAIN: mock_nodes}, clear=True)
+
+
+#
+# Web Auth
+#
+@pytest.fixture(scope='module')
+def basic_auth_file(temp_dir_path):
+    basic_auth = Path(temp_dir_path) / 'htpasswd'
+    with basic_auth.open("w") as f:
+        # username: "admin", password: "admin"
+        f.write("admin:$apr1$hlEpWVoI$0qjykXrvdZ0yO2TnBggQO0\n")
+    yield basic_auth
+    basic_auth.unlink()

--- a/tests/integration/porter/control/conftest.py
+++ b/tests/integration/porter/control/conftest.py
@@ -26,6 +26,12 @@ def federated_porter_web_controller(federated_porter):
     yield web_controller.test_client()
 
 
+@pytest.fixture(scope='module')
+def federated_porter_basic_auth_web_controller(federated_porter, basic_auth_file):
+    web_controller = federated_porter.make_web_controller(crash_on_error=True, htpasswd_filepath=basic_auth_file)
+    yield web_controller.test_client()
+
+
 #
 # RPC
 #


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Based over #2724 .

Allows Porter to facilitate Basic Authentication over HTTPS based on a provided `htpasswd` file via `--basic-auth-filepath`. Updated Docker/docker-compose files accordingly.

**Issues fixed/closed:**
Fixes #2706  - does it fully "fix" it? perhaps for now unless users decide they want something more robust. However, this is a good starting point.

**Why it's needed:**
User authentication in some form will be needed if Porter is to be used as a public service.
