### PR TITLE
Don't put bytes directly into log - instead write as hex

### DIFF
--- a/newsfragments/2762.bugfix.rst
+++ b/newsfragments/2762.bugfix.rst
@@ -1,0 +1,1 @@
+Stop writing bytes to log file which causes exceptions - instead write the hex representation.

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -822,7 +822,7 @@ class Learner:
             # TODO: Bucket separately and report.
             unresponsive_nodes.add(current_teacher)  # This does nothing.
             self.known_nodes.mark_as(current_teacher.InvalidNode, current_teacher)
-            self.log.warn(f"Teacher {str(current_teacher)} is invalid: {bytes(current_teacher)}:{e}.")
+            self.log.warn(f"Teacher {str(current_teacher)} is invalid (hex={bytes(current_teacher).hex()}):{e}.")
             self.suspicious_activities_witnessed['vladimirs'].append(current_teacher)
             return
         except RuntimeError as e:
@@ -832,11 +832,13 @@ class Learner:
                 return RELAX
             else:
                 self.log.warn(
-                    f"Unhandled error while learning from {str(current_teacher)}: {bytes(current_teacher)}:{e}.")
+                    f"Unhandled error while learning from {str(current_teacher)} "
+                    f"(hex={bytes(current_teacher).hex()}):{e}.")
                 raise
         except Exception as e:
             self.log.warn(
-                f"Unhandled error while learning from {str(current_teacher)}: {bytes(current_teacher)}:{e}.")  # To track down 2345 / 1698
+                f"Unhandled error while learning from {str(current_teacher)} "
+                f"(hex={bytes(current_teacher).hex()}):{e}.")  # To track down 2345 / 1698
             raise
         finally:
             # Is cycling happening in the right order?


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Attempting to write bytes to the log file causes exceptions to be thrown. The exceptions don't seem to affect operation, but are unsightly. Related to #2412 


This is observed in the status monitor.

```
crawler_1   | Traceback (most recent call last):
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/monitor/crawler.py", line 292, in learn_from_teacher_node
crawler_1   |     new_nodes = super().learn_from_teacher_node(*args, **kwargs)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/nucypher/network/nodes.py", line 797, in learn_from_teacher_node
crawler_1   |     self.log.warn(f"Teacher {str(current_teacher)} is invalid: {bytes(current_teacher)}:{e}.")
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_logger.py", line 238, in warn
crawler_1   |     self.emit(LogLevel.warn, format, **kwargs)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_logger.py", line 144, in emit
crawler_1   |     self.observer(event)
crawler_1   | --- <exception caught here> ---
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_observer.py", line 131, in __call__
crawler_1   |     observer(event)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_file.py", line 50, in __call__
crawler_1   |     text = self.formatEvent(event)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_json.py", line 252, in <lambda>
crawler_1   |     lambda event: u"{0}{1}\n".format(recordSeparator, eventAsJSON(event))
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_json.py", line 203, in eventAsJSON
crawler_1   |     flattenEvent(event)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_flatten.py", line 87, in flattenEvent
crawler_1   |     aFormatter.parse(event["log_format"])
crawler_1   | builtins.ValueError: unexpected '{' in field name
```

```
crawler_1   | Traceback (most recent call last):
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/monitor/crawler.py", line 292, in learn_from_teacher_node
crawler_1   |     new_nodes = super().learn_from_teacher_node(*args, **kwargs)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/nucypher/network/nodes.py", line 797, in learn_from_teacher_node
crawler_1   |     self.log.warn(f"Teacher {str(current_teacher)} is invalid: {bytes(current_teacher)}:{e}.")
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_logger.py", line 238, in warn
crawler_1   |     self.emit(LogLevel.warn, format, **kwargs)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_logger.py", line 144, in emit
crawler_1   |     self.observer(event)
crawler_1   | --- <exception caught here> ---
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_observer.py", line 131, in __call__
crawler_1   |     observer(event)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_file.py", line 50, in __call__
crawler_1   |     text = self.formatEvent(event)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_json.py", line 252, in <lambda>
crawler_1   |     lambda event: u"{0}{1}\n".format(recordSeparator, eventAsJSON(event))
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_json.py", line 203, in eventAsJSON
crawler_1   |     flattenEvent(event)
crawler_1   |   File "/usr/local/lib/python3.7/site-packages/twisted/logger/_flatten.py", line 87, in flattenEvent
crawler_1   |     aFormatter.parse(event["log_format"])
crawler_1   | builtins.ValueError: Single '}' encountered in format string
```