### PR TITLE
Wider lanes

### DIFF
--- a/newsfragments/2805.feature.rst
+++ b/newsfragments/2805.feature.rst
@@ -1,0 +1,1 @@
+Extend brand size in ``Versioned`` to 4 bytes

--- a/nucypher/network/retrieval.py
+++ b/nucypher/network/retrieval.py
@@ -192,7 +192,7 @@ class ReencryptionRequest(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'RQ'
+        return b'ReRq'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:
@@ -244,7 +244,7 @@ class ReencryptionResponse(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'RR'
+        return b'ReRs'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:

--- a/nucypher/policy/kits.py
+++ b/nucypher/policy/kits.py
@@ -122,7 +122,7 @@ class MessageKit(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'MK'
+        return b'MKit'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:
@@ -181,7 +181,7 @@ class RetrievalKit(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'RK'
+        return b'RKit'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:

--- a/nucypher/policy/maps.py
+++ b/nucypher/policy/maps.py
@@ -105,7 +105,7 @@ class TreasureMap(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'TM'
+        return b'TMap'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:
@@ -205,7 +205,7 @@ class AuthorizedKeyFrag(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'KF'
+        return b'AKF_'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:
@@ -330,7 +330,7 @@ class EncryptedTreasureMap(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'EM'
+        return b'EMap'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -58,7 +58,7 @@ class Arrangement(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'AR'
+        return b'Arng'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -74,7 +74,7 @@ class RevocationOrder(Versioned):
 
     @classmethod
     def _brand(cls) -> bytes:
-        return b'RV'
+        return b'Revo'
 
     @classmethod
     def _version(cls) -> Tuple[int, int]:

--- a/tests/integration/characters/test_specifications.py
+++ b/tests/integration/characters/test_specifications.py
@@ -90,12 +90,12 @@ def test_treasure_map_validation(enacted_federated_policy,
     assert "Could not parse tmap" in str(e)
     assert "Invalid base64-encoded string" in str(e)
 
-    base64_header = base64.b64encode(EncryptedTreasureMapClass._header()).decode()
-
     # valid base64 but invalid treasuremap
-    bad_map = base64_header + "VGhpcyBpcWgb3RhbGx5IG5vdCBhIHRyZWFzdXJlbWg=="
+    bad_map = EncryptedTreasureMapClass._header() + b"your face looks like a treasure map"
+    bad_map_b64 = base64.b64encode(bad_map).decode()
+
     with pytest.raises(InvalidInputData) as e:
-        EncryptedTreasureMapsOnly().load({'tmap': bad_map})
+        EncryptedTreasureMapsOnly().load({'tmap': bad_map_b64})
 
     assert "Could not convert input for tmap to an EncryptedTreasureMap" in str(e)
     assert "Invalid encrypted treasure map contents." in str(e)
@@ -121,10 +121,11 @@ def test_treasure_map_validation(enacted_federated_policy,
     assert "Invalid base64-encoded string" in str(e)
 
     # valid base64 but invalid treasuremap
-    base64_header = base64.b64encode(TreasureMapClass._header()).decode()
-    bad_map = base64_header + "VGhpcyBpcyB0b3RhbGx5IG5vdCBhIHRyZWFzdXJlbWFwLg=="
+    bad_map = TreasureMapClass._header() + b"your face looks like a treasure map"
+    bad_map_b64 = base64.b64encode(bad_map).decode()
+
     with pytest.raises(InvalidInputData) as e:
-        UnenncryptedTreasureMapsOnly().load({'tmap': bad_map})
+        UnenncryptedTreasureMapsOnly().load({'tmap': bad_map_b64})
 
     assert "Could not convert input for tmap to a TreasureMap" in str(e)
     assert "Invalid treasure map contents." in str(e)
@@ -153,9 +154,11 @@ def test_messagekit_validation(capsule_side_channel):
     assert "Incorrect padding" in str(e)
 
     # valid base64 but invalid messagekit
-    b64header = base64.b64encode(MessageKit._header()).decode()
+    bad_kit = MessageKit._header() + b"I got a message for you"
+    bad_kit_b64 = base64.b64encode(bad_kit).decode()
+
     with pytest.raises(SpecificationError) as e:
-        MessageKitsOnly().load({'mkit': b64header + "V3da=="})
+        MessageKitsOnly().load({'mkit': bad_kit_b64})
 
     assert "Could not parse mkit" in str(e)
     assert "Not enough bytes to constitute message types" in str(e)


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Extend the brand size in `Versioned` to 4 bytes to make it easier to resolve name clashes in the future.
- Allow all regexp `\w` characters in brands.

The exact values for new 4-byte brands are open for suggestions.