### PR TITLE
[WIP]Add proxy endpoints to Porter

### DIFF
--- a/nucypher/control/controllers.py
+++ b/nucypher/control/controllers.py
@@ -315,7 +315,7 @@ class WebController(InterfaceControlServer):
 
             request_data = control_request.data
             # handle bytes in request body
-            if request_headers.get('CONTENT-TYPE') == 'application/octet-stream':
+            if request_headers.get('CONTENT-TYPE') in ['application/octet-stream', 'application/x-www-form-urlencoded']:
                 request_body = {"data": bytes(request_data)}
             # handle JSON in request body
             else:

--- a/nucypher/utilities/porter/control/interfaces.py
+++ b/nucypher/utilities/porter/control/interfaces.py
@@ -17,10 +17,11 @@
 from typing import List, Optional
 
 from eth_typing import ChecksumAddress
-from nucypher.crypto.umbral_adapter import PublicKey
 
 from nucypher.characters.control.specifications.fields import TreasureMap
 from nucypher.control.interfaces import ControlInterface, attach_schema
+from nucypher.control.specifications.base import BaseSchema
+from nucypher.crypto.umbral_adapter import PublicKey
 from nucypher.utilities.porter.control.specifications import porter_schema
 
 
@@ -28,7 +29,8 @@ class PorterInterface(ControlInterface):
     def __init__(self, porter: 'Porter' = None, *args, **kwargs):
         super().__init__(implementer=porter, *args, **kwargs)
         # set federated/non-federated context for publish treasure map schema
-        PorterInterface.publish_treasure_map._schema.context[TreasureMap.IS_FEDERATED_CONTEXT_KEY] = porter.federated_only
+        PorterInterface.publish_treasure_map._schema.context[
+            TreasureMap.IS_FEDERATED_CONTEXT_KEY] = porter.federated_only
 
     #
     # Alice Endpoints
@@ -88,3 +90,14 @@ class PorterInterface(ControlInterface):
                                                              work_order_payload=work_order_payload)
         response_data = {'work_order_result': work_order_result}
         return response_data
+
+    #
+    # Ursula Endpoints
+    #
+    @attach_schema(BaseSchema)
+    def proxy_consider_arrangement(self, proxy_destination: str, data: bytes) -> dict:
+        return self.implementer.proxy_consider_arrangement(ursula_uri=proxy_destination, data=data)
+
+    @attach_schema(BaseSchema)
+    def proxy_kfrag(self, proxy_destination: str, data: bytes, kfrag_id: str) -> dict:
+        return self.implementer.proxy_kfrag(ursula_uri=proxy_destination, data=data, kfrag_id=kfrag_id)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
- Adds `/proxy/consider_arrangement` and `/proxy/kFrag/<kfrag_id>` endpoints for Porter
- Porter resends requests from `/proxy` endpoints to Ursula specified in `X-PROXY-DESTINATION` header
- Minor changes were introduced in the Porter controller in order to facilitate these changes, i.e. request header and URL parameter parsing

**Issues fixed/closed:**
 - Fixes #2763 

**Why it's needed:**
- This is a transient solution for enabling `nucypher-ts` to work in the browser

**Notes for reviewers:**
- Awaits testing with `nucypher-ts`
- `nucypher:porter` was set as a merging base for ease of reviewing
