### PR TITLE
Porter should properly check that Ursula is reachable when sampling

### DIFF
--- a/newsfragments/2888.bugfix.rst
+++ b/newsfragments/2888.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Porter sampling check that ensures Ursula is reachable to be more comprehensive; previously an unreachable Ursula could still be deemed as reachable.

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -127,16 +127,13 @@ the Pipe for PRE Application network operations
             ursula_address = to_checksum_address(ursula_address)
             ursula = self.known_nodes[ursula_address]
             try:
-                # verify node is valid
-                self.network_middleware.client.verify_and_parse_node_or_host_and_port(node_or_sprout=ursula,
-                                                                                      host=None,
-                                                                                      port=None)
-
+                # ensure node is up and reachable
+                self.network_middleware.ping(ursula)
                 return Porter.UrsulaInfo(checksum_address=ursula_address,
                                          uri=f"{ursula.rest_interface.formal_uri}",
                                          encrypting_key=ursula.public_keys(DecryptingPower))
             except Exception as e:
-                self.log.debug(f"Unable to obtain Ursula information ({ursula_address}): {str(e)}")
+                self.log.debug(f"Ursula ({ursula_address}) is unreachable: {str(e)}")
                 raise
 
         self.block_until_number_of_known_nodes_is(quantity,


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Updates to Porter
#. Properly ensure that Ursula is reachable during sampling.

**Why it's needed:**
Noticed on Porter IBEX that a node that was returned from sampling, was down (my laptop node 😅  when it wasn't running)
