### PR TITLE
Porter - return meaningful error if there are not enough Ursulas

### DIFF
--- a/nucypher/policy/reservoir.py
+++ b/nucypher/policy/reservoir.py
@@ -14,7 +14,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-from typing import Iterable, Optional, List
+from typing import Iterable, List, Optional
 
 from eth_typing import ChecksumAddress
 
@@ -86,6 +86,8 @@ class MergedReservoir:
         else:
             return None
 
+    def __len__(self):
+        return len(self.values) + len(self.reservoir)
 
 class PrefetchStrategy:
     """

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -134,6 +134,10 @@ the Pipe for nucypher network operations
                     exclude_ursulas: Optional[Sequence[ChecksumAddress]] = None,
                     include_ursulas: Optional[Sequence[ChecksumAddress]] = None) -> List[UrsulaInfo]:
         reservoir = self._make_staker_reservoir(quantity, duration_periods, exclude_ursulas, include_ursulas)
+
+        if len(reservoir) < quantity:
+            raise ValueError(f"Requested quantity={quantity} Ursulas, but only {len(reservoir)} are available")
+
         value_factory = PrefetchStrategy(reservoir, quantity)
 
         def get_ursula_info(ursula_address) -> Porter.UrsulaInfo:


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- Currently, if there are not enough Ursulas in `reservoir`, Porter will return `0 total failures recorded` error from `concurrency.py`
- This PR checks for the number of Ursulas before contacting them; if the number of Ursulas is too low, it returns a meaningful error message to the user
- Found this to be useful while testing on Rinkeby

