### PR TITLE
Fix obtaining metadata from a node

### DIFF
--- a/newsfragments/2877.bugfix.rst
+++ b/newsfragments/2877.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an incorrect usage of node object in ``FleetSensor``.

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -110,7 +110,7 @@ class FleetState:
             if node.checksum_address in nodes_to_remove:
                 continue
             unknown = node.checksum_address not in self._nodes
-            if unknown or bytes(self._nodes[node.checksum_address]) != bytes(node):
+            if unknown or bytes(self._nodes[node.checksum_address].metadata()) != bytes(node.metadata()):
                 nodes_updated.append(node.checksum_address)
 
         nodes_removed = []


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

Not sure how it worked before, but there hasn't been `bytes(node)` for a while. `metadata()` needs to be called explicitly.