### PR TITLE
Don't include stakers with expired stakes in the `missing_stakers` results for `StakingEscrowAgent.partition_stakers_by_activity()`

### DIFF
--- a/newsfragments/2764.bugfix.rst
+++ b/newsfragments/2764.bugfix.rst
@@ -1,0 +1,1 @@
+``StakingEscrow.partition_stakers_by_activity()`` no longer includes stakers with expired stakes in the ``missing_stakers`` value returned, thereby no longer overstating the number of inactive stakers.

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -301,6 +301,10 @@ class StakingEscrowAgent(EthereumContractAgent):
             elif last_committed_period == current_period:
                 pending_stakers.append(staker)
             else:
+                locked_stake = self.non_withdrawable_stake(staker_address=staker)
+                if locked_stake == 0:
+                    # don't include stakers with expired stakes
+                    continue
                 missing_stakers.append(staker)
 
         return active_stakers, pending_stakers, missing_stakers


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Ignores stakers with expired stakes.

**Issues fixed/closed:**
Fixes #2760 .

**Why it's needed:**
Including stakers with expired stakes causes an overstating of the number of inactive stakers on the network i.e. stakers who haven't committed to the current period.
