### PR TITLE
Fix some remaining occurrences of `n` instead of `shares`

### DIFF
--- a/docs/NuCypher_Beachhead.ipynb
+++ b/docs/NuCypher_Beachhead.ipynb
@@ -341,8 +341,8 @@
    "source": [
     "policy = ALICE.grant(BOB, \n",
     "                     label,\n",
-    "                     m=m, \n",
-    "                     n=n,\n",
+    "                     threshold=m, \n",
+    "                     shares=n,\n",
     "                     expiration=policy_end_datetime)"
    ]
   },

--- a/newsfragments/2829.bugfix.rst
+++ b/newsfragments/2829.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed some occurrences of the old term for ``shares`` (``n``)

--- a/nucypher/cli/actions/collect.py
+++ b/nucypher/cli/actions/collect.py
@@ -120,10 +120,10 @@ def collect_policy_rate_and_value(alice: Alice, rate: int, value: int, shares: i
             default_gwei = Web3.fromWei(rate, 'gwei')  # wei -> gwei
             prompt = "Confirm rate of {node_rate} gwei * {shares} nodes ({period_rate} gwei per period)?"
 
-            if not click.confirm(prompt.format(node_rate=default_gwei, period_rate=default_gwei * shares, n=shares), default=True):
+            if not click.confirm(prompt.format(node_rate=default_gwei, period_rate=default_gwei * shares, shares=shares), default=True):
                 interactive_rate = click.prompt('Enter rate per period in gwei', type=GWEI)
                 # TODO: Interactive rate sampling & validation (#1709)
-                interactive_prompt = prompt.format(node_rate=interactive_rate, period_rate=interactive_rate * shares, n=shares)
+                interactive_prompt = prompt.format(node_rate=interactive_rate, period_rate=interactive_rate * shares, shares=shares)
                 click.confirm(interactive_prompt, default=True, abort=True)
                 rate = Web3.toWei(interactive_rate, 'gwei')  # gwei -> wei
 

--- a/nucypher/cli/actions/confirm.py
+++ b/nucypher/cli/actions/confirm.py
@@ -156,7 +156,7 @@ def confirm_staged_grant(emitter, grant_request: Dict, federated: bool, seconds_
         return
 
     period_rate = Web3.fromWei(pretty_request['shares'] * pretty_request['rate'], 'gwei')
-    pretty_request['rate'] = f"{pretty_request['rate']} wei/period * {pretty_request['n']} nodes"
+    pretty_request['rate'] = f"{pretty_request['rate']} wei/period * {pretty_request['shares']} nodes"
 
     expiration = pretty_request['expiration']
     periods = calculate_period_duration(future_time=MayaDT.from_datetime(expiration),


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
Fixes a bug reported on Discord, where an old name for the `shares` parameter is used.