### PR TITLE
Adapt nucypher-ops tutorial for mainnet

### DIFF
--- a/docs/source/pre_application/cloud_node_management.rst
+++ b/docs/source/pre_application/cloud_node_management.rst
@@ -35,7 +35,9 @@ Now we can deploy the PRE Node:
 
 .. code-block:: bash
 
-    nucypher-ops ursula deploy --eth-provider $INFURA_MAINNET_URL --nucypher-image nucypher/nucypher:latest --payment-provider $INFURA_POLYGON_URL --network mainnet
+    nucypher-ops ursula deploy
+
+Follow the prompts to enter your ethereum and polygon provider URIs.
 
 This should produce a lot of log messages as the ansible playbooks install all the requirements and setup the node.
 The final output should be similar to:

--- a/docs/source/pre_application/cloud_node_management.rst
+++ b/docs/source/pre_application/cloud_node_management.rst
@@ -1,4 +1,4 @@
-.. _managing-cloud-nodes:
+    .. _managing-cloud-nodes:
 
 ===============================
 PRE Node Deployment Automation
@@ -13,48 +13,11 @@ PRE Node Deployment Automation
 
 In this tutorial we're going to setup a Threshold PRE Node using a remote cloud provider (Digital Ocean, AWS, and more in the future).
 Whilst this example will demonstrate how to deploy to Digital Ocean, the steps for any other infrastructure provider are virtually identical.
-There are a few pre-requisites before we can get started.
-First, we need to create accounts at `Digital Ocean <https://cloud.digitalocean.com/>`_ and `Infura <https://infura.io>`_.
-
-In order to run a node will also need to have an existing Threshold stake.  For more information see
+There are a few pre-requisites before we can get started. First, we need to create accounts at `Digital Ocean <https://cloud.digitalocean.com/>`_ and `Infura <https://infura.io>`_.
 
 
-Digital Ocean
--------------
-All of the Digital Ocean configuration will be done automatically, but there are two local environment variables we need to set in order to make this work:
-
-- ``DIGITALOCEAN_ACCESS_TOKEN`` - your Digital Ocean `access token <https://docs.digitalocean.com/reference/api/create-personal-access-token/>`_.
-- ``DIGITAL_OCEAN_KEY_FINGERPRINT`` - your Digital Ocean `key fingerprint <https://docs.digitalocean.com/products/droplets/how-to/add-ssh-keys/to-account/>`_.
-
-Follow those two blog posts and either ``export`` the environment variables or add them to your ``~/.bashrc`` file.
-
-
-Infura
-------
-We need a way to interact with both the Ethereum and Polygon networks; Infura makes this easy for us.
-Create a new project at Infura with product type ``ETHEREUM``.
-Also, add the Polygon add-on to this project.
-We're going to create two more environment variables:
-
-- ``INFURA_MAINNET_URL``
-- ``INFURA_POLYGON_URL``
-
-In the **Project Settings**, change the ``ENDPOINTS`` to ``MAINNET`` / ``POLYGON``.
-Set the above environment variables to the corresponding ``https`` endpoint.
-
-
-Overall the environment variable process should look something like:
-
-.. code-block:: bash
-
-    $ export INFURA_MAINNET_URL=https://mainnet.infura.io/v3/bd76baxxxxxxxxxxxxxxxxxxxxxf0ff0
-    $ export INFURA_POLYGON_URL=https://polygon.infura.io/v3/bd76baxxxxxxxxxxxxxxxxxxxxxf0ff0
-    $ export DIGITALOCEAN_ACCESS_TOKEN=4ade7a8701xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxbafd23
-    $ export DIGITAL_OCEAN_KEY_FINGERPRINT=28:38:e7xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:ca:5c
-
-
-Setup Remote Node
------------------
+Launch Remote Node
+-------------------
 Locally, we will install `NuCypher Ops <https://github.com/nucypher/nucypher-ops>`_ to handle the heavy lifting of setting up a node.
 
 .. code-block:: bash
@@ -65,7 +28,7 @@ Now NuCypher Ops is installed we can create a droplet on Digital Ocean:
 
 .. code-block:: bash
 
-    nucypher-ops nodes create --network mainnet --count 1 --cloudprovider digitalocean
+    nucypher-ops nodes create
 
 At this point you should see the droplet in your Digital Ocean dashboard.
 Now we can deploy the PRE Node:
@@ -103,9 +66,24 @@ Let's ``ssh`` into it and look at the logs:
     ...
 
 These lines will print repeatedly until the Operator is funded with some mainnet ETH and bonded to a staking provider.
-Send mainnet ETH to the operator address that is printed
+Send mainnet ETH to the operator address that is printed.
 
-Once you've funded and staking transaction is confirmed, view the logs of the node. You should see:
+
+Stake an Bond
+-------------
+
+If you have not already done so you'll need to establish a stake on the threshold
+staking dashboard ``https://dashboard.threshold.network/overview/network``.
+After you've established your stake, proceed to the PRE node bonding dashboard to bond your node's
+operator address to your stake. ``https://stake.nucypher.network/manage/operator``.
+
+
+Monitor Remote Node
+-------------------
+
+Send a small amount of ETH to your operator address so it can perform the initial start transaction which signals that your
+node is open for business. Once you've funded and your staking transaction is confirmed, view the logs of the node.
+It will automatically detect that you have staked.  You should see:
 
 .. code-block:: bash
 
@@ -117,3 +95,5 @@ Once you've funded and staking transaction is confirmed, view the logs of the no
     Working ~ Keep Ursula Online!
 
 You can view the status of your node by visiting ``https://YOUR_NODE_IP:9151/status``
+
+That's all!

--- a/docs/source/pre_application/cloud_node_management.rst
+++ b/docs/source/pre_application/cloud_node_management.rst
@@ -1,8 +1,8 @@
 .. _managing-cloud-nodes:
 
-=========================
-PRE Node Cloud Automation
-=========================
+===============================
+PRE Node Deployment Automation
+===============================
 
 .. note::
 
@@ -11,26 +11,12 @@ PRE Node Cloud Automation
     via `nucypher-ops <https://github.com/nucypher/nucypher-ops>`_.
 
 
-.. warning::
-
-    `nucypher-ops <https://github.com/nucypher/nucypher-ops>`_ is under active development, and
-    should currently **only be used on testnet**.
-
-
-PRE Node Testnet Cloud Automation
-=================================
-
-In this tutorial we're going to setup a Threshold PRE Node on the rinkeby testnet using a remote cloud provider (Digital Ocean, AWS, and more in the future).
+In this tutorial we're going to setup a Threshold PRE Node using a remote cloud provider (Digital Ocean, AWS, and more in the future).
 Whilst this example will demonstrate how to deploy to Digital Ocean, the steps for any other infrastructure provider are virtually identical.
 There are a few pre-requisites before we can get started.
 First, we need to create accounts at `Digital Ocean <https://cloud.digitalocean.com/>`_ and `Infura <https://infura.io>`_.
-We also need at least 40,000T in our wallet.
-There are currently no Threshold testnet faucets but if you ask in the `Discord <https://discord.gg/Threshold>`_ channel, someone will be happy to help you out.
 
-.. warning::
-
-  Ensure that you are using a wallet on the rinkeby testnet, **don't** use a mainnet address.
-
+In order to run a node will also need to have an existing Threshold stake.  For more information see
 
 
 Digital Ocean
@@ -45,15 +31,15 @@ Follow those two blog posts and either ``export`` the environment variables or a
 
 Infura
 ------
-We need a way to interact with both the Ethereum and Polygon testnet networks; Infura makes this easy for us.
+We need a way to interact with both the Ethereum and Polygon networks; Infura makes this easy for us.
 Create a new project at Infura with product type ``ETHEREUM``.
 Also, add the Polygon add-on to this project.
 We're going to create two more environment variables:
 
-- ``INFURA_RINKEBY_URL``
-- ``INFURA_MUMBAI_URL``
-  
-In the **Project Settings**, change the ``ENDPOINTS`` to ``RINKEBY`` / ``POLYGON_MUMBAI``.
+- ``INFURA_MAINNET_URL``
+- ``INFURA_POLYGON_URL``
+
+In the **Project Settings**, change the ``ENDPOINTS`` to ``MAINNET`` / ``POLYGON``.
 Set the above environment variables to the corresponding ``https`` endpoint.
 
 
@@ -61,8 +47,8 @@ Overall the environment variable process should look something like:
 
 .. code-block:: bash
 
-    $ export INFURA_RINKEBY_URL=https://rinkeby.infura.io/v3/bd76baxxxxxxxxxxxxxxxxxxxxxf0ff0
-    $ export INFURA_MUMBAI_URL=https://polygon-mumbai.infura.io/v3/bd76baxxxxxxxxxxxxxxxxxxxxxf0ff0
+    $ export INFURA_MAINNET_URL=https://mainnet.infura.io/v3/bd76baxxxxxxxxxxxxxxxxxxxxxf0ff0
+    $ export INFURA_POLYGON_URL=https://polygon.infura.io/v3/bd76baxxxxxxxxxxxxxxxxxxxxxf0ff0
     $ export DIGITALOCEAN_ACCESS_TOKEN=4ade7a8701xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxbafd23
     $ export DIGITAL_OCEAN_KEY_FINGERPRINT=28:38:e7xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx:ca:5c
 
@@ -79,14 +65,14 @@ Now NuCypher Ops is installed we can create a droplet on Digital Ocean:
 
 .. code-block:: bash
 
-    nucypher-ops nodes create --network ibex --count 1 --cloudprovider digitalocean
+    nucypher-ops nodes create --network mainnet --count 1 --cloudprovider digitalocean
 
 At this point you should see the droplet in your Digital Ocean dashboard.
 Now we can deploy the PRE Node:
 
 .. code-block:: bash
 
-    nucypher-ops ursula deploy --eth-provider $INFURA_RINKEBY_URL --nucypher-image nucypher/nucypher:experimental --payment-provider $INFURA_MUMBAI_URL --network ibex
+    nucypher-ops ursula deploy --eth-provider $INFURA_MAINNET_URL --nucypher-image nucypher/nucypher:latest --payment-provider $INFURA_POLYGON_URL --network mainnet
 
 This should produce a lot of log messages as the ansible playbooks install all the requirements and setup the node.
 The final output should be similar to:
@@ -94,14 +80,14 @@ The final output should be similar to:
 .. code-block:: bash
 
     some relevant info:
-    config file: "/SOME_PATH/nucypher-ops/configs/ibex/nucypher/ibex-nucypher.json"
-    inventory file: /SOME_PATH/nucypher-ops/configs/ibex-nucypher-2022-03-25.ansible_inventory.yml
+    config file: "/SOME_PATH/nucypher-ops/configs/mainnet/nucypher/mainnet-nucypher.json"
+    inventory file: /SOME_PATH/nucypher-ops/configs/mainnet-nucypher-2022-03-25.ansible_inventory.yml
     If you like, you can run the same playbook directly in ansible with the following:
-        ansible-playbook -i "/SOME_PATH/nucypher-ops/configs/ibex-nucypher-2022-03-25.ansible_inventory.yml" "src/playbooks/setup_remote_workers.yml"
+        ansible-playbook -i "/SOME_PATH/nucypher-ops/configs/mainnet-nucypher-2022-03-25.ansible_inventory.yml" "src/playbooks/setup_remote_workers.yml"
     You may wish to ssh into your running hosts:
         ssh root@123.456.789.xxx
     *** Local backups containing sensitive data may have been created. ***
-    Backup data can be found here: /SOME_PATH//nucypher-ops/configs/ibex/nucypher/remote_worker_backups/
+    Backup data can be found here: /SOME_PATH//nucypher-ops/configs/mainnet/nucypher/remote_worker_backups/
 
 This tells us the location of several config files and helpfully prints the IP address of our newly created node (you can also see this on the Digital Ocean dashboard).
 Let's ``ssh`` into it and look at the logs:
@@ -109,41 +95,17 @@ Let's ``ssh`` into it and look at the logs:
 .. code-block:: bash
 
     $ ssh root@123.456.789.xxx
-    root@nucypher-ibex-1:~#
-    root@nucypher-ibex-1:~# sudo docker logs --follow ursula
+    root@nucypher-mainnet-1:~#
+    root@nucypher-mainnet-1:~# sudo docker logs --follow ursula
     ...
     ! Operator 0x06E11400xxxxxxxxxxxxxxxxxxxxxxxxxxxx1Fc0 is not funded with ETH
     ! Operator 0x06E11400xxxxxxxxxxxxxxxxxxxxxxxxxxxx1Fc0 is not bonded to a staking provider
     ...
 
-These lines will print repeatedly until the Operator is funded with some rinkeby ETH and bonded to a staking provider.
-Send rinkeby ETH to the operator address that is printed
+These lines will print repeatedly until the Operator is funded with some mainnet ETH and bonded to a staking provider.
+Send mainnet ETH to the operator address that is printed
 
-
-Stake and Bond
---------------
-Now that our operator is funded with ETH, we're ready to stake and bond.
-At this point you need some testnet ETH and 40,000 T in a metamask wallet.
-Again, ask in the discord if you need help with this.
-
-Navigate to the `Testnet Staking Dashboard <https://dn3gsazzaajb.cloudfront.net/manage/stake>`_ and connect your metamask wallet.
-Go to the **stake** tab and click "Stake liquid T on rinkeby"
-
-.. image:: ../.static/img/testnet_stake_dashboard.png
-    :target: ../.static/img/testnet_stake_dashboard.png
-
-Allow the 40,000 T spend, and then stake it.
-Both transactions will require authorization via metamask.
-You can ignore the **Configure Addresses** option - they should all default to the currently connected account.
-
-Once those transactions are confirmed, swith to the **bond** tab.
-Here you will paste the Operator address that is being printed by the docker logs:
-
-.. image:: ../.static/img/testnet_bond_dashboard.png
-    :target: ../.static/img/testnet_bond_dashboard.png
-
-Once that transaction is confirmed, switch back to view the logs of the node.
-You should see:
+Once you've funded and staking transaction is confirmed, view the logs of the node. You should see:
 
 .. code-block:: bash
 

--- a/docs/source/pre_application/cloud_node_management.rst
+++ b/docs/source/pre_application/cloud_node_management.rst
@@ -12,12 +12,18 @@ PRE Node Deployment Automation
 
 
 In this tutorial we're going to setup a Threshold PRE Node using a remote cloud provider (Digital Ocean, AWS, and more in the future).
-Whilst this example will demonstrate how to deploy to Digital Ocean, the steps for any other infrastructure provider are virtually identical.
-There are a few pre-requisites before we can get started. First, we need to create accounts at `Digital Ocean <https://cloud.digitalocean.com/>`_ and `Infura <https://infura.io>`_.
+This example will demonstrate how to deploy to Digital Ocean. There are a few pre-requisites before we can get started.
+First, we need to create accounts on `Digital Ocean <https://cloud.digitalocean.com/>`_ and `Infura <https://infura.io>`_.
+Also ensure that your local environment has python 3.8 or later installed.
 
 
 Launch Remote Node
 -------------------
+
+.. note::
+
+    nucypher-ops requires python 3.8 or later.
+
 Locally, we will install `NuCypher Ops <https://github.com/nucypher/nucypher-ops>`_ to handle the heavy lifting of setting up a node.
 
 .. code-block:: bash
@@ -30,7 +36,8 @@ Now NuCypher Ops is installed we can create a droplet on Digital Ocean:
 
     nucypher-ops nodes create
 
-At this point you should see the droplet in your Digital Ocean dashboard.
+Follow the interactive prompts to select the Digital Ocean provider.
+After this command completes you will see a new droplet in your Digital Ocean dashboard.
 Now we can deploy the PRE Node:
 
 .. code-block:: bash
@@ -68,24 +75,25 @@ Let's ``ssh`` into it and look at the logs:
     ...
 
 These lines will print repeatedly until the Operator is funded with some mainnet ETH and bonded to a staking provider.
-Send mainnet ETH to the operator address that is printed.
 
+Stake and Bond
+--------------
 
-Stake an Bond
--------------
-
-If you have not already done so you'll need to establish a stake on the threshold
-staking dashboard ``https://dashboard.threshold.network/overview/network``.
-After you've established your stake, proceed to the PRE node bonding dashboard to bond your node's
-operator address to your stake. ``https://stake.nucypher.network/manage/operator``.
+If you have not already done so you'll need to establish a stake on the `Threshold
+Dashboard <https://dashboard.threshold.network/overview/network>`_.
+After you've established your stake, proceed to the
+`PRE node bonding dashboard <https://stake.nucypher.network/manage/operator>`_ to bond your node's
+Operator address to your stake.
 
 
 Monitor Remote Node
 -------------------
 
-Send a small amount of ETH to your operator address so it can perform the initial start transaction which signals that your
-node is open for business. Once you've funded and your staking transaction is confirmed, view the logs of the node.
-It will automatically detect that you have staked.  You should see:
+Send a small amount of ETH to your Operator address so it can perform the initial confirmation transaction which signals that your
+node is open for business. Once you've funded the Operator address and bonded to the stake, view the node's logs.
+It will automatically detect both completed actions.
+
+After funding and bonding the node will resume startup displaying the following logs:
 
 .. code-block:: bash
 
@@ -96,6 +104,6 @@ It will automatically detect that you have staked.  You should see:
     ✓ Rest Server https://123.456.789.000:9151
     Working ~ Keep Ursula Online!
 
-You can view the status of your node by visiting ``https://YOUR_NODE_IP:9151/status``
+You can view the status of your node by visiting ``https://<YOUR_NODE_IP>:9151/status``
 
 That's all!

--- a/docs/source/pre_application/overview.rst
+++ b/docs/source/pre_application/overview.rst
@@ -88,10 +88,6 @@ In order to provide the PRE service and receive rewards, there are three options
   of the PRE client.
 * **Self-Managed, Automated**: Run your own PRE node on either Digital Ocean or AWS, leveraging :ref:`automation tools <managing-cloud-nodes>` that speed up and simplify the installation process. In this case too, stakers are entirely responsible for setup, operation, and monitoring of the PRE client.
 
-  .. note::
-
-     The :ref:`automation tools <managing-cloud-nodes>` are under active development, and should currently **only be used on testnet**.
-
 Note that setting up a PRE node from scratch is non-trivial, but is typically inexpensive and unburdensome to maintain.
 PRE end-users expect and require an on-demand service, wherein their *grant*, *revoke* and *re-encryption* requests are answered reliably, correctly, and without interruption.
 Hence the most critical responsibility for stakers is ensuring that their PRE node remains online **at all times**. If this is not certain using a local machine, it is highly recommended to use cloud infrastructure instead.

--- a/docs/source/pre_application/testnet.rst
+++ b/docs/source/pre_application/testnet.rst
@@ -13,3 +13,25 @@ You can view it on `etherscan <https://rinkeby.etherscan.io/address/0xc3871e2c11
 .. attention::
 
     This testnet is currently being migrated to Threshold Network.
+
+
+Stake and Bond
+--------------
+You need some rinkeby testnet ETH and 40,000 T in a metamask wallet.
+Ask in the discord if you need help with this.
+
+Navigate to the `Testnet Staking Dashboard <https://dn3gsazzaajb.cloudfront.net/manage/stake>`_ and connect your metamask wallet.
+Go to the **stake** tab and click "Stake liquid T on mainnet"
+
+.. image:: ../.static/img/testnet_stake_dashboard.png
+    :target: ../.static/img/testnet_stake_dashboard.png
+
+Allow the 40,000 T spend, and then stake it.
+Both transactions will require authorization via metamask.
+You can ignore the **Configure Addresses** option - they should all default to the currently connected account.
+
+Once those transactions are confirmed, switch to the **bond** tab.
+Here you will paste the Operator address that is being printed by the docker logs:
+
+.. image:: ../.static/img/testnet_bond_dashboard.png
+    :target: ../.static/img/testnet_bond_dashboard.png

--- a/docs/source/pre_application/testnet.rst
+++ b/docs/source/pre_application/testnet.rst
@@ -17,7 +17,7 @@ You can view it on `etherscan <https://rinkeby.etherscan.io/address/0xc3871e2c11
 
 Stake and Bond
 --------------
-You need some rinkeby testnet ETH and 40,000 T in a metamask wallet.
+You need some Rinkeby testnet ETH and 40,000 T in a metamask wallet.
 Ask in the discord if you need help with this.
 
 Navigate to the `Testnet Staking Dashboard <https://dn3gsazzaajb.cloudfront.net/manage/stake>`_ and connect your metamask wallet.

--- a/newsfragments/2916.doc.rst
+++ b/newsfragments/2916.doc.rst
@@ -1,0 +1,2 @@
+Updates to nucypher-ops guides for mainnet usage
+


### PR DESCRIPTION
**Type of PR:**
Documentation

**Required reviews:** 
2

**What this does:**
- Adapt the nucypher ops tutorial (originally by @theref) for usage on maainnet
- Relocate some portions of the tutorial to a separate page about testnets
- Additional instructions to clarify nucypher-ops usage on mainnet and testnets

**Why it's needed:**
- Emphasize superior deployment methods
- Improves on-boarding experience for new node operators
- more...
