### PR TITLE
Correct missing call to .public_key() when generating keystore ID.

### DIFF
--- a/newsfragments/2800.bugfix.rst
+++ b/newsfragments/2800.bugfix.rst
@@ -1,0 +1,1 @@
+Only use public data to generate keystore IDs and filenames.

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -285,7 +285,7 @@ class Keystore:
 
         # Derive verifying key (for use as ID)
         verifying_key = secret_key_factory_from_seed(secret).secret_key_by_label(_SIGNING_INFO)
-        keystore_id = bytes(verifying_key).hex()[:Keystore._ID_SIZE]
+        keystore_id = bytes(verifying_key.public_key()).hex()[:Keystore._ID_SIZE]
 
         # Generate paths
         keystore_dir = keystore_dir or Keystore._DEFAULT_DIR


### PR DESCRIPTION
**Type of PR:**
Bugfix


**Required reviews:** 
1

**Issues fixed/closed:**
Fixes #2799 
