### PR TITLE
Fix creation of filepath for output of events to csv file

### DIFF
--- a/newsfragments/2786.bugfix.rst
+++ b/newsfragments/2786.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug when generating file for output of events from status & stake cli commands.

--- a/nucypher/cli/commands/stake.py
+++ b/nucypher/cli/commands/stake.py
@@ -132,7 +132,7 @@ from nucypher.cli.types import (
 )
 from nucypher.cli.utils import retrieve_events, setup_emitter
 from nucypher.config.characters import StakeHolderConfiguration
-from nucypher.utilities.events import generate_events_csv_filename
+from nucypher.utilities.events import generate_events_csv_filepath
 from nucypher.utilities.gas_strategies import construct_fixed_price_gas_strategy
 
 option_csv = click.option('--csv',
@@ -1175,7 +1175,7 @@ def events(general_config, staker_options, config_file, event_name, from_block, 
     if csv or csv_output_file:
         if not csv_output_file:
             # use default file path if not specified
-            csv_output_file = generate_events_csv_filename(contract_name=contract_name, event_name=event_name)
+            csv_output_file = generate_events_csv_filepath(contract_name=contract_name, event_name=event_name)
 
     emitter.echo(f"Retrieving events from block {from_block} to {to_block}")
     title = f" {contract_name} Events ".center(40, "-")

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -50,7 +50,7 @@ from nucypher.cli.utils import (
     parse_event_filters_into_argument_filters
 )
 from nucypher.config.constants import NUCYPHER_ENVVAR_PROVIDER_URI
-from nucypher.utilities.events import generate_events_csv_filename
+from nucypher.utilities.events import generate_events_csv_filepath
 
 
 class RegistryOptions:
@@ -227,7 +227,7 @@ def events(general_config, registry_options, contract_name, from_block, to_block
             csv_output_file = csv_file
             if csv or csv_output_file:
                 if not csv_output_file:
-                    csv_output_file = generate_events_csv_filename(contract_name=agent.contract_name, event_name=name)
+                    csv_output_file = generate_events_csv_filepath(contract_name=agent.contract_name, event_name=name)
 
             retrieve_events(emitter=emitter,
                             agent=agent,

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -26,8 +26,8 @@ from nucypher.blockchain.eth.agents import EthereumContractAgent
 from nucypher.blockchain.eth.events import EventRecord
 
 
-def generate_events_csv_filename(contract_name: str, event_name: str) -> str:
-    return f'{contract_name}_{event_name}_{maya.now().datetime().strftime("%Y-%m-%d_%H-%M-%S")}.csv'
+def generate_events_csv_filepath(contract_name: str, event_name: str) -> Path:
+    return Path(f'{contract_name}_{event_name}_{maya.now().datetime().strftime("%Y-%m-%d_%H-%M-%S")}.csv')
 
 
 def write_events_to_csv_file(csv_file: Path,


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

Related to #2692.

Fixes missed spot for `Path` use instead of `str`.
```
  File "/Users/derek/Documents/Github/repos/forks/derek/nucypher/nucypher/cli/options.py", line 172, in wrapper
    return func(**kwargs)
  File "/Users/derek/Documents/Github/repos/forks/derek/nucypher/nucypher/cli/commands/status.py", line 238, in events
    csv_output_file=csv_output_file)
  File "/Users/derek/Documents/Github/repos/forks/derek/nucypher/nucypher/cli/utils.py", line 269, in retrieve_events
    if csv_output_file.exists():
AttributeError: 'str' object has no attribute 'exists'
```