### PR TITLE
force pull latest tagged image on external geth deployment

### DIFF
--- a/deploy/ansible/worker/include/run_external_geth.yml
+++ b/deploy/ansible/worker/include/run_external_geth.yml
@@ -10,6 +10,7 @@
         name: geth
         state: started
         restart: yes
+        pull: true
         image: ethereum/client-go:stable
         restart_policy: "unless-stopped"
         command: "{{geth_options}} --http --http.addr 0.0.0.0 --http.api eth,web3,net --nousb --syncmode fast --rpcvhosts=* --cache 2000"

--- a/newsfragments/2766.bugfix.rst
+++ b/newsfragments/2766.bugfix.rst
@@ -1,0 +1,1 @@
+force pull latest tagged image on external geth deployment


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix

**Required reviews:** 
- [X] 1


**What this does:**
Fixes ansible geth deployment to force pull stable image even if a version of it is downloaded already.

**Why it's needed:**
If the node already had an image tagged `stable` it was not pulling the latest.

