### PR TITLE
Embed videos within docs

### DIFF
--- a/docs/source/architecture/character.rst
+++ b/docs/source/architecture/character.rst
@@ -14,9 +14,19 @@ role.
 .. _Umbral: https://github.com/nucypher/umbral-doc/blob/master/umbral-doc.pdf
 
 
+.. raw:: html
+
+    <div>
+        <div style="position:relative;padding-top:56.25%;">
+            <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="https://www.youtube-nocookie.com/embed/SXn1zShgVI8?rel=0&controls=1&modestbranding=1" frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+   </div>
+   <br/>
+
+
 Character Actions
 -----------------
-
 
 Alice::Grant
 ^^^^^^^^^^^^

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,6 +17,18 @@ The Threshold Network powers user sovereignty on the public blockchain. It provi
 network of nodes that perform threshold cryptography operations as a service to ensure full control over
 your digital assets.
 
+
+.. raw:: html
+
+    <div>
+        <div style="position:relative;padding-top:56.25%;">
+            <iframe style="position:absolute;top:0;left:0;width:100%;height:100%;" src="https://www.youtube-nocookie.com/embed/8MzE_FG67Z8?rel=0&controls=1&modestbranding=1" frameborder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+   </div>
+   <br/>
+
+
 Proxy Re-Encryption (PRE) Application
 =====================================
 

--- a/newsfragments/2882.doc.rst
+++ b/newsfragments/2882.doc.rst
@@ -1,0 +1,1 @@
+Embed Threshold Network videos within docs.


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [X] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Embed Threshold Network intro video in the index page (home page), and embedThreshold PRE Characters video in the architecture/character.html ("Character Concepts") page.

See:
* https://157434-100446516-gh.circle-artifacts.com/0/docs/build/html/index.html
* https://157434-100446516-gh.circle-artifacts.com/0/docs/build/html/architecture/character.html

Based over #2878 .