### PR TITLE
Porter: Nginx, CORS support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -462,7 +462,7 @@ commands:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - save_cache:
-          key: pip-v8-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pip-v9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
           paths:
             - "~/.local/bin"
             - "~/.local/lib/python3.7/site-packages"
@@ -477,7 +477,7 @@ commands:
       - run: sudo chown -R circleci:circleci /usr/local/bin
       - run: sudo chown -R circleci:circleci /usr/local/lib/python3.7/site-packages
       - restore_cache:  # ensure this step occurs *before* installing dependencies
-          key: pip-v8-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
+          key: pip-v9-{{ .Branch }}-{{ checksum "Pipfile.lock" }}
       - restore_cache:
           key: solc-v2-{{ checksum "nucypher/blockchain/eth/sol/__conf__.py" }}
 
@@ -869,7 +869,7 @@ jobs:
       - setup_remote_docker
       - restore_cache:
           keys:
-            - v2-{{ .Branch }}-{{ arch }}
+            - v3-{{ .Branch }}-{{ arch }}
           paths:
             - ~/docker/nucypher-porter.tar
       - run:
@@ -887,7 +887,7 @@ jobs:
             mkdir -p ~/docker
             docker save -o ~/docker/nucypher-porter.tar nucypher/porter:circle
       - save_cache:
-          key: v2-{{ .Branch }}-{{ arch }}
+          key: v3-{{ .Branch }}-{{ arch }}
           paths:
             - ~/docker/nucypher-porter.tar
 
@@ -977,7 +977,7 @@ jobs:
       - setup_remote_docker
       - restore_cache:
           keys:
-            - v2-{{ .Branch }}-{{ arch }}
+            - v3-{{ .Branch }}-{{ arch }}
           paths:
             - ~/docker/nucypher-porter.tar
       - run:

--- a/deploy/docker/porter/docker-compose.yml
+++ b/deploy/docker/porter/docker-compose.yml
@@ -16,7 +16,8 @@ services:
       - ~/.local/share/nucypher:/nucypher
     command: ["nucypher", "porter", "run",
               "--provider", "${WEB3_PROVIDER_URI}",
-              "--network", "${NUCYPHER_NETWORK}"]
+              "--network", "${NUCYPHER_NETWORK}",
+              "--allow-origins", "${PORTER_CORS_ALLOW_ORIGINS}"]  # empty string if env var not defined which translates to CORS not enabled by default
 
   porter-https:
     restart: on-failure
@@ -33,7 +34,8 @@ services:
                "--provider", "${WEB3_PROVIDER_URI}",
                "--network", "${NUCYPHER_NETWORK}",
                "--tls-key-filepath", "/etc/porter/tls/key.pem",
-               "--tls-certificate-filepath", "/etc/porter/tls/cert.pem"]
+               "--tls-certificate-filepath", "/etc/porter/tls/cert.pem",
+               "--allow-origins", "${PORTER_CORS_ALLOW_ORIGINS}"]  # empty string if env var not defined which translates to CORS not enabled by default
 
   porter-https-auth:
     restart: on-failure
@@ -52,4 +54,5 @@ services:
                "--network", "${NUCYPHER_NETWORK}",
                "--tls-key-filepath", "/etc/porter/tls/key.pem",
                "--tls-certificate-filepath", "/etc/porter/tls/cert.pem",
-               "--basic-auth-filepath", "/etc/porter/auth/htpasswd"]
+               "--basic-auth-filepath", "/etc/porter/auth/htpasswd",
+               "--allow-origins", "${PORTER_CORS_ALLOW_ORIGINS}"]  # empty string if env var not defined which translates to CORS not enabled by default

--- a/deploy/docker/porter/nginx/Dockerfile
+++ b/deploy/docker/porter/nginx/Dockerfile
@@ -1,4 +1,4 @@
 FROM nginxproxy/nginx-proxy:alpine
 
-# Copy porter.local location additional configuration
+# Copy porter.local virtual host location configuration file
 COPY ./deploy/docker/porter/nginx/porter.local_location /etc/nginx/vhost.d/

--- a/deploy/docker/porter/nginx/Dockerfile
+++ b/deploy/docker/porter/nginx/Dockerfile
@@ -1,0 +1,4 @@
+FROM nginxproxy/nginx-proxy:alpine
+
+# Copy porter.local location additional configuration
+COPY ./deploy/docker/porter/nginx/porter.local_location /etc/nginx/vhost.d/

--- a/deploy/docker/porter/nginx/docker-compose.yml
+++ b/deploy/docker/porter/nginx/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3'
+
+services:
+
+  nginx-proxy:
+    restart: always
+    image: nginxproxy/nginx-proxy:alpine
+    build:
+      context: ../../../..
+      dockerfile: deploy/docker/porter/nginx/Dockerfile
+    ports:
+      - "443:443"
+    volumes:
+      - /var/run/docker.sock:/tmp/docker.sock:ro
+      # because of the vhost name used below, the cert and key should be named "porter.local.crt" and "porter.local.key" respectively
+      - "${TLS_DIR}:/etc/nginx/certs/"
+
+  nginx-porter:
+    restart: on-failure
+    image: porter:latest
+    build:
+      context: ../../../..
+      dockerfile: deploy/docker/porter/Dockerfile
+    expose:
+      # Default Porter port
+      - "9155"
+    volumes:
+      - .:/code
+      - ~/.local/share/nucypher:/nucypher
+    command: [ "nucypher", "porter", "run",
+               "--provider", "${WEB3_PROVIDER_URI}",
+               "--network", "${NUCYPHER_NETWORK}" ]
+    environment:
+      - VIRTUAL_HOST=porter.local
+      - VIRTUAL_PORT=9155
+    depends_on:
+      - nginx-proxy

--- a/deploy/docker/porter/nginx/porter.local_location
+++ b/deploy/docker/porter/nginx/porter.local_location
@@ -1,0 +1,4 @@
+#
+# Allow CORS for any domain - should be editied if specific domains are desired
+#
+add_header 'Access-Control-Allow-Origin' '*';

--- a/deploy/docker/porter/nginx/porter.local_location
+++ b/deploy/docker/porter/nginx/porter.local_location
@@ -1,4 +1,2 @@
-#
-# Allow CORS for any domain - should be editied if specific domains are desired
-#
+# Allow CORS for any domain by default - should be edited if specific domains are desired
 add_header 'Access-Control-Allow-Origin' '*';

--- a/deploy/docker/porter/nginx/porter.local_location
+++ b/deploy/docker/porter/nginx/porter.local_location
@@ -1,2 +1,27 @@
-# Allow CORS for any domain by default - should be edited if specific domains are desired
-add_header 'Access-Control-Allow-Origin' '*';
+set $allow_origin "";
+
+#
+# Allow CORS for any domain by default - comment out if not desired
+#
+if ($http_origin ~* (.*)) {
+    set $allow_origin "true";
+}
+
+#
+# Allow CORS for specific domain. For specifying conditions, see https://nginx.org/en/docs/http/ngx_http_rewrite_module.html#if.
+# Uncomment and edit if desired. There can be one or more of these 'if' directives for various origin checks.
+#
+#if ($http_origin ~* (.*\.yourdomain\.com$)) {
+#    set $allow_origin "true";
+#}
+
+#
+# For multiple top-level domains:
+#
+#if ($http_origin ~* (.*\.yourdomain\.(com|org)$)) {
+#    set $allow_origin "true";
+#}
+
+if ($allow_origin = "true") {
+    add_header 'Access-Control-Allow-Origin' '$http_origin';
+}

--- a/newsfragments/2807.bugfix.rst
+++ b/newsfragments/2807.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed WebController bug caused by Path object for TLS/certificate path provided to Hendrix instead of a string.

--- a/newsfragments/2807.feature.rst
+++ b/newsfragments/2807.feature.rst
@@ -1,0 +1,1 @@
+Added opt-in CORS origins support to Porter; no origins allowed by default. Also, provide docker-compose execution for Porter to run behind an Nginx reverse proxy server. Allows for more complex web configurations to be achieved with Nginx.

--- a/newsfragments/2807.feature.rst
+++ b/newsfragments/2807.feature.rst
@@ -1,1 +1,3 @@
-Added opt-in CORS origins support to Porter; no origins allowed by default. Also, provide docker-compose execution for Porter to run behind an Nginx reverse proxy server. Allows for more complex web configurations to be achieved with Nginx.
+CORS, NGINX support for Porter:
+- Added opt-in CORS origins support to Porter; no origins allowed by default when running Porter directly.
+- Provided docker-compose execution for Porter to run behind an NGINX reverse proxy server - all origins allowed by default for CORS, but can be customized. NGINX allows for the potential for more complex infrastructure configurations.

--- a/nucypher/cli/commands/porter.py
+++ b/nucypher/cli/commands/porter.py
@@ -21,8 +21,13 @@ import click
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.config import group_general_config
-from nucypher.cli.literature import BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED, PORTER_RUN_MESSAGE, \
-    BASIC_AUTH_REQUIRES_HTTPS
+from nucypher.cli.literature import (
+    PORTER_BASIC_AUTH_ENABLED,
+    PORTER_BASIC_AUTH_REQUIRES_HTTPS,
+    PORTER_BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED,
+    PORTER_CORS_ALLOWED_ORIGINS,
+    PORTER_RUN_MESSAGE,
+)
 from nucypher.cli.options import (
     option_network,
     option_provider_uri,
@@ -34,7 +39,6 @@ from nucypher.cli.options import (
 from nucypher.cli.types import NETWORK_PORT
 from nucypher.cli.utils import setup_emitter, get_registry
 from nucypher.config.constants import TEMPORARY_DOMAIN
-from nucypher.utilities.porter.control.interfaces import PorterInterface
 from nucypher.utilities.porter.porter import Porter
 
 
@@ -58,7 +62,7 @@ def porter():
 @click.option('--tls-certificate-filepath', help="Pre-signed TLS certificate filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
 @click.option('--tls-key-filepath', help="TLS private key filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
 @click.option('--basic-auth-filepath', help="htpasswd filepath for basic authentication", type=click.Path(dir_okay=False, exists=True, resolve_path=True, path_type=Path))
-@click.option('--allow-origins', help="The CORS origin(s) to allow requests from - allows all origins by default", type=click.STRING, required=False, default="*")
+@click.option('--allow-origins', help="The CORS origin(s) string to allow requests from - used as the value for the 'Access-Control-Allow-Origin' response header; not configured by default", type=click.STRING)
 @click.option('--dry-run', '-x', help="Execute normally without actually starting Porter", is_flag=True)
 @click.option('--eager', help="Start learning and scraping the network before starting up other services", is_flag=True, default=True)
 def run(general_config,
@@ -81,14 +85,14 @@ def run(general_config,
     # HTTP/HTTPS
     if bool(tls_key_filepath) ^ bool(tls_certificate_filepath):
         raise click.BadOptionUsage(option_name='--tls-key-filepath, --tls-certificate-filepath',
-                                   message=BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED)
+                                   message=PORTER_BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED)
 
     is_https = (tls_key_filepath and tls_certificate_filepath)
 
     # check authentication
     if basic_auth_filepath and not is_https:
         raise click.BadOptionUsage(option_name='--basic-auth-filepath',
-                                   message=BASIC_AUTH_REQUIRES_HTTPS)
+                                   message=PORTER_BASIC_AUTH_REQUIRES_HTTPS)
 
     if federated_only:
         if not teacher_uri:
@@ -138,12 +142,17 @@ def run(general_config,
     if not federated_only:
         emitter.message(f"Provider: {provider_uri}", color='green')
 
+    # firm up falsy status (i.e. change specified empty string to None)
+    allow_origins = allow_origins if allow_origins else None
+    if allow_origins:
+        emitter.message(PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins=allow_origins), color='green')
+
     if basic_auth_filepath:
-        emitter.message("Basic Authentication enabled", color='green')
+        emitter.message(PORTER_BASIC_AUTH_ENABLED, color='green')
 
     controller = PORTER.make_web_controller(crash_on_error=False,
                                             htpasswd_filepath=basic_auth_filepath,
-                                            cors_origins=allow_origins)
+                                            cors_allow_origins=allow_origins)
     http_scheme = "https" if is_https else "http"
     message = PORTER_RUN_MESSAGE.format(http_scheme=http_scheme, http_port=http_port)
     emitter.message(message, color='green', bold=True)

--- a/nucypher/cli/commands/porter.py
+++ b/nucypher/cli/commands/porter.py
@@ -58,6 +58,7 @@ def porter():
 @click.option('--tls-certificate-filepath', help="Pre-signed TLS certificate filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
 @click.option('--tls-key-filepath', help="TLS private key filepath", type=click.Path(dir_okay=False, exists=True, path_type=Path))
 @click.option('--basic-auth-filepath', help="htpasswd filepath for basic authentication", type=click.Path(dir_okay=False, exists=True, resolve_path=True, path_type=Path))
+@click.option('--allow-origins', help="The CORS origin(s) to allow requests from - allows all origins by default", type=click.STRING, required=False, default="*")
 @click.option('--dry-run', '-x', help="Execute normally without actually starting Porter", is_flag=True)
 @click.option('--eager', help="Start learning and scraping the network before starting up other services", is_flag=True, default=True)
 def run(general_config,
@@ -71,6 +72,7 @@ def run(general_config,
         tls_certificate_filepath,
         tls_key_filepath,
         basic_auth_filepath,
+        allow_origins,
         dry_run,
         eager):
     """Start Porter's Web controller."""
@@ -139,7 +141,9 @@ def run(general_config,
     if basic_auth_filepath:
         emitter.message("Basic Authentication enabled", color='green')
 
-    controller = PORTER.make_web_controller(htpasswd_filepath=basic_auth_filepath, crash_on_error=False)
+    controller = PORTER.make_web_controller(crash_on_error=False,
+                                            htpasswd_filepath=basic_auth_filepath,
+                                            cors_origins=allow_origins)
     http_scheme = "https" if is_https else "http"
     message = PORTER_RUN_MESSAGE.format(http_scheme=http_scheme, http_port=http_port)
     emitter.message(message, color='green', bold=True)

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -722,6 +722,10 @@ SUCCESSFUL_MANUALLY_SAVE_METADATA = "Successfully saved node metadata to {metada
 
 PORTER_RUN_MESSAGE = "Running Porter Web Controller at {http_scheme}://127.0.0.1:{http_port}"
 
-BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED = "Both --tls-key-filepath and --tls-certificate-filepath must be provided to launch porter with TLS; only one specified"
+PORTER_BASIC_AUTH_ENABLED = "Basic Authentication enabled"
 
-BASIC_AUTH_REQUIRES_HTTPS = "Basic authentication can only be used with HTTPS. --tls-key-filepath and --tls-certificate-filepath must also be provided"
+PORTER_CORS_ALLOWED_ORIGINS = "CORS Allow Origins: {allow_origins}"
+
+PORTER_BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED = "Both --tls-key-filepath and --tls-certificate-filepath must be provided to launch porter with TLS; only one specified"
+
+PORTER_BASIC_AUTH_REQUIRES_HTTPS = "Basic authentication can only be used with HTTPS. --tls-key-filepath and --tls-certificate-filepath must also be provided"

--- a/nucypher/control/controllers.py
+++ b/nucypher/control/controllers.py
@@ -20,6 +20,7 @@ import inspect
 import json
 from abc import ABC, abstractmethod
 from json import JSONDecodeError
+from pathlib import Path
 from typing import Optional
 
 import maya
@@ -269,8 +270,8 @@ class WebController(InterfaceControlServer):
 
     def start(self,
               port: int,
-              tls_key_filepath: str = None,
-              tls_certificate_filepath: str = None,
+              tls_key_filepath: Path = None,
+              tls_certificate_filepath: Path = None,
               dry_run: bool = False):
         if dry_run:
             return
@@ -279,8 +280,8 @@ class WebController(InterfaceControlServer):
             self.log.info("Starting HTTPS Control...")
             # HTTPS endpoint
             hx_deployer = HendrixDeployTLS(action="start",
-                                           key=tls_key_filepath,
-                                           cert=tls_certificate_filepath,
+                                           key=str(tls_key_filepath.absolute()),
+                                           cert=str(tls_certificate_filepath.absolute()),
                                            options={
                                                "wsgi": self._transport,
                                                "https_port": port,

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -14,6 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+from pathlib import Path
 from typing import List, NamedTuple, Optional, Sequence
 
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION, NO_CONTROL_PROTOCOL
@@ -199,7 +200,7 @@ the Pipe for nucypher network operations
         self.controller = controller
         return controller
 
-    def make_web_controller(self, crash_on_error: bool = False, htpasswd_filepath: str = None):
+    def make_web_controller(self, crash_on_error: bool = False, htpasswd_filepath: Path = None, cors_origins: str = '*'):
         controller = WebController(app_name=self.APP_NAME,
                                    crash_on_error=crash_on_error,
                                    interface=self._interface_class(porter=self))
@@ -207,14 +208,20 @@ the Pipe for nucypher network operations
 
         # Register Flask Decorator
         porter_flask_control = controller.make_control_transport()
-        if htpasswd_filepath:
-            try:
-                from flask_htpasswd import HtPasswdAuth
-            except ImportError:
-                raise ImportError('Porter installation is required for basic authentication '
-                                  '- run "pip install nucypher[porter]" and try again.')
 
-            porter_flask_control.config['FLASK_HTPASSWD_PATH'] = htpasswd_filepath
+        try:
+            from flask_cors import CORS
+            from flask_htpasswd import HtPasswdAuth
+        except ImportError:
+            raise ImportError('Porter installation is required - run "pip install nucypher[porter]" and try again.')
+
+        # CORS
+        porter_flask_control.config['CORS_ORIGINS'] = cors_origins
+        _ = CORS(app=porter_flask_control)
+
+        # Basic Auth
+        if htpasswd_filepath:
+            porter_flask_control.config['FLASK_HTPASSWD_PATH'] = str(htpasswd_filepath.absolute())
             # ensure basic auth required for all endpoints
             porter_flask_control.config['FLASK_AUTH_ALL'] = True
             _ = HtPasswdAuth(app=porter_flask_control)

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -203,7 +203,7 @@ the Pipe for nucypher network operations
     def make_web_controller(self,
                             crash_on_error: bool = False,
                             htpasswd_filepath: Path = None,
-                            cors_allow_origins: str = None):
+                            cors_allow_origins_list: List[str] = None):
         controller = WebController(app_name=self.APP_NAME,
                                    crash_on_error=crash_on_error,
                                    interface=self._interface_class(porter=self))
@@ -213,15 +213,13 @@ the Pipe for nucypher network operations
         porter_flask_control = controller.make_control_transport()
 
         # CORS origins
-        if cors_allow_origins:
+        if cors_allow_origins_list:
             try:
                 from flask_cors import CORS
             except ImportError:
                 raise ImportError('Porter installation is required for to specify CORS origins '
                                   '- run "pip install nucypher[porter]" and try again.')
-
-            porter_flask_control.config['CORS_ORIGINS'] = cors_allow_origins
-            _ = CORS(app=porter_flask_control)
+            _ = CORS(app=porter_flask_control, origins=cors_allow_origins_list)
 
         # Basic Auth
         if htpasswd_filepath:

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ DEPLOY_REQUIRES = [
 URSULA_REQUIRES = ['prometheus_client', 'sentry-sdk']  # TODO: Consider renaming to 'monitor', etc.
 ALICE_REQUIRES = ['qrcode']
 BOB_REQUIRES = ['qrcode']
-PORTER_REQUIRES = ['flask-htpasswd']  # needed for basic authentication
+PORTER_REQUIRES = ['flask-htpasswd', 'flask-cors']  # needed for basic authentication, cors
 
 EXTRAS = {
 

--- a/tests/acceptance/cli/test_porter.py
+++ b/tests/acceptance/cli/test_porter.py
@@ -352,7 +352,7 @@ def test_blockchain_porter_cli_run_https_with_cors_origin(click_runner,
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code == 0
     assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
-    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins=allow_origins) in result.output
+    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins=[allow_origins]) in result.output
 
 
 def test_blockchain_porter_cli_run_https_basic_auth(click_runner,

--- a/tests/acceptance/cli/test_porter.py
+++ b/tests/acceptance/cli/test_porter.py
@@ -22,9 +22,10 @@ import pytest
 
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.literature import (
-    PORTER_RUN_MESSAGE,
-    BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED,
-    BASIC_AUTH_REQUIRES_HTTPS
+    PORTER_BASIC_AUTH_ENABLED,
+    PORTER_BASIC_AUTH_REQUIRES_HTTPS,
+    PORTER_BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED,
+    PORTER_RUN_MESSAGE, PORTER_CORS_ALLOWED_ORIGINS
 )
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.constants import TEMPORARY_DOMAIN
@@ -96,7 +97,7 @@ def test_federated_porter_cli_run_tls_filepath_and_certificate(click_runner,
                           '--tls-key-filepath', tempfile_path)  # only tls-key provided
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code != 0  # both --tls-key-filepath and --tls-certificate-filepath must be provided for TLS
-    assert BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
+    assert PORTER_BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
 
     porter_run_command = ('porter', 'run',
                           '--dry-run',
@@ -105,7 +106,7 @@ def test_federated_porter_cli_run_tls_filepath_and_certificate(click_runner,
                           '--tls-certificate-filepath', tempfile_path)  # only certificate provided
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code != 0  # both --tls-key-filepath and --tls-certificate-filepath must be provided for TLS
-    assert BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
+    assert PORTER_BOTH_TLS_KEY_AND_CERTIFICATION_MUST_BE_PROVIDED in result.output
 
     #
     # tls-key and certificate filepaths must exist
@@ -156,6 +157,56 @@ def test_federated_cli_run_https(click_runner, federated_ursulas, temp_dir_path,
     assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
 
 
+def test_federated_cli_run_https_with_cors_origin(click_runner,
+                                                  federated_ursulas,
+                                                  temp_dir_path,
+                                                  federated_teacher_uri):
+    tls_key_path = Path(temp_dir_path) / 'key.pem'
+    _write_random_data(tls_key_path)
+    certificate_file_path = Path(temp_dir_path) / 'fullchain.pem'
+    _write_random_data(certificate_file_path)
+
+    allow_origins = "nucypher.com"
+
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri,
+                          '--tls-key-filepath', tls_key_path,
+                          '--tls-certificate-filepath', certificate_file_path,
+                          '--allow-origins', allow_origins)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
+    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins=allow_origins) in result.output
+
+
+def test_federated_cli_run_https_with_empty_string_cors_origin(click_runner,
+                                                               federated_ursulas,
+                                                               temp_dir_path,
+                                                               federated_teacher_uri):
+    tls_key_path = Path(temp_dir_path) / 'key.pem'
+    _write_random_data(tls_key_path)
+    certificate_file_path = Path(temp_dir_path) / 'fullchain.pem'
+    _write_random_data(certificate_file_path)
+
+    empty_string_allow_origins = ""
+
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--federated-only',
+                          '--teacher', federated_teacher_uri,
+                          '--tls-key-filepath', tls_key_path,
+                          '--tls-certificate-filepath', certificate_file_path,
+                          '--allow-origins', empty_string_allow_origins)
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
+    # empty string translates to CORS not being enabled - empty origin string provides wild card comparison
+    # with just header
+    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins='') not in result.output
+
+
 def test_federated_cli_run_https_basic_auth(click_runner,
                                             federated_ursulas,
                                             federated_teacher_uri,
@@ -175,7 +226,7 @@ def test_federated_cli_run_https_basic_auth(click_runner,
                           '--basic-auth-filepath', basic_auth_file)
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code == 0
-    assert "Basic Authentication enabled" in result.output
+    assert PORTER_BASIC_AUTH_ENABLED in result.output
 
 
 def test_blockchain_porter_cli_run_simple(click_runner,
@@ -271,6 +322,37 @@ def test_blockchain_porter_cli_run_https(click_runner,
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code == 0
     assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
+    # no CORS configured by default; empty origin string provides wild card comparison with just header
+    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins='') not in result.output
+
+
+def test_blockchain_porter_cli_run_https_with_cors_origin(click_runner,
+                                                          blockchain_ursulas,
+                                                          testerchain,
+                                                          agency_local_registry,
+                                                          temp_dir_path,
+                                                          blockchain_teacher_uri):
+    tls_key_path = Path(temp_dir_path) / 'key.pem'
+    _write_random_data(tls_key_path)
+    certificate_file_path = Path(temp_dir_path) / 'fullchain.pem'
+    _write_random_data(certificate_file_path)
+
+    allow_origins = "*"
+
+    porter_run_command = ('porter', 'run',
+                          '--dry-run',
+                          '--network', TEMPORARY_DOMAIN,
+                          '--provider', TEST_PROVIDER_URI,
+                          '--registry-filepath', agency_local_registry.filepath,
+                          '--teacher', blockchain_teacher_uri,
+                          '--tls-key-filepath', tls_key_path,
+                          '--tls-certificate-filepath', certificate_file_path,
+                          '--allow-origins', allow_origins)
+
+    result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
+    assert result.exit_code == 0
+    assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
+    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins=allow_origins) in result.output
 
 
 def test_blockchain_porter_cli_run_https_basic_auth(click_runner,
@@ -297,7 +379,7 @@ def test_blockchain_porter_cli_run_https_basic_auth(click_runner,
 
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code != 0
-    assert BASIC_AUTH_REQUIRES_HTTPS in result.output
+    assert PORTER_BASIC_AUTH_REQUIRES_HTTPS in result.output
 
     # Basic Auth
     porter_run_command = ('porter', 'run',
@@ -312,7 +394,7 @@ def test_blockchain_porter_cli_run_https_basic_auth(click_runner,
 
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code == 0
-    assert "Basic Authentication enabled" in result.output
+    assert PORTER_BASIC_AUTH_ENABLED in result.output
 
 
 def _write_random_data(filepath: Path):

--- a/tests/acceptance/cli/test_porter.py
+++ b/tests/acceptance/cli/test_porter.py
@@ -166,7 +166,7 @@ def test_federated_cli_run_https_with_cors_origin(click_runner,
     certificate_file_path = Path(temp_dir_path) / 'fullchain.pem'
     _write_random_data(certificate_file_path)
 
-    allow_origins = "nucypher.com"
+    allow_origins = ".*\.example\.com,.*\.otherexample\.org"
 
     porter_run_command = ('porter', 'run',
                           '--dry-run',
@@ -178,7 +178,7 @@ def test_federated_cli_run_https_with_cors_origin(click_runner,
     result = click_runner.invoke(nucypher_cli, porter_run_command, catch_exceptions=False)
     assert result.exit_code == 0
     assert PORTER_RUN_MESSAGE.format(http_scheme="https", http_port=Porter.DEFAULT_PORT) in result.output
-    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins=allow_origins) in result.output
+    assert PORTER_CORS_ALLOWED_ORIGINS.format(allow_origins=allow_origins.split(",")) in result.output
 
 
 def test_federated_cli_run_https_with_empty_string_cors_origin(click_runner,


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Add CORS support to Porter directly
- Support use of Nginx reverse proxy for Porter
    - TLS support via nginx
    - CORS support via nginx

**Issues fixed/closed:**
> - Fixes #...

Side note: Fixes bug with TLS cert/key filepaths introduced via #2692 , where `Path` object cannot be passed to Hendrix.
```
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/SSL.py", line 843, in use_certificate_file
     certfile = _path_string(certfile)
  File "/usr/local/lib/python3.8/site-packages/OpenSSL/_util.py", line 111, in path_string
     raise TypeError("Path must be represented as bytes or unicode string")
TypeError: Path must be represented as bytes or unicode string
```

**Why it's needed:**
Running Porter on infrastructure will need CORS support - either within Porter itself, or proxied via nginx.

**Notes for reviewers:**

