### PR TITLE
Fix bug in git url of docs dependancy `jsonschema2rst`

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -11,7 +11,7 @@ coverage==6.3.2; python_version >= '3.7'
 docutils==0.17.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 dulwich==0.19.16
 execnet==1.9.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-git+git://github.com/inspirehep/jsonschema2rst.git@d211d9709046431a6b6a4594c97c22d8713d854b#egg=jsonschema2rst
+git+https://github.com/inspirehep/jsonschema2rst.git@d211d9709046431a6b6a4594c97c22d8713d854b#egg=jsonschema2rst
 idna==3.3; python_version >= '3'
 imagesize==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 incremental==21.3.0

--- a/scripts/dependencies/docs/Pipfile
+++ b/scripts/dependencies/docs/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 python_version = "3"
 
 [packages]
-jsonschema2rst = {git = "git://github.com/inspirehep/jsonschema2rst.git", editable = false, ref="d211d9709046431a6b6a4594c97c22d8713d854b"}
+jsonschema2rst = {git = "https://github.com/inspirehep/jsonschema2rst.git", editable = false, ref="d211d9709046431a6b6a4594c97c22d8713d854b"}
 py-solc-x = "==0.10.1"
 sphinx = "==3.0.1"
 sphinx_rtd_theme = "*"


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Fixes bug in the git url of dependancy `jsonschema2rst`.
The cause of the issue is described [here](https://teknotopnews.com/otomotif-https-github.blog/2021-09-01-improving-git-protocol-security-github/) and [here](https://teknotopnews.com/a/70663683).
This bug was expected from Jan. 11th, 2022.


**Why it's needed:**
Docs cannot be built by circleci because it cannot install the dependancies, as seen here https://app.circleci.com/pipelines/github/nucypher/nucypher/9307/workflows/e680a4ca-71cb-4cbf-9106-29e50e9e2b10/jobs/157929


