### PR TITLE
Ensure that gas price used for transactions is an int

### DIFF
--- a/newsfragments/2753.bugfix.rst
+++ b/newsfragments/2753.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed failing transactions when gas price used is not an integer.

--- a/nucypher/utilities/gas_strategies.py
+++ b/nucypher/utilities/gas_strategies.py
@@ -79,7 +79,7 @@ def construct_datafeed_median_strategy(speed: Optional[str] = None) -> Callable:
 
         if prices:
             median_price = statistics.median(prices)
-            return median_price
+            return int(median_price)  # must return an int
         else:  # Worst-case scenario, we get the price from the ETH node itself
             return rpc_gas_price_strategy(web3, transaction_params)
     return datafeed_median_gas_price_strategy


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
Problem observed where transactions are failing because of an invalid "gasPrice" field:

```
TypeError: Transaction had invalid fields: {'gasPrice': 19316500000.0}
```

The value provided was not an int hence the failure. By default, when determining the gas price, 3 different data feeds are used and the median value is used. The median value of 3 values is one of the values which is an int. However, if one of the feeds goes down (which occurred in this case), then two values remain and the median of 2 values is the average, and yields a non-integer value thereby causing the problem.

The issue was relatively short-lived as the relevant data feed came back online, however, we should protect against this happening again.