### PR TITLE
build and deploy monitor with ansible

### DIFF
--- a/deploy/ansible/monitor/include/run_monitor.yml
+++ b/deploy/ansible/monitor/include/run_monitor.yml
@@ -1,0 +1,52 @@
+- name: "Run Ursula"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+  gather_facts: no
+  tasks:
+    - name: Clone Monitor Repo
+      become: yes
+      become_user: nucypher
+      ansible.builtin.git:
+        repo: https://github.com/nucypher/nucypher-monitor.git
+        dest: /home/nucypher/nucypher-monitor
+        recursive: yes
+        force: yes
+
+    - name: setup certs dir
+      become: yes
+      ansible.builtin.file:
+        path: "{{NUCYPHER_LETSENCRYPT_DIR}}"
+        state: directory
+        owner: nucypher
+        group: nucypher
+        mode: '0700'
+
+    # - name: Clean any existing Influx DB directory
+    #   ansible.builtin.file:
+    #     path: /home/nucypher/influxdb
+    #     state: absent
+
+    - name: Copy SSL Certs
+      become: yes
+      ansible.builtin.copy:
+        src: "{{LOCAL_CERTS_DIR }}/{{item}}"
+        dest: "{{NUCYPHER_LETSENCRYPT_DIR}}/{{item}}"
+        owner: nucypher
+        group: nucypher
+        mode: '0700'
+      loop:
+        - cert.pem
+        - chain.pem
+        - fullchain.pem
+        - privkey.pem
+
+    - name: Run Monitor (docker-compose up)
+      become: yes
+      become_user: nucypher
+      ansible.builtin.command: docker-compose -f /home/nucypher/nucypher-monitor/deploy/docker-compose.yml up -d --build
+      args:
+        chdir: /home/nucypher/
+      environment:
+        - WEB3_PROVIDER_URI: "{{WEB3_PROVIDER_URI}}"
+        - NUCYPHER_NETWORK: "{{NUCYPHER_NETWORK}}"
+        - NUCYPHER_LETSENCRYPT_DIR: "{{NUCYPHER_LETSENCRYPT_DIR}}"

--- a/deploy/ansible/monitor/setup_monitor.yml
+++ b/deploy/ansible/monitor/setup_monitor.yml
@@ -1,0 +1,7 @@
+- name: "Setup Remote Geth"
+  hosts: "{{ play_hosts }}"
+  remote_user: "{{default_user}}"
+
+- import_playbook: ../worker/include/setup_user.yml
+- import_playbook: ../worker/include/setup_docker.yml
+- import_playbook: include/run_monitor.yml

--- a/deploy/ansible/worker/include/setup_docker.yml
+++ b/deploy/ansible/worker/include/setup_docker.yml
@@ -39,6 +39,25 @@
         name: nucypher
         group: docker
 
+    - name: Download docker-compose
+      get_url:
+        url : https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64
+        dest: ~/docker-compose
+        mode: 'u+x,g+x'
+
+    - name: Check docker-compose exists
+      stat: path=~/docker-compose
+      register: docker_compose
+
+    - name: Move docker-compose to /usr/local/bin/docker-compose
+      command: mv ~/docker-compose /usr/local/bin/docker-compose
+      when: docker_compose.stat.exists
+
+    - name: chown docker-compose so nucypher user can use it
+      file:
+        path: /usr/local/bin/docker-compose
+        group: docker
+
     - name: Ensure Docker has started
       service:
         name: docker

--- a/newsfragments/2801.feature.rst
+++ b/newsfragments/2801.feature.rst
@@ -1,0 +1,1 @@
+Adds ansible build/deploy for Monitor (status.nucypher.network)


### PR DESCRIPTION
**Type of PR:**
- [x] Feature

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Adds an automated build workflow for an existing ssh accessible cloud ubuntu host to deploy and fully configure a working nucypher-monitor instance.

**Why it's needed:**
Having standardized configs for our Ursulas, Eth nodes and now the monitor is nice.

