### PR TITLE
Use nucypher/rust-python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -386,28 +386,28 @@ python_36_base: &python_36_base
   parallelism: 1
   working_directory: ~/nucypher
   docker:
-    - image: kprasch/rust-python:3.6.9
+    - image: nucypher/rust-python:3.6.9
       user: circleci
 
 python_37_base: &python_37_base
   parallelism: 1
   working_directory: ~/nucypher
   docker:
-    - image: kprasch/rust-python:3.7.9
+    - image: nucypher/rust-python:3.7.9
       user: circleci
 
 python_38_base: &python_38_base
   parallelism: 1
   working_directory: ~/nucypher
   docker:
-    - image: kprasch/rust-python:3.8.9
+    - image: nucypher/rust-python:3.8.9
       user: circleci
 
 python_39_base: &python_39_base
   parallelism: 1
   working_directory: ~/nucypher
   docker:
-    - image: kprasch/rust-python:3.9.9
+    - image: nucypher/rust-python:3.9.9
       user: circleci
 
 commands:

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM kprasch/rust-python:3.8.9
+FROM nucypher/rust-python:3.8.9
 
 WORKDIR /code
 COPY . /code

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -4,5 +4,6 @@ WORKDIR /code
 COPY . /code
 
 RUN pip3 install .[ursula]
+RUN export PATH="$HOME/.local/bin:$PATH"
 
 CMD ["/bin/bash"]

--- a/dev/docker/Dockerfile
+++ b/dev/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.7
+FROM nucypher/rust-python:3.9.9
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONPATH /code
 

--- a/scripts/demos/run_finnegans_wake_demo.sh
+++ b/scripts/demos/run_finnegans_wake_demo.sh
@@ -8,10 +8,6 @@ echo "Starting Up Finnegans Wake Demo Test..."
 # Move to demo directory
 cd "${0%/*}"/../../examples/finnegans_wake_demo/
 
-# Download book text
-echo "Download Book Text"
-./download_finnegans_wake.sh
-
 # Run demo
 echo "Starting Demo"
-python3 finnegans-wake-demo.py
+python3 finnegans-wake-demo-federated.py

--- a/scripts/demos/run_finnegans_wake_demo_docker.sh
+++ b/scripts/demos/run_finnegans_wake_demo_docker.sh
@@ -11,13 +11,9 @@ docker-compose -f $COMPOSE_FILE up -d
 echo "Wait for Ursula learning to occur"
 sleep 5
 
-# Download book text
-echo "Download Book Text"
-docker-compose -f $COMPOSE_FILE run -w $DEMO_DIR nucypher-dev bash download_finnegans_wake.sh
-
 # Run demo
 echo "Starting Demo"
-docker-compose -f $COMPOSE_FILE run -w $DEMO_DIR nucypher-dev python finnegans-wake-demo.py 172.28.1.3:11500
+docker-compose -f $COMPOSE_FILE run -w $DEMO_DIR nucypher-dev python finnegans-wake-demo-federated.py 172.28.1.3:11500
 
 # tear it down
 docker-compose -f $COMPOSE_FILE stop


### PR DESCRIPTION
**Type of PR:**
Ops

**Required reviews:** 
1

**What this does:**
- Use nucypher-hosted rust/python docker images for CI and deployments.
- Fixes missed renaming of examples script

**Why it's needed:**
- Follow-up for #2835 #2809
- Examples CI compatibility with locally-built nucypher-core

**Notes for Reviewers**
- The two demo failures on CI are expected and will be fixed in a follow-up PR.  This one is only for pointing configs at the nucypher docker repo instead of my personal one.
