### PR TITLE
wrap node_information call in try

### DIFF
--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1156,10 +1156,10 @@ class Teacher:
                 self.certificate_filepath = self._cert_store_function(self.certificate, port=self.rest_interface.port)
             certificate_filepath = self.certificate_filepath
 
-        response_data = network_middleware_client.node_information(host=self.rest_interface.host,
-                                                                   port=self.rest_interface.port)
 
         try:
+            response_data = network_middleware_client.node_information(host=self.rest_interface.host,
+                                                                       port=self.rest_interface.port)
             sprout = self.from_metadata_bytes(response_data)
         except Exception as e:
             raise self.InvalidNode(str(e))


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
- catches unhandled errors


**Why it's needed:**
I was unable to get a response from Porter when making the following call

`https://porter-ibex.nucypher.community/get_ursulas?quantity=3`

 because it was hanging with 

`2022-04-05T22:23:48+0000 [Porter#warn] Unhandled error during node learning: Traceback (most recent call last):
2022-04-05T22:23:56+0000 [Porter#warn] Unhandled error while learning from (Ursula)⇀PaleGreen Four MediumAquaMarine Whiskey↽ (0xeE449FFE36139620B0eBAe041f32f1381b0C72d1) (hex=4e644d640001000092c440fad2d81e5f7a92b0880432abdb6b3af16d110ce4d03462c7342f87c5b2c92a6907daa33a3eb29e8315f517f2b1f39a72f6a7fc9bba0e6764007b27ba87f6b6a799c414ee449ffe36139620b0ebae041f32f1381b0c72d1a469626578ce6241c706c4210239eb7f6c5e8938466d2f2995e5e19f5446d8c5718d6ea7c097792f29e1cdfb5fc4210225a3c33cf97bb60bd9338baea38ab2da8b52dc89b07105776105cc75d3b1ff68c50187308201833082010aa00302010202140d876f705ed3648b92a430941f81f58544dc640c300a06082a8648ce3d04030430193117301506035504030c0e39392e3232352e3130362e313534301e170d3232303332383134333135325a170d3233303332383134333135325a30193117301506035504030c0e39392e3232352e3130362e3135343076301006072a8648ce3d020106052b8104002203620004eba13e9286cd03c5e1dcab285b7f0888dd0cf7dacda52d764d8f0198dcc47c53424cc6d5aac0ba60445b1113eea1543841b982b2cf1b36f9b2a07604d2d487c83da8b4ecac2689234c11d11c7f782c60bbb223a2759c81d915f6732599787ad5a3133011300f0603551d1104083006870463e16a9a300a06082a8648ce3d04030403670030640230261a263a6543bf38ed25350ae00d3f18d0b489539b109ce56643742b0871b44b742d2d80464bae6d7c8e9602cf74276a023063cc39c1ef1af10863ec0a9aa72c6e92784a52a56d09a3f63226a7eee011aa66c43589dda174ddb5edf69c057e98fe94ae39392e3232352e3130362e313534cd2160c4418bd8cb569dd71ce4ac2d5e45443a47d752c7c2dde9481595c3b03ad54230192463ceda613d5f21800d9d3b8e222f6d18c4586412dca88cff087ebe6b6055300f00):Node EXEMPT_FROM_VERIFICATION 99.225.106.154:8544 is unreachable: [Errno 111] Connection refused.
`
Wrapping this allowed a  nodes to be found without crashing.

quantity 3 and higher works in the following call now:

`https://porter-ibex.nucypher.community/get_ursulas?quantity=3`




**Notes for reviewers:**
This is not a full fix, but only a bandaid.

The following from derek:

re: timeouts

Basically when porter samples, it has to attempt to ensure that each node sampled is actually online  (basically a ping) or else they are useless. This is done concurrently (not sequentially) via a thread pool - so multiple nodes can be checked at the same time.

There is an overall timeout of 10s to check the sufficient 'quantity' of nodes specified (remember the checks are concurrent), see https://github.com/nucypher/nucypher/blob/development/nucypher/utilities/porter/porter.py#L69 and https://github.com/nucypher/nucypher/blob/development/nucypher/utilities/porter/porter.py#L144.

The problem is if an insufficient number of nodes (based on the quantity specified) can be checked concurrently within the overall 10s, then Porter errors out as a timeout. However, because it is concurrent, out of all the concurrent failures which failure do you return? We take a random one to append to the typical "Execution timed out after 10s)" - https://github.com/nucypher/nucypher/blob/development/nucypher/control/controllers.py#L365

Porter's timeout was based on previous 2s socket timeouts for node communication - that was recently changed to 4s because of certificate fetching if I'm not mistaken. I think optimizing our cert fetching (which is currently top priority from internal conversations this morning) would improve the situation here. Porter taking more than 10s is probably excessive for a web service. 


