### PR TITLE
Removes snapshots logic from `StakingEscrow`

### DIFF
--- a/newsfragments/2831.feature.rst
+++ b/newsfragments/2831.feature.rst
@@ -1,1 +1,1 @@
-Removes snapshots logic from `StakingEscrow`
+Removes snapshots logic from ``StakingEscrow``

--- a/newsfragments/2831.feature.rst
+++ b/newsfragments/2831.feature.rst
@@ -1,0 +1,1 @@
+Removes snapshots logic from `StakingEscrow`

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -359,7 +359,7 @@ contract StakingEscrow is Upgradeable, IERC900History {
         if (isUpgrade == UPGRADE_TRUE) {
             return balanceHistory.getValueAt(_blockNumber);
         }
-        return 0;
+        return token.totalSupply();
     }
 
     function supportsHistory() external pure override returns (bool) {

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -158,7 +158,7 @@ contract StakingEscrow is Upgradeable, IERC900History {
     mapping (address => address) public stakerFromWorker;  // outdated
 
     mapping (uint16 => uint256) stub1; // former slot for lockedPerPeriod
-    uint128[] public balanceHistory;
+    uint128[] public balanceHistory;  // outdated
 
     address stub2; // former slot for PolicyManager
     address stub3; // former slot for Adjudicator
@@ -344,7 +344,7 @@ contract StakingEscrow is Upgradeable, IERC900History {
     /**
     * @notice Return the length of the array of stakers
     */
-    function getStakersLength() external view returns (uint256) {
+    function getStakersLength() external view virtual returns (uint256) {
         return stakers.length;
     }
 
@@ -402,7 +402,7 @@ contract StakingEscrow is Upgradeable, IERC900History {
         return stakerInfo[_owner].history.getValueAt(_blockNumber);
     }
 
-    function totalStakedAt(uint256 _blockNumber) public view virtual override returns (uint256) {
+    function totalStakedAt(uint256 _blockNumber) public view override returns (uint256) {
         return balanceHistory.getValueAt(_blockNumber);
     }
 
@@ -440,13 +440,6 @@ contract StakingEscrow is Upgradeable, IERC900History {
             infoToCheck.value == info.value &&
             infoToCheck.flags == info.flags
         );
-
-        // it's not perfect because checks not only slot value but also decoding
-        // at least without additional functions
-        require(delegateGet(_testTarget, this.totalStakedForAt.selector, staker, bytes32(block.number)) ==
-            totalStakedForAt(stakerAddress, block.number));
-        require(delegateGet(_testTarget, this.totalStakedAt.selector, bytes32(block.number)) ==
-            totalStakedAt(block.number));
     }
 
 }

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -60,7 +60,7 @@ contract StakingEscrowBad is StakingEscrow {
     {
     }
 
-    function totalStakedAt(uint256) public view override returns (uint256) {}
+    function getStakersLength() external override view returns (uint256) {}
 
 }
 

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -10,7 +10,6 @@ import "contracts/NuCypherToken.sol";
 * @notice Enhanced version of StakingEscrow to use in tests
 */
 contract EnhancedStakingEscrow is StakingEscrow {
-    using AdditionalMath for uint16;
 
     constructor(
         NuCypherToken _token,

--- a/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
@@ -137,42 +137,6 @@ def test_upgrading(testerchain, token, token_economics, deploy_contract):
     assert event_args['sender'] == creator
 
 
-def test_flags(testerchain, token, escrow):
-    staker = testerchain.client.accounts[1]
-
-    snapshots_log = escrow.events.SnapshotSet.createFilter(fromBlock='latest')
-
-    # Check flag defaults
-    snapshots = escrow.functions.getFlags(staker).call()
-    assert snapshots
-
-    # There should be no events so far
-    assert 0 == len(snapshots_log.get_all_entries())
-
-    # Setting the flags to their current values should not affect anything, not even events
-    tx = escrow.functions.setSnapshots(True).transact({'from': staker})
-    testerchain.wait_for_receipt(tx)
-
-    snapshots = escrow.functions.getFlags(staker).call()
-    assert snapshots
-
-    # There should be no events so far
-    assert len(snapshots_log.get_all_entries()) == 0
-
-    # Let's change the value of the snapshots flag: obviously, only this flag should be affected
-    tx = escrow.functions.setSnapshots(False).transact({'from': staker})
-    testerchain.wait_for_receipt(tx)
-
-    snapshots = escrow.functions.getFlags(staker).call()
-    assert not snapshots
-
-    assert len(snapshots_log.get_all_entries()) == 1
-
-    event_args = snapshots_log.get_all_entries()[-1]['args']
-    assert staker == event_args['staker'] == staker
-    assert not event_args['snapshotsEnabled']
-
-
 def test_measure_work(testerchain, token, worklock, escrow, token_economics):
     creator, staker, *everyone_else = testerchain.w3.eth.accounts
 
@@ -194,136 +158,13 @@ def test_measure_work(testerchain, token, worklock, escrow, token_economics):
 
 def test_snapshots(testerchain, token, escrow, worklock):
 
-    # HELPER FUNCTIONS #
-
-    class TestSnapshot:
-        """Mimics how our Snapshots library work in a contract"""
-        def __init__(self):
-            self.history = {0: 0}
-            self.timestamps = [0]
-
-        def add_value_at(self, time, value):
-            if self.timestamps[-1] == time:
-                self.history[time] = value
-                return
-            elif time < self.timestamps[-1]:
-                assert False
-            self.timestamps.append(time)
-            self.history[time] = value
-
-        def add_value(self, value):
-            self.add_value_at(testerchain.get_block_number(), value)
-
-        def last_value(self):
-            return self.history[self.timestamps[-1]]
-
-        def get_value_at(self, time):
-            if time > self.timestamps[-1]:
-                return self.last_value()
-            else:
-                return self.history[self.timestamps[bisect(self.timestamps, time) - 1]]
-
-        @classmethod
-        def from_list(cls, snapshots):
-            s = cls()
-            for t, v in snapshots:
-                s.timestamps.append(t)
-                s.history[t] = v
-            return s
-
-        def __str__(self):
-            return str(self.history)
-
-        def __eq__(self, other):
-            return self.history == other.history and self.timestamps == other.timestamps
-
-    def staker_has_snapshots_enabled(staker) -> bool:
-        snapshots_enabled = escrow.functions.getFlags(staker).call()
-        return snapshots_enabled
-
-    def decode_snapshots_from_slot(slot):
-        slot = to_bytes32(slot)
-        snapshot_2 = Web3.toInt(slot[:4]), Web3.toInt(slot[4:16])
-        snapshot_1 = Web3.toInt(slot[16:20]), Web3.toInt(slot[20:32])
-        return snapshot_1, snapshot_2
-
-    def get_staker_history_from_storage(staker):
-        STAKERS_MAPPING_SLOT = 6
-        HISTORY_SLOT_IN_STAKER_INFO = 12
-
-        # See https://solidity.readthedocs.io/en/latest/internals/layout_in_storage.html#mappings-and-dynamic-arrays
-        staker_location = get_mapping_entry_location(key=to_bytes32(hexstr=staker),
-                                                     mapping_location=STAKERS_MAPPING_SLOT)
-        length_position = staker_location + HISTORY_SLOT_IN_STAKER_INFO
-
-        data_position = get_array_data_location(length_position)
-
-        length = testerchain.read_storage_slot(escrow.address, length_position)
-        length_in_slots = (length + 1)//2
-        slots = [testerchain.read_storage_slot(escrow.address, data_position + i) for i in range(length_in_slots)]
-        snapshots = list()
-        for snapshot_1, snapshot_2 in map(decode_snapshots_from_slot, slots):
-            snapshots.append(snapshot_1)
-            if snapshot_2 != (0, 0):
-                snapshots.append(snapshot_2)
-        return TestSnapshot.from_list(snapshots)
-
-    def get_global_history_from_storage():
-        GLOBAL_HISTORY_SLOT_IN_CONTRACT = 10
-        # See https://solidity.readthedocs.io/en/latest/internals/layout_in_storage.html#mappings-and-dynamic-arrays
-        length = testerchain.read_storage_slot(escrow.address, GLOBAL_HISTORY_SLOT_IN_CONTRACT)
-
-        snapshots = list()
-        for i in range(length):
-            snapshot_bytes = Web3.toBytes(escrow.functions.balanceHistory(i).call()).rjust(16, b'\0')
-            snapshots.append((Web3.toInt(snapshot_bytes[:4]), Web3.toInt(snapshot_bytes[4:16])))
-        return TestSnapshot.from_list(snapshots)
-
-    #
-    # TEST STARTS HERE #
-    #
-
     creator = testerchain.client.accounts[0]
     staker1 = testerchain.client.accounts[1]
     staker2 = testerchain.client.accounts[2]
 
-    snapshot_log = escrow.events.SnapshotSet.createFilter(fromBlock='latest')
-
-    expected_staker1_balance = TestSnapshot()
-    expected_staker2_balance = TestSnapshot()
-    expected_global_balance = TestSnapshot()
-    assert expected_staker1_balance == get_staker_history_from_storage(staker1)
-    assert expected_staker2_balance == get_staker_history_from_storage(staker2)
-    assert expected_global_balance == get_global_history_from_storage()
-
-    # Set snapshot parameter even before depositing. Disabling snapshots always creates a new snapshot with value 0
-    assert staker_has_snapshots_enabled(staker1)
-    tx = escrow.functions.setSnapshots(False).transact({'from': staker1})
-    testerchain.wait_for_receipt(tx)
-    assert not staker_has_snapshots_enabled(staker1)
-    expected_staker1_balance.add_value(0)
-    expected_global_balance.add_value(0)
-    assert expected_staker1_balance == get_staker_history_from_storage(staker1)
-    assert expected_global_balance == get_global_history_from_storage()
-
-    # Activating the snapshots again will create a new snapshot with current balance, which is 0
-    tx = escrow.functions.setSnapshots(True).transact({'from': staker1})
-    testerchain.wait_for_receipt(tx)
-    assert staker_has_snapshots_enabled(staker1)
-    expected_staker1_balance.add_value(0)
-    expected_global_balance.add_value(0)
-    assert expected_staker1_balance == get_staker_history_from_storage(staker1)
-    assert expected_global_balance == get_global_history_from_storage()
-
-    # Check emitted events
-    events = snapshot_log.get_all_entries()
-    assert 2 == len(events)
-    event_args = events[0]['args']
-    assert staker1 == event_args['staker']
-    assert not event_args['snapshotsEnabled']
-    event_args = events[1]['args']
-    assert staker1 == event_args['staker']
-    assert event_args['snapshotsEnabled']
+    now = testerchain.get_block_number()
+    assert escrow.functions.totalStakedForAt(staker1, now).call() == 0
+    assert escrow.functions.totalStakedAt(now).call() == 0
 
     # Staker deposits some tokens
     value = NU(15_000, 'NU').to_nunits()
@@ -333,58 +174,11 @@ def test_snapshots(testerchain, token, escrow, worklock):
     tx = worklock.functions.depositFromWorkLock(staker1, initial_deposit, 0).transact()
     testerchain.wait_for_receipt(tx)
 
-    expected_staker1_balance.add_value(initial_deposit)
-    expected_global_balance.add_value(initial_deposit)
-    assert expected_staker1_balance == get_staker_history_from_storage(staker1)
-    assert expected_global_balance == get_global_history_from_storage()
-
     now = testerchain.get_block_number()
-    assert escrow.functions.totalStakedForAt(staker1, now).call() == expected_staker1_balance.get_value_at(now)
-    assert escrow.functions.totalStakedAt(now).call() == expected_global_balance.get_value_at(now)
-
-    # Now that we do have a positive balance, let's deactivate snapshots and check them
-    tx = escrow.functions.setSnapshots(False).transact({'from': staker1})
-    testerchain.wait_for_receipt(tx)
-    assert not staker_has_snapshots_enabled(staker1)
-    expected_staker1_balance.add_value(0)
-    expected_global_balance.add_value(0)
-    assert expected_staker1_balance == get_staker_history_from_storage(staker1)
-    assert expected_global_balance == get_global_history_from_storage()
-
-    assert initial_deposit == escrow.functions.getAllTokens(staker1).call()
-    now = testerchain.get_block_number()
-    assert 0 == escrow.functions.totalStakedForAt(staker1, now).call()
-    assert 0 == escrow.functions.totalStakedAt(now).call()
-    assert initial_deposit == escrow.functions.totalStakedForAt(staker1, now - 1).call()
-    assert initial_deposit == escrow.functions.totalStakedAt(now - 1).call()
-
-    # Activating the snapshots again will create a new snapshot with current balance (100)
-    tx = escrow.functions.setSnapshots(True).transact({'from': staker1})
-    testerchain.wait_for_receipt(tx)
-    assert staker_has_snapshots_enabled(staker1)
-    expected_staker1_balance.add_value(initial_deposit)
-    expected_global_balance.add_value(initial_deposit)
-    assert expected_staker1_balance == get_staker_history_from_storage(staker1)
-    assert expected_global_balance == get_global_history_from_storage()
-
-    now = testerchain.get_block_number()
-    assert initial_deposit == escrow.functions.totalStakedForAt(staker1, now).call()
-    assert initial_deposit == escrow.functions.totalStakedAt(now).call()
-    assert 0 == escrow.functions.totalStakedForAt(staker1, now - 1).call()
-    assert 0 == escrow.functions.totalStakedAt(now - 1).call()
+    assert escrow.functions.totalStakedForAt(staker1, now).call() == 0
+    assert escrow.functions.totalStakedAt(now).call() == 0
 
     # A SECOND STAKER APPEARS:
-
-    # Disable snapshots even before deposit. This creates a new snapshot with value 0
-    balance_staker1 = escrow.functions.getAllTokens(staker1).call()
-    assert staker_has_snapshots_enabled(staker2)
-    tx = escrow.functions.setSnapshots(False).transact({'from': staker2})
-    testerchain.wait_for_receipt(tx)
-    assert not staker_has_snapshots_enabled(staker2)
-    expected_staker2_balance.add_value(0)
-    expected_global_balance.add_value(balance_staker1)
-    assert expected_staker2_balance == get_staker_history_from_storage(staker2)
-    assert expected_global_balance == get_global_history_from_storage()
 
     # Staker 2 deposits some tokens. Since snapshots are disabled, no changes in history
     deposit_staker2 = 2 * initial_deposit
@@ -392,23 +186,9 @@ def test_snapshots(testerchain, token, escrow, worklock):
     testerchain.wait_for_receipt(tx)
 
     assert deposit_staker2 == escrow.functions.getAllTokens(staker2).call()
-    assert expected_staker2_balance == get_staker_history_from_storage(staker2)
-    assert expected_global_balance == get_global_history_from_storage()
-
-    # Now that we do have a positive balance, let's activate snapshots and check them
-    tx = escrow.functions.setSnapshots(True).transact({'from': staker2})
-    testerchain.wait_for_receipt(tx)
-    assert staker_has_snapshots_enabled(staker2)
-    expected_staker2_balance.add_value(deposit_staker2)
-    expected_global_balance.add_value(balance_staker1 + deposit_staker2)
-    assert expected_staker2_balance == get_staker_history_from_storage(staker2)
-    assert expected_global_balance == get_global_history_from_storage()
-
     now = testerchain.get_block_number()
-    assert deposit_staker2 == escrow.functions.totalStakedForAt(staker2, now).call()
-    assert deposit_staker2 + balance_staker1 == escrow.functions.totalStakedAt(now).call()
-    assert 0 == escrow.functions.totalStakedForAt(staker2, now - 1).call()
-    assert balance_staker1 == escrow.functions.totalStakedAt(now - 1).call()
+    assert escrow.functions.totalStakedForAt(staker2, now).call() == 0
+    assert escrow.functions.totalStakedAt(now).call() == 0
 
     # # Finally, the first staker withdraws some tokens
     # withdrawal = 42

--- a/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
+++ b/tests/contracts/main/staking_escrow/test_staking_escrow_additional.py
@@ -156,7 +156,7 @@ def test_measure_work(testerchain, token, worklock, escrow, token_economics):
     assert escrow.functions.getCompletedWork(staker).call() == token_economics.total_supply
 
 
-def test_snapshots(testerchain, token, escrow, worklock):
+def test_snapshots(testerchain, token, escrow, worklock, token_economics):
 
     creator = testerchain.client.accounts[0]
     staker1 = testerchain.client.accounts[1]
@@ -164,7 +164,7 @@ def test_snapshots(testerchain, token, escrow, worklock):
 
     now = testerchain.get_block_number()
     assert escrow.functions.totalStakedForAt(staker1, now).call() == 0
-    assert escrow.functions.totalStakedAt(now).call() == 0
+    assert escrow.functions.totalStakedAt(now).call() == token_economics.total_supply
 
     # Staker deposits some tokens
     value = NU(15_000, 'NU').to_nunits()
@@ -176,7 +176,7 @@ def test_snapshots(testerchain, token, escrow, worklock):
 
     now = testerchain.get_block_number()
     assert escrow.functions.totalStakedForAt(staker1, now).call() == 0
-    assert escrow.functions.totalStakedAt(now).call() == 0
+    assert escrow.functions.totalStakedAt(now).call() == token_economics.total_supply
 
     # A SECOND STAKER APPEARS:
 
@@ -188,7 +188,7 @@ def test_snapshots(testerchain, token, escrow, worklock):
     assert deposit_staker2 == escrow.functions.getAllTokens(staker2).call()
     now = testerchain.get_block_number()
     assert escrow.functions.totalStakedForAt(staker2, now).call() == 0
-    assert escrow.functions.totalStakedAt(now).call() == 0
+    assert escrow.functions.totalStakedAt(now).call() == token_economics.total_supply
 
     # # Finally, the first staker withdraws some tokens
     # withdrawal = 42


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 1

**Why it's needed:**
To remove staker power in DAO
