### PR TITLE
Increment cache version to force rebuild of dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,7 @@ commands:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - save_cache:
-          key: pip-v6-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pip-v7-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "~/.local/bin"
             - "~/.local/lib/python3.7/site-packages"
@@ -434,7 +434,7 @@ commands:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: pip-v6-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pip-v7-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - restore_cache:
           key: solc-v2-{{ checksum "nucypher/blockchain/eth/sol/__conf__.py" }}
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

@KPrasch testing out this quick fix.

Fix dependency issues randomly observed on CircleCI regarding `appdirs` library. 

 https://app.circleci.com/pipelines/github/nucypher/nucypher/8193/workflows/15b6c3b6-bf70-40e2-ae77-18a2d02796e1/jobs/138713
```
ImportError while loading conftest '/home/circleci/nucypher/tests/conftest.py'.
tests/conftest.py:24: in <module>
    from nucypher.characters.control.emitters import WebEmitter
nucypher/characters/control/emitters.py:27: in <module>
    from nucypher.utilities.logging import Logger
nucypher/utilities/logging.py:33: in <module>
    from nucypher.config.constants import (
nucypher/config/constants.py:23: in <module>
    from appdirs import AppDirs
E   ModuleNotFoundError: No module named 'appdirs'
```
