### PR TITLE
Release Cycle and Versioning Docs

### DIFF
--- a/docs/source/support/contribution.rst
+++ b/docs/source/support/contribution.rst
@@ -312,13 +312,13 @@ Release Cycle
 Versioning
 ^^^^^^^^^^
 
-The versioning scheme used is inspired by [semantic versioning 2.0](https://semver.org/), but adds development stage and release candidate tags. The basic idea:
+The versioning scheme used is inspired by `semantic versioning 2.0<https://semver.org/>`_, but adds development stage and release candidate tags. The basic idea:
 
-> MAJOR version when you make incompatible API changes,
-> MINOR version when you add functionality in a backwards compatible manner, and
-> PATCH version when you make backwards compatible bug fixes.
+- MAJOR version when you make incompatible API changes
+- MINOR version when you add functionality in a backwards compatible manner
+- PATCH version when you make backwards compatible bug fixes
 
-Two additional tags are used: ``-dev`` and ``-rc.x`` (ie ``v1.2.3-dev`` or ``v4.5.6-rc.0``)
+Two additional tags are used: ``-dev`` and ``-rc.x`` (i.e. ``v1.2.3-dev`` or ``v4.5.6-rc.0``)
 
 Upstream Branches
 ^^^^^^^^^^^^^^^^^
@@ -350,8 +350,8 @@ Sometimes changes are needed to fix a release blocker after a release candidate 
 
 In the event that a release blocker's fix introduces unexpected backwards incompatibility during a minor release, bump the major version instead skipping directly to ``-rc.0``.
 
-Patches (bugfixes, security patches,"hotfixes")
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Patches (bugfixes, security patches, "hotfixes")
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Sometimes urgent changes need to be made outside of a planned minor or major release.  If the required changes are backwards compatible open a pull request into ``main``.  Once the changes are reviewed and merged, ``development`` must be rebased over ``main``
 

--- a/docs/source/support/contribution.rst
+++ b/docs/source/support/contribution.rst
@@ -312,7 +312,7 @@ Release Cycle
 Versioning
 ^^^^^^^^^^
 
-The versioning scheme used is inspired by `semantic versioning 2.0<https://semver.org/>`_, but adds development stage and release candidate tags. The basic idea:
+The versioning scheme used is inspired by `semantic versioning 2.0 <https://semver.org/>`_, but adds development stage and release candidate tags. The basic idea:
 
 - MAJOR version when you make incompatible API changes
 - MINOR version when you add functionality in a backwards compatible manner

--- a/docs/source/support/contribution.rst
+++ b/docs/source/support/contribution.rst
@@ -309,7 +309,8 @@ We provide both a ``docker-compose.yml`` and a ``Dockerfile`` which can be used 
 Release Cycle
 -------------
 
-##### Versioning
+Versioning
+^^^^^^^^^^
 
 The versioning scheme used is inspired by [semantic versioning 2.0](https://semver.org/), but adds development stage and release candidate tags. The basic idea:
 
@@ -317,43 +318,47 @@ The versioning scheme used is inspired by [semantic versioning 2.0](https://semv
 > MINOR version when you add functionality in a backwards compatible manner, and
 > PATCH version when you make backwards compatible bug fixes.
 
-Two additional tags are used: `-dev` and `-rc.x` (ie `v1.2.3-dev` or `v4.5.6-rc.0`)
+Two additional tags are used: ``-dev`` and ``-rc.x`` (ie ``v1.2.3-dev`` or ``v4.5.6-rc.0``)
 
-##### Upstream Branches
+Upstream Branches
+^^^^^^^^^^^^^^^^^
 
-- `main` is the stable and released version published to PyPI and docker cloud (`v6.0.0`).
-- `development` is the default upstream base branch containing new changes ahead of `main` and tagged with `-dev` (`v6.1.0-dev`).
+- ``main`` is the stable and released version published to PyPI and docker cloud (``v6.0.0``).
+- ``development`` is the default upstream base branch containing new changes ahead of ``main`` and tagged with ``-dev`` (``v6.1.0-dev``).
 
-##### Major/Minor Release Cycle
+Major/Minor Release Cycle
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
-- New pull requests are made into `development`.
-- When a commit from `development` is selected as a release candidate the version tag is changed from `-dev` to `rc.0` (`v6.1.0-rc.0`).  Selecting a release candidate implies a feature freeze.
+- New pull requests are made into ``development``.
+- When a commit from ``development`` is selected as a release candidate the version tag is changed from ``-dev`` to ``rc.0`` (``v6.1.0-rc.0``).  Selecting a release candidate implies a feature freeze.
 - The release candidate is deployed to beta testers, staging, and testnet environments for QA.
-- If the candidate is suitable, it is tagged, merged into `main`, and published:
-    - All version tags are removed (`v6.1.0-dev` -> `v6.1.0`)
-    - A new upstream git version tag is pushed (triggering publication on CI) (`v6.1.0`)
-    - `development` is merged into `main`
-- `development` version is bumped and the `-dev` tag is appended (`v6.2.0-dev` or `v7.0.0-dev`)
+- If the candidate is suitable, it is tagged, merged into ``main``, and published:
+    - All version tags are removed (``v6.1.0-dev`` -> ``v6.1.0``)
+    - A new upstream git version tag is pushed (triggering publication on CI) (``v6.1.0``)
+    - ``development`` is merged into ``main``
+- `development` version is bumped and the `-dev` tag is appended (``v6.2.0-dev`` or ``v7.0.0-dev``)
 
-##### Release Blockers
+Release Blockers
+^^^^^^^^^^^^^^^^
 
-Sometimes changes are needed to fix a release blocker after a release candidate has already been selected. Normally the best course of action is to open a pull request into `development`.
+Sometimes changes are needed to fix a release blocker after a release candidate has already been selected. Normally the best course of action is to open a pull request into ``development``.
 
-- Merge the pull request into `development`
-- Bump the release candidate's development number (`v7.0.0-rc.0` -> `v7.0.0-rc.1`)
+- Merge the pull request into ``development``
+- Bump the release candidate's development number (``v7.0.0-rc.0`` -> ``v7.0.0-rc.1``)
 - Redeploy beta testing environments, experimental nodes, staging, testnets, etc.
 - Rinse & repeat until a suitable release candidate is found.
 
-In the event that a release blocker's fix introduces unexpected backwards incompatibility during a minor release, bump the major version instead skipping directly to `-rc.0`.
+In the event that a release blocker's fix introduces unexpected backwards incompatibility during a minor release, bump the major version instead skipping directly to ``-rc.0``.
 
-##### Patches (bugfixes, security patches,"hotfixes")
+Patches (bugfixes, security patches,"hotfixes")
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sometimes urgent changes need to me made outside of a planned minor or major release.  If the required changes are backwards compatible open a pull request into `main`.  Once the changes are reviewed and merged, `development` must be rebased over `main`
+Sometimes urgent changes need to be made outside of a planned minor or major release.  If the required changes are backwards compatible open a pull request into ``main``.  Once the changes are reviewed and merged, ``development`` must be rebased over ``main``
 
-- Pull request is merged into `main`
-- The version's patch number is bumped (`v6.1.0` -> `v6.1.1`)
-- A new upstream tag is pushed, triggering the publication build on CI (`v6.1.1`)
-- `development` is rebased over `main`, amending the existing bumpversion commit with the new patch (this will be a merge conflict).
+- Pull request is merged into ``main``
+- The version's patch number is bumped (``v6.1.0`` -> ``v6.1.1``)
+- A new upstream tag is pushed, triggering the publication build on CI (``v6.1.1``)
+- ``development`` is rebased over ``main``, amending the existing bumpversion commit with the new patch (this will be a merge conflict).
 - Rinse & repeat
 
 

--- a/docs/source/support/contribution.rst
+++ b/docs/source/support/contribution.rst
@@ -306,8 +306,59 @@ We provide both a ``docker-compose.yml`` and a ``Dockerfile`` which can be used 
   (nucypher)$ docker-compose -f deploy/docker/docker-compose.yml build .
 
 
-Issuing a New Release
----------------------
+Release Cycle
+-------------
+
+##### Versioning
+
+The versioning scheme used is inspired by [semantic versioning 2.0](https://semver.org/), but adds development stage and release candidate tags. The basic idea:
+
+> MAJOR version when you make incompatible API changes,
+> MINOR version when you add functionality in a backwards compatible manner, and
+> PATCH version when you make backwards compatible bug fixes.
+
+Two additional tags are used: `-dev` and `-rc.x` (ie `v1.2.3-dev` or `v4.5.6-rc.0`)
+
+##### Upstream Branches
+
+- `main` is the stable and released version published to PyPI and docker cloud (`v6.0.0`).
+- `development` is the default upstream base branch containing new changes ahead of `main` and tagged with `-dev` (`v6.1.0-dev`).
+
+##### Major/Minor Release Cycle
+
+- New pull requests are made into `development`.
+- When a commit from `development` is selected as a release candidate the version tag is changed from `-dev` to `rc.0` (`v6.1.0-rc.0`).  Selecting a release candidate implies a feature freeze.
+- The release candidate is deployed to beta testers, staging, and testnet environments for QA.
+- If the candidate is suitable, it is tagged, merged into `main`, and published:
+    - All version tags are removed (`v6.1.0-dev` -> `v6.1.0`)
+    - A new upstream git version tag is pushed (triggering publication on CI) (`v6.1.0`)
+    - `development` is merged into `main`
+- `development` version is bumped and the `-dev` tag is appended (`v6.2.0-dev` or `v7.0.0-dev`)
+
+##### Release Blockers
+
+Sometimes changes are needed to fix a release blocker after a release candidate has already been selected. Normally the best course of action is to open a pull request into `development`.
+
+- Merge the pull request into `development`
+- Bump the release candidate's development number (`v7.0.0-rc.0` -> `v7.0.0-rc.1`)
+- Redeploy beta testing environments, experimental nodes, staging, testnets, etc.
+- Rinse & repeat until a suitable release candidate is found.
+
+In the event that a release blocker's fix introduces unexpected backwards incompatibility during a minor release, bump the major version instead skipping directly to `-rc.0`.
+
+##### Patches (bugfixes, security patches,"hotfixes")
+
+Sometimes urgent changes need to me made outside of a planned minor or major release.  If the required changes are backwards compatible open a pull request into `main`.  Once the changes are reviewed and merged, `development` must be rebased over `main`
+
+- Pull request is merged into `main`
+- The version's patch number is bumped (`v6.1.0` -> `v6.1.1`)
+- A new upstream tag is pushed, triggering the publication build on CI (`v6.1.1`)
+- `development` is rebased over `main`, amending the existing bumpversion commit with the new patch (this will be a merge conflict).
+- Rinse & repeat
+
+
+Release Automation
+--------------------
 
 .. note::
 


### PR DESCRIPTION
**Type of PR:**
Documentation

**Required reviews:** 
2

**What this does:**
Adds a detailed explanation of the new release cycle and versioning practices for nucypher.

**Why it's needed:**
The legacy versioning scheme had several weaknesses making it difficult to to track issues, compatibility, and coordinate infrastructure deployments.

**Notes for reviewers:**
This is a minimal formality and change to our conventional practices.
