### PR TITLE
More informative `WorkerPool` errors

### DIFF
--- a/newsfragments/2744.misc.rst
+++ b/newsfragments/2744.misc.rst
@@ -1,0 +1,1 @@
+Added a more informative error message for ``WorkerPool`` exceptions.


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 1

**What this does:**
Before if there were some worker errors, and the required number of successes was not reached, the resulting `WorkerPool` error didn't give any context:
```
...
        elif result == PRODUCER_STOPPED:
>           raise self.OutOfValues()
E           nucypher.utilities.concurrency.WorkerPool.OutOfValues
```

With this PR it is more informative:
```
...
        elif result == PRODUCER_STOPPED:
>           raise self.OutOfValues(format_failures(self.get_failures()))
E           nucypher.utilities.concurrency.WorkerPool.OutOfValues: 7 total failures recorded;
E           for example, for the value (Ursula)⇀DarkMagenta Yankee DarkSeaGreen Mike↽ (0x5A83529ff76Ac5723A87008c4D9B436AD4CA7d28):
E             File "/Users/bogdan/wb/github/nucypher/nucypher/utilities/concurrency.py", line 260, in _worker_wrapper
E               result = self._worker(value)
E             File "/Users/bogdan/wb/github/nucypher/nucypher/policy/policies.py", line 108, in put_treasure_map_on_node
E               raise Exception(message)
E           
E           Putting treasure map on (Ursula)⇀DarkMagenta Yankee DarkSeaGreen Mike↽ (0x5A83529ff76Ac5723A87008c4D9B436AD4CA7d28) failed with response status: 402 PAYMENT REQUIRED
```
