### PR TITLE
Fix additional issues from Airship

### DIFF
--- a/newsfragments/2886.bugfix.rst
+++ b/newsfragments/2886.bugfix.rst
@@ -1,0 +1,1 @@
+Fix runaway WorkTracker task that ensures operator confirmed transaction occurs but continues running and making web3 requests even after operator already confirmed.

--- a/newsfragments/2886.feature.rst
+++ b/newsfragments/2886.feature.rst
@@ -1,0 +1,1 @@
+Proactively shut down Ursula if it is no longer bonded to any staking provider.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -363,7 +363,9 @@ class Operator(BaseActor):
                 if ether_balance:
                     # funds found
                     funded, balance = True, Web3.fromWei(ether_balance, 'ether')
-                    emitter.message(f"✓ Operator is funded with {balance} ETH", color='green')
+                    emitter.message(f"✓ Operator {self.operator_address} is funded with {balance} ETH", color='green')
+                else:
+                    emitter.message(f"! Operator {self.operator_address} is not funded with ETH", color="yellow")
 
             if (not bonded) and (self.get_staking_provider_address() != NULL_ADDRESS):
                 bonded = True

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -417,7 +417,7 @@ class WorkTrackerBase:
         raise NotImplementedError
 
     def _all_work_completed(self) -> bool:
-        """ allows the work tracker to indicate that its work is completed it can be shut down """
+        """ allows the work tracker to indicate that its work is completed and it can be shut down """
         raise NotImplementedError
 
 

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -181,7 +181,7 @@ def perform_startup_ip_check(emitter: StdoutEmitter, ursula: Ursula, force: bool
 
     ip_mismatch = external_ip != rest_host
     if ip_mismatch and not force:
-        error = f'\nX External IP address ({external_ip}) does not match configuration ({ursula.rest_interface.host}).\n'
+        error = f'\nx External IP address ({external_ip}) does not match configuration ({ursula.rest_interface.host}).\n'
         hint = f"Run 'nucypher ursula config ip-address' to reconfigure the IP address then try " \
                f"again or use --no-ip-checkup to bypass this check (not recommended).\n"
         emitter.message(error, color='red')

--- a/nucypher/network/trackers.py
+++ b/nucypher/network/trackers.py
@@ -16,16 +16,58 @@
 """
 
 import random
+from typing import Union
 
 import maya
 from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
-from typing import Union
+from twisted.python.failure import Failure
 
+from nucypher.blockchain.eth.agents import ContractAgency, PREApplicationAgent
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.control.emitters import StdoutEmitter
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
 from nucypher.network.nodes import NodeSprout
 from nucypher.utilities.logging import Logger
+from nucypher.utilities.task import SimpleTask
+
+
+class OperatorBondedTracker(SimpleTask):
+    INTERVAL = 60 * 60  # 1 hour
+
+    class OperatorNoLongerBonded(RuntimeError):
+        """Raised when a running node is no longer associated with a staking provider."""
+
+    def __init__(self, ursula):
+        self._ursula = ursula
+        super().__init__()
+
+    def run(self) -> None:
+        application_agent = ContractAgency.get_agent(PREApplicationAgent,
+                                                     registry=self._ursula.registry,
+                                                     eth_provider_uri=self._ursula.eth_provider_uri)
+        staking_provider_address = application_agent.get_staking_provider_from_operator(
+            operator_address=self._ursula.operator_address)
+        if staking_provider_address == NULL_ADDRESS:
+            # forcibly shut down ursula
+            self._shutdown_ursula(halt_reactor=True)
+
+    def _shutdown_ursula(self, halt_reactor=False):
+        emitter = StdoutEmitter()
+        emitter.message(f'x [Operator {self._ursula.operator_address} is no longer bonded to any '
+                        f'staking provider] - Commencing auto-shutdown sequence...', color="red")
+        try:
+            raise self.OperatorNoLongerBonded()
+        finally:
+            self._ursula.stop(halt_reactor=halt_reactor)
+
+    def handle_errors(self, failure: Failure) -> None:
+        cleaned_traceback = self.clean_traceback(failure)
+        self.log.warn(f"Unhandled error during operator bonded check: {cleaned_traceback}")
+        if failure.check([self.OperatorNoLongerBonded]):
+            # this type of exception we want to propagate because we will shut down
+            failure.raiseException()
 
 
 class AvailabilityTracker:

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -62,8 +62,9 @@ IP_DETECTION_LOGGER = Logger('external-ip-detection')
 
 def validate_operator_ip(ip: str) -> None:
     if ip in RESERVED_IP_ADDRESSES:
-        raise InvalidOperatorIP(f'{ip} is not a valid or permitted worker IP address.  '
-                              f'Verify the rest_host is set to the external IPV4 address')
+        raise InvalidOperatorIP(f"{ip} is not a valid or permitted operator IP address. "
+                                f"Verify the 'rest_host' configuration value is set to the "
+                                f"external IPV4 address")
 
 
 def _request(url: str, certificate=None) -> Union[str, None]:

--- a/nucypher/utilities/task.py
+++ b/nucypher/utilities/task.py
@@ -1,0 +1,64 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+from abc import ABC, abstractmethod
+
+from twisted.internet.task import LoopingCall
+from twisted.python.failure import Failure
+
+from nucypher.utilities.logging import Logger
+
+
+class SimpleTask(ABC):
+    """Simple Twisted Looping Call abstract base class."""
+    INTERVAL = 60  # 60s default
+
+    def __init__(self):
+        self.log = Logger(self.__class__.__name__)
+        self.__task = LoopingCall(self.run)
+
+    @property
+    def running(self) -> bool:
+        """Determine whether the task is already running."""
+        return self.__task.running
+
+    def start(self, now: bool = False):
+        """Start task."""
+        if not self.running:
+            d = self.__task.start(interval=self.INTERVAL, now=now)
+            d.addErrback(self.handle_errors)
+
+    def stop(self):
+        """Stop task."""
+        if self.running:
+            self.__task.stop()
+
+    @abstractmethod
+    def run(self):
+        """Task method that should be periodically run."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def handle_errors(self, *args, **kwargs):
+        """Error callback for error handling during execution."""
+        raise NotImplementedError
+
+    @staticmethod
+    def clean_traceback(failure: Failure) -> str:
+        # FIXME: Amazing.
+        cleaned_traceback = failure.getTraceback().replace('{', '').replace('}', '')
+        return cleaned_traceback

--- a/tests/unit/test_operator_bonded_tracker.py
+++ b/tests/unit/test_operator_bonded_tracker.py
@@ -1,0 +1,83 @@
+"""
+This file is part of nucypher.
+
+nucypher is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+nucypher is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import pytest
+import pytest_twisted
+from twisted.internet import threads
+
+from nucypher.blockchain.eth.agents import ContractAgency
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.network.trackers import OperatorBondedTracker
+
+
+@pytest_twisted.inlineCallbacks
+def test_operator_never_bonded(mocker, get_random_checksum_address):
+    ursula = mocker.Mock()
+    operator_address = get_random_checksum_address()
+    ursula.operator_address = operator_address
+
+    application_agent = mocker.Mock()
+    application_agent.get_staking_provider_from_operator.return_value = NULL_ADDRESS
+
+    mocker.patch.object(ContractAgency, 'get_agent', return_value=application_agent)
+
+    tracker = OperatorBondedTracker(ursula=ursula)
+    try:
+        d = threads.deferToThread(tracker.start)
+        yield d
+
+        with pytest.raises(OperatorBondedTracker.OperatorNoLongerBonded):
+            d = threads.deferToThread(tracker.run)
+            yield d
+    finally:
+        application_agent.get_staking_provider_from_operator.assert_called_once()
+        ursula.stop.assert_called_once_with(halt_reactor=True)  # stop entire reactor
+        tracker.stop()
+
+
+@pytest_twisted.inlineCallbacks
+def test_operator_bonded_but_becomes_unbonded(mocker, get_random_checksum_address):
+    ursula = mocker.Mock()
+    operator_address = get_random_checksum_address()
+    ursula.operator_address = operator_address
+
+    application_agent = mocker.Mock()
+    staking_provider = get_random_checksum_address()
+    application_agent.get_staking_provider_from_operator.return_value = staking_provider
+
+    mocker.patch.object(ContractAgency, 'get_agent', return_value=application_agent)
+
+    tracker = OperatorBondedTracker(ursula=ursula)
+    try:
+        d = threads.deferToThread(tracker.start)
+        yield d
+
+        # bonded
+        for i in range(1, 10):
+            d = threads.deferToThread(tracker.run)
+            yield d
+            assert application_agent.get_staking_provider_from_operator.call_count == i, "check for operator bonded called"
+            ursula.stop.assert_not_called()
+
+        # becomes unbonded
+        application_agent.get_staking_provider_from_operator.return_value = NULL_ADDRESS
+        with pytest.raises(OperatorBondedTracker.OperatorNoLongerBonded):
+            d = threads.deferToThread(tracker.run)
+            yield d
+    finally:
+        ursula.stop.assert_called_once_with(halt_reactor=True)  # stop entire reactor
+        tracker.stop()


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Builds on the `airship` PR ( #2873 ), and fixes / addresses some issues observed during testing.

* Fixes large number of web3 requests made due to the continued running of WorkTracker - the repurposed task used to make sure the operator confirmed transaction is performed on startup. On the first run of Ursula, the WorkTracker is started and tries to confirm the operator, but once it does, the node continues running but the task never shuts down i.e. once the operator is confirmed the WorkTracker isn't proactively stopped. If Ursula is subsequently restarted then all is fine because the operator was already confirmed and the WorkTracker is not needed and is never started.

<img width="665" alt="Screen_Shot_2022-03-24_at_9 06 26_AM" src="https://user-images.githubusercontent.com/19150641/160146357-b971ca61-36ed-4ec9-99e3-f499b74331bd.png">

* Whenever an Ursula's operator address is no longer bonded to a staking provider, it should not keep running i.e. it should be proactively shutdown.

**Why it's needed:**
* Free infura accounts have daily limits, which will be exceeded if the WorkTracker isn't stopped when no longer needed
* An unbonded Ursula running in the network is useless.
