### PR TITLE
Update the usage of nucypher-core with the changes planned for 0.1

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=3.4"
 lmdb = "*"
-nucypher-core = ">=0.0.4"
+nucypher-core = ">=0.1.1"
 # Cryptography
 pyopenssl = "*"
 cryptography = ">=3.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e65ed513ea24851c084af00236292f815901cb353ea9746f3eda7218aca513f0"
+            "sha256": "7557a2ad36adbf9fd3a2d481b54f1a04e22e3a3f8cd7ecdf20e8ed5a4e9f5087"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,10 +34,10 @@
         },
         "autobahn": {
             "hashes": [
-                "sha256:17e1b58b6ae1a63ca7d926b1d71bb9e4fd6b9ac9a1a2277d8ee40e0b61f54746"
+                "sha256:60e1f4c602aacd052ffe3d46ae40b6b75f8286b3c46922c213b523162e58c17e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==22.1.1"
+            "version": "==22.2.2"
         },
         "automat": {
             "hashes": [
@@ -193,36 +193,35 @@
         },
         "construct": {
             "hashes": [
-                "sha256:730235fedf4f2fee5cfadda1d14b83ef1bf23790fb1cc579073e10f70a050883"
+                "sha256:7b2a3fd8e5f597a5aa1d614c3bd516fa065db01704c72a1efaaeec6ef23d8b45"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.10.67"
+            "version": "==2.10.68"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0a817b961b46894c5ca8a66b599c745b9a3d9f822725221f0e0fe49dc043a3a3",
-                "sha256:2d87cdcb378d3cfed944dac30596da1968f88fb96d7fc34fdae30a99054b2e31",
-                "sha256:30ee1eb3ebe1644d1c3f183d115a8c04e4e603ed6ce8e394ed39eea4a98469ac",
-                "sha256:391432971a66cfaf94b21c24ab465a4cc3e8bf4a939c1ca5c3e3a6e0abebdbcf",
-                "sha256:39bdf8e70eee6b1c7b289ec6e5d84d49a6bfa11f8b8646b5b3dfe41219153316",
-                "sha256:4caa4b893d8fad33cf1964d3e51842cd78ba87401ab1d2e44556826df849a8ca",
-                "sha256:53e5c1dc3d7a953de055d77bef2ff607ceef7a2aac0353b5d630ab67f7423638",
-                "sha256:596f3cd67e1b950bc372c33f1a28a0692080625592ea6392987dba7f09f17a94",
-                "sha256:5d59a9d55027a8b88fd9fd2826c4392bd487d74bf628bb9d39beecc62a644c12",
-                "sha256:6c0c021f35b421ebf5976abf2daacc47e235f8b6082d3396a2fe3ccd537ab173",
-                "sha256:73bc2d3f2444bcfeac67dd130ff2ea598ea5f20b40e36d19821b4df8c9c5037b",
-                "sha256:74d6c7e80609c0f4c2434b97b80c7f8fdfaa072ca4baab7e239a15d6d70ed73a",
-                "sha256:7be0eec337359c155df191d6ae00a5e8bbb63933883f4f5dffc439dac5348c3f",
-                "sha256:94ae132f0e40fe48f310bba63f477f14a43116f05ddb69d6fa31e93f05848ae2",
-                "sha256:bb5829d027ff82aa872d76158919045a7c1e91fbf241aec32cb07956e9ebd3c9",
-                "sha256:ca238ceb7ba0bdf6ce88c1b74a87bffcee5afbfa1e41e173b1ceb095b39add46",
-                "sha256:ca28641954f767f9822c24e927ad894d45d5a1e501767599647259cbf030b903",
-                "sha256:e0344c14c9cb89e76eb6a060e67980c9e35b3f36691e15e1b7a9e58a0a6c6dc3",
-                "sha256:ebc15b1c22e55c4d5566e3ca4db8689470a0ca2babef8e3a9ee057a8b82ce4b1",
-                "sha256:ec63da4e7e4a5f924b90af42eddf20b698a70e58d86a72d943857c4c6045b3ee"
+                "sha256:0a3bf09bb0b7a2c93ce7b98cb107e9170a90c51a0162a20af1c61c765b90e60b",
+                "sha256:1f64a62b3b75e4005df19d3b5235abd43fa6358d5516cfc43d87aeba8d08dd51",
+                "sha256:32db5cc49c73f39aac27574522cecd0a4bb7384e71198bc65a0d23f901e89bb7",
+                "sha256:4881d09298cd0b669bb15b9cfe6166f16fc1277b4ed0d04a22f3d6430cb30f1d",
+                "sha256:53e0285b49fd0ab6e604f4c5d9c5ddd98de77018542e88366923f152dbeb3c29",
+                "sha256:70f8f4f7bb2ac9f340655cbac89d68c527af5bb4387522a8413e841e3e6628c9",
+                "sha256:7b2d54e787a884ffc6e187262823b6feb06c338084bbe80d45166a1cb1c6c5bf",
+                "sha256:7be666cc4599b415f320839e36367b273db8501127b38316f3b9f22f17a0b815",
+                "sha256:8241cac0aae90b82d6b5c443b853723bcc66963970c67e56e71a2609dc4b5eaf",
+                "sha256:82740818f2f240a5da8dfb8943b360e4f24022b093207160c77cadade47d7c85",
+                "sha256:8897b7b7ec077c819187a123174b645eb680c13df68354ed99f9b40a50898f77",
+                "sha256:c2c5250ff0d36fd58550252f54915776940e4e866f38f3a7866d92b32a654b86",
+                "sha256:ca9f686517ec2c4a4ce930207f75c00bf03d94e5063cbc00a1dc42531511b7eb",
+                "sha256:d2b3d199647468d410994dbeb8cec5816fb74feb9368aedf300af709ef507e3e",
+                "sha256:da73d095f8590ad437cd5e9faf6628a218aa7c387e1fdf67b888b47ba56a17f0",
+                "sha256:e167b6b710c7f7bc54e67ef593f8731e1f45aa35f8a8a7b72d6e42ec76afd4b3",
+                "sha256:ea634401ca02367c1567f012317502ef3437522e2fc44a3ea1844de028fa4b84",
+                "sha256:ec6597aa85ce03f3e507566b8bcdf9da2227ec86c4266bd5e6ab4d9e0cc8dab2",
+                "sha256:f64b232348ee82f13aac22856515ce0195837f6968aeaa94a3d0353ea2ec06a6"
             ],
             "index": "pypi",
-            "version": "==36.0.1"
+            "version": "==36.0.2"
         },
         "cytoolz": {
             "hashes": [
@@ -272,9 +271,6 @@
             "version": "==1.0.4"
         },
         "eth-hash": {
-            "extras": [
-                "pycryptodome"
-            ],
             "hashes": [
                 "sha256:3f40cecd5ead88184aa9550afc19d057f103728108c5102f592f8415949b5a76",
                 "sha256:de7385148a8e0237ba1240cddbc06d53f56731140f8593bdb8429306f6b42271"
@@ -463,65 +459,65 @@
         },
         "mako": {
             "hashes": [
-                "sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2",
-                "sha256:afaf8e515d075b22fad7d7b8b30e4a1c90624ff2f3733a06ec125f5a5f043a57"
+                "sha256:23aab11fdbbb0f1051b93793a58323ff937e98e34aece1c4219675122e57e4ba",
+                "sha256:9a7c7e922b87db3686210cf49d5d767033a41d4010b284e747682c92bddd8b39"
             ],
             "index": "pypi",
-            "version": "==1.1.6"
+            "version": "==1.2.0"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:023af8c54fe63530545f70dd2a2a7eed18d07a9a77b94e8bf1e2ff7f252db9a3",
-                "sha256:09c86c9643cceb1d87ca08cdc30160d1b7ab49a8a21564868921959bd16441b8",
-                "sha256:142119fb14a1ef6d758912b25c4e803c3ff66920635c44078666fe7cc3f8f759",
-                "sha256:1d1fb9b2eec3c9714dd936860850300b51dbaa37404209c8d4cb66547884b7ed",
-                "sha256:204730fd5fe2fe3b1e9ccadb2bd18ba8712b111dcabce185af0b3b5285a7c989",
-                "sha256:24c3be29abb6b34052fd26fc7a8e0a49b1ee9d282e3665e8ad09a0a68faee5b3",
-                "sha256:290b02bab3c9e216da57c1d11d2ba73a9f73a614bbdcc027d299a60cdfabb11a",
-                "sha256:3028252424c72b2602a323f70fbf50aa80a5d3aa616ea6add4ba21ae9cc9da4c",
-                "sha256:30c653fde75a6e5eb814d2a0a89378f83d1d3f502ab710904ee585c38888816c",
-                "sha256:3cace1837bc84e63b3fd2dfce37f08f8c18aeb81ef5cf6bb9b51f625cb4e6cd8",
-                "sha256:4056f752015dfa9828dce3140dbadd543b555afb3252507348c493def166d454",
-                "sha256:454ffc1cbb75227d15667c09f164a0099159da0c1f3d2636aa648f12675491ad",
-                "sha256:598b65d74615c021423bd45c2bc5e9b59539c875a9bdb7e5f2a6b92dfcfc268d",
-                "sha256:599941da468f2cf22bf90a84f6e2a65524e87be2fce844f96f2dd9a6c9d1e635",
-                "sha256:5ddea4c352a488b5e1069069f2f501006b1a4362cb906bee9a193ef1245a7a61",
-                "sha256:62c0285e91414f5c8f621a17b69fc0088394ccdaa961ef469e833dbff64bd5ea",
-                "sha256:679cbb78914ab212c49c67ba2c7396dc599a8479de51b9a87b174700abd9ea49",
-                "sha256:6e104c0c2b4cd765b4e83909cde7ec61a1e313f8a75775897db321450e928cce",
-                "sha256:736895a020e31b428b3382a7887bfea96102c529530299f426bf2e636aacec9e",
-                "sha256:75bb36f134883fdbe13d8e63b8675f5f12b80bb6627f7714c7d6c5becf22719f",
-                "sha256:7d2f5d97fcbd004c03df8d8fe2b973fe2b14e7bfeb2cfa012eaa8759ce9a762f",
-                "sha256:80beaf63ddfbc64a0452b841d8036ca0611e049650e20afcb882f5d3c266d65f",
-                "sha256:84ad5e29bf8bab3ad70fd707d3c05524862bddc54dc040982b0dbcff36481de7",
-                "sha256:8da5924cb1f9064589767b0f3fc39d03e3d0fb5aa29e0cb21d43106519bd624a",
-                "sha256:961eb86e5be7d0973789f30ebcf6caab60b844203f4396ece27310295a6082c7",
-                "sha256:96de1932237abe0a13ba68b63e94113678c379dca45afa040a17b6e1ad7ed076",
-                "sha256:a0a0abef2ca47b33fb615b491ce31b055ef2430de52c5b3fb19a4042dbc5cadb",
-                "sha256:b2a5a856019d2833c56a3dcac1b80fe795c95f401818ea963594b345929dffa7",
-                "sha256:b8811d48078d1cf2a6863dafb896e68406c5f513048451cd2ded0473133473c7",
-                "sha256:c532d5ab79be0199fa2658e24a02fce8542df196e60665dd322409a03db6a52c",
-                "sha256:d3b64c65328cb4cd252c94f83e66e3d7acf8891e60ebf588d7b493a55a1dbf26",
-                "sha256:d4e702eea4a2903441f2735799d217f4ac1b55f7d8ad96ab7d4e25417cb0827c",
-                "sha256:d5653619b3eb5cbd35bfba3c12d575db2a74d15e0e1c08bf1db788069d410ce8",
-                "sha256:d66624f04de4af8bbf1c7f21cc06649c1c69a7f84109179add573ce35e46d448",
-                "sha256:e67ec74fada3841b8c5f4c4f197bea916025cb9aa3fe5abf7d52b655d042f956",
-                "sha256:e6f7f3f41faffaea6596da86ecc2389672fa949bd035251eab26dc6697451d05",
-                "sha256:f02cf7221d5cd915d7fa58ab64f7ee6dd0f6cddbb48683debf5d04ae9b1c2cc1",
-                "sha256:f0eddfcabd6936558ec020130f932d479930581171368fd728efcfb6ef0dd357",
-                "sha256:fabbe18087c3d33c5824cb145ffca52eccd053061df1d79d4b66dafa5ad2a5ea",
-                "sha256:fc3150f85e2dbcf99e65238c842d1cfe69d3e7649b19864c1cc043213d9cd730"
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.1.0"
+            "version": "==2.1.1"
         },
         "marshmallow": {
             "hashes": [
-                "sha256:04438610bc6dadbdddb22a4a55bcc7f6f8099e69580b2e67f5a681933a1f4400",
-                "sha256:4c05c1684e0e97fe779c62b91878f173b937fe097b356cd82f793464f5bc6138"
+                "sha256:2aaaab4f01ef4f5a011a21319af9fce17ab13bf28a026d1252adab0e035648d5",
+                "sha256:ff79885ed43b579782f48c251d262e062bce49c65c52412458769a4fb57ac30f"
             ],
             "index": "pypi",
-            "version": "==3.14.1"
+            "version": "==3.15.0"
         },
         "maya": {
             "hashes": [
@@ -609,25 +605,33 @@
         },
         "nucypher-core": {
             "hashes": [
-                "sha256:08ceaecd294e271db6b7aad2a0dbfe143371de941d6014f77c02a595e1ea24c1",
-                "sha256:15f8d76e60e020e10dba93822591fc5df98bec390935fcc93c660861712f432a",
-                "sha256:30e255c9d5fac67fbe7ce0b1e1ae0d557c3ea5fcb6c3893b6f1b97a9a92e0347",
-                "sha256:4401d3758aa1fdd73a5625be9422b5a744ea1c9f5533643c065a26e51c112fc3",
-                "sha256:587e8fbb48f1512f6e234cb97dc4fbee877ae79111bd57210e7de0b0ceaf0ffd",
-                "sha256:68318b1f88c76df73ba2e578ebe6a022313981c6ec0ee40c692d6e421b7bf26a",
-                "sha256:6f5971c9ae2f1f88233a5b4889fa7c0a690d09ca03a4bffcd1b37e54fdbfbf8e",
-                "sha256:7609de08636bfcaab3f319a69a2755aeb359f61775afc5325c9df35c2565470b",
-                "sha256:943d7224c1d7275f79d3433ff74ed355903c723543449df50be5db6dcd2877f6",
-                "sha256:a3768c18d3ad54293b3872ef9311d741800adda62843a2ed7e705e9abe088feb",
-                "sha256:a7cdbbdfb6a049de49c01a2d19bd33ee03185feb16366b080f5a6f01445f3c48",
-                "sha256:b9ce04e4b64a7ff645b32db4eb692cd7e25191b75e3b8b6b123e2da889da4405",
-                "sha256:c414bc144f993af4b4c4e1c22a497bb5389ad9e3431864b48f373abcf76e65ed",
-                "sha256:c6c53224843b2584fb806c7dc67047e45097e4331582f901a925f9305f271d14",
-                "sha256:d4bdc861440a66f8378b04ced5ca40e3fb3f4886b4c6eec44ab6b3f002a0a46c",
-                "sha256:e6613ff0d99df1999110f4ec47639ae2d4bc63891dbbe7a5ca6654e3cfd5a63d"
+                "sha256:08f96de444166e63dd4dca5f0321e9e9cd345f193ef35da2fdcba986898bd31a",
+                "sha256:12822ee4b7f4f1389cf4877f4e957a79318dbbd2b0393d0f5808f0313a86980b",
+                "sha256:189e02ab085f120fbe018dfe86ab63e8a2787623cc9f9010454a4d9e7d9264e9",
+                "sha256:2158d34d868fcc5ab4d2cfe3d16a8bf453faf5112a60b585cb66932637152b09",
+                "sha256:5c22edef77f8a8b2c0d9145dd937b91427027f16ecf181a30a6eb35f85633135",
+                "sha256:6db4575b55b8225d745290b3aecad45905181a3fab9f4e30cca0f3ecf837ac9b",
+                "sha256:6eceb191ba899f08f8370d8996c9d04db66114711586465ee505d1be40aa7676",
+                "sha256:76a1e40f702ff48e848c65d01be069dde8be0763d382a23de7075363753c09f4",
+                "sha256:7c8187a9b836737d919b6f10e31440acc111af96fa3c56ec7a905b53a3af0aea",
+                "sha256:8e283c29e4286a2a0c5938989522d7a4cfba5fbfd0cbacae1b8b2c6800417e93",
+                "sha256:98dd72fddda5cf9458952a9c7afa6bdf5fad02701684dd76515fd55fcd258037",
+                "sha256:a4db3afae160b9e0b7142b8ef3773be26d7766405d2dc6746dd460aebe5e5abd",
+                "sha256:bf5574d1961ff45ebfb58b07ed4a819bb001600df180d4fffe31c20936b19857",
+                "sha256:d9ac4d85a7dc771ea8d43cfcb8aad958986763a1296f1ba9d4557528439628a6",
+                "sha256:f68ccce18e7d2673ae8924b2d7418fb891bb690be990d82416483c8c90b094b7",
+                "sha256:f9f0cc1c7dedc74f7d028e1cdd4ecd355a27c4302949315d99ca37d09e00553b"
             ],
             "index": "pypi",
-            "version": "==0.0.4"
+            "version": "==0.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
         },
         "parsimonious": {
             "hashes": [
@@ -705,35 +709,33 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:072fbc78d705d3edc7ccac58a62c4c8e0cec856987da7df8aca86e647be4e35c",
-                "sha256:09297b7972da685ce269ec52af761743714996b4381c085205914c41fcab59fb",
-                "sha256:16f519de1313f1b7139ad70772e7db515b1420d208cb16c6d7858ea989fc64a9",
-                "sha256:1c91ef4110fdd2c590effb5dca8fdbdcb3bf563eece99287019c4204f53d81a4",
-                "sha256:3112b58aac3bac9c8be2b60a9daf6b558ca3f7681c130dcdd788ade7c9ffbdca",
-                "sha256:36cecbabbda242915529b8ff364f2263cd4de7c46bbe361418b5ed859677ba58",
-                "sha256:4276cdec4447bd5015453e41bdc0c0c1234eda08420b7c9a18b8d647add51e4b",
-                "sha256:435bb78b37fc386f9275a7035fe4fb1364484e38980d0dd91bc834a02c5ec909",
-                "sha256:48ed3877fa43e22bcacc852ca76d4775741f9709dd9575881a373bd3e85e54b2",
-                "sha256:54a1473077f3b616779ce31f477351a45b4fef8c9fd7892d6d87e287a38df368",
-                "sha256:69da7d39e39942bd52848438462674c463e23963a1fdaa84d88df7fbd7e749b2",
-                "sha256:6cbc312be5e71869d9d5ea25147cdf652a6781cf4d906497ca7690b7b9b5df13",
-                "sha256:7bb03bc2873a2842e5ebb4801f5c7ff1bfbdf426f85d0172f7644fcda0671ae0",
-                "sha256:7ca7da9c339ca8890d66958f5462beabd611eca6c958691a8fe6eccbd1eb0c6e",
-                "sha256:835a9c949dc193953c319603b2961c5c8f4327957fe23d914ca80d982665e8ee",
-                "sha256:84123274d982b9e248a143dadd1b9815049f4477dc783bf84efe6250eb4b836a",
-                "sha256:8961c3a78ebfcd000920c9060a262f082f29838682b1f7201889300c1fbe0616",
-                "sha256:96bd766831596d6014ca88d86dc8fe0fb2e428c0b02432fd9db3943202bf8c5e",
-                "sha256:9df0c10adf3e83015ced42a9a7bd64e13d06c4cf45c340d2c63020ea04499d0a",
-                "sha256:b38057450a0c566cbd04890a40edf916db890f2818e8682221611d78dc32ae26",
-                "sha256:bd95d1dfb9c4f4563e6093a9aa19d9c186bf98fa54da5252531cc0d3a07977e7",
-                "sha256:c1068287025f8ea025103e37d62ffd63fec8e9e636246b89c341aeda8a67c934",
-                "sha256:c438268eebb8cf039552897d78f402d734a404f1360592fef55297285f7f953f",
-                "sha256:cdc076c03381f5c1d9bb1abdcc5503d9ca8b53cf0a9d31a9f6754ec9e6c8af0f",
-                "sha256:f358aa33e03b7a84e0d91270a4d4d8f5df6921abe99a377828839e8ed0c04e07",
-                "sha256:f51d5a9f137f7a2cec2d326a74b6e3fc79d635d69ffe1b036d39fc7d75430d37"
+                "sha256:0209bc6805fd41958147d57661675a33b2bab182784728f4afc42ce2e816f227",
+                "sha256:07008fc9163c3fb2b127674e647a207f73be83fcc8c315889befc5b7de666d63",
+                "sha256:2a54f109e226e887ee57976dae982d7a68715beff2208caeff9d1cf65850769a",
+                "sha256:2b521182fb9f4eee819aa304035f597003c33e3dc8cc50e6b3ab5846062a5dee",
+                "sha256:3be54d8bf6708086ef29f35db4d0d4e302523c60811e334e3b011e57ebc3000f",
+                "sha256:504de18b944724b29abe00aa27acda8077d7fd494dc737bf7697513ce6073adb",
+                "sha256:54afd960374ba6a6da4c45bf88a546efe9edb76fa29b25ef352a1614fa042365",
+                "sha256:5bbc58e9835d1e85498712c32efc5c259357bde2f8711504e2f6169a2e78691c",
+                "sha256:5f5fbdec3104bf526712741881b4fcf40a7fa2e95b6284d14787c2dc17c5ea95",
+                "sha256:696642ca02ec407472375fada149fa38c31d53733494235e5430e9c070161a6c",
+                "sha256:6c68ef8a07d708faee9593e1e704568b38e15ca280de182f1ee24e8a81ee0891",
+                "sha256:736cb735bb652ffb633be3b6c74caab8b0f0a2bfde93527d15b31f0eaf5ffd30",
+                "sha256:79463bb565e27c0827a48257bc9ed8f6b8f772788cd4e2c67dbe0bd217f4712f",
+                "sha256:7f5566d7abddf092e72c99be98f21bf8a3b60bf747c64c8d6d96897fa586f9ae",
+                "sha256:861a5f3ade5ca10c0e00b0f61da6b154ee541214552cf2cfb346f63ceb484a14",
+                "sha256:92adb2ae4ae205e75ff5257bce9ad1b5f3383eca2f18b4502deb6662692e2bcf",
+                "sha256:a729da811ddff4b4cbdb01b9b23c3f8f0539ce222a0cad6d6be7cc31573fe831",
+                "sha256:b0a63371697f497f5b31bdc39f98ea5753438a6bc86375a5df7506e02bd7d2c4",
+                "sha256:bb568219d5071efe9a576ff0b551b8dfc3b78c02b59dc23ca11ee4b5b9a09a6d",
+                "sha256:bc6a87ed8b5925a7bebe842fb7185831da1d79047afd0620aed2a67aac16b31e",
+                "sha256:ce1aeb0e389ef13377d48e7db25159505f40fac9d1aeddd6fcf1396fad391aaa",
+                "sha256:e40a97c76b63bdcfe42f40cf46acec7471f324de7efd7687a9bd04ef678e39c6",
+                "sha256:f72934e18f6fa8ba9c131a94000b57e88a481ce69b81a33035346ec8d65df1b8",
+                "sha256:fa86ea97649a36482eb4a5c01ce30c330288148debebdaf522d78a9744d84876"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==3.19.4"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.20.0rc1"
         },
         "py-ecc": {
             "hashes": [
@@ -873,6 +875,14 @@
             "index": "pypi",
             "version": "==22.0.0"
         },
+        "pyparsing": {
+            "hashes": [
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.0.7"
+        },
         "pyrsistent": {
             "hashes": [
                 "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c",
@@ -962,82 +972,83 @@
         },
         "regex": {
             "hashes": [
-                "sha256:04611cc0f627fc4a50bc4a9a2e6178a974c6a6a4aa9c1cca921635d2c47b9c87",
-                "sha256:0b5d6f9aed3153487252d00a18e53f19b7f52a1651bc1d0c4b5844bc286dfa52",
-                "sha256:0d2f5c3f7057530afd7b739ed42eb04f1011203bc5e4663e1e1d01bb50f813e3",
-                "sha256:11772be1eb1748e0e197a40ffb82fb8fd0d6914cd147d841d9703e2bef24d288",
-                "sha256:1333b3ce73269f986b1fa4d5d395643810074dc2de5b9d262eb258daf37dc98f",
-                "sha256:16f81025bb3556eccb0681d7946e2b35ff254f9f888cff7d2120e8826330315c",
-                "sha256:1a171eaac36a08964d023eeff740b18a415f79aeb212169080c170ec42dd5184",
-                "sha256:1d6301f5288e9bdca65fab3de6b7de17362c5016d6bf8ee4ba4cbe833b2eda0f",
-                "sha256:1e031899cb2bc92c0cf4d45389eff5b078d1936860a1be3aa8c94fa25fb46ed8",
-                "sha256:1f8c0ae0a0de4e19fddaaff036f508db175f6f03db318c80bbc239a1def62d02",
-                "sha256:2245441445099411b528379dee83e56eadf449db924648e5feb9b747473f42e3",
-                "sha256:22709d701e7037e64dae2a04855021b62efd64a66c3ceed99dfd684bfef09e38",
-                "sha256:24c89346734a4e4d60ecf9b27cac4c1fee3431a413f7aa00be7c4d7bbacc2c4d",
-                "sha256:25716aa70a0d153cd844fe861d4f3315a6ccafce22b39d8aadbf7fcadff2b633",
-                "sha256:2dacb3dae6b8cc579637a7b72f008bff50a94cde5e36e432352f4ca57b9e54c4",
-                "sha256:34316bf693b1d2d29c087ee7e4bb10cdfa39da5f9c50fa15b07489b4ab93a1b5",
-                "sha256:36b2d700a27e168fa96272b42d28c7ac3ff72030c67b32f37c05616ebd22a202",
-                "sha256:37978254d9d00cda01acc1997513f786b6b971e57b778fbe7c20e30ae81a97f3",
-                "sha256:38289f1690a7e27aacd049e420769b996826f3728756859420eeee21cc857118",
-                "sha256:385ccf6d011b97768a640e9d4de25412204fbe8d6b9ae39ff115d4ff03f6fe5d",
-                "sha256:3c7ea86b9ca83e30fa4d4cd0eaf01db3ebcc7b2726a25990966627e39577d729",
-                "sha256:49810f907dfe6de8da5da7d2b238d343e6add62f01a15d03e2195afc180059ed",
-                "sha256:519c0b3a6fbb68afaa0febf0d28f6c4b0a1074aefc484802ecb9709faf181607",
-                "sha256:51f02ca184518702975b56affde6c573ebad4e411599005ce4468b1014b4786c",
-                "sha256:552a39987ac6655dad4bf6f17dd2b55c7b0c6e949d933b8846d2e312ee80005a",
-                "sha256:596f5ae2eeddb79b595583c2e0285312b2783b0ec759930c272dbf02f851ff75",
-                "sha256:6014038f52b4b2ac1fa41a58d439a8a00f015b5c0735a0cd4b09afe344c94899",
-                "sha256:61ebbcd208d78658b09e19c78920f1ad38936a0aa0f9c459c46c197d11c580a0",
-                "sha256:6213713ac743b190ecbf3f316d6e41d099e774812d470422b3a0f137ea635832",
-                "sha256:637e27ea1ebe4a561db75a880ac659ff439dec7f55588212e71700bb1ddd5af9",
-                "sha256:6aa427c55a0abec450bca10b64446331b5ca8f79b648531138f357569705bc4a",
-                "sha256:6ca45359d7a21644793de0e29de497ef7f1ae7268e346c4faf87b421fea364e6",
-                "sha256:6db1b52c6f2c04fafc8da17ea506608e6be7086715dab498570c3e55e4f8fbd1",
-                "sha256:752e7ddfb743344d447367baa85bccd3629c2c3940f70506eb5f01abce98ee68",
-                "sha256:760c54ad1b8a9b81951030a7e8e7c3ec0964c1cb9fee585a03ff53d9e531bb8e",
-                "sha256:768632fd8172ae03852e3245f11c8a425d95f65ff444ce46b3e673ae5b057b74",
-                "sha256:7a0b9f6a1a15d494b35f25ed07abda03209fa76c33564c09c9e81d34f4b919d7",
-                "sha256:7e070d3aef50ac3856f2ef5ec7214798453da878bb5e5a16c16a61edf1817cc3",
-                "sha256:7e12949e5071c20ec49ef00c75121ed2b076972132fc1913ddf5f76cae8d10b4",
-                "sha256:7e26eac9e52e8ce86f915fd33380f1b6896a2b51994e40bb094841e5003429b4",
-                "sha256:85ffd6b1cb0dfb037ede50ff3bef80d9bf7fa60515d192403af6745524524f3b",
-                "sha256:8618d9213a863c468a865e9d2ec50221015f7abf52221bc927152ef26c484b4c",
-                "sha256:8acef4d8a4353f6678fd1035422a937c2170de58a2b29f7da045d5249e934101",
-                "sha256:8d2f355a951f60f0843f2368b39970e4667517e54e86b1508e76f92b44811a8a",
-                "sha256:90b6840b6448203228a9d8464a7a0d99aa8fa9f027ef95fe230579abaf8a6ee1",
-                "sha256:9187500d83fd0cef4669385cbb0961e227a41c0c9bc39219044e35810793edf7",
-                "sha256:93c20777a72cae8620203ac11c4010365706062aa13aaedd1a21bb07adbb9d5d",
-                "sha256:93cce7d422a0093cfb3606beae38a8e47a25232eea0f292c878af580a9dc7605",
-                "sha256:94c623c331a48a5ccc7d25271399aff29729fa202c737ae3b4b28b89d2b0976d",
-                "sha256:97f32dc03a8054a4c4a5ab5d761ed4861e828b2c200febd4e46857069a483916",
-                "sha256:9a2bf98ac92f58777c0fafc772bf0493e67fcf677302e0c0a630ee517a43b949",
-                "sha256:a602bdc8607c99eb5b391592d58c92618dcd1537fdd87df1813f03fed49957a6",
-                "sha256:a9d24b03daf7415f78abc2d25a208f234e2c585e5e6f92f0204d2ab7b9ab48e3",
-                "sha256:abfcb0ef78df0ee9df4ea81f03beea41849340ce33a4c4bd4dbb99e23ec781b6",
-                "sha256:b013f759cd69cb0a62de954d6d2096d648bc210034b79b1881406b07ed0a83f9",
-                "sha256:b02e3e72665cd02afafb933453b0c9f6c59ff6e3708bd28d0d8580450e7e88af",
-                "sha256:b52cc45e71657bc4743a5606d9023459de929b2a198d545868e11898ba1c3f59",
-                "sha256:ba37f11e1d020969e8a779c06b4af866ffb6b854d7229db63c5fdddfceaa917f",
-                "sha256:bb804c7d0bfbd7e3f33924ff49757de9106c44e27979e2492819c16972ec0da2",
-                "sha256:bf594cc7cc9d528338d66674c10a5b25e3cde7dd75c3e96784df8f371d77a298",
-                "sha256:c38baee6bdb7fe1b110b6b3aaa555e6e872d322206b7245aa39572d3fc991ee4",
-                "sha256:c73d2166e4b210b73d1429c4f1ca97cea9cc090e5302df2a7a0a96ce55373f1c",
-                "sha256:c9099bf89078675c372339011ccfc9ec310310bf6c292b413c013eb90ffdcafc",
-                "sha256:cf0db26a1f76aa6b3aa314a74b8facd586b7a5457d05b64f8082a62c9c49582a",
-                "sha256:d19a34f8a3429bd536996ad53597b805c10352a8561d8382e05830df389d2b43",
-                "sha256:da80047524eac2acf7c04c18ac7a7da05a9136241f642dd2ed94269ef0d0a45a",
-                "sha256:de2923886b5d3214be951bc2ce3f6b8ac0d6dfd4a0d0e2a4d2e5523d8046fdfb",
-                "sha256:defa0652696ff0ba48c8aff5a1fac1eef1ca6ac9c660b047fc8e7623c4eb5093",
-                "sha256:e54a1eb9fd38f2779e973d2f8958fd575b532fe26013405d1afb9ee2374e7ab8",
-                "sha256:e5c31d70a478b0ca22a9d2d76d520ae996214019d39ed7dd93af872c7f301e52",
-                "sha256:ebaeb93f90c0903233b11ce913a7cb8f6ee069158406e056f884854c737d2442",
-                "sha256:ecfe51abf7f045e0b9cdde71ca9e153d11238679ef7b5da6c82093874adf3338",
-                "sha256:f99112aed4fb7cee00c7f77e8b964a9b10f69488cdff626ffd797d02e2e4484f",
-                "sha256:fd914db437ec25bfa410f8aa0aa2f3ba87cdfc04d9919d608d02330947afaeab"
+                "sha256:0008650041531d0eadecc96a73d37c2dc4821cf51b0766e374cb4f1ddc4e1c14",
+                "sha256:03299b0bcaa7824eb7c0ebd7ef1e3663302d1b533653bfe9dc7e595d453e2ae9",
+                "sha256:06b1df01cf2aef3a9790858af524ae2588762c8a90e784ba00d003f045306204",
+                "sha256:09b4b6ccc61d4119342b26246ddd5a04accdeebe36bdfe865ad87a0784efd77f",
+                "sha256:0be0c34a39e5d04a62fd5342f0886d0e57592a4f4993b3f9d257c1f688b19737",
+                "sha256:0d96eec8550fd2fd26f8e675f6d8b61b159482ad8ffa26991b894ed5ee19038b",
+                "sha256:0eb0e2845e81bdea92b8281a3969632686502565abf4a0b9e4ab1471c863d8f3",
+                "sha256:13bbf0c9453c6d16e5867bda7f6c0c7cff1decf96c5498318bb87f8136d2abd4",
+                "sha256:17e51ad1e6131c496b58d317bc9abec71f44eb1957d32629d06013a21bc99cac",
+                "sha256:1977bb64264815d3ef016625adc9df90e6d0e27e76260280c63eca993e3f455f",
+                "sha256:1e30762ddddb22f7f14c4f59c34d3addabc789216d813b0f3e2788d7bcf0cf29",
+                "sha256:1e73652057473ad3e6934944af090852a02590c349357b79182c1b681da2c772",
+                "sha256:20e6a27959f162f979165e496add0d7d56d7038237092d1aba20b46de79158f1",
+                "sha256:286ff9ec2709d56ae7517040be0d6c502642517ce9937ab6d89b1e7d0904f863",
+                "sha256:297c42ede2c81f0cb6f34ea60b5cf6dc965d97fa6936c11fc3286019231f0d66",
+                "sha256:320c2f4106962ecea0f33d8d31b985d3c185757c49c1fb735501515f963715ed",
+                "sha256:35ed2f3c918a00b109157428abfc4e8d1ffabc37c8f9abc5939ebd1e95dabc47",
+                "sha256:3d146e5591cb67c5e836229a04723a30af795ef9b70a0bbd913572e14b7b940f",
+                "sha256:42bb37e2b2d25d958c25903f6125a41aaaa1ed49ca62c103331f24b8a459142f",
+                "sha256:42d6007722d46bd2c95cce700181570b56edc0dcbadbfe7855ec26c3f2d7e008",
+                "sha256:43eba5c46208deedec833663201752e865feddc840433285fbadee07b84b464d",
+                "sha256:452519bc4c973e961b1620c815ea6dd8944a12d68e71002be5a7aff0a8361571",
+                "sha256:4b9c16a807b17b17c4fa3a1d8c242467237be67ba92ad24ff51425329e7ae3d0",
+                "sha256:5510932596a0f33399b7fff1bd61c59c977f2b8ee987b36539ba97eb3513584a",
+                "sha256:55820bc631684172b9b56a991d217ec7c2e580d956591dc2144985113980f5a3",
+                "sha256:57484d39447f94967e83e56db1b1108c68918c44ab519b8ecfc34b790ca52bf7",
+                "sha256:58ba41e462653eaf68fc4a84ec4d350b26a98d030be1ab24aba1adcc78ffe447",
+                "sha256:5bc5f921be39ccb65fdda741e04b2555917a4bced24b4df14eddc7569be3b493",
+                "sha256:5dcc4168536c8f68654f014a3db49b6b4a26b226f735708be2054314ed4964f4",
+                "sha256:5f92a7cdc6a0ae2abd184e8dfd6ef2279989d24c85d2c85d0423206284103ede",
+                "sha256:67250b36edfa714ba62dc62d3f238e86db1065fccb538278804790f578253640",
+                "sha256:6df070a986fc064d865c381aecf0aaff914178fdf6874da2f2387e82d93cc5bd",
+                "sha256:729aa8ca624c42f309397c5fc9e21db90bf7e2fdd872461aabdbada33de9063c",
+                "sha256:72bc3a5effa5974be6d965ed8301ac1e869bc18425c8a8fac179fbe7876e3aee",
+                "sha256:74d86e8924835f863c34e646392ef39039405f6ce52956d8af16497af4064a30",
+                "sha256:79e5af1ff258bc0fe0bdd6f69bc4ae33935a898e3cbefbbccf22e88a27fa053b",
+                "sha256:7b103dffb9f6a47ed7ffdf352b78cfe058b1777617371226c1894e1be443afec",
+                "sha256:83f03f0bd88c12e63ca2d024adeee75234d69808b341e88343b0232329e1f1a1",
+                "sha256:86d7a68fa53688e1f612c3246044157117403c7ce19ebab7d02daf45bd63913e",
+                "sha256:878c626cbca3b649e14e972c14539a01191d79e58934e3f3ef4a9e17f90277f8",
+                "sha256:878f5d649ba1db9f52cc4ef491f7dba2d061cdc48dd444c54260eebc0b1729b9",
+                "sha256:87bc01226cd288f0bd9a4f9f07bf6827134dc97a96c22e2d28628e824c8de231",
+                "sha256:8babb2b5751105dc0aef2a2e539f4ba391e738c62038d8cb331c710f6b0f3da7",
+                "sha256:91e0f7e7be77250b808a5f46d90bf0032527d3c032b2131b63dee54753a4d729",
+                "sha256:9557545c10d52c845f270b665b52a6a972884725aa5cf12777374e18f2ea8960",
+                "sha256:9ccb0a4ab926016867260c24c192d9df9586e834f5db83dfa2c8fffb3a6e5056",
+                "sha256:9d828c5987d543d052b53c579a01a52d96b86f937b1777bbfe11ef2728929357",
+                "sha256:9efa41d1527b366c88f265a227b20bcec65bda879962e3fc8a2aee11e81266d7",
+                "sha256:aaf5317c961d93c1a200b9370fb1c6b6836cc7144fef3e5a951326912bf1f5a3",
+                "sha256:ab69b4fe09e296261377d209068d52402fb85ef89dc78a9ac4a29a895f4e24a7",
+                "sha256:ad397bc7d51d69cb07ef89e44243f971a04ce1dca9bf24c992c362406c0c6573",
+                "sha256:ae17fc8103f3b63345709d3e9654a274eee1c6072592aec32b026efd401931d0",
+                "sha256:af4d8cc28e4c7a2f6a9fed544228c567340f8258b6d7ea815b62a72817bbd178",
+                "sha256:b22ff939a8856a44f4822da38ef4868bd3a9ade22bb6d9062b36957c850e404f",
+                "sha256:b549d851f91a4efb3e65498bd4249b1447ab6035a9972f7fc215eb1f59328834",
+                "sha256:be319f4eb400ee567b722e9ea63d5b2bb31464e3cf1b016502e3ee2de4f86f5c",
+                "sha256:c0446b2871335d5a5e9fcf1462f954586b09a845832263db95059dcd01442015",
+                "sha256:c68d2c04f7701a418ec2e5631b7f3552efc32f6bcc1739369c6eeb1af55f62e0",
+                "sha256:c87ac58b9baaf50b6c1b81a18d20eda7e2883aa9a4fb4f1ca70f2e443bfcdc57",
+                "sha256:caa2734ada16a44ae57b229d45091f06e30a9a52ace76d7574546ab23008c635",
+                "sha256:cb34c2d66355fb70ae47b5595aafd7218e59bb9c00ad8cc3abd1406ca5874f07",
+                "sha256:cb3652bbe6720786b9137862205986f3ae54a09dec8499a995ed58292bdf77c2",
+                "sha256:cf668f26604e9f7aee9f8eaae4ca07a948168af90b96be97a4b7fa902a6d2ac1",
+                "sha256:d326ff80ed531bf2507cba93011c30fff2dd51454c85f55df0f59f2030b1687b",
+                "sha256:d6c2441538e4fadd4291c8420853431a229fcbefc1bf521810fbc2629d8ae8c2",
+                "sha256:d6ecfd1970b3380a569d7b3ecc5dd70dba295897418ed9e31ec3c16a5ab099a5",
+                "sha256:e5602a9b5074dcacc113bba4d2f011d2748f50e3201c8139ac5b68cf2a76bd8b",
+                "sha256:ef806f684f17dbd6263d72a54ad4073af42b42effa3eb42b877e750c24c76f86",
+                "sha256:f3356afbb301ec34a500b8ba8b47cba0b44ed4641c306e1dd981a08b416170b5",
+                "sha256:f6f7ee2289176cb1d2c59a24f50900f8b9580259fa9f1a739432242e7d254f93",
+                "sha256:f7e8f1ee28e0a05831c92dc1c0c1c94af5289963b7cf09eca5b5e3ce4f8c91b0",
+                "sha256:f8169ec628880bdbca67082a9196e2106060a4a5cbd486ac51881a4df805a36f",
+                "sha256:fbc88d3ba402b5d041d204ec2449c4078898f89c4a6e6f0ed1c1a510ef1e221d",
+                "sha256:fbd3fe37353c62fd0eb19fb76f78aa693716262bcd5f9c14bb9e5aca4b3f0dc4"
             ],
-            "version": "==2022.1.18"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.3.2"
         },
         "requests": {
             "hashes": [
@@ -1132,19 +1143,19 @@
         },
         "twisted": {
             "hashes": [
-                "sha256:b5f6f129901afb655d52b9cadeebd36318acf0648aa5c768eb4ec02a6ba7ba96",
-                "sha256:f9bed1786ef7335d033861260ccd4f9a5ba8a06dcfbd68d8b6dc1eacfbb1b0e8"
+                "sha256:57f32b1f6838facb8c004c89467840367ad38e9e535f8252091345dba500b4f2",
+                "sha256:5c63c149eb6b8fe1e32a0215b1cef96fabdba04f705d8efb9174b1ccf5b49d49"
             ],
             "markers": "python_full_version >= '3.6.7'",
-            "version": "==22.2.0rc1"
+            "version": "==22.2.0"
         },
         "txaio": {
             "hashes": [
-                "sha256:7d6f89745680233f1c4db9ddb748df5e88d2a7a37962be174c0fd04c8dba1dc8",
-                "sha256:c16b55f9a67b2419cfdf8846576e2ec9ba94fe6978a83080c352a80db31c93fb"
+                "sha256:2e4582b70f04b2345908254684a984206c0d9b50e3074a24a4c55aba21d24d01",
+                "sha256:41223af4a9d5726e645a8ee82480f413e5e300dd257db94bc38ae12ea48fb2e5"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==21.2.1"
+            "version": "==22.2.1"
         },
         "typing-extensions": {
             "hashes": [
@@ -1318,11 +1329,11 @@
         },
         "bandit": {
             "hashes": [
-                "sha256:6d11adea0214a43813887bfe71a377b5a9955e4c826c8ffd341b494e3ab25260",
-                "sha256:e20402cadfd126d85b68ed4c8862959663c8c372dbbb1fca8f8e2c9f55a067ec"
+                "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2",
+                "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"
             ],
             "index": "pypi",
-            "version": "==1.7.2"
+            "version": "==1.7.4"
         },
         "certifi": {
             "hashes": [
@@ -1498,19 +1509,19 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:c0098b3fedffd97636accf70d4bd45047e386ec67bac4587d3dc2a2e52f7d67d",
-                "sha256:cbc8bda86856987ca83fb429d0a65dcac9c503253384628b9f723084b9513c1b"
+                "sha256:92f1c58e994e109897fd9b3c6d44eb3bd45ed95bf3c079c35f36fa0801fc5f31",
+                "sha256:f496dd053fb951b6da9611481fb4e54eeab1d37b594da5efe869083fad3ae621"
             ],
             "index": "pypi",
-            "version": "==6.37.1"
+            "version": "==6.39.3"
         },
         "identify": {
             "hashes": [
-                "sha256:7d10baf6ba6f1912a0a49f4c1c2c49fa1718765c3a37d72d13b07779567c5b85",
-                "sha256:e12b2aea3cf108de73ae055c2260783bde6601de09718f6768cf8e9f6f6322a6"
+                "sha256:2986942d3974c8f2e5019a190523b0b0e2a07cb8e89bf236727fb4b26f27f8fd",
+                "sha256:fd906823ed1db23c7a48f9b176a1d71cb8abede1e21ebe614bac7bdd688d9213"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.4.10"
+            "version": "==2.4.11"
         },
         "idna": {
             "hashes": [
@@ -1529,29 +1540,32 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce",
-                "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d",
-                "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069",
-                "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c",
-                "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d",
-                "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714",
-                "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a",
-                "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d",
-                "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05",
-                "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266",
-                "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697",
-                "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc",
-                "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799",
-                "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd",
-                "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00",
-                "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7",
-                "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a",
-                "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0",
-                "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0",
-                "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"
+                "sha256:080097eee5393fd740f32c63f9343580aaa0fb1cda0128fd859dfcf081321c3d",
+                "sha256:0d3bcbe146247997e03bf030122000998b076b3ac6925b0b6563f46d1ce39b50",
+                "sha256:0dd441fbacf48e19dc0c5c42fafa72b8e1a0ba0a39309c1af9c84b9397d9b15a",
+                "sha256:108f3c7e14a038cf097d2444fa0155462362c6316e3ecb2d70f6dd99cd36084d",
+                "sha256:3bada0cf7b6965627954b3a128903a87cac79a79ccd83b6104912e723ef16c7b",
+                "sha256:3cf77f138efb31727ee7197bc824c9d6d7039204ed96756cc0f9ca7d8e8fc2a4",
+                "sha256:42c216a33d2bdba08098acaf5bae65b0c8196afeb535ef4b870919a788a27259",
+                "sha256:465a6ce9ca6268cadfbc27a2a94ddf0412568a6b27640ced229270be4f5d394d",
+                "sha256:6a8e1f63357851444940351e98fb3252956a15f2cabe3d698316d7a2d1f1f896",
+                "sha256:745071762f32f65e77de6df699366d707fad6c132a660d1342077cbf671ef589",
+                "sha256:818cfc51c25a5dbfd0705f3ac1919fff6971eb0c02e6f1a1f6a017a42405a7c0",
+                "sha256:8e5974583a77d630a5868eee18f85ac3093caf76e018c510aeb802b9973304ce",
+                "sha256:8eaf55fdf99242a1c8c792247c455565447353914023878beadb79600aac4a2a",
+                "sha256:98f61aad0bb54f797b17da5b82f419e6ce214de0aa7e92211ebee9e40eb04276",
+                "sha256:b2ce2788df0c066c2ff4ba7190fa84f18937527c477247e926abeb9b1168b8cc",
+                "sha256:b30d29251dff4c59b2e5a1fa1bab91ff3e117b4658cb90f76d97702b7a2ae699",
+                "sha256:bf446223b2e0e4f0a4792938e8d885e8a896834aded5f51be5c3c69566495540",
+                "sha256:cbcc691d8b507d54cb2b8521f0a2a3d4daa477f62fe77f0abba41e5febb377b7",
+                "sha256:d051ce0946521eba48e19b25f27f98e5ce4dbc91fff296de76240c46b4464df0",
+                "sha256:d61b73c01fc1de799226963f2639af831307fe1556b04b7c25e2b6c267a3bc76",
+                "sha256:eea10982b798ff0ccc3b9e7e42628f932f552c5845066970e67cd6858655d52c",
+                "sha256:f79137d012ff3227866222049af534f25354c07a0d6b9a171dba9f1d6a1fdef4",
+                "sha256:fc5ecff5a3bbfbe20091b1cad82815507f5ae9c380a3a9bf40f740c70ce30a9b"
             ],
             "index": "pypi",
-            "version": "==0.931"
+            "version": "==0.941"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1815,11 +1829,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:45e1d053cad4cd453181ae877c4ffc053546ae99e7dd049b9ff1d9be7491abf7",
-                "sha256:e0621bcbf4160e4e1030f05065c8834b4e93f4fcc223255db2a823440aca9c14"
+                "sha256:dd448d1ded9f14d1a4bfa6bfc0c5b96ae3be3f2d6c6c159b23ddcfd701baa021",
+                "sha256:e9dd1a1359d70137559034c0f5433b34caf504af2dc756367be86a5a32967134"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.13.1"
+            "version": "==20.13.3"
         }
     }
 }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 -i https://pypi.python.org/simple
 attrs==21.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-bandit==1.7.2
+bandit==1.7.4
 certifi==2021.10.8
 cfgv==3.3.1; python_full_version >= '3.6.1'
 charset-normalizer==2.0.12; python_version >= '3'
@@ -12,12 +12,12 @@ filelock==3.6.0; python_version >= '3.7'
 gitdb==4.0.9; python_version >= '3.6'
 gitpython==3.1.27; python_version >= '3.7'
 greenlet==2.0.0a1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-hypothesis==6.37.1
-identify==2.4.10; python_version >= '3.7'
+hypothesis==6.39.3
+identify==2.4.11; python_version >= '3.7'
 idna==3.3; python_version >= '3'
 iniconfig==1.1.1
 mypy-extensions==0.4.3
-mypy==0.931
+mypy==0.941
 nodeenv==1.6.0
 packaging==21.3; python_version >= '3.6'
 pbr==5.8.1; python_version >= '2.6'
@@ -46,4 +46,4 @@ toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 tomli==2.0.1; python_version >= '3.7'
 typing-extensions==3.10.0.2
 urllib3==1.26.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
-virtualenv==20.13.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+virtualenv==20.13.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -16,9 +16,9 @@ idna==3.3; python_version >= '3'
 imagesize==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 incremental==21.3.0
 iniconfig==1.1.1
-isort==5.10.1; python_full_version >= '3.6.1' and python_version < '4'
+isort==5.10.1; python_full_version >= '3.6.1' and python_version < '4.0'
 jinja2==3.0.3; python_version >= '3.6'
-markupsafe==2.1.0; python_version >= '3.7'
+markupsafe==2.1.1; python_version >= '3.7'
 mock==4.0.3; python_version >= '3.6'
 packaging==21.3; python_version >= '3.6'
 pep8==1.7.1
@@ -30,7 +30,7 @@ pyparsing==3.0.7; python_version >= '3.6'
 pytest-cache==1.0
 pytest-cov==3.0.0; python_version >= '3.6'
 pytest-pep8==1.0.6
-pytest==7.0.1; python_version >= '3.6'
+pytest==7.1.0; python_version >= '3.7'
 pytz==2021.3
 pyyaml==6.0; python_version >= '3.6'
 requests==2.27.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
@@ -45,6 +45,6 @@ sphinxcontrib-htmlhelp==2.0.0; python_version >= '3.6'
 sphinxcontrib-jsmath==1.0.1; python_version >= '3.5'
 sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
-tomli==2.0.1; python_version >= '3.6'
+tomli==2.0.1; python_version >= '3.7'
 towncrier==21.9.0
-urllib3==1.26.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+urllib3==1.26.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'

--- a/newsfragments/2883.feature.rst
+++ b/newsfragments/2883.feature.rst
@@ -1,0 +1,1 @@
+Updated nucypher-core to 0.1

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1045,7 +1045,7 @@ class Ursula(Teacher, Character, Operator):
                                       operator_signature=operator_signature,
                                       verifying_key=self.public_keys(SigningPower),
                                       encrypting_key=self.public_keys(DecryptingPower),
-                                      certificate_bytes=self.certificate.public_bytes(Encoding.PEM),
+                                      certificate_der=self.certificate.public_bytes(Encoding.DER),
                                       host=self.rest_interface.host,
                                       port=self.rest_interface.port,
                                       )

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1039,7 +1039,7 @@ class Ursula(Teacher, Character, Operator):
             operator_signature = None
         else:
             operator_signature = self.operator_signature
-        payload = NodeMetadataPayload(staker_address=self.canonical_address,
+        payload = NodeMetadataPayload(staking_provider_address=self.canonical_address,
                                       domain=self.domain,
                                       timestamp_epoch=timestamp.epoch,
                                       decentralized_identity_evidence=operator_signature,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1028,7 +1028,7 @@ class Ursula(Teacher, Character, Operator):
 
     @property
     def operator_signature_from_metadata(self):
-        return self._metadata.payload.decentralized_identity_evidence or NOT_SIGNED
+        return self._metadata.payload.operator_signature or NOT_SIGNED
 
     def _generate_metadata(self) -> NodeMetadata:
         # Assuming that the attributes collected there do not change,
@@ -1042,7 +1042,7 @@ class Ursula(Teacher, Character, Operator):
         payload = NodeMetadataPayload(staking_provider_address=self.canonical_address,
                                       domain=self.domain,
                                       timestamp_epoch=timestamp.epoch,
-                                      decentralized_identity_evidence=operator_signature,
+                                      operator_signature=operator_signature,
                                       verifying_key=self.public_keys(SigningPower),
                                       encrypting_key=self.public_keys(DecryptingPower),
                                       certificate_bytes=self.certificate.public_bytes(Encoding.PEM),

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -95,7 +95,7 @@ class Vladimir(Ursula):
         # so it should work regardless of the binary format.
 
         # Our basic replacement. We want to impersonate the target Ursula.
-        metadata_bytes = metadata_bytes.replace(metadata.payload.staker_address,
+        metadata_bytes = metadata_bytes.replace(metadata.payload.staking_provider_address,
                                                 vladimir.canonical_address)
 
         # Use our own verifying key

--- a/nucypher/config/storages.py
+++ b/nucypher/config/storages.py
@@ -326,7 +326,7 @@ class LocalFileBasedNodeStorage(NodeStorage):
         """Deserialize an X509 certificate from a filepath"""
         try:
             with open(filepath, 'rb') as certificate_file:
-                certificate = x509.load_pem_x509_certificate(certificate_file.read(), backend=default_backend())
+                certificate = x509.load_der_x509_certificate(certificate_file.read(), backend=default_backend())
                 return certificate
         except FileNotFoundError:
             raise FileNotFoundError("No SSL certificate found at {}".format(filepath))

--- a/nucypher/crypto/tls.py
+++ b/nucypher/crypto/tls.py
@@ -54,7 +54,7 @@ def _read_tls_certificate(filepath: Path) -> Certificate:
     """Deserialize an X509 certificate from a filepath"""
     try:
         with open(filepath, 'rb') as certificate_file:
-            cert = x509.load_pem_x509_certificate(certificate_file.read(), backend=default_backend())
+            cert = x509.load_der_x509_certificate(certificate_file.read(), backend=default_backend())
             return cert
     except FileNotFoundError:
         raise FileNotFoundError("No SSL certificate found at {}".format(filepath))

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -186,7 +186,8 @@ class RestMiddleware:
 
         try:
             self.log.info(f"Fetching seednode {host}:{port} TLS certificate")
-            seednode_certificate = ssl.get_server_certificate(addr=(host, port))
+            seednode_certificate_pem = ssl.get_server_certificate(addr=(host, port))
+            seednode_certificate = ssl.PEM_cert_to_DER_cert(seednode_certificate_pem)
 
         except socket.timeout:
             if current_attempt == retry_attempts:
@@ -201,7 +202,7 @@ class RestMiddleware:
             raise  # TODO: #1835
 
         else:
-            certificate = x509.load_pem_x509_certificate(seednode_certificate.encode(),
+            certificate = x509.load_der_x509_certificate(seednode_certificate,
                                                          backend=default_backend())
             return certificate
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -120,7 +120,7 @@ class NodeSprout:
 
     @property
     def canonical_address(self):
-        return self._metadata_payload.staker_address
+        return self._metadata_payload.staking_provider_address
 
     @property
     def nickname(self):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -32,7 +32,7 @@ from constant_sorrow.constants import (
     NO_STORAGE_AVAILABLE,
     RELAX,
 )
-from cryptography.x509 import Certificate, load_pem_x509_certificate
+from cryptography.x509 import Certificate, load_der_x509_certificate
 from cryptography.hazmat.backends import default_backend
 from eth_utils import to_checksum_address
 from requests.exceptions import SSLError
@@ -179,7 +179,7 @@ class NodeSprout:
                       domain=self._metadata_payload.domain,
                       timestamp=self.timestamp,
                       operator_signature_from_metadata=self.operator_signature_from_metadata,
-                      certificate=load_pem_x509_certificate(self._metadata_payload.certificate_bytes, backend=default_backend()),
+                      certificate=load_der_x509_certificate(self._metadata_payload.certificate_der, backend=default_backend()),
                       metadata=self._metadata
                       )
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -150,7 +150,7 @@ class NodeSprout:
 
     @property
     def operator_signature_from_metadata(self):
-        return self._metadata_payload.decentralized_identity_evidence or NOT_SIGNED
+        return self._metadata_payload.operator_signature or NOT_SIGNED
 
     @property
     def timestamp(self):

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -29,7 +29,7 @@ class RevocationKit:
         self.revocations = dict()
         for staking_provider_address, encrypted_kfrag in treasure_map.destinations.items():
             self.revocations[staking_provider_address] = RevocationOrder(signer=signer.as_umbral_signer(),
-                                                                         staker_address=staking_provider_address,
+                                                                         staking_provider_address=staking_provider_address,
                                                                          encrypted_kfrag=encrypted_kfrag)
 
     def __iter__(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -i https://pypi.python.org/simple
 appdirs==1.4.4
 attrs==21.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-autobahn==22.1.1; python_version >= '3.7'
+autobahn==22.2.2; python_version >= '3.7'
 automat==20.2.0
 base58==2.1.1; python_version >= '3.5'
 bitarray==1.2.2
@@ -15,15 +15,15 @@ click==8.0.4
 colorama==0.4.4
 constant-sorrow==0.1.0a9
 constantly==15.1.0
-construct==2.10.67; python_version >= '3.6'
-cryptography==36.0.1
+construct==2.10.68; python_version >= '3.6'
+cryptography==36.0.2
 cytoolz==0.11.2; implementation_name == 'cpython'
 dateparser==1.1.0; python_version >= '3.5'
 ecdsa==0.18.0b2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 eth-abi==2.1.1; python_version >= '3.6' and python_version < '4'
 eth-account==0.5.7; python_version >= '3.6' and python_version < '4'
 eth-bloom==1.0.4; python_version >= '3.6' and python_version < '4'
-eth-hash[pycryptodome]==0.3.2; python_version >= '3.5' and python_version < '4'
+eth-hash==0.3.2; python_version >= '3.5' and python_version < '4'
 eth-keyfile==0.5.1
 eth-keys==0.3.4
 eth-rlp==0.2.1; python_version >= '3.6' and python_version < '4'
@@ -44,9 +44,9 @@ jsonschema==3.2.0
 libusb1==3.0.0
 lmdb==1.3.0
 lru-dict==1.1.7
-mako==1.1.6
-markupsafe==2.1.0; python_version >= '3.7'
-marshmallow==3.14.1
+mako==1.2.0
+markupsafe==2.1.1; python_version >= '3.7'
+marshmallow==3.15.0
 maya==0.6.1
 mnemonic==0.20; python_version >= '3.5'
 msgpack-python==0.5.6
@@ -54,11 +54,12 @@ msgpack==1.0.3
 multiaddr==0.0.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 mypy-extensions==0.4.3
 netaddr==0.8.0
-nucypher-core==0.0.4
+nucypher-core==0.1.1
+packaging==21.3; python_version >= '3.6'
 parsimonious==0.8.1
 pendulum==2.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 pillow==9.0.1; python_version >= '3.7'
-protobuf==3.19.4; python_version >= '3.5'
+protobuf==3.20.0rc1; python_version >= '3.7'
 py-ecc==4.1.0; python_version >= '3.5' and python_version < '4'
 py-evm==0.4.0a3
 py-geth==3.7.0
@@ -70,13 +71,14 @@ pycryptodome==3.14.1
 pyethash==0.1.27
 pynacl==1.5.0
 pyopenssl==22.0.0
+pyparsing==3.0.7; python_version >= '3.6'
 pyrsistent==0.18.1; python_version >= '3.7'
 pysha3==1.0.2
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 pytz==2021.3
 pytzdata==2020.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 qrcode[pil]==7.3.1
-regex==2022.1.18
+regex==2022.3.2; python_version >= '3.6'
 requests==2.27.1
 rlp==2.0.1
 semantic-version==2.9.0; python_version >= '2.7'
@@ -89,8 +91,8 @@ tabulate==0.8.9
 toolz==0.11.2; python_version >= '3.5'
 trezor==0.13.0
 trie==2.0.0a5; python_version >= '3.6' and python_version < '4'
-twisted==22.2.0rc1; python_full_version >= '3.6.7'
-txaio==21.2.1; python_version >= '3.6'
+twisted==22.2.0; python_full_version >= '3.6.7'
+txaio==22.2.1; python_version >= '3.6'
 typing-extensions==3.10.0.2
 tzlocal==2.1
 urllib3==1.26.8; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'

--- a/tests/integration/config/test_keystore_integration.py
+++ b/tests/integration/config/test_keystore_integration.py
@@ -110,7 +110,7 @@ def test_tls_hosting_certificate_remains_the_same(temp_dir_path, mocker):
     assert ursula.keystore is keystore
     assert ursula.certificate == ursula._crypto_power.power_ups(TLSHostingPower).keypair.certificate
 
-    original_certificate_bytes = ursula.certificate.public_bytes(encoding=Encoding.PEM)
+    original_certificate_bytes = ursula.certificate.public_bytes(encoding=Encoding.DER)
     ursula.disenchant()
     del ursula
 
@@ -124,7 +124,7 @@ def test_tls_hosting_certificate_remains_the_same(temp_dir_path, mocker):
                               domain=TEMPORARY_DOMAIN)
 
     assert recreated_ursula.keystore is keystore
-    assert recreated_ursula.certificate.public_bytes(encoding=Encoding.PEM) == original_certificate_bytes
+    assert recreated_ursula.certificate.public_bytes(encoding=Encoding.DER) == original_certificate_bytes
     tls_hosting_power = recreated_ursula._crypto_power.power_ups(TLSHostingPower)
     spy_rest_server_init.assert_called_once_with(ANY,  # self
                                                  rest_host=LOOPBACK_ADDRESS,

--- a/tests/mock/performance_mocks.py
+++ b/tests/mock/performance_mocks.py
@@ -128,7 +128,7 @@ class NotACert:
         return NotAPublicKey()
 
 
-mock_cert_loading = patch("nucypher.network.nodes.load_pem_x509_certificate",
+mock_cert_loading = patch("nucypher.network.nodes.load_der_x509_certificate",
                           new=lambda *args, **kwargs: NotACert())
 
 

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -68,7 +68,7 @@ class Dummy:  # Teacher
 
     def metadata(self):
         signer = Signer(SecretKey.random())
-        payload = NodeMetadataPayload(staker_address=self.canonical_address,
+        payload = NodeMetadataPayload(staking_provider_address=self.canonical_address,
                                       domain=':dummy:',
                                       timestamp_epoch=0,
                                       decentralized_identity_evidence=b'\x00' * LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY,

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -78,7 +78,7 @@ class Dummy:  # Teacher
                                       operator_signature=dummy_signature,
                                       verifying_key=signer.verifying_key(),
                                       encrypting_key=SecretKey.random().public_key(),
-                                      certificate_bytes=b'not a certificate',
+                                      certificate_der=b'not a certificate',
                                       host='127.0.0.1',
                                       port=1111,
                                       )

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -68,10 +68,14 @@ class Dummy:  # Teacher
 
     def metadata(self):
         signer = Signer(SecretKey.random())
+
+        # A dummy signature with the recovery byte
+        dummy_signature = bytes(signer.sign(b'whatever')) + b'\x00'
+
         payload = NodeMetadataPayload(staking_provider_address=self.canonical_address,
                                       domain=':dummy:',
                                       timestamp_epoch=0,
-                                      decentralized_identity_evidence=b'\x00' * LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY,
+                                      operator_signature=dummy_signature,
                                       verifying_key=signer.verifying_key(),
                                       encrypting_key=SecretKey.random().public_key(),
                                       certificate_bytes=b'not a certificate',


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 1

**What this does:**
The following API changes in nucypher-core 0.1 accounted for:
- `staker_address` was renamed to `staking_provider_address`
- `decentralized_identity_evidence` was renamed to `operator_signature`
- `certificate_bytes` was renamed to `certificate_der`
- also, the usage of PEM-encoded certificates was changed to DER (to reviewers: check that I didn't miss anything here)
- `nucypher-core` bumped to 0.1 and dependencies relocked
