### PR TITLE
Renames operator to staking provider and worker to operator

### DIFF
--- a/newsfragments/2851.feature.rst
+++ b/newsfragments/2851.feature.rst
@@ -1,0 +1,1 @@
+Renames operator to staking provider and worker to operator

--- a/nucypher/blockchain/eth/sol/source/contracts/SimplePREApplication.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/SimplePREApplication.sol
@@ -13,21 +13,21 @@ import "threshold/IStaking.sol";
 contract SimplePREApplication {
 
     /**
-    * @notice Signals that a worker was bonded to the operator
-    * @param operator Operator address
+    * @notice Signals that a worker was bonded to the staking provider
+    * @param stakingProvider Staking provider address
     * @param worker Worker address
     * @param startTimestamp Timestamp bonding occurred
     */
-    event WorkerBonded(address indexed operator, address indexed worker, uint256 startTimestamp);
+    event WorkerBonded(address indexed stakingProvider, address indexed worker, uint256 startTimestamp);
 
     /**
     * @notice Signals that a worker address is confirmed
-    * @param operator Operator address
+    * @param stakingProvider Staking provider address
     * @param worker Worker address
     */
-    event WorkerConfirmed(address indexed operator, address indexed worker);
+    event WorkerConfirmed(address indexed stakingProvider, address indexed worker);
 
-    struct OperatorInfo {
+    struct StakingProviderInfo {
         address worker;
         bool workerConfirmed;
         uint256 workerStartTimestamp;
@@ -38,9 +38,9 @@ contract SimplePREApplication {
 
     IStaking public immutable tStaking;
 
-    mapping (address => OperatorInfo) public operatorInfo;
-    address[] public operators;
-    mapping(address => address) internal _operatorFromWorker;
+    mapping (address => StakingProviderInfo) public stakingProviderInfo;
+    address[] public stakingProviders;
+    mapping(address => address) internal _stakingProviderFromWorker;
 
 
     /**
@@ -64,14 +64,14 @@ contract SimplePREApplication {
     }
 
     /**
-    * @dev Checks caller is an operator or stake owner
+    * @dev Checks caller is a staking provider or stake owner
     */
-    modifier onlyOwnerOrOperator(address _operator)
+    modifier onlyOwnerOrStakingProvider(address _stakingProvider)
     {
-        require(isAuthorized(_operator), "Not owner or operator");
-        if (_operator != msg.sender) {
-            (address owner,,) = tStaking.rolesOf(_operator);
-            require(owner == msg.sender, "Not owner or operator");
+        require(isAuthorized(_stakingProvider), "Not owner or provider");
+        if (_stakingProvider != msg.sender) {
+            (address owner,,) = tStaking.rolesOf(_stakingProvider);
+            require(owner == msg.sender, "Not owner or provider");
         }
         _;
     }
@@ -79,144 +79,148 @@ contract SimplePREApplication {
 
     //-------------------------Main-------------------------
     /**
-    * @notice Returns operator for specified worker
+    * @notice Returns staking provider for specified worker
     */
-    function operatorFromWorker(address _worker) public view returns (address) {
-        return _operatorFromWorker[_worker];
+    function stakingProviderFromWorker(address _worker) public view returns (address) {
+        return _stakingProviderFromWorker[_worker];
     }
 
     /**
-    * @notice Returns worker for specified operator
+    * @notice Returns worker for specified staking provider
     */
-    function getWorkerFromOperator(address _operator) public view returns (address) {
-        return operatorInfo[_operator].worker;
+    function getWorkerFromStakingProvider(address _stakingProvider) public view returns (address) {
+        return stakingProviderInfo[_stakingProvider].worker;
     }
 
     /**
-    * @notice Get all tokens delegated to the operator
+    * @notice Get all tokens delegated to the staking provider
     */
-    function authorizedStake(address _operator) public view returns (uint96) {
-        (uint96 tStake, uint96 keepInTStake, uint96 nuInTStake) = tStaking.stakes(_operator);
+    function authorizedStake(address _stakingProvider) public view returns (uint96) {
+        (uint96 tStake, uint96 keepInTStake, uint96 nuInTStake) = tStaking.stakes(_stakingProvider);
         return tStake + keepInTStake + nuInTStake;
     }
 
     /**
-    * @notice Get the value of authorized tokens for active operators as well as operators and their authorized tokens
-    * @param _startIndex Start index for looking in operators array
-    * @param _maxOperators Max operators for looking, if set 0 then all will be used
-    * @return allAuthorizedTokens Sum of authorized tokens for active operators
-    * @return activeOperators Array of operators and their authorized tokens. Operators addresses stored as uint256
-    * @dev Note that activeOperators[0] is an array of uint256, but you want addresses. Careful when used directly!
+    * @notice Get the value of authorized tokens for active providers as well as providers and their authorized tokens
+    * @param _startIndex Start index for looking in providers array
+    * @param _maxStakingProviders Max providers for looking, if set 0 then all will be used
+    * @return allAuthorizedTokens Sum of authorized tokens for active providers
+    * @return activeStakingProviders Array of providers and their authorized tokens.
+    * Providers addresses stored as uint256
+    * @dev Note that activeStakingProviders[0] is an array of uint256, but you want addresses.
+    * Careful when used directly!
     */
-    function getActiveOperators(uint256 _startIndex, uint256 _maxOperators)
-        external view returns (uint256 allAuthorizedTokens, uint256[2][] memory activeOperators)
+    function getActiveStakingProviders(uint256 _startIndex, uint256 _maxStakingProviders)
+        external view returns (uint256 allAuthorizedTokens, uint256[2][] memory activeStakingProviders)
     {
-        uint256 endIndex = operators.length;
+        uint256 endIndex = stakingProviders.length;
         require(_startIndex < endIndex, "Wrong start index");
-        if (_maxOperators != 0 && _startIndex + _maxOperators < endIndex) {
-            endIndex = _startIndex + _maxOperators;
+        if (_maxStakingProviders != 0 && _startIndex + _maxStakingProviders < endIndex) {
+            endIndex = _startIndex + _maxStakingProviders;
         }
-        activeOperators = new uint256[2][](endIndex - _startIndex);
+        activeStakingProviders = new uint256[2][](endIndex - _startIndex);
         allAuthorizedTokens = 0;
 
         uint256 resultIndex = 0;
         for (uint256 i = _startIndex; i < endIndex; i++) {
-            address operator = operators[i];
-            OperatorInfo storage info = operatorInfo[operator];
-            uint256 eligibleAmount = authorizedStake(operator);
+            address stakingProvider = stakingProviders[i];
+            StakingProviderInfo storage info = stakingProviderInfo[stakingProvider];
+            uint256 eligibleAmount = authorizedStake(stakingProvider);
             if (eligibleAmount < minAuthorization || !info.workerConfirmed) {
                 continue;
             }
-            activeOperators[resultIndex][0] = uint256(uint160(operator));
-            activeOperators[resultIndex++][1] = eligibleAmount;
+            activeStakingProviders[resultIndex][0] = uint256(uint160(stakingProvider));
+            activeStakingProviders[resultIndex++][1] = eligibleAmount;
             allAuthorizedTokens += eligibleAmount;
         }
         assembly {
-            mstore(activeOperators, resultIndex)
+            mstore(activeStakingProviders, resultIndex)
         }
     }
 
     /**
-    * @notice Returns beneficiary related to the operator
+    * @notice Returns beneficiary related to the staking provider
     */
-    function getBeneficiary(address _operator) public view returns (address payable beneficiary) {
-        (, beneficiary,) = tStaking.rolesOf(_operator);
+    function getBeneficiary(address _stakingProvider) public view returns (address payable beneficiary) {
+        (, beneficiary,) = tStaking.rolesOf(_stakingProvider);
     }
 
     /**
-    * @notice Returns true if operator has authorized stake to this application
+    * @notice Returns true if staking provider has authorized stake to this application
     */
-    function isAuthorized(address _operator) public view returns (bool) {
-        return authorizedStake(_operator) >= minAuthorization;
+    function isAuthorized(address _stakingProvider) public view returns (bool) {
+        return authorizedStake(_stakingProvider) >= minAuthorization;
     }
 
     /**
     * @notice Returns true if worker has confirmed address
     */
-    // TODO maybe _operator instead of _worker?
+    // TODO maybe _stakingProvider instead of _worker?
     function isWorkerConfirmed(address _worker) public view returns (bool) {
-        address operator = _operatorFromWorker[_worker];
-        OperatorInfo storage info = operatorInfo[operator];
+        address stakingProvider = _stakingProviderFromWorker[_worker];
+        StakingProviderInfo storage info = stakingProviderInfo[stakingProvider];
         return info.workerConfirmed;
     }
 
     /**
-    * @notice Return the length of the array of operators
+    * @notice Return the length of the array of staking providers
     */
-    function getOperatorsLength() external view returns (uint256) {
-        return operators.length;
+    function getStakingProvidersLength() external view returns (uint256) {
+        return stakingProviders.length;
     }
 
     /**
     * @notice Bond worker
-    * @param _operator Operator address
+    * @param _stakingProvider Staking provider address
     * @param _worker Worker address. Must be a real address, not a contract
     */
-    function bondWorker(address _operator, address _worker) external onlyOwnerOrOperator(_operator) {
-        OperatorInfo storage info = operatorInfo[_operator];
-        require(_worker != info.worker, "Specified worker is already bonded with this operator");
+    function bondWorker(address _stakingProvider, address _worker)
+        external onlyOwnerOrStakingProvider(_stakingProvider)
+    {
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        require(_worker != info.worker, "Specified worker is already bonded with this provider");
         // If this staker had a worker ...
         if (info.worker != address(0)) {
             require(
                 block.timestamp >= info.workerStartTimestamp + minWorkerSeconds,
                 "Not enough time passed to change worker"
             );
-            // Remove the old relation "worker->operator"
-            _operatorFromWorker[info.worker] = address(0);
+            // Remove the old relation "worker->stakingProvider"
+            _stakingProviderFromWorker[info.worker] = address(0);
         }
 
         if (_worker != address(0)) {
-            require(_operatorFromWorker[_worker] == address(0), "Specified worker is already in use");
+            require(_stakingProviderFromWorker[_worker] == address(0), "Specified worker is already in use");
             require(
-                _worker == _operator || getBeneficiary(_worker) == address(0),
-                "Specified worker is an operator"
+                _worker == _stakingProvider || getBeneficiary(_worker) == address(0),
+                "Specified worker is a provider"
             );
-            // Set new worker->operator relation
-            _operatorFromWorker[_worker] = _operator;
+            // Set new worker->stakingProvider relation
+            _stakingProviderFromWorker[_worker] = _stakingProvider;
         }
 
         if (info.workerStartTimestamp == 0) {
-            operators.push(_operator);
+            stakingProviders.push(_stakingProvider);
         }
 
         // Bond new worker (or unbond if _worker == address(0))
         info.worker = _worker;
         info.workerStartTimestamp = block.timestamp;
         info.workerConfirmed = false;
-        emit WorkerBonded(_operator, _worker, block.timestamp);
+        emit WorkerBonded(_stakingProvider, _worker, block.timestamp);
     }
 
     /**
     * @notice Make a confirmation by worker
     */
     function confirmWorkerAddress() external {
-        address operator = _operatorFromWorker[msg.sender];
-        require(isAuthorized(operator), "No stake associated with the worker");
-        OperatorInfo storage info = operatorInfo[operator];
+        address stakingProvider = _stakingProviderFromWorker[msg.sender];
+        require(isAuthorized(stakingProvider), "No stake associated with the worker");
+        StakingProviderInfo storage info = stakingProviderInfo[stakingProvider];
         require(!info.workerConfirmed, "Worker address is already confirmed");
         require(msg.sender == tx.origin, "Only worker with real address can make a confirmation");
         info.workerConfirmed = true;
-        emit WorkerConfirmed(operator, msg.sender);
+        emit WorkerConfirmed(stakingProvider, msg.sender);
     }
 
 }

--- a/nucypher/blockchain/eth/sol/source/contracts/SimplePREApplication.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/SimplePREApplication.sol
@@ -179,7 +179,7 @@ contract SimplePREApplication {
     {
         StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
         require(_operator != info.operator, "Specified operator is already bonded with this provider");
-        // If this staker had a operator ...
+        // If this staker had an operator ...
         if (info.operator != address(0)) {
             require(
                 block.timestamp >= info.operatorStartTimestamp + minOperatorSeconds,

--- a/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
+++ b/nucypher/blockchain/eth/sol/source/contracts/StakingEscrow.sol
@@ -107,9 +107,9 @@ contract StakingEscrow is Upgradeable, IERC900History {
     /**
     * @notice Signals that the staker requested merge with T staking contract
     * @param staker Staker address
-    * @param operator Operator address
+    * @param stakingProvider Staking provider address
     */
-    event MergeRequested(address indexed staker, address indexed operator);
+    event MergeRequested(address indexed staker, address indexed stakingProvider);
 
     struct StakerInfo {
         uint256 value;
@@ -126,7 +126,7 @@ contract StakingEscrow is Upgradeable, IERC900History {
 
         uint256 vestingReleaseTimestamp;
         uint256 vestingReleaseRate;
-        address operator;
+        address stakingProvider;
 
         uint256 reservedSlot4;
         uint256 reservedSlot5;
@@ -272,7 +272,7 @@ contract StakingEscrow is Upgradeable, IERC900History {
         require(_value > 0, "Value must be specified");
         StakerInfo storage info = stakerInfo[msg.sender];
         require(
-            _value + tStaking.stakedNu(info.operator) <= info.value,
+            _value + tStaking.stakedNu(info.stakingProvider) <= info.value,
             "Not enough tokens unstaked in T staking contract"
         );
         require(
@@ -331,22 +331,22 @@ contract StakingEscrow is Upgradeable, IERC900History {
     /**
     * @notice Request migration to threshold network
     * @param _staker Staker address
-    * @param _operator Operator address
+    * @param _stakingProvider Staking provider address
     * @return Amount of tokens
     */
-    function requestMerge(address _staker, address _operator)
+    function requestMerge(address _staker, address _stakingProvider)
         external onlyTStakingContract returns (uint256)
     {
         StakerInfo storage info = stakerInfo[_staker];
         require(
-            info.operator == address(0) ||
-            info.operator == _operator ||
-            tStaking.stakedNu(info.operator) == 0,
-            "Operator already set for the staker"
+            info.stakingProvider == address(0) ||
+            info.stakingProvider == _stakingProvider ||
+            tStaking.stakedNu(info.stakingProvider) == 0,
+            "Staking provider already set for the staker"
         );
-        if (info.operator != _operator) {
-            info.operator = _operator;
-            emit MergeRequested(_staker, _operator);
+        if (info.stakingProvider != _stakingProvider) {
+            info.stakingProvider = _stakingProvider;
+            emit MergeRequested(_staker, _stakingProvider);
         }
         return info.value;
     }
@@ -434,7 +434,7 @@ contract StakingEscrow is Upgradeable, IERC900History {
         require(infoToCheck.value == info.value &&
             infoToCheck.vestingReleaseTimestamp == info.vestingReleaseTimestamp &&
             infoToCheck.vestingReleaseRate == info.vestingReleaseRate &&
-            infoToCheck.operator == info.operator &&
+            infoToCheck.stakingProvider == info.stakingProvider &&
             infoToCheck.flags == info.flags
         );
     }

--- a/nucypher/blockchain/eth/sol/source/threshold/IStaking.sol
+++ b/nucypher/blockchain/eth/sol/source/threshold/IStaking.sol
@@ -1,11 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
 pragma solidity ^0.8.0;
 
 /// @title Interface of Threshold Network staking contract
 /// @notice The staking contract enables T owners to have their wallets offline
-///         and their stake operated by operators on their behalf. All off-chain
-///         client software should be able to run without exposing operator’s
+///         and their stake managed by providers on their behalf. All off-chain
+///         client software should be able to run without exposing provider’s
 ///         private key and should not require any owner’s keys at all.
 ///         The stake delegation optimizes the network throughput without
 ///         compromising the security of the owners’ stake.
@@ -23,12 +36,12 @@ interface IStaking {
     //
 
     /// @notice Creates a delegation with `msg.sender` owner with the given
-    ///         operator, beneficiary, and authorizer. Transfers the given
+    ///         provider, beneficiary, and authorizer. Transfers the given
     ///         amount of T to the staking contract.
     /// @dev The owner of the delegation needs to have the amount approved to
     ///      transfer to the staking contract.
     function stake(
-        address operator,
+        address stakingProvider,
         address payable beneficiary,
         address authorizer,
         uint96 amount
@@ -38,20 +51,20 @@ interface IStaking {
     ///         staking contract. No tokens are transferred. Caches the active
     ///         stake amount from KEEP staking contract. Can be called by
     ///         anyone.
-    function stakeKeep(address operator) external;
+    function stakeKeep(address stakingProvider) external;
 
     /// @notice Copies delegation from the legacy NU staking contract to T
     ///         staking contract, additionally appointing beneficiary and
     ///         authorizer roles. Caches the amount staked in NU staking
     ///         contract. Can be called only by the original delegation owner.
     function stakeNu(
-        address operator,
+        address stakingProvider,
         address payable beneficiary,
         address authorizer
     ) external;
 
     /// @notice Refresh Keep stake owner. Can be called only by the old owner.
-    function refreshKeepStakeOwner(address operator) external;
+    function refreshKeepStakeOwner(address stakingProvider) external;
 
     /// @notice Allows the Governance to set the minimum required stake amount.
     ///         This amount is required to protect against griefing the staking
@@ -69,56 +82,58 @@ interface IStaking {
     ///         before individual stake authorizers are able to authorize it.
     function approveApplication(address application) external;
 
-    /// @notice Increases the authorization of the given operator for the given
+    /// @notice Increases the authorization of the given provider for the given
     ///         application by the given amount. Can only be called by the given
-    ///         operator’s authorizer.
-    /// @dev Calls `authorizationIncreased(address operator, uint256 amount)`
+    ///         provider’s authorizer.
+    /// @dev Calls `authorizationIncreased(address stakingProvider, uint256 amount)`
     ///      on the given application to notify the application about
     ///      authorization change. See `IApplication`.
     function increaseAuthorization(
-        address operator,
+        address stakingProvider,
         address application,
         uint96 amount
     ) external;
 
-    /// @notice Requests decrease of the authorization for the given operator on
+    /// @notice Requests decrease of the authorization for the given provider on
     ///         the given application by the provided amount.
     ///         It may not change the authorized amount immediatelly. When
     ///         it happens depends on the application. Can only be called by the
-    ///         given operator’s authorizer. Overwrites pending authorization
-    ///         decrease for the given operator and application.
-    /// @dev Calls `authorizationDecreaseRequested(address operator, uint256 amount)`
+    ///         given provider’s authorizer. Overwrites pending authorization
+    ///         decrease for the given provider and application.
+    /// @dev Calls `authorizationDecreaseRequested(address stakingProvider, uint256 amount)`
     ///      on the given application. See `IApplication`.
     function requestAuthorizationDecrease(
-        address operator,
+        address stakingProvider,
         address application,
         uint96 amount
     ) external;
 
-    /// @notice Requests decrease of all authorizations for the given operator on
+    /// @notice Requests decrease of all authorizations for the given provider on
     ///         the applications by all authorized amount.
     ///         It may not change the authorized amount immediatelly. When
     ///         it happens depends on the application. Can only be called by the
-    ///         given operator’s authorizer. Overwrites pending authorization
-    ///         decrease for the given operator and application.
-    /// @dev Calls `authorizationDecreaseRequested(address operator, uint256 amount)`
+    ///         given provider’s authorizer. Overwrites pending authorization
+    ///         decrease for the given provider and application.
+    /// @dev Calls `authorizationDecreaseRequested(address stakingProvider, uint256 amount)`
     ///      for each authorized application. See `IApplication`.
-    function requestAuthorizationDecrease(address operator) external;
+    function requestAuthorizationDecrease(address stakingProvider) external;
 
     /// @notice Called by the application at its discretion to approve the
     ///         previously requested authorization decrease request. Can only be
     ///         called by the application that was previously requested to
-    ///         decrease the authorization for that operator.
+    ///         decrease the authorization for that provider.
     ///         Returns resulting authorized amount for the application.
-    function approveAuthorizationDecrease(address operator)
+    function approveAuthorizationDecrease(address stakingProvider)
         external
         returns (uint96);
 
-    /// @notice Decreases the authorization for the given `operator` on
+    /// @notice Decreases the authorization for the given `stakingProvider` on
     ///         the given disabled `application`, for all authorized amount.
     ///         Can be called by anyone.
-    function forceDecreaseAuthorization(address operator, address application)
-        external;
+    function forceDecreaseAuthorization(
+        address stakingProvider,
+        address application
+    ) external;
 
     /// @notice Pauses the given application’s eligibility to slash stakes.
     ///         Besides that stakers can't change authorization to the application.
@@ -142,7 +157,7 @@ interface IStaking {
     ///         role address should be set to 0x0 address.
     function setPanicButton(address application, address panicButton) external;
 
-    /// @notice Sets the maximum number of applications one operator can
+    /// @notice Sets the maximum number of applications one provider can
     ///         authorize. Used to protect against DoSing slashing queue.
     ///         Can only be called by the Governance.
     function setAuthorizationCeiling(uint256 ceiling) external;
@@ -153,21 +168,21 @@ interface IStaking {
     //
     //
 
-    /// @notice Increases the amount of the stake for the given operator.
-    ///         Can be called only by the owner or operator.
+    /// @notice Increases the amount of the stake for the given provider.
+    ///         Can be called only by the owner or provider.
     /// @dev The sender of this transaction needs to have the amount approved to
     ///      transfer to the staking contract.
-    function topUp(address operator, uint96 amount) external;
+    function topUp(address stakingProvider, uint96 amount) external;
 
     /// @notice Propagates information about stake top-up from the legacy KEEP
     ///         staking contract to T staking contract. Can be called only by
-    ///         the owner or operator.
-    function topUpKeep(address operator) external;
+    ///         the owner or provider.
+    function topUpKeep(address stakingProvider) external;
 
     /// @notice Propagates information about stake top-up from the legacy NU
     ///         staking contract to T staking contract. Can be called only by
-    ///         the owner or operator.
-    function topUpNu(address operator) external;
+    ///         the owner or provider.
+    function topUpNu(address stakingProvider) external;
 
     //
     //
@@ -180,8 +195,8 @@ interface IStaking {
     ///         authorization higher than the sum of the legacy stake and
     ///         remaining liquid T stake or if the unstake amount is higher than
     ///         the liquid T stake amount. Can be called only by the owner or
-    ///         operator.
-    function unstakeT(address operator, uint96 amount) external;
+    ///         provider.
+    function unstakeT(address stakingProvider, uint96 amount) external;
 
     /// @notice Sets the legacy KEEP staking contract active stake amount cached
     ///         in T staking contract to 0. Reverts if the amount of liquid T
@@ -189,26 +204,26 @@ interface IStaking {
     ///         application authorization. This function allows to unstake from
     ///         KEEP staking contract and still being able to operate in T
     ///         network and earning rewards based on the liquid T staked. Can be
-    ///         called only by the delegation owner and operator.
-    function unstakeKeep(address operator) external;
+    ///         called only by the delegation owner and provider.
+    function unstakeKeep(address stakingProvider) external;
 
     /// @notice Reduces cached legacy NU stake amount by the provided amount.
     ///         Reverts if there is at least one authorization higher than the
     ///         sum of remaining legacy NU stake and liquid T stake for that
-    ///         operator or if the untaked amount is higher than the cached
+    ///         provider or if the untaked amount is higher than the cached
     ///         legacy stake amount. If succeeded, the legacy NU stake can be
     ///         partially or fully undelegated on the legacy staking contract.
     ///         This function allows to unstake from NU staking contract and
     ///         still being able to operate in T network and earning rewards
     ///         based on the liquid T staked. Can be called only by the
-    ///         delegation owner and operator.
-    function unstakeNu(address operator, uint96 amount) external;
+    ///         delegation owner and provider.
+    function unstakeNu(address stakingProvider, uint96 amount) external;
 
     /// @notice Sets cached legacy stake amount to 0, sets the liquid T stake
     ///         amount to 0 and withdraws all liquid T from the stake to the
     ///         owner. Reverts if there is at least one non-zero authorization.
-    ///         Can be called only by the delegation owner and operator.
-    function unstakeAll(address operator) external;
+    ///         Can be called only by the delegation owner and provider.
+    function unstakeAll(address stakingProvider) external;
 
     //
     //
@@ -217,26 +232,26 @@ interface IStaking {
     //
 
     /// @notice Notifies about the discrepancy between legacy KEEP active stake
-    ///         and the amount cached in T staking contract. Slashes the operator
+    ///         and the amount cached in T staking contract. Slashes the provider
     ///         in case the amount cached is higher than the actual active stake
     ///         amount in KEEP staking contract. Needs to update authorizations
     ///         of all affected applications and execute an involuntary
     ///         allocation decrease on all affected applications. Can be called
     ///         by anyone, notifier receives a reward.
-    function notifyKeepStakeDiscrepancy(address operator) external;
+    function notifyKeepStakeDiscrepancy(address stakingProvider) external;
 
     /// @notice Notifies about the discrepancy between legacy NU active stake
     ///         and the amount cached in T staking contract. Slashes the
-    ///         operator in case the amount cached is higher than the actual
+    ///         provider in case the amount cached is higher than the actual
     ///         active stake amount in NU staking contract. Needs to update
     ///         authorizations of all affected applications and execute an
     ///         involuntary allocation decrease on all affected applications.
     ///         Can be called by anyone, notifier receives a reward.
-    function notifyNuStakeDiscrepancy(address operator) external;
+    function notifyNuStakeDiscrepancy(address stakingProvider) external;
 
     /// @notice Sets the penalty amount for stake discrepancy and reward
     ///         multiplier for reporting it. The penalty is seized from the
-    ///         operator account, and 5% of the penalty, scaled by the
+    ///         provider account, and 5% of the penalty, scaled by the
     ///         multiplier, is given to the notifier. The rest of the tokens are
     ///         burned. Can only be called by the Governance. See `seize` function.
     function setStakeDiscrepancyPenalty(
@@ -245,7 +260,7 @@ interface IStaking {
     ) external;
 
     /// @notice Sets reward in T tokens for notification of misbehaviour
-    ///         of one operator. Can only be called by the governance.
+    ///         of one provider. Can only be called by the governance.
     function setNotificationReward(uint96 reward) external;
 
     /// @notice Transfer some amount of T tokens as reward for notifications
@@ -257,20 +272,20 @@ interface IStaking {
     function withdrawNotificationReward(address recipient, uint96 amount)
         external;
 
-    /// @notice Adds operators to the slashing queue along with the amount that
+    /// @notice Adds providers to the slashing queue along with the amount that
     ///         should be slashed from each one of them. Can only be called by
-    ///         application authorized for all operators in the array.
-    function slash(uint96 amount, address[] memory operators) external;
+    ///         application authorized for all providers in the array.
+    function slash(uint96 amount, address[] memory stakingProviders) external;
 
-    /// @notice Adds operators to the slashing queue along with the amount.
-    ///         The notifier will receive reward per each operator from
+    /// @notice Adds providers to the slashing queue along with the amount.
+    ///         The notifier will receive reward per each provider from
     ///         notifiers treasury. Can only be called by application
-    ///         authorized for all operators in the array.
+    ///         authorized for all providers in the array.
     function seize(
         uint96 amount,
         uint256 rewardMultipier,
         address notifier,
-        address[] memory operators
+        address[] memory stakingProviders
     ) external;
 
     /// @notice Takes the given number of queued slashing operations and
@@ -285,17 +300,17 @@ interface IStaking {
     //
     //
 
-    /// @notice Returns the authorized stake amount of the operator for the
+    /// @notice Returns the authorized stake amount of the provider for the
     ///         application.
-    function authorizedStake(address operator, address application)
+    function authorizedStake(address stakingProvider, address application)
         external
         view
         returns (uint96);
 
     /// @notice Returns staked amount of T, Keep and Nu for the specified
-    ///         operator.
+    ///         staking provider.
     /// @dev    All values are in T denomination
-    function stakes(address operator)
+    function stakes(address stakingProvider)
         external
         view
         returns (
@@ -304,24 +319,24 @@ interface IStaking {
             uint96 nuInTStake
         );
 
-    /// @notice Returns start staking timestamp for T stake.
+    /// @notice Returns start staking timestamp for T/NU stake.
     /// @dev    This value is set at most once, and only when a stake is created
-    ///         with T tokens. If a stake is created from a legacy stake,
-    ///         this value will remain as zero
-    function getStartTStakingTimestamp(address operator)
+    ///         with T or NU tokens. If a stake is created from a legacy KEEP
+    ///         stake, this value will remain as zero
+    function getStartStakingTimestamp(address stakingProvider)
         external
         view
         returns (uint256);
 
-    /// @notice Returns staked amount of NU for the specified operator
-    function stakedNu(address operator) external view returns (uint256);
+    /// @notice Returns staked amount of NU for the specified provider
+    function stakedNu(address stakingProvider) external view returns (uint256);
 
     /// @notice Gets the stake owner, the beneficiary and the authorizer
-    ///         for the specified operator address.
+    ///         for the specified provider address.
     /// @return owner Stake owner address.
     /// @return beneficiary Beneficiary address.
     /// @return authorizer Authorizer address.
-    function rolesOf(address operator)
+    function rolesOf(address stakingProvider)
         external
         view
         returns (
@@ -337,22 +352,28 @@ interface IStaking {
     function getSlashingQueueLength() external view returns (uint256);
 
     /// @notice Returns minimum possible stake for T, KEEP or NU in T denomination
-    /// @dev    For example, if the given operator has 10 T, 20 KEEP, and
-    ///         30 NU staked, their max authorization is 40, then `getMinStaked`
-    ///         for that operator returns 0 for KEEP stake type, 10 for NU stake
-    ///         type, and 0 for T stake type. In other words, minimum staked
-    ///         amount for the given stake type is the minimum amount of stake
-    ///         of the given type that needs to be preserved in the contract to
-    ///         satisfy the maximum application authorization given the amounts
-    ///         of other stake types for that operator.
-    function getMinStaked(address operator, StakeType stakeTypes)
+    /// @dev For example, suppose the given provider has 10 T, 20 T worth
+    ///      of KEEP, and 30 T worth of NU all staked, and the maximum
+    ///      application authorization is 40 T, then `getMinStaked` for
+    ///      that provider returns:
+    ///          * 0 T if KEEP stake type specified i.e.
+    ///            min = 40 T max - (10 T + 30 T worth of NU) = 0 T
+    ///          * 10 T if NU stake type specified i.e.
+    ///            min = 40 T max - (10 T + 20 T worth of KEEP) = 10 T
+    ///          * 0 T if T stake type specified i.e.
+    ///            min = 40 T max - (20 T worth of KEEP + 30 T worth of NU) < 0 T
+    ///      In other words, the minimum stake amount for the specified
+    ///      stake type is the minimum amount of stake of the given type
+    ///      needed to satisfy the maximum application authorization given
+    ///      the staked amounts of the other stake types for that provider.
+    function getMinStaked(address stakingProvider, StakeType stakeTypes)
         external
         view
         returns (uint96);
 
     /// @notice Returns available amount to authorize for the specified application
-    function getAvailableToAuthorize(address operator, address application)
-        external
-        view
-        returns (uint96);
+    function getAvailableToAuthorize(
+        address stakingProvider,
+        address application
+    ) external view returns (uint96);
 }

--- a/tests/contracts/contracts/PREApplicationTestSet.sol
+++ b/tests/contracts/contracts/PREApplicationTestSet.sol
@@ -128,7 +128,7 @@ contract ThresholdStakingForPREApplicationMock {
 
 
 /**
-* @notice Intermediary contract for testing worker
+* @notice Intermediary contract for testing operator
 */
 contract Intermediary {
 
@@ -138,12 +138,12 @@ contract Intermediary {
         preApplication = _preApplication;
     }
 
-    function bondWorker(address _worker) external {
-        preApplication.bondWorker(address(this), _worker);
+    function bondOperator(address _operator) external {
+        preApplication.bondOperator(address(this), _operator);
     }
 
-    function confirmWorkerAddress() external {
-        preApplication.confirmWorkerAddress();
+    function confirmOperatorAddress() external {
+        preApplication.confirmOperatorAddress();
     }
 
 }

--- a/tests/contracts/contracts/PREApplicationTestSet.sol
+++ b/tests/contracts/contracts/PREApplicationTestSet.sol
@@ -25,7 +25,7 @@ import "contracts/SimplePREApplication.sol";
 */
 contract ThresholdStakingForPREApplicationMock {
 
-    struct OperatorInfo {
+    struct StakingProviderInfo {
         address owner;
         address payable beneficiary;
         address authorizer;
@@ -36,78 +36,78 @@ contract ThresholdStakingForPREApplicationMock {
 
     SimplePREApplication public preApplication;
 
-    mapping (address => OperatorInfo) public operatorInfo;
+    mapping (address => StakingProviderInfo) public stakingProviderInfo;
 
     function setApplication(SimplePREApplication _preApplication) external {
         preApplication = _preApplication;
     }
 
     function setRoles(
-        address _operator,
+        address _stakingProvider,
         address _owner,
         address payable _beneficiary,
         address _authorizer
     )
         external
     {
-        OperatorInfo storage info = operatorInfo[_operator];
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
         info.owner = _owner;
         info.beneficiary = _beneficiary;
         info.authorizer = _authorizer;
     }
 
     /**
-    * @dev If the function is called with only the _operator parameter,
+    * @dev If the function is called with only the _stakingProvider parameter,
     * we presume that the caller wants that address set for the other roles as well.
     */
-    function setRoles(address _operator) external {
-        OperatorInfo storage info = operatorInfo[_operator];
-        info.owner = _operator;
-        info.beneficiary = payable(_operator);
-        info.authorizer = _operator;
+    function setRoles(address _stakingProvider) external {
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        info.owner = _stakingProvider;
+        info.beneficiary = payable(_stakingProvider);
+        info.authorizer = _stakingProvider;
     }
 
     function setStakes(
-        address _operator,
+        address _stakingProvider,
         uint96 _tStake,
         uint96 _keepInTStake,
         uint96 _nuInTStake
     )
         external
     {
-        OperatorInfo storage info = operatorInfo[_operator];
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
         info.tStake = _tStake;
         info.keepInTStake = _keepInTStake;
         info.nuInTStake = _nuInTStake;
     }
 
-    function authorizedStake(address _operator, address _application) external view returns (uint96) {
+    function authorizedStake(address _stakingProvider, address _application) external view returns (uint96) {
         return 0;
     }
 
-    function stakes(address _operator) external view returns (
+    function stakes(address _stakingProvider) external view returns (
         uint96 tStake,
         uint96 keepInTStake,
         uint96 nuInTStake
     ) {
-        OperatorInfo storage info = operatorInfo[_operator];
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
         tStake = info.tStake;
         keepInTStake = info.keepInTStake;
         nuInTStake = info.nuInTStake;
     }
 
-    function rolesOf(address _operator) external view returns (
+    function rolesOf(address _stakingProvider) external view returns (
         address owner,
         address payable beneficiary,
         address authorizer
     ) {
-        OperatorInfo storage info = operatorInfo[_operator];
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
         owner = info.owner;
         beneficiary = info.beneficiary;
         authorizer = info.authorizer;
     }
 
-//    function approveAuthorizationDecrease(address _operator) external returns (uint96) {
+//    function approveAuthorizationDecrease(address _stakingProvider) external returns (uint96) {
 //
 //    }
 
@@ -115,13 +115,13 @@ contract ThresholdStakingForPREApplicationMock {
 //        uint96 _amount,
 //        uint256 _rewardMultipier,
 //        address _notifier,
-//        address[] memory _operators
+//        address[] memory _stakingProviders
 //    ) external {
 //
 //    }
 
-//    function authorizationIncreased(address _operator, uint96 _fromAmount, uint96 _toAmount) external {
-//        preApplication.authorizationIncreased(_operator, _fromAmount, _toAmount);
+//    function authorizationIncreased(address _stakingProvider, uint96 _fromAmount, uint96 _toAmount) external {
+//        preApplication.authorizationIncreased(_stakingProvider, _fromAmount, _toAmount);
 //    }
 
 }

--- a/tests/contracts/contracts/StakingEscrowTestSet.sol
+++ b/tests/contracts/contracts/StakingEscrowTestSet.sol
@@ -130,27 +130,27 @@ contract ThresholdStakingForStakingEscrowMock {
 
     StakingEscrow public escrow;
 
-    struct OperatorInfo {
+    struct StakingProviderInfo {
         uint256 staked;
         uint96 minStaked;
     }
 
-    mapping(address => OperatorInfo) public operators;
+    mapping(address => StakingProviderInfo) public stakingProviders;
 
     function setStakingEscrow(StakingEscrow _escrow) external {
         escrow = _escrow;
     }
 
-    function stakedNu(address _operator) external view returns (uint256) {
-        return operators[_operator].staked;
+    function stakedNu(address _stakingProvider) external view returns (uint256) {
+        return stakingProviders[_stakingProvider].staked;
     }
 
-    function getMinStaked(address _operator, IStaking.StakeType _stakeTypes) external view returns (uint96) {
+    function getMinStaked(address _stakingProvider, IStaking.StakeType _stakeTypes) external view returns (uint96) {
         require(_stakeTypes == IStaking.StakeType.NU);
-        return operators[_operator].minStaked;
+        return stakingProviders[_stakingProvider].minStaked;
     }
 
-    function stakes(address _operator) external view returns
+    function stakes(address _stakingProvider) external view returns
     (
         uint96 tStake,
         uint96 keepInTStake,
@@ -158,7 +158,7 @@ contract ThresholdStakingForStakingEscrowMock {
     ) {
         tStake = 0;
         keepInTStake = 0;
-        nuInTStake = uint96(operators[_operator].staked);
+        nuInTStake = uint96(stakingProviders[_stakingProvider].staked);
     }
 
     function slashStaker(
@@ -172,17 +172,17 @@ contract ThresholdStakingForStakingEscrowMock {
         escrow.slashStaker(_staker, _penalty, _investigator, _reward);
     }
 
-    function requestMerge(address _staker, address _operator) external {
-        operators[_operator].staked = escrow.requestMerge(_staker, _operator);
+    function requestMerge(address _staker, address _stakingProvider) external {
+        stakingProviders[_stakingProvider].staked = escrow.requestMerge(_staker, _stakingProvider);
     }
 
-    function setStakedNu(address _operator, uint256 _staked) external {
-        require(_staked <= operators[_operator].staked);
-        operators[_operator].staked = _staked;
+    function setStakedNu(address _stakingProvider, uint256 _staked) external {
+        require(_staked <= stakingProviders[_stakingProvider].staked);
+        stakingProviders[_stakingProvider].staked = _staked;
     }
 
-    function setMinStaked(address _operator, uint96 _minStaked) external {
-        require(_minStaked <= operators[_operator].staked);
-        operators[_operator].minStaked = _minStaked;
+    function setMinStaked(address _stakingProvider, uint96 _minStaked) external {
+        require(_minStaked <= stakingProviders[_stakingProvider].staked);
+        stakingProviders[_stakingProvider].minStaked = _minStaked;
     }
 }

--- a/tests/contracts/main/application/test_operator.py
+++ b/tests/contracts/main/application/test_operator.py
@@ -24,14 +24,14 @@ from eth_utils import to_checksum_address
 CONFIRMATION_SLOT = 1
 
 
-def test_bond_worker(testerchain, threshold_staking, pre_application, token_economics):
+def test_bond_operator(testerchain, threshold_staking, pre_application, token_economics):
     creator, staking_provider_1, staking_provider_2, staking_provider_3, staking_provider_4, \
-    worker1, worker2, worker3, owner3, beneficiary, authorizer, *everyone_else = \
+    operator1, operator2, operator3, owner3, beneficiary, authorizer, *everyone_else = \
         testerchain.client.accounts
     min_authorization = token_economics.minimum_allowed_locked
-    min_worker_seconds = 24 * 60 * 60
+    min_operator_seconds = 24 * 60 * 60
 
-    worker_log = pre_application.events.WorkerBonded.createFilter(fromBlock='latest')
+    operator_log = pre_application.events.OperatorBonded.createFilter(fromBlock='latest')
 
     # Prepare staking providers: two with intermediary contract and two just a staking provider
     tx = threshold_staking.functions.setRoles(staking_provider_1).transact()
@@ -52,46 +52,48 @@ def test_bond_worker(testerchain, threshold_staking, pre_application, token_econ
     tx = threshold_staking.functions.setStakes(staking_provider_4, 0, 0, min_authorization).transact()
     testerchain.wait_for_receipt(tx)
 
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_1).call() == NULL_ADDRESS
-    assert pre_application.functions.stakingProviderFromWorker(staking_provider_1).call() == NULL_ADDRESS
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_2).call() == NULL_ADDRESS
-    assert pre_application.functions.stakingProviderFromWorker(staking_provider_2).call() == NULL_ADDRESS
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_3).call() == NULL_ADDRESS
-    assert pre_application.functions.stakingProviderFromWorker(staking_provider_3).call() == NULL_ADDRESS
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_4).call() == NULL_ADDRESS
-    assert pre_application.functions.stakingProviderFromWorker(staking_provider_4).call() == NULL_ADDRESS
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_1).call() == NULL_ADDRESS
+    assert pre_application.functions.stakingProviderFromOperator(staking_provider_1).call() == NULL_ADDRESS
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_2).call() == NULL_ADDRESS
+    assert pre_application.functions.stakingProviderFromOperator(staking_provider_2).call() == NULL_ADDRESS
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_3).call() == NULL_ADDRESS
+    assert pre_application.functions.stakingProviderFromOperator(staking_provider_3).call() == NULL_ADDRESS
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_4).call() == NULL_ADDRESS
+    assert pre_application.functions.stakingProviderFromOperator(staking_provider_4).call() == NULL_ADDRESS
 
-    # Staking provider can't confirm worker address because there is no worker by default
+    # Staking provider can't confirm operator address because there is no operator by default
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.confirmWorkerAddress().transact({'from': staking_provider_1})
+        tx = pre_application.functions.confirmOperatorAddress().transact({'from': staking_provider_1})
         testerchain.wait_for_receipt(tx)
 
-    # Staking provider can't bond another staking provider as worker
+    # Staking provider can't bond another staking provider as operator
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_1, staking_provider_2).transact({'from': staking_provider_1})
+        tx = pre_application.functions.bondOperator(staking_provider_1, staking_provider_2)\
+            .transact({'from': staking_provider_1})
         testerchain.wait_for_receipt(tx)
 
-    # Staking provider can't bond worker if stake is less than minimum
+    # Staking provider can't bond operator if stake is less than minimum
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_2, worker1).transact({'from': staking_provider_2})
+        tx = pre_application.functions.bondOperator(staking_provider_2, operator1)\
+            .transact({'from': staking_provider_2})
         testerchain.wait_for_receipt(tx)
 
-    # Only staking provider or stake owner can bond worker
+    # Only staking provider or stake owner can bond operator
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_3, worker1).transact({'from': beneficiary})
+        tx = pre_application.functions.bondOperator(staking_provider_3, operator1).transact({'from': beneficiary})
         testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_3, worker1).transact({'from': authorizer})
+        tx = pre_application.functions.bondOperator(staking_provider_3, operator1).transact({'from': authorizer})
         testerchain.wait_for_receipt(tx)
 
-    # Staking provider bonds worker and now worker can make a confirmation
-    tx = pre_application.functions.bondWorker(staking_provider_3, worker1).transact({'from': owner3})
+    # Staking provider bonds operator and now operator can make a confirmation
+    tx = pre_application.functions.bondOperator(staking_provider_3, operator1).transact({'from': owner3})
     testerchain.wait_for_receipt(tx)
     timestamp = testerchain.w3.eth.getBlock('latest').timestamp
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_3).call() == worker1
-    assert pre_application.functions.stakingProviderFromWorker(worker1).call() == staking_provider_3
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_3).call() == operator1
+    assert pre_application.functions.stakingProviderFromOperator(operator1).call() == staking_provider_3
     assert not pre_application.functions.stakingProviderInfo(staking_provider_3).call()[CONFIRMATION_SLOT]
-    assert not pre_application.functions.isWorkerConfirmed(worker1).call()
+    assert not pre_application.functions.isOperatorConfirmed(operator1).call()
     assert pre_application.functions.getStakingProvidersLength().call() == 1
     assert pre_application.functions.stakingProviders(0).call() == staking_provider_3
 
@@ -100,205 +102,205 @@ def test_bond_worker(testerchain, threshold_staking, pre_application, token_econ
     assert all_locked == 0
     assert len(staking_providers) == 0
 
-    tx = pre_application.functions.confirmWorkerAddress().transact({'from': worker1})
+    tx = pre_application.functions.confirmOperatorAddress().transact({'from': operator1})
     testerchain.wait_for_receipt(tx)
     assert pre_application.functions.stakingProviderInfo(staking_provider_3).call()[CONFIRMATION_SLOT]
-    assert pre_application.functions.isWorkerConfirmed(worker1).call()
+    assert pre_application.functions.isOperatorConfirmed(operator1).call()
 
     number_of_events = 1
-    events = worker_log.get_all_entries()
+    events = operator_log.get_all_entries()
     assert len(events) == number_of_events
     event_args = events[-1]['args']
     assert event_args['stakingProvider'] == staking_provider_3
-    assert event_args['worker'] == worker1
+    assert event_args['operator'] == operator1
     assert event_args['startTimestamp'] == timestamp
 
-    # After confirmation worker is becoming active
+    # After confirmation operator is becoming active
     all_locked, staking_providers = pre_application.functions.getActiveStakingProviders(0, 0).call()
     assert all_locked == min_authorization
     assert len(staking_providers) == 1
     assert to_checksum_address(staking_providers[0][0]) == staking_provider_3
     assert staking_providers[0][1] == min_authorization
 
-    # Worker is in use so other stakingProviders can't bond him
+    # Operator is in use so other stakingProviders can't bond him
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_4, worker1).transact({'from': staking_provider_4})
+        tx = pre_application.functions.bondOperator(staking_provider_4, operator1).transact({'from': staking_provider_4})
         testerchain.wait_for_receipt(tx)
 
-    # # Worker can't be a staking provider
-    # tx = threshold_staking.functions.setRoles(worker1).transact()
+    # # Operator can't be a staking provider
+    # tx = threshold_staking.functions.setRoles(operator1).transact()
     # testerchain.wait_for_receipt(tx)
-    # tx = threshold_staking.functions.setStakes(worker1, min_authorization, 0, 0).transact()
+    # tx = threshold_staking.functions.setStakes(operator1, min_authorization, 0, 0).transact()
     # testerchain.wait_for_receipt(tx)
     # with pytest.raises((TransactionFailed, ValueError)):
     #     tx = threshold_staking.functions.increaseAuthorization(
-    #         worker1, min_authorization, pre_application.address).transact({'from': worker1})
+    #         operator1, min_authorization, pre_application.address).transact({'from': operator1})
     #     testerchain.wait_for_receipt(tx)
 
-    # Can't bond worker twice too soon
+    # Can't bond operator twice too soon
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_3, worker2).transact({'from': staking_provider_3})
+        tx = pre_application.functions.bondOperator(staking_provider_3, operator2).transact({'from': staking_provider_3})
         testerchain.wait_for_receipt(tx)
 
-    # She can't unbond her worker too, until enough time has passed
+    # She can't unbond her operator too, until enough time has passed
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_3, NULL_ADDRESS).transact({'from': staking_provider_3})
+        tx = pre_application.functions.bondOperator(staking_provider_3, NULL_ADDRESS).transact({'from': staking_provider_3})
         testerchain.wait_for_receipt(tx)
 
-    # Let's advance some time and unbond the worker
-    testerchain.time_travel(seconds=min_worker_seconds)
-    tx = pre_application.functions.bondWorker(staking_provider_3, NULL_ADDRESS).transact({'from': staking_provider_3})
+    # Let's advance some time and unbond the operator
+    testerchain.time_travel(seconds=min_operator_seconds)
+    tx = pre_application.functions.bondOperator(staking_provider_3, NULL_ADDRESS).transact({'from': staking_provider_3})
     testerchain.wait_for_receipt(tx)
     timestamp = testerchain.w3.eth.getBlock('latest').timestamp
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_3).call() == NULL_ADDRESS
-    assert pre_application.functions.stakingProviderFromWorker(staking_provider_3).call() == NULL_ADDRESS
-    assert pre_application.functions.stakingProviderFromWorker(worker1).call() == NULL_ADDRESS
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_3).call() == NULL_ADDRESS
+    assert pre_application.functions.stakingProviderFromOperator(staking_provider_3).call() == NULL_ADDRESS
+    assert pre_application.functions.stakingProviderFromOperator(operator1).call() == NULL_ADDRESS
     assert not pre_application.functions.stakingProviderInfo(staking_provider_3).call()[CONFIRMATION_SLOT]
-    assert not pre_application.functions.isWorkerConfirmed(worker1).call()
+    assert not pre_application.functions.isOperatorConfirmed(operator1).call()
     assert pre_application.functions.getStakingProvidersLength().call() == 1
     assert pre_application.functions.stakingProviders(0).call() == staking_provider_3
 
-    # Resetting worker removes from active list before next confirmation
+    # Resetting operator removes from active list before next confirmation
     all_locked, staking_providers = pre_application.functions.getActiveStakingProviders(0, 0).call()
     assert all_locked == 0
     assert len(staking_providers) == 0
 
     number_of_events += 1
-    events = worker_log.get_all_entries()
+    events = operator_log.get_all_entries()
     assert len(events) == number_of_events
     event_args = events[-1]['args']
     assert event_args['stakingProvider'] == staking_provider_3
-    # Now the worker has been unbonded ...
-    assert event_args['worker'] == NULL_ADDRESS
+    # Now the operator has been unbonded ...
+    assert event_args['operator'] == NULL_ADDRESS
     # ... with a new starting period.
     assert event_args['startTimestamp'] == timestamp
 
-    # The staking provider can bond now a new worker, without waiting additional time.
-    tx = pre_application.functions.bondWorker(staking_provider_3, worker2).transact({'from': staking_provider_3})
+    # The staking provider can bond now a new operator, without waiting additional time.
+    tx = pre_application.functions.bondOperator(staking_provider_3, operator2).transact({'from': staking_provider_3})
     testerchain.wait_for_receipt(tx)
     timestamp = testerchain.w3.eth.getBlock('latest').timestamp
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_3).call() == worker2
-    assert pre_application.functions.stakingProviderFromWorker(worker2).call() == staking_provider_3
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_3).call() == operator2
+    assert pre_application.functions.stakingProviderFromOperator(operator2).call() == staking_provider_3
     assert not pre_application.functions.stakingProviderInfo(staking_provider_3).call()[CONFIRMATION_SLOT]
-    assert not pre_application.functions.isWorkerConfirmed(worker2).call()
+    assert not pre_application.functions.isOperatorConfirmed(operator2).call()
     assert pre_application.functions.getStakingProvidersLength().call() == 1
     assert pre_application.functions.stakingProviders(0).call() == staking_provider_3
 
     number_of_events += 1
-    events = worker_log.get_all_entries()
+    events = operator_log.get_all_entries()
     assert len(events) == number_of_events
     event_args = events[-1]['args']
     assert event_args['stakingProvider'] == staking_provider_3
-    assert event_args['worker'] == worker2
+    assert event_args['operator'] == operator2
     assert event_args['startTimestamp'] == timestamp
 
-    # Now the previous worker can no longer make a confirmation
+    # Now the previous operator can no longer make a confirmation
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.confirmWorkerAddress().transact({'from': worker1})
+        tx = pre_application.functions.confirmOperatorAddress().transact({'from': operator1})
         testerchain.wait_for_receipt(tx)
-    # Only new worker can
-    tx = pre_application.functions.confirmWorkerAddress().transact({'from': worker2})
+    # Only new operator can
+    tx = pre_application.functions.confirmOperatorAddress().transact({'from': operator2})
     testerchain.wait_for_receipt(tx)
-    assert not pre_application.functions.isWorkerConfirmed(worker1).call()
-    assert pre_application.functions.isWorkerConfirmed(worker2).call()
+    assert not pre_application.functions.isOperatorConfirmed(operator1).call()
+    assert pre_application.functions.isOperatorConfirmed(operator2).call()
     assert pre_application.functions.stakingProviderInfo(staking_provider_3).call()[CONFIRMATION_SLOT]
 
-    # Another staker can bond a free worker
-    tx = pre_application.functions.bondWorker(staking_provider_4, worker1).transact({'from': staking_provider_4})
+    # Another staker can bond a free operator
+    tx = pre_application.functions.bondOperator(staking_provider_4, operator1).transact({'from': staking_provider_4})
     testerchain.wait_for_receipt(tx)
     timestamp = testerchain.w3.eth.getBlock('latest').timestamp
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_4).call() == worker1
-    assert pre_application.functions.stakingProviderFromWorker(worker1).call() == staking_provider_4
-    assert not pre_application.functions.isWorkerConfirmed(worker1).call()
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_4).call() == operator1
+    assert pre_application.functions.stakingProviderFromOperator(operator1).call() == staking_provider_4
+    assert not pre_application.functions.isOperatorConfirmed(operator1).call()
     assert not pre_application.functions.stakingProviderInfo(staking_provider_4).call()[CONFIRMATION_SLOT]
     assert pre_application.functions.getStakingProvidersLength().call() == 2
     assert pre_application.functions.stakingProviders(1).call() == staking_provider_4
 
     number_of_events += 1
-    events = worker_log.get_all_entries()
+    events = operator_log.get_all_entries()
     assert len(events) == number_of_events
     event_args = events[-1]['args']
     assert event_args['stakingProvider'] == staking_provider_4
-    assert event_args['worker'] == worker1
+    assert event_args['operator'] == operator1
     assert event_args['startTimestamp'] == timestamp
 
-    # # The first worker still can't be a staking provider
-    # tx = threshold_staking.functions.setRoles(worker1).transact()
+    # # The first operator still can't be a staking provider
+    # tx = threshold_staking.functions.setRoles(operator1).transact()
     # testerchain.wait_for_receipt(tx)
-    # tx = threshold_staking.functions.setStakes(worker1, min_authorization, 0, 0).transact()
+    # tx = threshold_staking.functions.setStakes(operator1, min_authorization, 0, 0).transact()
     # testerchain.wait_for_receipt(tx)
     # with pytest.raises((TransactionFailed, ValueError)):
     #     tx = threshold_staking.functions.increaseAuthorization(
-    #         worker1, min_authorization, pre_application.address).transact({'from': worker1})
+    #         operator1, min_authorization, pre_application.address).transact({'from': operator1})
     #     testerchain.wait_for_receipt(tx)
 
-    # Bond worker again
-    tx = pre_application.functions.confirmWorkerAddress().transact({'from': worker1})
+    # Bond operator again
+    tx = pre_application.functions.confirmOperatorAddress().transact({'from': operator1})
     testerchain.wait_for_receipt(tx)
-    assert pre_application.functions.isWorkerConfirmed(worker1).call()
+    assert pre_application.functions.isOperatorConfirmed(operator1).call()
     assert pre_application.functions.stakingProviderInfo(staking_provider_4).call()[CONFIRMATION_SLOT]
-    testerchain.time_travel(seconds=min_worker_seconds)
-    tx = pre_application.functions.bondWorker(staking_provider_4, worker3).transact({'from': staking_provider_4})
+    testerchain.time_travel(seconds=min_operator_seconds)
+    tx = pre_application.functions.bondOperator(staking_provider_4, operator3).transact({'from': staking_provider_4})
     testerchain.wait_for_receipt(tx)
     timestamp = testerchain.w3.eth.getBlock('latest').timestamp
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_4).call() == worker3
-    assert pre_application.functions.stakingProviderFromWorker(worker3).call() == staking_provider_4
-    assert pre_application.functions.stakingProviderFromWorker(worker1).call() == NULL_ADDRESS
-    assert not pre_application.functions.isWorkerConfirmed(worker3).call()
-    assert not pre_application.functions.isWorkerConfirmed(worker1).call()
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_4).call() == operator3
+    assert pre_application.functions.stakingProviderFromOperator(operator3).call() == staking_provider_4
+    assert pre_application.functions.stakingProviderFromOperator(operator1).call() == NULL_ADDRESS
+    assert not pre_application.functions.isOperatorConfirmed(operator3).call()
+    assert not pre_application.functions.isOperatorConfirmed(operator1).call()
     assert not pre_application.functions.stakingProviderInfo(staking_provider_4).call()[CONFIRMATION_SLOT]
     assert pre_application.functions.getStakingProvidersLength().call() == 2
     assert pre_application.functions.stakingProviders(1).call() == staking_provider_4
 
-    # Resetting worker removes from active list before next confirmation
+    # Resetting operator removes from active list before next confirmation
     all_locked, staking_providers = pre_application.functions.getActiveStakingProviders(1, 0).call()
     assert all_locked == 0
     assert len(staking_providers) == 0
 
     number_of_events += 1
-    events = worker_log.get_all_entries()
+    events = operator_log.get_all_entries()
     assert len(events) == number_of_events
     event_args = events[-1]['args']
     assert event_args['stakingProvider'] == staking_provider_4
-    assert event_args['worker'] == worker3
+    assert event_args['operator'] == operator3
     assert event_args['startTimestamp'] == timestamp
 
-    # The first worker is free and can deposit tokens and become a staker
-    tx = threshold_staking.functions.setRoles(worker1).transact()
+    # The first operator is free and can deposit tokens and become a staker
+    tx = threshold_staking.functions.setRoles(operator1).transact()
     testerchain.wait_for_receipt(tx)
     tx = threshold_staking.functions.setStakes(
-        worker1, min_authorization // 3, min_authorization // 3, min_authorization // 3).transact()
+        operator1, min_authorization // 3, min_authorization // 3, min_authorization // 3).transact()
     testerchain.wait_for_receipt(tx)
     # tx = threshold_staking.functions.increaseAuthorization(
-    #     worker1, min_authorization, pre_application.address).transact({'from': worker1})
+    #     operator1, min_authorization, pre_application.address).transact({'from': operator1})
     # testerchain.wait_for_receipt(tx)
-    assert pre_application.functions.getWorkerFromStakingProvider(worker1).call() == NULL_ADDRESS
-    assert pre_application.functions.stakingProviderFromWorker(worker1).call() == NULL_ADDRESS
+    assert pre_application.functions.getOperatorFromStakingProvider(operator1).call() == NULL_ADDRESS
+    assert pre_application.functions.stakingProviderFromOperator(operator1).call() == NULL_ADDRESS
 
-    testerchain.time_travel(seconds=min_worker_seconds)
+    testerchain.time_travel(seconds=min_operator_seconds)
 
-    # Staking provider can't bond the first worker again because worker is a provider now
+    # Staking provider can't bond the first operator again because operator is a provider now
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.bondWorker(staking_provider_4, worker1).transact({'from': staking_provider_4})
+        tx = pre_application.functions.bondOperator(staking_provider_4, operator1).transact({'from': staking_provider_4})
         testerchain.wait_for_receipt(tx)
 
-    # Provider without intermediary contract can bond itself as worker
+    # Provider without intermediary contract can bond itself as operator
     # (Probably not best idea, but whatever)
-    tx = pre_application.functions.bondWorker(
+    tx = pre_application.functions.bondOperator(
         staking_provider_1, staking_provider_1).transact({'from': staking_provider_1})
     testerchain.wait_for_receipt(tx)
     timestamp = testerchain.w3.eth.getBlock('latest').timestamp
-    assert pre_application.functions.getWorkerFromStakingProvider(staking_provider_1).call() == staking_provider_1
-    assert pre_application.functions.stakingProviderFromWorker(staking_provider_1).call() == staking_provider_1
+    assert pre_application.functions.getOperatorFromStakingProvider(staking_provider_1).call() == staking_provider_1
+    assert pre_application.functions.stakingProviderFromOperator(staking_provider_1).call() == staking_provider_1
     assert pre_application.functions.getStakingProvidersLength().call() == 3
     assert pre_application.functions.stakingProviders(2).call() == staking_provider_1
 
     number_of_events += 1
-    events = worker_log.get_all_entries()
+    events = operator_log.get_all_entries()
     assert len(events) == number_of_events
     event_args = events[-1]['args']
     assert event_args['stakingProvider'] == staking_provider_1
-    assert event_args['worker'] == staking_provider_1
+    assert event_args['operator'] == staking_provider_1
     assert event_args['startTimestamp'] == timestamp
 
     # If stake will be less than minimum then confirmation is not possible
@@ -306,13 +308,13 @@ def test_bond_worker(testerchain, threshold_staking, pre_application, token_econ
     testerchain.wait_for_receipt(tx)
 
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.confirmWorkerAddress().transact({'from': staking_provider_1})
+        tx = pre_application.functions.confirmOperatorAddress().transact({'from': staking_provider_1})
         testerchain.wait_for_receipt(tx)
 
     # Now provider can make a confirmation
     tx = threshold_staking.functions.setStakes(staking_provider_1, 0, 0, min_authorization).transact()
     testerchain.wait_for_receipt(tx)
-    tx = pre_application.functions.confirmWorkerAddress().transact({'from': staking_provider_1})
+    tx = pre_application.functions.confirmOperatorAddress().transact({'from': staking_provider_1})
     testerchain.wait_for_receipt(tx)
 
     # If stake will be less than minimum then provider is not active
@@ -331,54 +333,54 @@ def test_bond_worker(testerchain, threshold_staking, pre_application, token_econ
 
 
 def test_confirm_address(testerchain, threshold_staking, pre_application, token_economics, deploy_contract):
-    creator, staking_provider, worker, *everyone_else = testerchain.client.accounts
+    creator, staking_provider, operator, *everyone_else = testerchain.client.accounts
     min_authorization = token_economics.minimum_allowed_locked
-    min_worker_seconds = 24 * 60 * 60
+    min_operator_seconds = 24 * 60 * 60
 
-    confirmations_log = pre_application.events.WorkerConfirmed.createFilter(fromBlock='latest')
+    confirmations_log = pre_application.events.OperatorConfirmed.createFilter(fromBlock='latest')
 
-    # Worker must be associated with provider that has minimum amount of tokens
+    # Operator must be associated with provider that has minimum amount of tokens
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.confirmWorkerAddress().transact({'from': staking_provider})
+        tx = pre_application.functions.confirmOperatorAddress().transact({'from': staking_provider})
         testerchain.wait_for_receipt(tx)
     tx = threshold_staking.functions.setRoles(staking_provider).transact()
     testerchain.wait_for_receipt(tx)
     tx = threshold_staking.functions.setStakes(staking_provider, min_authorization - 1, 0, 0).transact()
     testerchain.wait_for_receipt(tx)
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.confirmWorkerAddress().transact({'from': staking_provider})
+        tx = pre_application.functions.confirmOperatorAddress().transact({'from': staking_provider})
         testerchain.wait_for_receipt(tx)
 
     # Deploy intermediary contract
     intermediary, _ = deploy_contract('Intermediary', pre_application.address)
 
-    # Bond contract as a worker
+    # Bond contract as a operator
     tx = threshold_staking.functions.setStakes(staking_provider, min_authorization, 0, 0).transact()
     testerchain.wait_for_receipt(tx)
-    tx = pre_application.functions.bondWorker(staking_provider, intermediary.address).transact({'from': staking_provider})
+    tx = pre_application.functions.bondOperator(staking_provider, intermediary.address).transact({'from': staking_provider})
     testerchain.wait_for_receipt(tx)
 
     # But can't make a confirmation using an intermediary contract
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = intermediary.functions.confirmWorkerAddress().transact({'from': staking_provider})
+        tx = intermediary.functions.confirmOperatorAddress().transact({'from': staking_provider})
         testerchain.wait_for_receipt(tx)
 
-    # Bond worker again and make confirmation
-    testerchain.time_travel(seconds=min_worker_seconds)
-    tx = pre_application.functions.bondWorker(staking_provider, worker).transact({'from': staking_provider})
+    # Bond operator again and make confirmation
+    testerchain.time_travel(seconds=min_operator_seconds)
+    tx = pre_application.functions.bondOperator(staking_provider, operator).transact({'from': staking_provider})
     testerchain.wait_for_receipt(tx)
-    tx = pre_application.functions.confirmWorkerAddress().transact({'from': worker})
+    tx = pre_application.functions.confirmOperatorAddress().transact({'from': operator})
     testerchain.wait_for_receipt(tx)
-    assert pre_application.functions.isWorkerConfirmed(worker).call()
+    assert pre_application.functions.isOperatorConfirmed(operator).call()
     assert pre_application.functions.stakingProviderInfo(staking_provider).call()[CONFIRMATION_SLOT]
 
     events = confirmations_log.get_all_entries()
     assert len(events) == 1
     event_args = events[-1]['args']
     assert event_args['stakingProvider'] == staking_provider
-    assert event_args['worker'] == worker
+    assert event_args['operator'] == operator
 
     # Can't confirm twice
     with pytest.raises((TransactionFailed, ValueError)):
-        tx = pre_application.functions.confirmWorkerAddress().transact({'from': worker})
+        tx = pre_application.functions.confirmOperatorAddress().transact({'from': operator})
         testerchain.wait_for_receipt(tx)


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
Renames operator to staking provider and worker to operator

**Notes for reviewers:**
See threshold-network/solidity-contracts#66 and threshold-network/solidity-contracts#67
