### PR TITLE
Generate metadata if the timestamp is requested

### DIFF
--- a/newsfragments/2819.bugfix.rst
+++ b/newsfragments/2819.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a missing timestamp error when a node's status is requested before it participated in metadata exchange.

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1006,12 +1006,11 @@ class Ursula(Teacher, Character, Worker):
     def metadata(self):
         if not self._metadata:
             self._metadata = self._generate_metadata()
-            self._timestamp = maya.MayaDT(self._metadata.timestamp_epoch)
         return self._metadata
 
     @property
     def timestamp(self):
-        return maya.MayaDT(self._metadata.timestamp_epoch)
+        return maya.MayaDT(self.metadata().timestamp_epoch)
 
     #
     # Alternate Constructors


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
Make `Ursula.timestamp` available regardless of whether `metadata()` has been called before or not.