### PR TITLE
Cleanup CLI References

### DIFF
--- a/docs/source/references/cli_reference.rst
+++ b/docs/source/references/cli_reference.rst
@@ -123,50 +123,6 @@ Ursula
 +--------------------------+---------------------------------------------------------------------+
 
 
-Cloudworkers
-------------
-
-Manage PRE Node operations on cloud infrastructure.
-
-.. code:: bash
-
-    (nucypher)$ nucypher cloudworkers ACTION [OPTIONS]
-
-**Cloudworkers Command Actions**
-
-+----------------------+-------------------------------------------------------------------------------+
-| Action               |  Description                                                                  |
-+======================+===============================================================================+
-|  ``up``              | Creates and deploys hosts for all active local stakers.                       |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``create``          | Creates and deploys the given number of hosts independent of stakes           |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``add``             | Add an existing host to be managed by cloudworkers CLI tools                  |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``add_for_stake``   | Add an existing host to be managed for a specified local staker address       |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``deploy``          | Install and run Ursula on existing managed hosts.                             |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``update``          | Update or manage existing installed Ursula.                                   |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``destroy``         | Shut down and cleanup resources deployed on AWS or Digital Ocean              |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``stop``            | Stop the selected nodes.                                                      |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``status``          | Prints a formatted status of selected managed hosts.                          |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``logs``            | Download and display the accumulated stdout logs of selected hosts            |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``backup``          | Download local copies of critical data from selected installed Ursulas        |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``restore``         | Reconstitute and deploy an operating Ursula from backed up data               |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``list_hosts``      | Print local nicknames of all managed hosts under a given namespace            |
-+----------------------+-------------------------------------------------------------------------------+
-|  ``list_namespaces`` | Print namespaces under a given network                                        |
-+----------------------+-------------------------------------------------------------------------------+
-
-
 Status
 ------
 

--- a/docs/source/references/cli_reference.rst
+++ b/docs/source/references/cli_reference.rst
@@ -2,6 +2,99 @@
 CLI Reference
 ==============
 
+Ursula
+------
+
+"Ursula the Untrusted" PRE Re-encryption node management commands.
+
+
+.. code:: bash
+
+    (nucypher)$ nucypher ursula ACTION [OPTIONS]
+
+
+**Ursula Command Actions**
+
+
++--------------------------+---------------------------------------------------------------------+
+| Action                   | Description                                                         |
++==========================+=====================================================================+
+| ``init``                 | Create a brand new persistent Ursula.                               |
++--------------------------+---------------------------------------------------------------------+
+| ``config``               | View and optionally update an existing Ursula's configuration.      |
++--------------------------+---------------------------------------------------------------------+
+| ``destroy``              | Delete existing Ursula's configuration.                             |
++--------------------------+---------------------------------------------------------------------+
+| ``forget``               | Delete all stored peer metadata.                                    |
++--------------------------+---------------------------------------------------------------------+
+| ``save-metadata``        | Manually write node metadata to disk without running.               |
++--------------------------+---------------------------------------------------------------------+
+| ``run``                  | Start Ursula.                                                       |
++--------------------------+---------------------------------------------------------------------+
+
+
+Bond
+----
+
+Bond an Operator to a Staking Provider. The Staking Provider must be authorized to use the PREApplication.
+
+.. code:: bash
+
+    (nucypher)$ nucypher bond [OPTIONS]
+
+
+Unbond
+------
+
+Unbonds an operator from an authorized Staking Provider.
+
+.. code:: bash
+
+    (nucypher)$ nucypher unbond [OPTIONS]
+
+
+Enrico
+-------
+
+"Enrico the Encryptor" management commands.
+
+
+.. code:: bash
+
+    (nucypher)$ nucypher enrico ACTION [OPTIONS]
+
+**Enrico Command Actions**
+
+
++--------------------------+-------------------------------------------------------------------------------+
+| Action                   | Description                                                                   |
++==========================+===============================================================================+
+| ``encrypt``              | Encrypt a message under a given policy public key.                            |
++--------------------------+-------------------------------------------------------------------------------+
+| ``run``                  | Start Enrico's HTTP controller.                                               |
++--------------------------+-------------------------------------------------------------------------------+
+
+
+Status
+------
+
+Echo a snapshot of live PRE Application metadata.
+
+.. code:: bash
+
+    (nucypher)$ nucypher status ACTION [OPTIONS]
+
+
+**Status Command Actions**
+
+
++--------------------------+---------------------------------------------------------------------+
+| Action                   | Description                                                         |
++==========================+=====================================================================+
+| ``events``               | Show events associated to PRE Application contracts.                |
++--------------------------+---------------------------------------------------------------------+
+
+
 Alice
 -----
 
@@ -38,6 +131,7 @@ Alice
 | ``run``                  | Start Alice's HTTP controller.                                                |
 +--------------------------+-------------------------------------------------------------------------------+
 
+
 Bob
 ---
 
@@ -68,96 +162,3 @@ Bob
 +--------------------------+-------------------------------------------------------------------------------+
 | ``run``                  | Start Bob's HTTP controller.                                                  |
 +--------------------------+-------------------------------------------------------------------------------+
-
-
-Enrico
--------
-
-"Enrico the Encryptor" management commands.
-
-
-.. code:: bash
-
-    (nucypher)$ nucypher enrico ACTION [OPTIONS]
-
-**Enrico Command Actions**
-
-
-+--------------------------+-------------------------------------------------------------------------------+
-| Action                   | Description                                                                   |
-+==========================+===============================================================================+
-| ``encrypt``              | Encrypt a message under a given policy public key.                            |
-+--------------------------+-------------------------------------------------------------------------------+
-| ``run``                  | Start Enrico's HTTP controller.                                               |
-+--------------------------+-------------------------------------------------------------------------------+
-
-
-Ursula
-------
-
-"Ursula the Untrusted" PRE Re-encryption node management commands.
-
-
-.. code:: bash
-
-    (nucypher)$ nucypher ursula ACTION [OPTIONS]
-
-
-**Ursula Command Actions**
-
-
-+--------------------------+---------------------------------------------------------------------+
-| Action                   | Description                                                         |
-+==========================+=====================================================================+
-| ``init``                 | Create a brand new persistent Ursula.                               |
-+--------------------------+---------------------------------------------------------------------+
-| ``config``               | View and optionally update an existing Ursula's configuration.      |
-+--------------------------+---------------------------------------------------------------------+
-| ``destroy``              | Delete existing Ursula's configuration.                             |
-+--------------------------+---------------------------------------------------------------------+
-| ``forget``               | Delete all stored peer metadata.                                    |
-+--------------------------+---------------------------------------------------------------------+
-| ``save-metadata``        | Manually write node metadata to disk without running.               |
-+--------------------------+---------------------------------------------------------------------+
-| ``run``                  | Start Ursula.                                                       |
-+--------------------------+---------------------------------------------------------------------+
-
-
-Status
-------
-
-Echo a snapshot of live PRE Application metadata.
-
-.. code:: bash
-
-    (nucypher)$ nucypher status ACTION [OPTIONS]
-
-
-**Status Command Actions**
-
-
-+--------------------------+---------------------------------------------------------------------+
-| Action                   | Description                                                         |
-+==========================+=====================================================================+
-| ``events``               | Show events associated to PRE Application contracts.                |
-+--------------------------+---------------------------------------------------------------------+
-
-
-Bond
-----
-
-Bond an Operator to a Staking Provider. The Staking Provider must be authorized to use the PREApplication.
-
-.. code:: bash
-
-    (nucypher)$ nucypher bond [OPTIONS]
-
-
-Unbond
-------
-
-Unbonds an operator from an authorized Staking Provider.
-
-.. code:: bash
-
-    (nucypher)$ nucypher unbond [OPTIONS]


### PR DESCRIPTION
**Type of PR:**
Documentation

**Required reviews:** 
1

**What this does:**
- Removes `cloudworkers` CLI reference table
- Sorts CLI reference tables by importance/relevance

**Why it's needed:**
- Improves the availability of relevant or popular CLI information.

