### PR TITLE
Versioning of bytes serializable protocol entities

### DIFF
--- a/newsfragments/2767.feature.rst
+++ b/newsfragments/2767.feature.rst
@@ -1,0 +1,1 @@
+Uniform versioning of bytes serializable protocol entities.

--- a/nucypher/network/retrieval.py
+++ b/nucypher/network/retrieval.py
@@ -43,6 +43,7 @@ from nucypher.network.nodes import Learner
 from nucypher.policy.hrac import HRAC, hrac_splitter
 from nucypher.policy.kits import MessageKit, RetrievalKit, RetrievalResult
 from nucypher.policy.maps import TreasureMap
+from nucypher.utilities.versioning import Versioned
 
 
 class RetrievalPlan:
@@ -138,15 +139,10 @@ class RetrievalWorkOrder:
         self.capsules = capsules
 
 
-class ReencryptionRequest:
+class ReencryptionRequest(Versioned):
     """
     A request for an Ursula to reencrypt for several capsules.
     """
-
-    _splitter = (hrac_splitter +
-                 key_splitter +
-                 key_splitter +
-                 BytestringSplitter((MessageKit, VariableLengthBytestring)))
 
     @classmethod
     def from_work_order(cls,
@@ -159,8 +155,7 @@ class ReencryptionRequest:
                    alice_verifying_key=alice_verifying_key,
                    bob_verifying_key=bob_verifying_key,
                    encrypted_kfrag=treasure_map.destinations[work_order.ursula_address],
-                   capsules=work_order.capsules,
-                   )
+                   capsules=work_order.capsules)
 
     def __init__(self,
                  hrac: HRAC,
@@ -175,20 +170,6 @@ class ReencryptionRequest:
         self.encrypted_kfrag = encrypted_kfrag
         self.capsules = capsules
 
-    def __bytes__(self):
-        return (bytes(self.hrac) +
-                bytes(self._alice_verifying_key) +
-                bytes(self._bob_verifying_key) +
-                VariableLengthBytestring(bytes(self.encrypted_kfrag)) +
-                b''.join(bytes(capsule) for capsule in self.capsules)
-                )
-
-    @classmethod
-    def from_bytes(cls, data: bytes):
-        hrac, alice_vk, bob_vk, ekfrag, remainder = cls._splitter(data, return_remainder=True)
-        capsules = capsule_splitter.repeat(remainder)
-        return cls(hrac, alice_vk, bob_vk, ekfrag, capsules)
-
     def alice(self) -> 'Alice':
         from nucypher.characters.lawful import Alice
         return Alice.from_public_keys(verifying_key=self._alice_verifying_key)
@@ -201,8 +182,39 @@ class ReencryptionRequest:
         from nucypher.characters.lawful import Alice
         return Alice.from_public_keys(verifying_key=self.encrypted_kfrag.sender_verifying_key)
 
+    def _payload(self) -> bytes:
+        return (bytes(self.hrac) +
+                bytes(self._alice_verifying_key) +
+                bytes(self._bob_verifying_key) +
+                VariableLengthBytestring(bytes(self.encrypted_kfrag)) +
+                b''.join(bytes(capsule) for capsule in self.capsules)
+                )
 
-class ReencryptionResponse:
+    @classmethod
+    def _brand(cls) -> bytes:
+        return b'RQ'
+
+    @classmethod
+    def _version(cls) -> int:
+        return 1
+
+    @classmethod
+    def _old_version_handlers(cls) -> Dict:
+        return {}
+
+    @classmethod
+    def _from_bytes_current(cls, data):
+        splitter = (hrac_splitter +
+                    key_splitter +
+                    key_splitter +
+                    BytestringSplitter((MessageKit, VariableLengthBytestring)))
+
+        hrac, alice_vk, bob_vk, ekfrag, remainder = splitter(data, return_remainder=True)
+        capsules = capsule_splitter.repeat(remainder)
+        return cls(hrac, alice_vk, bob_vk, ekfrag, capsules)
+
+
+class ReencryptionResponse(Versioned):
     """
     A response from Ursula with reencrypted capsule frags.
     """
@@ -226,20 +238,33 @@ class ReencryptionResponse:
         self.cfrags = cfrags
         self.signature = signature
 
+    def _payload(self) -> bytes:
+        """Returns the unversioned bytes serialized representation of this instance."""
+        return bytes(self.signature) + b''.join(bytes(cfrag) for cfrag in self.cfrags)
+
     @classmethod
-    def from_bytes(cls, data: bytes):
+    def _brand(cls) -> bytes:
+        return b'RR'
+
+    @classmethod
+    def _version(cls) -> int:
+        return 1
+
+    @classmethod
+    def _old_version_handlers(cls) -> Dict:
+        return {}
+
+    @classmethod
+    def _from_bytes_current(cls, data):
         signature, cfrags_bytes = signature_splitter(data, return_remainder=True)
 
         # We would never send a request with no capsules, so there should be cfrags.
         # The splitter would fail anyway, this just makes the error message more clear.
         if not cfrags_bytes:
-            raise ValueError("ReencryptionResponse contains no cfrags")
+            raise ValueError(f"{cls.__name__} contains no cfrags")
 
         cfrags = cfrag_splitter.repeat(cfrags_bytes)
         return cls(cfrags, signature)
-
-    def __bytes__(self):
-        return bytes(self.signature) + b''.join(bytes(cfrag) for cfrag in self.cfrags)
 
 
 class RetrievalClient:

--- a/nucypher/network/retrieval.py
+++ b/nucypher/network/retrieval.py
@@ -17,7 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 from collections import defaultdict
 import random
-from typing import Dict, Sequence, List
+from typing import Dict, Sequence, List, Tuple
 
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from eth_typing.evm import ChecksumAddress
@@ -195,8 +195,8 @@ class ReencryptionRequest(Versioned):
         return b'RQ'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:
@@ -247,8 +247,8 @@ class ReencryptionResponse(Versioned):
         return b'RR'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -40,7 +40,7 @@ from nucypher.network.protocols import InterfaceInfo
 from nucypher.network.retrieval import ReencryptionRequest, ReencryptionResponse
 from nucypher.policy.hrac import HRAC
 from nucypher.policy.kits import MessageKit
-from nucypher.policy.revocation import Revocation
+from nucypher.policy.revocation import RevocationOrder
 from nucypher.utilities.logging import Logger
 
 HERE = BASE_DIR = Path(__file__).parent
@@ -272,7 +272,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
 
     @rest_app.route('/revoke', methods=['POST'])
     def revoke():
-        revocation = Revocation.from_bytes(request.data)
+        revocation = RevocationOrder.from_bytes(request.data)
         # TODO: Implement offchain revocation.
         return Response(status=200)
 

--- a/nucypher/policy/kits.py
+++ b/nucypher/policy/kits.py
@@ -16,7 +16,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-from typing import Dict, Optional, Iterable, Set
+from typing import Dict, Optional, Iterable, Set, Tuple
 
 from bytestring_splitter import BytestringSplitter, VariableLengthBytestring
 from constant_sorrow.constants import (
@@ -125,8 +125,8 @@ class MessageKit(Versioned):
         return b'MK'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:
@@ -184,8 +184,8 @@ class RetrievalKit(Versioned):
         return b'RK'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:

--- a/nucypher/policy/maps.py
+++ b/nucypher/policy/maps.py
@@ -16,7 +16,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-from typing import Optional, Callable, Sequence, Dict
+from typing import Optional, Callable, Sequence, Dict, Tuple
 
 from bytestring_splitter import (
     BytestringSplitter,
@@ -108,8 +108,8 @@ class TreasureMap(Versioned):
         return b'TM'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:
@@ -208,8 +208,8 @@ class AuthorizedKeyFrag(Versioned):
         return b'KF'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:
@@ -333,8 +333,8 @@ class EncryptedTreasureMap(Versioned):
         return b'EM'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -44,8 +44,7 @@ from nucypher.utilities.versioning import Versioned
 class Arrangement(Versioned):
     """A contract between Alice and a single Ursula."""
 
-    def __init__(self, publisher_verifying_key: PublicKey, expiration: maya.MayaDT, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, publisher_verifying_key: PublicKey, expiration: maya.MayaDT):
         self.expiration = expiration
         self.publisher_verifying_key = publisher_verifying_key
 

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -62,8 +62,8 @@ class Arrangement(Versioned):
         return b'AR'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     def _payload(self) -> bytes:
         """Returns the unversioned bytes serialized representation of this instance."""

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -38,24 +38,19 @@ from nucypher.policy.reservoir import (
 from nucypher.policy.revocation import RevocationKit
 from nucypher.utilities.concurrency import WorkerPool
 from nucypher.utilities.logging import Logger
+from nucypher.utilities.versioning import Versioned
 
 
-class Arrangement:
-    """
-    A contract between Alice and a single Ursula.
-    """
+class Arrangement(Versioned):
+    """A contract between Alice and a single Ursula."""
 
-    splitter = BytestringSplitter(
-        key_splitter,                      # publisher_verifying_key
-        (bytes, VariableLengthBytestring)  # expiration
-    )
-
-    def __init__(self, publisher_verifying_key: PublicKey, expiration: maya.MayaDT):
+    def __init__(self, publisher_verifying_key: PublicKey, expiration: maya.MayaDT, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.expiration = expiration
         self.publisher_verifying_key = publisher_verifying_key
 
-    def __bytes__(self):
-        return bytes(self.publisher_verifying_key) + bytes(VariableLengthBytestring(self.expiration.iso8601().encode()))
+    def __repr__(self):
+        return f"Arrangement(publisher={self.publisher_verifying_key})"
 
     @classmethod
     def from_publisher(cls, publisher: 'Alice', expiration: maya.MayaDT) -> 'Arrangement':
@@ -63,13 +58,30 @@ class Arrangement:
         return cls(publisher_verifying_key=publisher_verifying_key, expiration=expiration)
 
     @classmethod
-    def from_bytes(cls, arrangement_as_bytes: bytes) -> 'Arrangement':
-        publisher_verifying_key, expiration_bytes = cls.splitter(arrangement_as_bytes)
+    def _brand(cls) -> bytes:
+        return b'AR'
+
+    @classmethod
+    def _version(cls) -> int:
+        return 1
+
+    def _payload(self) -> bytes:
+        """Returns the unversioned bytes serialized representation of this instance."""
+        return bytes(self.publisher_verifying_key) + bytes(VariableLengthBytestring(self.expiration.iso8601().encode()))
+
+    @classmethod
+    def _old_version_handlers(cls) -> Dict:
+        return {}
+
+    @classmethod
+    def _from_bytes_current(cls, data: bytes):
+        splitter = BytestringSplitter(
+            key_splitter,  # publisher_verifying_key
+            (bytes, VariableLengthBytestring)  # expiration
+        )
+        publisher_verifying_key, expiration_bytes = splitter(data)
         expiration = maya.MayaDT.from_iso8601(iso8601_string=expiration_bytes.decode())
         return cls(publisher_verifying_key=publisher_verifying_key, expiration=expiration)
-
-    def __repr__(self):
-        return f"Arrangement(publisher={self.publisher_verifying_key})"
 
 
 class Policy(ABC):

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -95,7 +95,7 @@ class Revocation(Versioned):
 
         splitter = BytestringSplitter(
             checksum_address_splitter,  # ursula canonical address
-            (bytes, AuthorizedKeyFrag.SERIALIZED_SIZE),  # encrypted kfrag payload (includes writ)
+            (bytes, Versioned._HEADER_SIZE+AuthorizedKeyFrag.SERIALIZED_SIZE),  # MessageKit version header + versioned ekfrag
             signature_splitter
         )
         ursula_canonical_address, ekfrag, signature = splitter(data)

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -30,7 +30,7 @@ from nucypher.policy.maps import AuthorizedKeyFrag
 from nucypher.utilities.versioning import Versioned
 
 
-class Revocation(Versioned):
+class RevocationOrder(Versioned):
     """
     Represents a string used by characters to perform a revocation on a specific
     Ursula. It's a bytestring made of the following format:
@@ -110,9 +110,9 @@ class RevocationKit:
     def __init__(self, treasure_map, signer: SignatureStamp):
         self.revocations = dict()
         for node_id, encrypted_kfrag in treasure_map:
-            self.revocations[node_id] = Revocation(ursula_checksum_address=node_id,
-                                                   encrypted_kfrag=encrypted_kfrag,
-                                                   signer=signer)
+            self.revocations[node_id] = RevocationOrder(ursula_checksum_address=node_id,
+                                                        encrypted_kfrag=encrypted_kfrag,
+                                                        signer=signer)
 
     def __iter__(self):
         return iter(self.revocations.values())

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -16,7 +16,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-from typing import Optional, Dict
+from typing import Optional, Dict, Tuple
 
 from bytestring_splitter import BytestringSplitter
 from eth_typing.evm import ChecksumAddress
@@ -77,8 +77,8 @@ class RevocationOrder(Versioned):
         return b'RV'
 
     @classmethod
-    def _version(cls) -> int:
-        return 1
+    def _version(cls) -> Tuple[int, int]:
+        return 1, 0
 
     @classmethod
     def _old_version_handlers(cls) -> Dict:

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -16,7 +16,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
-from typing import Optional
+from typing import Optional, Dict
 
 from bytestring_splitter import BytestringSplitter
 from eth_typing.evm import ChecksumAddress
@@ -27,9 +27,10 @@ from nucypher.crypto.splitters import signature_splitter, checksum_address_split
 from nucypher.crypto.umbral_adapter import Signature, PublicKey
 from nucypher.policy.kits import MessageKit
 from nucypher.policy.maps import AuthorizedKeyFrag
+from nucypher.utilities.versioning import Versioned
 
 
-class Revocation:
+class Revocation(Versioned):
     """
     Represents a string used by characters to perform a revocation on a specific
     Ursula. It's a bytestring made of the following format:
@@ -37,16 +38,9 @@ class Revocation:
     This is sent as a payload in a DELETE method to the /KFrag/ endpoint.
     """
 
-    PREFIX = b'REVOKE-'
-    revocation_splitter = BytestringSplitter(
-        (bytes, len(PREFIX)),
-        checksum_address_splitter, # ursula canonical address
-        (bytes, AuthorizedKeyFrag.ENCRYPTED_SIZE),  # encrypted kfrag payload (includes writ)
-        signature_splitter
-    )
-
     def __init__(self,
-                 ursula_checksum_address: ChecksumAddress,  # TODO: Use staker address instead (what if the staker rebonds)?
+                 ursula_checksum_address: ChecksumAddress,
+                 # TODO: Use staker address instead (what if the staker rebonds)?
                  encrypted_kfrag: MessageKit,
                  signer: Optional[SignatureStamp] = None,
                  signature: Optional[Signature] = None):
@@ -57,12 +51,9 @@ class Revocation:
         if not (bool(signer) ^ bool(signature)):
             raise ValueError("Either pass a signer or a signature; not both.")
         elif signer:
-            self.signature = signer(self.payload)
+            self.signature = signer(self._body())
         elif signature:
             self.signature = signature
-
-    def __bytes__(self):
-        return self.payload + bytes(self.signature)
 
     def __repr__(self):
         return bytes(self)
@@ -73,27 +64,45 @@ class Revocation:
     def __eq__(self, other):
         return bytes(self) == bytes(other)
 
-    @property
-    def payload(self):
-        return self.PREFIX                                          \
-               + to_canonical_address(self.ursula_checksum_address) \
-               + bytes(self.encrypted_kfrag)                        \
-
-    @classmethod
-    def from_bytes(cls, revocation_bytes):
-        prefix, ursula_canonical_address, ekfrag, signature = cls.revocation_splitter(revocation_bytes)
-        ursula_checksum_address = to_checksum_address(ursula_canonical_address)
-        return cls(ursula_checksum_address=ursula_checksum_address,
-                   encrypted_kfrag=ekfrag,
-                   signature=signature)
-
     def verify_signature(self, alice_verifying_key: PublicKey) -> bool:
         """
         Verifies the revocation was from the provided pubkey.
         """
-        if not self.signature.verify(self.payload, alice_verifying_key):
+        if not self.signature.verify(self._body(), alice_verifying_key):
             raise InvalidSignature(f"Revocation has an invalid signature: {self.signature}")
         return True
+
+    @classmethod
+    def _brand(cls) -> bytes:
+        return b'RV'
+
+    @classmethod
+    def _version(cls) -> int:
+        return 1
+
+    @classmethod
+    def _old_version_handlers(cls) -> Dict:
+        return {}
+
+    def _body(self) -> bytes:
+        return to_canonical_address(self.ursula_checksum_address) + bytes(self.encrypted_kfrag)
+
+    def _payload(self) -> bytes:
+        return self._body() + bytes(self.signature)
+
+    @classmethod
+    def _from_bytes_current(cls, data):
+
+        splitter = BytestringSplitter(
+            checksum_address_splitter,  # ursula canonical address
+            (bytes, AuthorizedKeyFrag.SERIALIZED_SIZE),  # encrypted kfrag payload (includes writ)
+            signature_splitter
+        )
+        ursula_canonical_address, ekfrag, signature = splitter(data)
+        ursula_checksum_address = to_checksum_address(ursula_canonical_address)
+        return cls(ursula_checksum_address=ursula_checksum_address,
+                   encrypted_kfrag=ekfrag,
+                   signature=signature)
 
 
 class RevocationKit:

--- a/nucypher/utilities/versioning.py
+++ b/nucypher/utilities/versioning.py
@@ -15,6 +15,7 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 from abc import abstractmethod, ABC
 from typing import Dict
 

--- a/nucypher/utilities/versioning.py
+++ b/nucypher/utilities/versioning.py
@@ -17,7 +17,7 @@
 
 
 from abc import abstractmethod, ABC
-from typing import Dict, Tuple, Callable, NamedTuple
+from typing import Dict, Tuple, Callable
 
 
 class Versioned(ABC):
@@ -95,12 +95,12 @@ class Versioned(ABC):
     def from_bytes(cls, data: bytes):
         """"Public deserialization API"""
         brand, version, payload = cls._parse_header(data)
-        version = cls._get_compatible_handler(data=data, version=version)
+        version = cls._resolve_version(version=version)
         handlers = cls._deserializers()
         return handlers[version](payload)
 
     @classmethod
-    def _get_compatible_handler(cls, data: bytes, version: Tuple[int, int]) -> Tuple[int, int]:
+    def _resolve_version(cls, version: Tuple[int, int]) -> Tuple[int, int]:
 
         # Unpack version metadata
         bytrestring_major, bytrestring_minor = version

--- a/nucypher/utilities/versioning.py
+++ b/nucypher/utilities/versioning.py
@@ -33,19 +33,76 @@ class Versioned(ABC):
         encountered during deserialization.
         """
 
+    class Empty(ValueError):
+        """Raised when 0 bytes are remaining after parsing the header."""
+
+    @classmethod
+    @abstractmethod
+    def _brand(cls) -> bytes:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def _version(cls) -> int:
+        raise NotImplementedError
+
+    def __init_subclass__(cls, **kwargs):
+        if len(cls._brand()) != cls._BRAND_LENGTH:
+            raise cls.InvalidHeader("Brand must be exactly two bytes.")
+        if not cls._brand().isalpha():
+            raise cls.InvalidHeader("Brand must be alphanumeric.")
+        brands = tuple(v._brand() for v in Versioned.__subclasses__())
+        if len(brands) != len(set(brands)):
+            raise cls.InvalidHeader(f"Duplicated_brand {cls._brand()}.")
+
+    #
+    # Serialize
+    #
+
     def __bytes__(self) -> bytes:
         return self._header() + self._payload()
 
     @classmethod
+    def _header(cls) -> bytes:
+        """The entire bytes header to prepend to the instance payload."""
+        version_bytes = cls._version().to_bytes(cls._VERSION_LENGTH, 'big')
+        return cls._brand() + version_bytes
+
+    @abstractmethod
+    def _payload(self) -> bytes:
+        """The unbranded and unversioned bytes-serialized representation of this instance."""
+        raise NotImplementedError
+
+    #
+    # Deserialize
+    #
+
+    @classmethod
+    @abstractmethod
+    def _from_bytes_current(cls, data):
+        """The current deserializer"""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def _old_version_handlers(cls) -> Dict:
+        """Old deserializer callables keyed by version."""
+        raise NotImplementedError
+
+    @classmethod
     def from_bytes(cls, data: bytes):
+        """"Public deserialization API"""
         brand, version, payload = cls._parse(data)
         handlers = cls._deserializers()
         return handlers[version](payload)
 
     @classmethod
     def _parse(cls, data: bytes) -> Tuple[bytes, int, bytes]:
+        """Parse bytes in"""
         brand, version = cls._parse_brand(data), cls._parse_version(data)
         payload = data[cls._HEADER_SIZE:]
+        if len(payload) == 0:
+            raise cls.Empty('No content to deserialize.')
         return brand, version, payload
 
     @classmethod
@@ -75,36 +132,6 @@ class Versioned(ABC):
         """Return a dict of all known deserialization handlers for this class keyed by version"""
         return {cls._version(): cls._from_bytes_current, **cls._old_version_handlers()}
 
-    @classmethod
-    def _header(cls) -> bytes:
-        if len(cls._brand()) != cls._BRAND_LENGTH:
-            raise cls.InvalidHeader("Brand must be exactly two bytes.")
-        if not cls._brand().isalpha():
-            raise cls.InvalidHeader("Brand must be alphanumeric.")
-        version_bytes = cls._version().to_bytes(cls._VERSION_LENGTH, 'big')
-        return cls._brand() + version_bytes
 
-    @abstractmethod
-    def _payload(self) -> bytes:
-        """Returns the unversioned bytes serialized representation of this instance."""
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def _brand(cls) -> bytes:
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def _version(cls) -> int:
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def _old_version_handlers(cls) -> Dict:
-        raise NotImplementedError
-
-    @classmethod
-    @abstractmethod
-    def _from_bytes_current(cls, data):
-        raise NotImplementedError
+# Collects the brands of every serializable entity
+SERIALIZABLE_ENTITIES = {v.__class__.__name__: v._brand() for v in Versioned.__subclasses__()}

--- a/nucypher/utilities/versioning.py
+++ b/nucypher/utilities/versioning.py
@@ -1,0 +1,83 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from abc import abstractmethod, ABC
+from typing import Dict
+
+
+class Versioned(ABC):
+
+    _BRAND_LENGTH = 2  # bytes
+    _VERSION_LENGTH = 2
+    _HEADER_SIZE = _BRAND_LENGTH + _VERSION_LENGTH
+
+    @classmethod
+    def from_bytes(cls, data):
+
+        # Metadata
+        brand = data[:cls._BRAND_LENGTH]
+        version_index = cls._BRAND_LENGTH + cls._VERSION_LENGTH
+        version_data = data[cls._BRAND_LENGTH:version_index]
+        version_number = int.from_bytes(version_data, 'big')
+
+        # Data passed to deserializer
+        remainder = data[version_index:]
+
+        # Validate and Deserialize
+        if brand != cls._brand():
+            raise ValueError(f"Incorrect brand.  Expected {cls._brand()}, Got {brand}")
+        if version_number == cls._version():
+            return cls._from_bytes_current(remainder)
+
+        handlers = cls._old_version_handlers()
+        try:
+            return handlers[version_number](remainder)
+        except KeyError:
+            raise ValueError(f"Incorrect or unknown version number ({version_number}).")
+
+    def __bytes__(self):
+        return self._header() + self._payload()
+
+    @classmethod
+    def _header(cls) -> bytes:
+        version_bytes = cls._version().to_bytes(cls._VERSION_LENGTH, 'big')
+        return cls._brand() + version_bytes
+
+    @classmethod
+    @abstractmethod
+    def _brand(cls) -> bytes:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def _version(cls) -> int:
+        raise NotImplementedError
+
+    @abstractmethod
+    def _payload(self) -> bytes:
+        """Returns the unversioned bytes serialized representation of this instance."""
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def _old_version_handlers(cls) -> Dict:
+        raise NotImplementedError
+
+    @classmethod
+    @abstractmethod
+    def _from_bytes_current(cls, data):
+        raise NotImplementedError

--- a/nucypher/utilities/versioning.py
+++ b/nucypher/utilities/versioning.py
@@ -55,16 +55,17 @@ class Versioned(ABC):
         if version_number == cls._version():
             return cls._from_bytes_current(remainder)
         handlers = cls._old_version_handlers()
-        try:
-            return handlers[version_number](remainder)  # process
-        except KeyError:
-            raise ValueError(f"Incorrect or unknown version number ({version_number}).")
+        return handlers[version_number](remainder)  # process
 
     def __bytes__(self):
         return self._header() + self._payload()
 
     @classmethod
     def _header(cls) -> bytes:
+        if len(cls._brand()) != cls._BRAND_LENGTH:
+            raise cls.InvalidHeader("Brand must be exactly two bytes.")
+        if not cls._brand().isalpha():
+            raise cls.InvalidHeader("Brand must be alphanumeric.")
         version_bytes = cls._version().to_bytes(cls._VERSION_LENGTH, 'big')
         return cls._brand() + version_bytes
 

--- a/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
+++ b/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
@@ -149,7 +149,7 @@ def test_retrieve_cfrags(blockchain_porter,
     cleartext_with_sig_header = blockchain_bob._crypto_power.power_ups(DecryptingPower).keypair.decrypt(policy_message_kit)
     sig_header, remainder = default_constant_splitter(cleartext_with_sig_header, return_remainder=True)
     signature_from_kit, cleartext = signature_splitter(remainder, return_remainder=True)
-    assert signature_from_kit.verify(message=cleartext, verifying_key=policy_message_kit.sender_verifying_key)
+    assert signature_from_kit.verify(message=cleartext, verifying_pk=policy_message_kit.sender_verifying_key)
     assert cleartext == original_message
 
     #

--- a/tests/integration/characters/test_federated_grant_and_revoke.py
+++ b/tests/integration/characters/test_federated_grant_and_revoke.py
@@ -24,7 +24,7 @@ import pytest
 from nucypher.characters.lawful import Enrico
 from nucypher.crypto.utils import keccak_digest
 from nucypher.policy.kits import MessageKit
-from nucypher.policy.revocation import Revocation
+from nucypher.policy.revocation import RevocationOrder
 
 
 def test_federated_grant(federated_alice, federated_bob, federated_ursulas):
@@ -113,7 +113,7 @@ def test_revocation(federated_alice, federated_bob):
     # Test Revocation deserialization
     revocation = policy.revocation_kit[node_id]
     revocation_bytes = bytes(revocation)
-    deserialized_revocation = Revocation.from_bytes(revocation_bytes)
+    deserialized_revocation = RevocationOrder.from_bytes(revocation_bytes)
     assert deserialized_revocation == revocation
 
     # Attempt to revoke the new policy

--- a/tests/integration/characters/test_specifications.py
+++ b/tests/integration/characters/test_specifications.py
@@ -90,7 +90,7 @@ def test_treasure_map_validation(enacted_federated_policy,
     assert "Could not parse tmap" in str(e)
     assert "Invalid base64-encoded string" in str(e)
 
-    base64_header = base64.b64encode(EncryptedTreasureMapClass._header()).decode()[:-2]  # remove "==" delimiter
+    base64_header = base64.b64encode(EncryptedTreasureMapClass._header()).decode()
 
     # valid base64 but invalid treasuremap
     bad_map = base64_header + "VGhpcyBpcWgb3RhbGx5IG5vdCBhIHRyZWFzdXJlbWg=="
@@ -121,7 +121,7 @@ def test_treasure_map_validation(enacted_federated_policy,
     assert "Invalid base64-encoded string" in str(e)
 
     # valid base64 but invalid treasuremap
-    base64_header = base64.b64encode(TreasureMapClass._header()).decode()[:-2]  # remove "==" delimiter
+    base64_header = base64.b64encode(TreasureMapClass._header()).decode()
     bad_map = base64_header + "VGhpcyBpcyB0b3RhbGx5IG5vdCBhIHRyZWFzdXJlbWFwLg=="
     with pytest.raises(InvalidInputData) as e:
         UnenncryptedTreasureMapsOnly().load({'tmap': bad_map})
@@ -153,7 +153,7 @@ def test_messagekit_validation(capsule_side_channel):
     assert "Incorrect padding" in str(e)
 
     # valid base64 but invalid messagekit
-    b64header = base64.b64encode(MessageKit._header())[:-2].decode()
+    b64header = base64.b64encode(MessageKit._header()).decode()
     with pytest.raises(SpecificationError) as e:
         MessageKitsOnly().load({'mkit': b64header + "V3da=="})
 

--- a/tests/integration/characters/test_specifications.py
+++ b/tests/integration/characters/test_specifications.py
@@ -29,6 +29,7 @@ from nucypher.control.specifications.base import BaseSchema
 from nucypher.control.specifications.exceptions import SpecificationError, InvalidInputData, InvalidArgumentCombo
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.crypto.umbral_adapter import PublicKey
+from nucypher.policy.kits import MessageKit
 from nucypher.policy.kits import MessageKit as MessageKitClass
 from nucypher.policy.maps import EncryptedTreasureMap as EncryptedTreasureMapClass, TreasureMap as TreasureMapClass
 
@@ -152,8 +153,9 @@ def test_messagekit_validation(capsule_side_channel):
     assert "Incorrect padding" in str(e)
 
     # valid base64 but invalid treasuremap
+    b64header = base64.b64encode(MessageKit._header())[:-2].decode()
     with pytest.raises(SpecificationError) as e:
-        MessageKitsOnly().load({'mkit': "V3da"})
+        MessageKitsOnly().load({'mkit': b64header + "V3da=="})
 
     assert "Could not parse mkit" in str(e)
     assert "Not enough bytes to constitute message types" in str(e)

--- a/tests/integration/characters/test_specifications.py
+++ b/tests/integration/characters/test_specifications.py
@@ -152,7 +152,7 @@ def test_messagekit_validation(capsule_side_channel):
     assert "Could not parse mkit" in str(e)
     assert "Incorrect padding" in str(e)
 
-    # valid base64 but invalid treasuremap
+    # valid base64 but invalid messagekit
     b64header = base64.b64encode(MessageKit._header())[:-2].decode()
     with pytest.raises(SpecificationError) as e:
         MessageKitsOnly().load({'mkit': b64header + "V3da=="})

--- a/tests/integration/network/test_failure_modes.py
+++ b/tests/integration/network/test_failure_modes.py
@@ -16,16 +16,18 @@
 """
 
 import datetime
-import maya
 import os
+from functools import partial
+
+import maya
 import pytest
 import pytest_twisted
 import requests
 from bytestring_splitter import BytestringSplittingError
-from functools import partial
 from twisted.internet import threads
 
-from nucypher.policy.policies import Policy
+from nucypher.policy.policies import Policy, Arrangement
+from nucypher.utilities.versioning import Versioned
 from tests.utils.middleware import EvilMiddleWare, NodeIsDownMiddleware
 from tests.utils.ursula import make_federated_ursulas
 
@@ -109,8 +111,9 @@ def test_huge_treasure_maps_are_rejected(federated_alice, federated_ursulas):
 
     firstula = list(federated_ursulas)[0]
 
+    header = Arrangement._header()
     ok_amount = 10 * 1024  # 10k
-    ok_data = os.urandom(ok_amount)
+    ok_data = header + os.urandom(ok_amount)
 
     with pytest.raises(BytestringSplittingError):
         federated_alice.network_middleware.upload_arbitrary_data(
@@ -143,8 +146,10 @@ def test_hendrix_handles_content_length_validation(ursula_federated_test_config)
     node_deployer.catalogServers(node_deployer.hendrix)
     node_deployer.start()
 
+    header = Arrangement._header()
+
     def check_node_rejects_large_posts(node):
-        too_much_data = os.urandom(100 * 1024)
+        too_much_data = header + os.urandom(100 * 1024)
         response = requests.post(
             "https://{}/consider_arrangement".format(node.rest_url()),
             data=too_much_data, verify=False)
@@ -153,7 +158,8 @@ def test_hendrix_handles_content_length_validation(ursula_federated_test_config)
         return node
 
     def check_node_accepts_normal_posts(node):
-        a_normal_arrangement = os.urandom(49 * 1024)  # 49K, the limit is 50K
+        under_limit = (49 * 1024)-Versioned._HEADER_SIZE  # 49K, the limit is 50K
+        a_normal_arrangement = header + os.urandom(under_limit)
         response = requests.post(
             "https://{}/consider_arrangement".format(node.rest_url()),
             data=a_normal_arrangement, verify=False)

--- a/tests/integration/network/test_failure_modes.py
+++ b/tests/integration/network/test_failure_modes.py
@@ -15,6 +15,7 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 import datetime
 import os
 from functools import partial

--- a/tests/integration/porter/control/test_porter_web_control_federated.py
+++ b/tests/integration/porter/control/test_porter_web_control_federated.py
@@ -147,7 +147,7 @@ def test_retrieve_cfrags(federated_porter,
     cleartext_with_sig_header = federated_bob._crypto_power.power_ups(DecryptingPower).keypair.decrypt(policy_message_kit)
     sig_header, remainder = default_constant_splitter(cleartext_with_sig_header, return_remainder=True)
     signature_from_kit, cleartext = signature_splitter(remainder, return_remainder=True)
-    assert signature_from_kit.verify(message=cleartext, verifying_key=policy_message_kit.sender_verifying_key)
+    assert signature_from_kit.verify(message=cleartext, verifying_pk=policy_message_kit.sender_verifying_key)
     assert cleartext == original_message
 
     #

--- a/tests/unit/test_porter.py
+++ b/tests/unit/test_porter.py
@@ -14,6 +14,8 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 from base64 import b64encode
 
 import pytest

--- a/tests/unit/test_versioning.py
+++ b/tests/unit/test_versioning.py
@@ -159,6 +159,23 @@ def test_incompatible_version(mocker):
     assert not current_spy.call_count
 
 
+def test_resolve_version():
+    # past
+    v2_0 = 2, 0
+    resolved_version = A._resolve_version(version=v2_0)
+    assert resolved_version == v2_0
+
+    # present
+    v2_1 = 2, 1
+    resolved_version = A._resolve_version(version=v2_1)
+    assert resolved_version == v2_1
+
+    # future minor version resolves to the latest minor version.
+    v2_2 = 2, 2
+    resolved_version = A._resolve_version(version=v2_2)
+    assert resolved_version == v2_1
+
+
 def test_old_minor_version_handler_routing(mocker):
     current_spy = mocker.spy(A, "_from_bytes_current")
     v2_0_spy = mocker.spy(A, "_from_bytes_v2_0")

--- a/tests/unit/test_versioning.py
+++ b/tests/unit/test_versioning.py
@@ -15,6 +15,7 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 from nucypher.utilities.versioning import Versioned
 import pytest
 

--- a/tests/unit/test_versioning.py
+++ b/tests/unit/test_versioning.py
@@ -1,0 +1,77 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from nucypher.utilities.versioning import Versioned
+import pytest
+
+
+class A(Versioned):
+
+    def __init__(self, x):
+        self.x = x
+
+    @classmethod
+    def _brand(cls):
+        return b"AA"
+
+    @classmethod
+    def _version(cls):
+        return 2
+
+    def _payload(self) -> bytes:
+        return bytes(self.x)
+
+    @classmethod
+    def _old_version_handlers(cls):
+        return {1: cls._from_bytes_v1}
+
+    @classmethod
+    def _from_bytes_v1(cls, data):
+        return cls(int(data))  # we used to keep it in decimal representation
+
+    @classmethod
+    def _from_bytes_current(cls, data):
+        return cls(int(data, 16))  # but now we switched to the hexadecimal
+
+
+def test_versioning_header_prepend():
+    a = A(1)  # stake sauce
+    serialized = bytes(a)
+    header = serialized[:Versioned._HEADER_SIZE]
+    brand = header[:Versioned._BRAND_LENGTH]
+    assert brand == A._brand()
+    version = header[Versioned._BRAND_LENGTH:]
+    version_number = int.from_bytes(version, 'big')
+    assert version_number == A._version()
+
+
+def test_versioning_brand():
+    invalid = b'\x00\x03\x00\x0112'
+    with pytest.raises(Versioned.InvalidHeader, match="Incompatible bytes for A."):
+        A.from_bytes(invalid)
+    incorrect = b'AB\x00\x0112'
+    with pytest.raises(Versioned.InvalidHeader, match="Incorrect brand. Expected b'AA', Got b'AB'."):
+        A.from_bytes(incorrect)
+
+
+def test_versioning_handlers():
+    s1 = b'AA\x00\x0112'
+    s2 = b'AA\x00\x0212'
+    a1 = A.from_bytes(s1)
+    assert a1.x == 12
+    a2 = A.from_bytes(s2)
+    assert a2.x == 18


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
2

**What this does:**
The goal of this PR is to gently introduce a unified version and branding scheme for the following entities (alphabetical):

| Entity         | Prefix       | V | Header |
|----------------|--------------|----|-----------|
| `Arrangement` | `b'AR'` | 1.0 | ` b'AR\x00\x01\x00\x00'` |
| `AuthorizedFrag` | `b'KF'` | 1.0 | ` b'KF\x00\x01\x00\x00'` |
| `EncryptedTreasureMap` | `b'EM'` | 1.0 | ` b'EM\x00\x01\x00\x00'` |
| `MessageKit` | `b'MK'` | 1.0 | ` b'MK\x00\x01\x00\x00'` |
| `RetrievalKit` | `b'RK'` | 1.0 | ` b'RK\x00\x01\x00\x00'` |
| `ReencryptionRequest` | `b'RQ'` | 1.0 | ` b'RQ\x00\x01\x00\x00'` |
| `ReencryptionResponse` | `b'RR'` | 1.0 | ` b'RR\x00\x01\x00\x00'` |
| `RevocationOrder` | `b'RV'` | 1.0 | ` b'RV\x00\x01\x00\x00'` |
| `TreasureMap` | `b'TM'` | 1.0 | ` b'TM\x00\x01\x00\x00'` |


Related changes: 
- Introduces `Versioned` ABC (inspired by @fjarri 's original gist).
- Subclasses `Versioned` and implement abstract methods on bytes-serializable entities listed above.
- Prepends six-byte header to bytestrings (two-byte brand, two-byte major version, two-byte minor version).
- Enforces Invalid or incompatible version and branding at deserialization time.
- Renames `Revocation` -> `RevocationOrder`.
- Adjusts size constant `AuthorizedKeyFrag.ENCRYPTED_SIZE` to accommodate headers.

**Issues fixed/closed:**
#343 #281 

**Why it's needed:**
- Required for management of future release backwards compatibility
- Supports immediate backwards-incompatibility with "Treasure Map Con KFrags"

**Notes for reviewers:**
- Model of this strategy by @fjarri <https://gist.github.com/fjarri/bad73af26927e6fb3b1aa5f61f8863e3>
- Provide backwards compatibility for unversioned entities?
- `Ursula` subclasses `Versioned` too? This will cause an additional major backwards incompatibility in node discovery.