### PR TITLE
[WIP] Add /consider-arrangement proxy endpoint

### DIFF
--- a/nucypher/control/controllers.py
+++ b/nucypher/control/controllers.py
@@ -30,13 +30,13 @@ from twisted.internet import reactor, stdio
 
 from nucypher.cli.processes import JSONRPCLineReceiver
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
-from nucypher.control.emitters import StdoutEmitter, JSONRPCStdoutEmitter, WebEmitter
+from nucypher.control.emitters import JSONRPCStdoutEmitter, StdoutEmitter, WebEmitter
 from nucypher.control.interfaces import ControlInterface
 from nucypher.control.specifications.exceptions import SpecificationError
 from nucypher.exceptions import DevelopmentInstallationRequired
 from nucypher.network.resources import get_static_resources
 from nucypher.utilities.concurrency import WorkerPool, WorkerPoolException
-from nucypher.utilities.logging import Logger, GlobalLoggerSettings
+from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 
 
 class ControllerBase(ABC):
@@ -310,14 +310,25 @@ class WebController(InterfaceControlServer):
                            self.emitter.MethodNotFound)
 
         try:
+            # handle request headers
+            request_headers = control_request.headers
+            request_headers = {header.upper(): value for (header, value) in request_headers.items()}
+
             request_data = control_request.data
-            request_body = json.loads(request_data) if request_data else dict()
+            # handle bytes in request body
+            if request_headers.get('CONTENT-TYPE') == 'application/octet-stream':
+                request_body = {"data": bytes(request_data)}
+            # handle JSON in request body
+            else:
+                request_body = json.loads(request_data) if request_data else dict()
 
             # handle query string parameters
             if hasattr(control_request, 'args'):
                 request_body.update(control_request.args)
 
             request_body.update(kwargs)
+            if request_headers.get('X-PROXY-DESTINATION'):
+                request_body['proxy_destination'] = request_headers['X-PROXY-DESTINATION']
 
             if method_name not in self._get_interfaces():
                 raise self.emitter.MethodNotFound(f'No method called {method_name}')

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -26,7 +26,6 @@ from constant_sorrow.constants import CERTIFICATE_NOT_SAVED, EXEMPT_FROM_VERIFIC
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 
-from nucypher.crypto.splitters import cfrag_splitter, signature_splitter
 from nucypher.utilities.logging import Logger
 
 EXEMPT_FROM_VERIFICATION.bool_value(False)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -14,15 +14,13 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-
 import uuid
 import weakref
 from pathlib import Path
 from typing import Tuple
 
 from constant_sorrow import constants
-from constant_sorrow.constants import FLEET_STATES_MATCH, RELAX, NOT_STAKING
+from constant_sorrow.constants import FLEET_STATES_MATCH, NOT_STAKING, RELAX
 from flask import Flask, Response, jsonify, request
 from mako import exceptions as mako_exceptions
 from mako.template import Template
@@ -30,16 +28,13 @@ from mako.template import Template
 from nucypher.blockchain.eth.utils import period_to_epoch
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
 from nucypher.crypto.keypairs import DecryptingKeypair
-from nucypher.crypto.powers import KeyPairBasedPower, PowerUpError
 from nucypher.crypto.signing import InvalidSignature
-from nucypher.datastore.datastore import Datastore
 from nucypher.datastore.models import ReencryptionRequest as ReencryptionRequestModel
+from nucypher.datastore.datastore import Datastore
 from nucypher.network import LEARNING_LOOP_VERSION
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.protocols import InterfaceInfo
-from nucypher.network.retrieval import ReencryptionRequest, ReencryptionResponse
-from nucypher.policy.hrac import HRAC
-from nucypher.policy.kits import MessageKit
+from nucypher.network.retrieval import ReencryptionRequest
 from nucypher.policy.revocation import Revocation
 from nucypher.utilities.logging import Logger
 

--- a/nucypher/utilities/porter/control/interfaces.py
+++ b/nucypher/utilities/porter/control/interfaces.py
@@ -19,6 +19,7 @@ from typing import List, Optional
 from eth_typing import ChecksumAddress
 
 from nucypher.control.interfaces import ControlInterface, attach_schema
+from nucypher.control.specifications.base import BaseSchema
 from nucypher.crypto.umbral_adapter import PublicKey
 from nucypher.policy.kits import RetrievalKit
 from nucypher.policy.maps import TreasureMap
@@ -69,6 +70,13 @@ class PorterInterface(ControlInterface):
                                                              bob_encrypting_key=bob_encrypting_key,
                                                              bob_verifying_key=bob_verifying_key,
                                                              policy_encrypting_key=policy_encrypting_key)
-        results = retrieval_results   # list of RetrievalResult objects
+        results = retrieval_results  # list of RetrievalResult objects
         response_data = {'retrieval_results': results}
         return response_data
+
+    #
+    # Ursula Endpoints
+    #
+    @attach_schema(BaseSchema)
+    def proxy_consider_arrangement(self, proxy_destination: str, data: bytes) -> dict:
+        return self.implementer.proxy_consider_arrangement(ursula_uri=proxy_destination, data=data)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Adds `/consider-arrangement` Porter endpoint in order to enable `nucypher-ts` in the browser.

**Issues fixed/closed:**
- #2763

**Notes for reviewers:**
- This PR is subject to change per discussion in #2763. I'm putting it out here in order to track this issue and reference it in `nucypher-ts` docs - Early `nucypher-ts` users could find it useful. 
