### PR TITLE
Bring your own key material

### DIFF
--- a/newsfragments/2742.feature.rst
+++ b/newsfragments/2742.feature.rst
@@ -1,0 +1,1 @@
+Allow importing of secret key material for power derivations.

--- a/nucypher/cli/commands/bob.py
+++ b/nucypher/cli/commands/bob.py
@@ -14,6 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 from base64 import b64decode
 from pathlib import Path
 
@@ -50,7 +52,8 @@ from nucypher.cli.options import (
     option_signer_uri,
     option_teacher_uri,
     option_lonely,
-    option_max_gas_price
+    option_max_gas_price,
+    option_key_material
 )
 from nucypher.cli.painting.help import paint_new_installation_help
 from nucypher.cli.painting.policies import paint_single_card
@@ -133,7 +136,7 @@ class BobConfigOptions:
                 handle_missing_configuration_file(character_config_class=BobConfiguration,
                                                   config_file=config_file)
 
-    def generate_config(self, emitter: StdoutEmitter, config_root: Path) -> BobConfiguration:
+    def generate_config(self, emitter: StdoutEmitter, config_root: Path, key_material: str) -> BobConfiguration:
 
         checksum_address = self.checksum_address
         if not checksum_address and not self.federated_only:
@@ -143,6 +146,7 @@ class BobConfigOptions:
 
         return BobConfiguration.generate(
             password=get_nucypher_password(emitter=emitter, confirm=True),
+            key_material=bytes.fromhex(key_material) if key_material else None,
             config_root=config_root,
             checksum_address=checksum_address,
             domain=self.domain,
@@ -227,12 +231,15 @@ def bob():
 @option_federated_only
 @option_config_root
 @group_general_config
-def init(general_config, config_options, config_root):
+@option_key_material
+def init(general_config, config_options, config_root, key_material):
     """Create a brand new persistent Bob."""
     emitter = setup_emitter(general_config)
     if not config_root:
         config_root = general_config.config_root
-    new_bob_config = config_options.generate_config(emitter, config_root)
+    new_bob_config = config_options.generate_config(emitter=emitter,
+                                                    config_root=config_root,
+                                                    key_material=key_material)
     filepath = new_bob_config.to_configuration_file()
     paint_new_installation_help(emitter, new_configuration=new_bob_config, filepath=filepath)
 

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -161,7 +161,7 @@ class UrsulaConfigOptions:
                 # TODO: Exit codes (not only for this, but for other exceptions)
                 return click.get_current_context().exit(1)
 
-    def generate_config(self, emitter, config_root, force, secret_key):
+    def generate_config(self, emitter, config_root, force, key_material):
 
         if self.dev:
             raise RuntimeError('Persistent configurations cannot be created in development mode.')
@@ -180,7 +180,7 @@ class UrsulaConfigOptions:
             self.rest_host = collect_worker_ip_address(emitter, network=self.domain, force=force)
 
         return UrsulaConfiguration.generate(password=get_nucypher_password(emitter=emitter, confirm=True),
-                                            secret_key=bytes.fromhex(secret_key),
+                                            key_material=bytes.fromhex(key_material) if key_material else None,
                                             config_root=config_root,
                                             rest_host=self.rest_host,
                                             rest_port=self.rest_port,
@@ -296,8 +296,8 @@ def ursula():
 @option_force
 @option_config_root
 @group_general_config
-@click.option('--secret-key', help="An custom pre-secured secret hex blob to use for key derivations", type=click.STRING)
-def init(general_config, config_options, force, config_root, secret_key):
+@click.option('--key-material', help="An custom pre-secured secret hex blob to use for key derivations", type=click.STRING)
+def init(general_config, config_options, force, config_root, key_material):
     """Create a new Ursula node configuration."""
     emitter = setup_emitter(general_config, config_options.worker_address)
     _pre_launch_warnings(emitter, dev=None, force=force)
@@ -307,7 +307,7 @@ def init(general_config, config_options, force, config_root, secret_key):
         raise click.BadOptionUsage('--provider', message="--provider is required to initialize a new ursula.")
     if not config_options.federated_only and not config_options.domain:
         config_options.domain = select_network(emitter)
-    ursula_config = config_options.generate_config(emitter, config_root, force, secret_key)
+    ursula_config = config_options.generate_config(emitter, config_root, force, key_material)
     filepath = ursula_config.to_configuration_file()
     paint_new_installation_help(emitter, new_configuration=ursula_config, filepath=filepath)
 

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -53,7 +53,8 @@ from nucypher.cli.options import (
     option_signer_uri,
     option_teacher_uri,
     option_lonely,
-    option_max_gas_price
+    option_max_gas_price,
+    option_key_material
 )
 from nucypher.cli.painting.help import paint_new_installation_help
 from nucypher.cli.types import EIP55_CHECKSUM_ADDRESS, NETWORK_PORT, WORKER_IP
@@ -296,7 +297,7 @@ def ursula():
 @option_force
 @option_config_root
 @group_general_config
-@click.option('--key-material', help="An custom pre-secured secret hex blob to use for key derivations", type=click.STRING)
+@option_key_material
 def init(general_config, config_options, force, config_root, key_material):
     """Create a new Ursula node configuration."""
     emitter = setup_emitter(general_config, config_options.worker_address)
@@ -307,7 +308,10 @@ def init(general_config, config_options, force, config_root, key_material):
         raise click.BadOptionUsage('--provider', message="--provider is required to initialize a new ursula.")
     if not config_options.federated_only and not config_options.domain:
         config_options.domain = select_network(emitter)
-    ursula_config = config_options.generate_config(emitter, config_root, force, key_material)
+    ursula_config = config_options.generate_config(emitter=emitter,
+                                                   config_root=config_root,
+                                                   force=force,
+                                                   key_material=key_material)
     filepath = ursula_config.to_configuration_file()
     paint_new_installation_help(emitter, new_configuration=ursula_config, filepath=filepath)
 

--- a/nucypher/cli/options.py
+++ b/nucypher/cli/options.py
@@ -49,6 +49,7 @@ option_federated_only = click.option('--federated-only/--decentralized', '-F', h
 option_force = click.option('--force', help="Don't ask for confirmation", is_flag=True)
 option_gas_price = click.option('--gas-price', help="Set a static gas price (in GWEI)", type=GWEI)
 option_gas_strategy = click.option('--gas-strategy', help="Operate with a specified gas price strategy", type=click.STRING)  # TODO: GAS_STRATEGY_CHOICES
+option_key_material = click.option('--key-material', help="An custom pre-secured secret hex blob to use for key derivations", type=click.STRING)
 option_max_gas_price = click.option('--max-gas-price', help="Maximum acceptable gas price (in GWEI)", type=GWEI)
 option_hw_wallet = click.option('--hw-wallet/--no-hw-wallet')
 option_light = click.option('--light', help="Indicate that node is light", is_flag=True, default=None)

--- a/nucypher/cli/options.py
+++ b/nucypher/cli/options.py
@@ -49,7 +49,7 @@ option_federated_only = click.option('--federated-only/--decentralized', '-F', h
 option_force = click.option('--force', help="Don't ask for confirmation", is_flag=True)
 option_gas_price = click.option('--gas-price', help="Set a static gas price (in GWEI)", type=GWEI)
 option_gas_strategy = click.option('--gas-strategy', help="Operate with a specified gas price strategy", type=click.STRING)  # TODO: GAS_STRATEGY_CHOICES
-option_key_material = click.option('--key-material', help="An custom pre-secured secret hex blob to use for key derivations", type=click.STRING)
+option_key_material = click.option('--key-material', help="A pre-secured hex-encoded secret to use for private key derivations", type=click.STRING)
 option_max_gas_price = click.option('--max-gas-price', help="Maximum acceptable gas price (in GWEI)", type=GWEI)
 option_hw_wallet = click.option('--hw-wallet/--no-hw-wallet')
 option_light = click.option('--light', help="Indicate that node is light", is_flag=True, default=None)

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -579,10 +579,10 @@ class CharacterConfiguration(BaseConfiguration):
         return super().update(filepath=self.config_file_location, **kwargs)
 
     @classmethod
-    def generate(cls, password: str, secret_key: bytes, *args, **kwargs):
+    def generate(cls, password: str, key_material: Optional[bytes] = None, *args, **kwargs):
         """Shortcut: Hook-up a new initial installation and configuration."""
         node_config = cls(dev_mode=False, *args, **kwargs)
-        node_config.initialize(secret_key=secret_key, password=password)
+        node_config.initialize(key_material=key_material, password=password)
         return node_config
 
     def cleanup(self) -> None:
@@ -769,7 +769,7 @@ class CharacterConfiguration(BaseConfiguration):
                 power_ups.append(power_up)
         return power_ups
 
-    def initialize(self, password: str, secret_key: Optional[bytes] = None) -> Path:
+    def initialize(self, password: str, key_material: Optional[bytes] = None) -> str:
         """Initialize a new configuration and write installation files to disk."""
 
         # Development
@@ -780,7 +780,9 @@ class CharacterConfiguration(BaseConfiguration):
         # Persistent
         else:
             self._ensure_config_root_exists()
-            self.write_keystore(secret_key=secret_key, password=password, interactive=self.MNEMONIC_KEYSTORE)
+            self.write_keystore(key_material=key_material,
+                                password=password,
+                                interactive=self.MNEMONIC_KEYSTORE)
 
         self._cache_runtime_filepaths()
         self.node_storage.initialize()
@@ -792,11 +794,11 @@ class CharacterConfiguration(BaseConfiguration):
         # Success
         message = "Created nucypher installation files at {}".format(self.config_root)
         self.log.debug(message)
-        return self.config_root
+        return Path(self.config_root)
 
-    def write_keystore(self, password: str, secret_key: Optional[bytes] = None, interactive: bool = True) -> Keystore:
-        if secret_key:
-            self.__keystore = Keystore.import_secure(secret=secret_key,
+    def write_keystore(self, password: str, key_material: Optional[bytes] = None, interactive: bool = True) -> Keystore:
+        if key_material:
+            self.__keystore = Keystore.import_secure(key_material=key_material,
                                                      password=password,
                                                      keystore_dir=self.keystore_dir)
         else:

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -321,6 +321,17 @@ class Keystore:
         return instance
 
     @classmethod
+    def import_secure(cls, secret: bytes, password: str, keystore_dir: Optional[Path] = None) -> 'Keystore':
+        """
+        Generate a Keystore using a a custom pre-secured entropy blob.
+        This method of keystore creation does not generate a mnemonic phrase - it is assumed
+        that the provided blob is recoverable and secure.
+        """
+        path = Keystore.__save(secret=secret, password=password, keystore_dir=keystore_dir)
+        keystore = cls(keystore_path=path)
+        return keystore
+
+    @classmethod
     def restore(cls, words: str, password: str, keystore_dir: Optional[Path] = None) -> 'Keystore':
         """Restore a keystore from seed words"""
         __mnemonic = Mnemonic(_MNEMONIC_LANGUAGE)

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -330,6 +330,8 @@ class Keystore:
         emitter = StdoutEmitter()
         emitter.message(f'WARNING: Key importing assumes that you have already secured your secret '
                         f'and can recover it. No mnemonic will be generated.\n', color='yellow')
+        if len(key_material) != SecretKey.serialized_size():
+            raise ValueError(f'Entropy bytes bust be exactly {SecretKey.serialized_size()}.')
         path = Keystore.__save(secret=key_material, password=password, keystore_dir=keystore_dir)
         keystore = cls(keystore_path=path)
         return keystore

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -327,6 +327,9 @@ class Keystore:
         This method of keystore creation does not generate a mnemonic phrase - it is assumed
         that the provided blob is recoverable and secure.
         """
+        emitter = StdoutEmitter()
+        emitter.message(f'WARNING: Key importing assumes that you have already secured your secret '
+                        f'and can recover it. No mnemonic will be generated.\n', color='yellow')
         path = Keystore.__save(secret=key_material, password=password, keystore_dir=keystore_dir)
         keystore = cls(keystore_path=path)
         return keystore

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -321,13 +321,13 @@ class Keystore:
         return instance
 
     @classmethod
-    def import_secure(cls, secret: bytes, password: str, keystore_dir: Optional[Path] = None) -> 'Keystore':
+    def import_secure(cls, key_material: bytes, password: str, keystore_dir: Optional[Path] = None) -> 'Keystore':
         """
         Generate a Keystore using a a custom pre-secured entropy blob.
         This method of keystore creation does not generate a mnemonic phrase - it is assumed
         that the provided blob is recoverable and secure.
         """
-        path = Keystore.__save(secret=secret, password=password, keystore_dir=keystore_dir)
+        path = Keystore.__save(secret=key_material, password=password, keystore_dir=keystore_dir)
         keystore = cls(keystore_path=path)
         return keystore
 

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -246,13 +246,13 @@ def test_import_custom_keystore(tmpdir):
     # Too short - 32 bytes is required
     custom_secret = b'tooshort'
     with pytest.raises(ValueError, match="Entropy must be at least 32 bytes."):
-        _keystore = Keystore.import_secure(secret=custom_secret,
+        _keystore = Keystore.import_secure(key_material=custom_secret,
                                            password=INSECURE_DEVELOPMENT_PASSWORD,
                                            keystore_dir=tmpdir)
 
     # Import private key
     custom_secret = os.urandom(32)  # not secure but works
-    keystore = Keystore.import_secure(secret=custom_secret,
+    keystore = Keystore.import_secure(key_material=custom_secret,
                                       password=INSECURE_DEVELOPMENT_PASSWORD,
                                       keystore_dir=tmpdir)
     keystore.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -41,6 +41,7 @@ from nucypher.crypto.keystore import (
     _read_keystore
 )
 from nucypher.crypto.powers import DecryptingPower, SigningPower, DelegatingPower
+from nucypher.crypto.umbral_adapter import SecretKey
 from nucypher.crypto.umbral_adapter import (
     secret_key_factory_from_seed,
     secret_key_factory_from_secret_key_factory
@@ -245,13 +246,20 @@ def test_import_custom_keystore(tmpdir):
 
     # Too short - 32 bytes is required
     custom_secret = b'tooshort'
-    with pytest.raises(ValueError, match="Entropy must be at least 32 bytes."):
+    with pytest.raises(ValueError, match=f'Entropy bytes bust be exactly {SecretKey.serialized_size()}.'):
+        _keystore = Keystore.import_secure(key_material=custom_secret,
+                                           password=INSECURE_DEVELOPMENT_PASSWORD,
+                                           keystore_dir=tmpdir)
+
+    # Too short - 32 bytes is required
+    custom_secret = b'thisisabunchofbytesthatisabittoolong'
+    with pytest.raises(ValueError, match=f'Entropy bytes bust be exactly {SecretKey.serialized_size()}.'):
         _keystore = Keystore.import_secure(key_material=custom_secret,
                                            password=INSECURE_DEVELOPMENT_PASSWORD,
                                            keystore_dir=tmpdir)
 
     # Import private key
-    custom_secret = os.urandom(32)  # not secure but works
+    custom_secret = os.urandom(SecretKey.serialized_size())  # insecure but works
     keystore = Keystore.import_secure(key_material=custom_secret,
                                       password=INSECURE_DEVELOPMENT_PASSWORD,
                                       keystore_dir=tmpdir)


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
2

**What this does:**
- Introduces `Keystore.import_secure` method for user-supplied entropy blobs for usage as keystore secrets.
- Introduces `nucypher ursula|alice|bob init --key-material xxx` to accept a user-supplied hex entropy blob to import.

**Issues fixed/closed:**
- Fixes #2655 

**Why it's needed:**
- Allow additional flexibility and portability of keystores.

**Notes for reviewers**
- Is supporting the import of the secret key material enough portability for browser wallet interoperability or do we also need to support importing keys for individual powers?
