### PR TITLE
Fix a memory leak in Ursula

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.3.2
+current_version = 5.3.3
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,7 +47,7 @@ author = 'NuCypher'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '5.3.2'
+release = '5.3.3'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/release_notes/releases.rst
+++ b/docs/source/release_notes/releases.rst
@@ -4,6 +4,15 @@ Releases
 
 .. towncrier release notes start
 
+v5.3.3 (2021-11-24)
+-------------------
+
+Bugfixes
+~~~~~~~~
+
+- Fixed a memory leak in Ursula; removed some teacher statistics accumulated over time. (`#2826 <https://github.com/nucypher/nucypher/issues/2826>`__)
+
+
 v5.3.2 (2021-10-15)
 -------------------
 

--- a/newsfragments/2820.bugfix.rst
+++ b/newsfragments/2820.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a memory leak in Ursula: removed some teacher statistics accumulated over time, and limited the amount of old fleet states stored.

--- a/nucypher/__about__.py
+++ b/nucypher/__about__.py
@@ -31,7 +31,7 @@ __url__ = "https://github.com/nucypher/nucypher"
 
 __summary__ = 'A proxy re-encryption network to empower privacy in decentralized systems.'
 
-__version__ = "5.3.2"
+__version__ = "5.3.3"
 
 __author__ = "NuCypher"
 

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -18,6 +18,7 @@
 
 import random
 import weakref
+from collections import deque
 from collections.abc import KeysView
 from typing import Optional, Dict, Iterable, List, Tuple, NamedTuple, Union, Any
 
@@ -236,7 +237,7 @@ class FleetSensor:
         self._domain = domain
 
         self._current_state = FleetState.new(this_node)
-        self._archived_states = [self._current_state.archived()]
+        self._archived_states = deque([self._current_state.archived()], maxlen=5)
         self._remote_states = {}
         self._remote_last_seen = {}
 
@@ -327,7 +328,7 @@ class FleetSensor:
         """
         # `_archived_states` is never empty, one state is created in the constructor
         previous_states_num = min(len(self._archived_states) - 1, quantity)
-        return self._archived_states[-previous_states_num-1:-1]
+        return list(self._archived_states)[-previous_states_num-1:-1]
 
     def addresses(self):
         return self._current_state.addresses()

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -271,8 +271,6 @@ class Learner:
 
         self.log = Logger("learning-loop")  # type: Logger
 
-        self.suspicious_activities_witnessed = defaultdict(list)  # TODO: Combine with buckets / node labeling
-
         self.learning_deferred = Deferred()
         self.domain = domain
         if not self.federated_only:
@@ -815,7 +813,7 @@ class Learner:
             unresponsive_nodes.add(current_teacher)  # This does nothing.
             self.known_nodes.mark_as(current_teacher.InvalidNode, current_teacher)
             self.log.warn(f"Teacher {str(current_teacher)} is invalid (hex={bytes(current_teacher.metadata()).hex()}):{e}.")
-            self.suspicious_activities_witnessed['vladimirs'].append(current_teacher)
+            # TODO (#567): bucket the node as suspicious
             return
         except RuntimeError as e:
             if canceller and canceller.stop_now:
@@ -859,8 +857,7 @@ class Learner:
         try:
             metadata.verify(current_teacher.stamp.as_umbral_pubkey())
         except InvalidSignature:
-            self.suspicious_activities_witnessed['vladimirs'].append(
-                ('Node payload improperly signed', response.content))
+            # TODO (#567): bucket the node as suspicious
             self.log.warn(
                 f"Invalid signature received from teacher {current_teacher} for MetadataResponse {response.content}")
             return

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -190,7 +190,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
         except Exception as e:
             message = f'{bob_identity_message} Invalid EncryptedKeyFrag: {e}.'
             log.info(message)
-            this_node.suspicious_activities_witnessed['unauthorized'].append(message)
+            # TODO (#567): bucket the node as suspicious
             return Response(message, status=HTTPStatus.BAD_REQUEST)
 
         # Verify KFrag Authorization (offchain)
@@ -200,7 +200,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
         except InvalidSignature as e:
             message = f'{bob_identity_message} Invalid signature for KeyFrag: {e}.'
             log.info(message)
-            this_node.suspicious_activities_witnessed['unauthorized'].append(message)
+            # TODO (#567): bucket the node as suspicious
             return Response(message, status=HTTPStatus.UNAUTHORIZED)  # 401 - Unauthorized
         except Exception as e:
             message = f'{bob_identity_message} Invalid KeyFrag: {e}.'
@@ -215,7 +215,7 @@ def _make_rest_app(datastore: Datastore, this_node, domain: str, log: Logger) ->
             except Policy.Unpaid:
                 message = f"{bob_identity_message} Policy {hrac} is unpaid."
                 record = (publisher_verifying_key, message)
-                this_node.suspicious_activities_witnessed['freeriders'].append(record)
+                # TODO (#567): bucket the node as suspicious
                 return Response(message, status=HTTPStatus.PAYMENT_REQUIRED)
             except Policy.Unknown:
                 message = f"{bob_identity_message} Policy {hrac} is not a published policy."

--- a/tests/acceptance/characters/test_freerider_attacks.py
+++ b/tests/acceptance/characters/test_freerider_attacks.py
@@ -58,10 +58,6 @@ def test_policy_simple_sinpa(blockchain_ursulas,
                                             alice_verifying_key=amonia.stamp.as_umbral_pubkey(),
                                             encrypted_treasure_map=bupkiss_policy.treasure_map)
 
-    for ursula in blockchain_ursulas:
-        # Reset the Ursula for the next test.
-        ursula.suspicious_activities_witnessed['freeriders'] = []
-
 
 def test_try_to_post_free_service_by_hacking_enact(blockchain_ursulas,
                                                    blockchain_alice,

--- a/tests/acceptance/learning/test_fault_tolerance.py
+++ b/tests/acceptance/learning/test_fault_tolerance.py
@@ -79,8 +79,15 @@ def test_blockchain_ursula_stamp_verification_tolerance(blockchain_ursulas, mock
         return bytes(response)
 
     mocker.patch.object(blockchain_teacher, 'bytestring_of_known_nodes', bad_bytestring_of_known_nodes)
+
+    globalLogPublisher.addObserver(warning_trapper)
     lonely_blockchain_learner.learn_from_teacher_node(eager=True)
-    assert len(lonely_blockchain_learner.suspicious_activities_witnessed['vladimirs']) == 1
+    globalLogPublisher.removeObserver(warning_trapper)
+
+    assert len(warnings) == 2
+    warning = warnings[1]['log_format']
+    assert str(blockchain_teacher) in warning
+    assert "Invalid signature received from teacher" in warning  # TODO: Cleanup logging templates
 
 
 @pytest.mark.skip("See Issue #1075")  # TODO: Issue #1075


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 2

**What this does:**
- Scraps `suspicious_activities_witnessed` from Ursula. We're not doing anything with it (until #567 is implemented), and it's clogging the memory over time. It is still logged, and I modified the corresponding tests to check the logs instead.
- Limits the number of retained fleet states (to 5, which is what the status page needs). Older states are discarded as the new ones are pushed.