### PR TITLE
Keystore.generate can return optional mnemonic words

### DIFF
--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -799,9 +799,15 @@ class CharacterConfiguration(BaseConfiguration):
                                                      password=password,
                                                      keystore_dir=self.keystore_dir)
         else:
-            self.__keystore, _ = Keystore.generate(password=password,
-                                                   keystore_dir=self.keystore_dir,
-                                                   interactive=interactive)
+            if interactive:
+                self.__keystore = Keystore.generate(password=password,
+                                                    keystore_dir=self.keystore_dir,
+                                                    interactive=interactive)
+            else:
+                self.__keystore, _ = Keystore.generate(password=password,
+                                                       keystore_dir=self.keystore_dir,
+                                                       interactive=interactive)
+
         return self.keystore
 
     @classmethod

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -799,9 +799,9 @@ class CharacterConfiguration(BaseConfiguration):
                                                      password=password,
                                                      keystore_dir=self.keystore_dir)
         else:
-            self.__keystore = Keystore.generate(password=password,
-                                                keystore_dir=self.keystore_dir,
-                                                interactive=interactive)
+            self.__keystore, _ = Keystore.generate(password=password,
+                                                   keystore_dir=self.keystore_dir,
+                                                   interactive=interactive)
         return self.keystore
 
     @classmethod

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -346,10 +346,10 @@ class Keystore:
             cls, password: str,
             keystore_dir: Optional[Path] = None,
             interactive: bool = True,
-            report_mnemonic: bool = False
+            return_mnemonic: bool = False
             ) -> Union['Keystore', Tuple['Keystore', str]]:
         """Generate a new nucypher keystore for use with characters"""
-        if report_mnemonic and interactive:
+        if return_mnemonic and interactive:
             raise ValueError("The two values: report_mnemonic and interactive,  may not both be `True`")
 
         mnemonic = Mnemonic(_MNEMONIC_LANGUAGE)
@@ -360,7 +360,7 @@ class Keystore:
         path = Keystore.__save(secret=__secret, password=password, keystore_dir=keystore_dir)
         keystore = cls(keystore_path=path)
 
-        if report_mnemonic:
+        if return_mnemonic:
             return keystore, __words
 
         return keystore

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -346,12 +346,8 @@ class Keystore:
             cls, password: str,
             keystore_dir: Optional[Path] = None,
             interactive: bool = True,
-            return_mnemonic: bool = False
             ) -> Union['Keystore', Tuple['Keystore', str]]:
         """Generate a new nucypher keystore for use with characters"""
-        if return_mnemonic and interactive:
-            raise ValueError("The two values: report_mnemonic and interactive,  may not both be `True`")
-
         mnemonic = Mnemonic(_MNEMONIC_LANGUAGE)
         __words = mnemonic.generate(strength=_ENTROPY_BITS)
         if interactive:
@@ -360,10 +356,10 @@ class Keystore:
         path = Keystore.__save(secret=__secret, password=password, keystore_dir=keystore_dir)
         keystore = cls(keystore_path=path)
 
-        if return_mnemonic:
-            return keystore, __words
+        if interactive:
+            return keystore
 
-        return keystore
+        return keystore, __words
 
     @staticmethod
     def _confirm_generate(__words: str) -> None:

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -347,7 +347,7 @@ class Keystore:
             keystore_dir: Optional[Path] = None,
             interactive: bool = True,
             report_mnemonic: bool = False
-            ) -> 'Keystore':
+            ) -> Union['Keystore', Tuple['Keystore', str]]:
         """Generate a new nucypher keystore for use with characters"""
         if report_mnemonic and interactive:
             raise ValueError("The two values: report_mnemonic and interactive,  may not both be `True`")

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -342,8 +342,16 @@ class Keystore:
         return keystore
 
     @classmethod
-    def generate(cls, password: str, keystore_dir: Optional[Path] = None, interactive: bool = True) -> 'Keystore':
+    def generate(
+            cls, password: str,
+            keystore_dir: Optional[Path] = None,
+            interactive: bool = True,
+            report_mnemonic: bool = False
+            ) -> 'Keystore':
         """Generate a new nucypher keystore for use with characters"""
+        if report_mnemonic and interactive:
+            raise ValueError("The two values: report_mnemonic and interactive,  may not both be `True`")
+
         mnemonic = Mnemonic(_MNEMONIC_LANGUAGE)
         __words = mnemonic.generate(strength=_ENTROPY_BITS)
         if interactive:
@@ -351,6 +359,10 @@ class Keystore:
         __secret = bytes(mnemonic.to_entropy(__words))
         path = Keystore.__save(secret=__secret, password=password, keystore_dir=keystore_dir)
         keystore = cls(keystore_path=path)
+
+        if report_mnemonic:
+            return keystore, __words
+
         return keystore
 
     @staticmethod

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -116,6 +116,20 @@ def test_keystore_invalid_password(tmpdir):
         _keystore = Keystore.generate('short', keystore_dir=tmpdir)
 
 
+def test_keystore_generate_report_mnemonic_true(tmpdir):
+    _keystore, words = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD,
+        keystore_dir=tmpdir,
+        interactive=False,
+        report_mnemonic=True)
+    assert len(words.split(" ")) == 24
+
+
+def test_keystore_generate_report_mnemonic_blocked_by_interactive(tmpdir):
+    with pytest.raises(ValueError):
+        _keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir, report_mnemonic=True)
+
+
 def test_keystore_derive_crypto_power_without_unlock(tmpdir):
     keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir)
     with pytest.raises(Keystore.Locked):

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -121,13 +121,13 @@ def test_keystore_generate_report_mnemonic_true(tmpdir):
         INSECURE_DEVELOPMENT_PASSWORD,
         keystore_dir=tmpdir,
         interactive=False,
-        report_mnemonic=True)
+        return_mnemonic=True)
     assert len(words.split(" ")) == 24
 
 
 def test_keystore_generate_report_mnemonic_blocked_by_interactive(tmpdir):
     with pytest.raises(ValueError, match="The two values: report_mnemonic and interactive,  may not both be `True`"):
-        _keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir, report_mnemonic=True)
+        _keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir, return_mnemonic=True)
 
 
 def test_keystore_derive_crypto_power_without_unlock(tmpdir):

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -116,18 +116,12 @@ def test_keystore_invalid_password(tmpdir):
         _keystore = Keystore.generate('short', keystore_dir=tmpdir)
 
 
-def test_keystore_generate_report_mnemonic_true(tmpdir):
+def test_keystore_generate_report_interactive_false(tmpdir):
     _keystore, words = Keystore.generate(
         INSECURE_DEVELOPMENT_PASSWORD,
         keystore_dir=tmpdir,
-        interactive=False,
-        return_mnemonic=True)
+        interactive=False)
     assert len(words.split(" ")) == 24
-
-
-def test_keystore_generate_report_mnemonic_blocked_by_interactive(tmpdir):
-    with pytest.raises(ValueError, match="The two values: report_mnemonic and interactive,  may not both be `True`"):
-        _keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir, return_mnemonic=True)
 
 
 def test_keystore_derive_crypto_power_without_unlock(tmpdir):

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -126,7 +126,7 @@ def test_keystore_generate_report_mnemonic_true(tmpdir):
 
 
 def test_keystore_generate_report_mnemonic_blocked_by_interactive(tmpdir):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="The two values: report_mnemonic and interactive,  may not both be `True`"):
         _keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir, report_mnemonic=True)
 
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
> I've added a field report_mnemonic that is by default False, so as to not affect any other tests.  When set to True, when interactive is set to False, generate method returns both keystore and mnemonic.   

> When interactive is True and report_mnemonic is also True, a ValueError is raised.

**Why it's needed:**
> Users who are using a function that calls Keystore.generate are not able to ever see their mnemonic and cannot store.

> For example, when a website calls a wrapper around nucypher code to generate a keystore, the user of that website can never see their mnemonic words the way code is currently structured.  With code change, wrapper code can call generate and return mnemonic __words to end user.

**Notes for reviewers:**
> Is name report_mnemonic OK?  I understand that code returns __words and not the mnemonic itself.

> Please pardon my branch name. Should have been something like: keystore-generate-report-mnemonic-words
