### PR TITLE
Cloudworkers: ignore errors on stopping of ursula containers

### DIFF
--- a/deploy/ansible/worker/include/init_ursula.yml
+++ b/deploy/ansible/worker/include/init_ursula.yml
@@ -19,6 +19,7 @@
         name: ursula
         state: stopped
         image: "{{ nucypher_image | default('nucypher/nucypher:latest') }}"
+      ignore_errors: yes
 
     - name: Keep disk space clean by pruning unneeded docker debris
       become: yes

--- a/deploy/ansible/worker/include/stop_containers.yml
+++ b/deploy/ansible/worker/include/stop_containers.yml
@@ -9,6 +9,7 @@
         name: ursula
         state: stopped
         image: "{{ nucypher_image | default('nucypher/nucypher:latest') }}"
+      ignore_errors: yes
 
     - set_fact: restarting_geth=True
     - name: Stop Geth

--- a/newsfragments/2728.bugfix.rst
+++ b/newsfragments/2728.bugfix.rst
@@ -1,0 +1,1 @@
+Cloudworkers: ignore errors on stopping of ursula containers


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1

**What this does:**
When running various Ansible flows that involved stopping Ursulas, errors encountered during the stop command would cause full failure for that node even if there was no Ursula running.  It should just keep going.

