### PR TITLE
Bump nucypher-core version to nucypher-core==0.0.4

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -985,7 +985,7 @@ class Ursula(Teacher, Character, Worker):
             decentralized_identity_evidence = None
         else:
             decentralized_identity_evidence = self.decentralized_identity_evidence
-        payload = NodeMetadataPayload(canonical_address=self.canonical_address,
+        payload = NodeMetadataPayload(staker_address=self.canonical_address,
                                       domain=self.domain,
                                       timestamp_epoch=timestamp.epoch,
                                       decentralized_identity_evidence=decentralized_identity_evidence,

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -93,7 +93,7 @@ class Vladimir(Ursula):
         # so it should work regardless of the binary format.
 
         # Our basic replacement. We want to impersonate the target Ursula.
-        metadata_bytes = metadata_bytes.replace(metadata.payload.canonical_address,
+        metadata_bytes = metadata_bytes.replace(metadata.payload.staker_address,
                                                 vladimir.canonical_address)
 
         # Use our own verifying key

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -120,7 +120,7 @@ class NodeSprout:
 
     @property
     def canonical_address(self):
-        return self._metadata_payload.canonical_address
+        return self._metadata_payload.staker_address
 
     @property
     def nickname(self):

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -29,7 +29,7 @@ class RevocationKit:
         self.revocations = dict()
         for ursula_address, encrypted_kfrag in treasure_map.destinations.items():
             self.revocations[ursula_address] = RevocationOrder(signer=signer.as_umbral_signer(),
-                                                               ursula_address=ursula_address,
+                                                               staker_address=ursula_address,
                                                                encrypted_kfrag=encrypted_kfrag)
 
     def __iter__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -104,4 +104,4 @@ web3==5.12.3
 websockets==8.1; python_full_version >= '3.6.1'
 werkzeug==2.0.1; python_version >= '3.6'
 zope.interface==5.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-nucypher-core==0.0.1;  python_version >= '3.7'
+nucypher-core==0.0.4;  python_version >= '3.7'

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -68,7 +68,7 @@ class Dummy:  # Teacher
 
     def metadata(self):
         signer = Signer(SecretKey.random())
-        payload = NodeMetadataPayload(canonical_address=self.canonical_address,
+        payload = NodeMetadataPayload(staker_address=self.canonical_address,
                                       domain=':dummy:',
                                       timestamp_epoch=0,
                                       decentralized_identity_evidence=b'\x00' * LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- Bump `nucypher-core==0.0.1` to `nucypher-core==0.0.4`
- Fixes error described in https://github.com/nucypher/nucypher-ts/pull/27

**Why it's needed:**
- Blocks progress in https://github.com/nucypher/nucypher-ts/pull/27

**Notes for reviewers:**
- I need to relock dependencies
- CLI test failure is unrelated and occurred previously on nightly: https://app.circleci.com/pipelines/github/nucypher/nucypher/9266/workflows/18093edc-069f-4e7d-a258-620144bf6be5/jobs/157194/tests#failed-test-0