### PR TITLE
Make `NodeSprout.stamp` be of type `SignatureStamp` and not `bytes`

### DIFF
--- a/newsfragments/2748.bugfix.rst
+++ b/newsfragments/2748.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a problem with node metadata being stored to a file with an incorrect name

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -62,6 +62,7 @@ from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.kits import UmbralMessageKit
 from nucypher.crypto.powers import DecryptingPower, NoSigningPower, SigningPower
 from nucypher.crypto.splitters import signature_splitter
+from nucypher.crypto.signing import SignatureStamp
 from nucypher.crypto.umbral_adapter import Signature
 from nucypher.crypto.utils import recover_address_eip_191, verify_eip_191
 from nucypher.network import LEARNING_LOOP_VERSION
@@ -123,8 +124,8 @@ class NodeSprout(PartiallyKwargifiedBytes):
         return version + b
 
     @property
-    def stamp(self) -> bytes:
-        return self.processed_objects['verifying_key'][0]
+    def stamp(self) -> SignatureStamp:
+        return SignatureStamp(self.verifying_key)
 
     @property
     def domain(self) -> str:


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 2

**What this does:**
Makes the `stamp` attribute of `NodeSprout` a typed `SignatureStamp` instead of plain bytes. This eliminates the bugs like https://app.circleci.com/pipelines/github/nucypher/nucypher/8166/workflows/09c311e0-3772-47e1-984e-25efdb1e1d52/jobs/138296 where node metadata is created with a repr-of-bytestring name, because `__generate_metadata_filepath()` wasn't applying `hex()` if it just got the stamp as bytes. 

We could just add a check in `__generate_metadata_filepath()` instead, but it is better to make that attribute typed to avoid future similar problems.
