### PR TITLE
Bump nucypher-core to 0.2 and relock dependencies

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=3.4"
 lmdb = "*"
-nucypher-core = ">=0.1.1"
+nucypher-core = ">=0.2"
 # Cryptography
 pyopenssl = "*"
 cryptography = ">=3.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "09907c225c7e637490f927649252b33dbc91d2493f3600b5fba3a965dbf2f21b"
+            "sha256": "bf4e46a246adb6e872215c899b8b10d6670c27e4063e275ed32bb642219f100f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -351,6 +351,9 @@
             "version": "==1.0.4"
         },
         "eth-hash": {
+            "extras": [
+                "pycryptodome"
+            ],
             "hashes": [
                 "sha256:3f40cecd5ead88184aa9550afc19d057f103728108c5102f592f8415949b5a76",
                 "sha256:de7385148a8e0237ba1240cddbc06d53f56731140f8593bdb8429306f6b42271"
@@ -516,14 +519,6 @@
             "markers": "python_version >= '3'",
             "version": "==3.3"
         },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6",
-                "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"
-            ],
-            "markers": "python_version < '3.10'",
-            "version": "==4.11.3"
-        },
         "incremental": {
             "hashes": [
                 "sha256:02f5de5aff48f6b9f665d99d48bfc7ec03b6e3943210de7cfc88856d755d6f57",
@@ -549,11 +544,11 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:539835f51a74a69f41b848a9645dbdc35b4f20a3b601e2d9a7e22947b15ff119",
-                "sha256:640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9"
+                "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
+                "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.1.1"
+            "index": "pypi",
+            "version": "==3.0.3"
         },
         "jsonschema": {
             "hashes": [
@@ -824,25 +819,25 @@
         },
         "nucypher-core": {
             "hashes": [
-                "sha256:08f96de444166e63dd4dca5f0321e9e9cd345f193ef35da2fdcba986898bd31a",
-                "sha256:12822ee4b7f4f1389cf4877f4e957a79318dbbd2b0393d0f5808f0313a86980b",
-                "sha256:189e02ab085f120fbe018dfe86ab63e8a2787623cc9f9010454a4d9e7d9264e9",
-                "sha256:2158d34d868fcc5ab4d2cfe3d16a8bf453faf5112a60b585cb66932637152b09",
-                "sha256:5c22edef77f8a8b2c0d9145dd937b91427027f16ecf181a30a6eb35f85633135",
-                "sha256:6db4575b55b8225d745290b3aecad45905181a3fab9f4e30cca0f3ecf837ac9b",
-                "sha256:6eceb191ba899f08f8370d8996c9d04db66114711586465ee505d1be40aa7676",
-                "sha256:76a1e40f702ff48e848c65d01be069dde8be0763d382a23de7075363753c09f4",
-                "sha256:7c8187a9b836737d919b6f10e31440acc111af96fa3c56ec7a905b53a3af0aea",
-                "sha256:8e283c29e4286a2a0c5938989522d7a4cfba5fbfd0cbacae1b8b2c6800417e93",
-                "sha256:98dd72fddda5cf9458952a9c7afa6bdf5fad02701684dd76515fd55fcd258037",
-                "sha256:a4db3afae160b9e0b7142b8ef3773be26d7766405d2dc6746dd460aebe5e5abd",
-                "sha256:bf5574d1961ff45ebfb58b07ed4a819bb001600df180d4fffe31c20936b19857",
-                "sha256:d9ac4d85a7dc771ea8d43cfcb8aad958986763a1296f1ba9d4557528439628a6",
-                "sha256:f68ccce18e7d2673ae8924b2d7418fb891bb690be990d82416483c8c90b094b7",
-                "sha256:f9f0cc1c7dedc74f7d028e1cdd4ecd355a27c4302949315d99ca37d09e00553b"
+                "sha256:1600cb8d2d8ce889fbabae52e2ef2407b2845e5f57b2b06152125be90226a998",
+                "sha256:1c1acb9595ed0b4ad95c8639c6fdf59a0ad3f9e647273700c7ee02aeb619e07b",
+                "sha256:263bb3e6ef9644aec32932955a5f93b7d7194f24f7406ba214ec74fb7525be3e",
+                "sha256:2b8bc62bbe0a8397ad19e15c9d3d65a1f774701e6f9a0cb7ae9ac97fc7bc3114",
+                "sha256:477a3a09d1f00e0a411d429f0fb9791321db0c7f0379dee3d49a99362f61da0f",
+                "sha256:5e6ab540c29b4b8815c18a0b3c6769a5cc22a86077f349141e4d1a7858ca7e32",
+                "sha256:7feb4977e068e36292912d207c8416c142631638faf4ad6fb5e5ab8a5380f6ad",
+                "sha256:914e82db2162d4db21a6aeadc1c76d0e2a2bdef9269be847528b26e1c0f5ce18",
+                "sha256:9336292965b3e493448b0c2fb69b879d07631b6cb214f37b936d243ba55eaa86",
+                "sha256:a508e09590ead0515197ffcbe9528a69d3da07c4a78549222f2e9a875ab18200",
+                "sha256:bb2c96c9d0bc1e86784fdf83af5445cfb778772c931ec3f8fb8d77e32b96664b",
+                "sha256:bd9e099d7dd1a2776afc95ab2885b5199dab564917a156805647f34428a97a7a",
+                "sha256:c1cc2d78df1ef99ef9e2eede09963030c8eb468620980b09c8430a2e9cc9de8b",
+                "sha256:d2ca630c098280845e63bd2a9712fe76673731bb43f76924cd907967076d35e3",
+                "sha256:d7cd9a485d9534cb9d42bb9264f02ffb0103a35d78c7bb2e9ae84ce9dfc78234",
+                "sha256:dab86aa6caaaec2a7fb5b219643d8507190816cfb20d3b489f0a284170a1a165"
             ],
             "index": "pypi",
-            "version": "==0.1.1"
+            "version": "==0.2.0"
         },
         "packaging": {
             "hashes": [
@@ -931,33 +926,33 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:001c2160c03b6349c04de39cf1a58e342750da3632f6978a1634a3dcca1ec10e",
-                "sha256:0b250c60256c8824219352dc2a228a6b49987e5bf94d3ffcf4c46585efcbd499",
-                "sha256:1d24c81c2310f0063b8fc1c20c8ed01f3331be9374b4b5c2de846f69e11e21fb",
-                "sha256:1eb13f5a5a59ca4973bcfa2fc8fff644bd39f2109c3f7a60bd5860cb6a49b679",
-                "sha256:25d2fcd6eef340082718ec9ad2c58d734429f2b1f7335d989523852f2bba220b",
-                "sha256:32bf4a90c207a0b4e70ca6dd09d43de3cb9898f7d5b69c2e9e3b966a7f342820",
-                "sha256:38fd9eb74b852e4ee14b16e9670cd401d147ee3f3ec0d4f7652e0c921d6227f8",
-                "sha256:47257d932de14a7b6c4ae1b7dbf592388153ee35ec7cae216b87ae6490ed39a3",
-                "sha256:4eda68bd9e2a4879385e6b1ea528c976f59cd9728382005cc54c28bcce8db983",
-                "sha256:52bae32a147c375522ce09bd6af4d2949aca32a0415bc62df1456b3ad17c6001",
-                "sha256:542f25a4adf3691a306dcc00bf9a73176554938ec9b98f20f929a044f80acf1b",
-                "sha256:5b5860b790498f233cdc8d635a17fc08de62e59d4dcd8cdb6c6c0d38a31edf2b",
-                "sha256:6efe066a7135233f97ce51a1aa007d4fb0be28ef093b4f88dac4ad1b3a2b7b6f",
-                "sha256:71b2c3d1cd26ed1ec7c8196834143258b2ad7f444efff26fdc366c6f5e752702",
-                "sha256:7a53d4035427b9dbfbb397f46642754d294f131e93c661d056366f2a31438263",
-                "sha256:7dcd84dc31ebb35ade755e06d1561d1bd3b85e85dbdbf6278011fc97b22810db",
-                "sha256:88c8be0558bdfc35e68c42ae5bf785eb9390d25915d4863bbc7583d23da77074",
-                "sha256:8be43a91ab66fe995e85ccdbdd1046d9f0443d59e060c0840319290de25b7d33",
-                "sha256:8d84453422312f8275455d1cb52d850d6a4d7d714b784e41b573c6f5bfc2a029",
-                "sha256:9d0f3aca8ca51c8b5e204ab92bd8afdb2a8e3df46bd0ce0bd39065d79aabcaa4",
-                "sha256:a1eebb6eb0653e594cb86cd8e536b9b083373fca9aba761ade6cd412d46fb2ab",
-                "sha256:bc14037281db66aa60856cd4ce4541a942040686d290e3f3224dd3978f88f554",
-                "sha256:fbcbb068ebe67c4ff6483d2e2aa87079c325f8470b24b098d6bf7d4d21d57a69",
-                "sha256:fd7133b885e356fa4920ead8289bb45dc6f185a164e99e10279f33732ed5ce15"
+                "sha256:06059eb6953ff01e56a25cd02cca1a9649a75a7e65397b5b9b4e929ed71d10cf",
+                "sha256:097c5d8a9808302fb0da7e20edf0b8d4703274d140fd25c5edabddcde43e081f",
+                "sha256:284f86a6207c897542d7e956eb243a36bb8f9564c1742b253462386e96c6b78f",
+                "sha256:32ca378605b41fd180dfe4e14d3226386d8d1b002ab31c969c366549e66a2bb7",
+                "sha256:3cc797c9d15d7689ed507b165cd05913acb992d78b379f6014e013f9ecb20996",
+                "sha256:62f1b5c4cd6c5402b4e2d63804ba49a327e0c386c99b1675c8a0fefda23b2067",
+                "sha256:69ccfdf3657ba59569c64295b7d51325f91af586f8d5793b734260dfe2e94e2c",
+                "sha256:6f50601512a3d23625d8a85b1638d914a0970f17920ff39cec63aaef80a93fb7",
+                "sha256:7403941f6d0992d40161aa8bb23e12575637008a5a02283a930addc0508982f9",
+                "sha256:755f3aee41354ae395e104d62119cb223339a8f3276a0cd009ffabfcdd46bb0c",
+                "sha256:77053d28427a29987ca9caf7b72ccafee011257561259faba8dd308fda9a8739",
+                "sha256:7e371f10abe57cee5021797126c93479f59fccc9693dafd6bd5633ab67808a91",
+                "sha256:9016d01c91e8e625141d24ec1b20fed584703e527d28512aa8c8707f105a683c",
+                "sha256:9be73ad47579abc26c12024239d3540e6b765182a91dbc88e23658ab71767153",
+                "sha256:adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9",
+                "sha256:adfc6cf69c7f8c50fd24c793964eef18f0ac321315439d94945820612849c388",
+                "sha256:af0ebadc74e281a517141daad9d0f2c5d93ab78e9d455113719a45a49da9db4e",
+                "sha256:cb29edb9eab15742d791e1025dd7b6a8f6fcb53802ad2f6e3adcb102051063ab",
+                "sha256:cd68be2559e2a3b84f517fb029ee611546f7812b1fdd0aa2ecc9bc6ec0e4fdde",
+                "sha256:cdee09140e1cd184ba9324ec1df410e7147242b94b5f8b0c64fc89e38a8ba531",
+                "sha256:db977c4ca738dd9ce508557d4fce0f5aebd105e158c725beec86feb1f6bc20d8",
+                "sha256:dd5789b2948ca702c17027c84c2accb552fc30f4622a98ab5c51fcfe8c50d3e7",
+                "sha256:e250a42f15bf9d5b09fe1b293bdba2801cd520a9f5ea2d7fb7536d4441811d20",
+                "sha256:ff8d8fa42675249bb456f5db06c00de6c2f4c27a065955917b28c4f15978b9c3"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.20.0"
+            "version": "==3.20.1"
         },
         "py-ecc": {
             "hashes": [
@@ -1091,11 +1086,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "pyrsistent": {
             "hashes": [
@@ -1296,11 +1291,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:7999cbd87f1b6e1f33bf47efa368b224bed5e27b5ef2c4d46580186cbcb1a86a",
-                "sha256:a65e3802053e99fc64c6b3b29c11132943d5b8c8facbcc461157511546510967"
+                "sha256:26ead7d1f93efc0f8c804d9fafafbe4a44b179580a7105754b245155f9af05a8",
+                "sha256:47c7b0c0f8fc10eec4cf1e71c6fdadf8decaa74ffa087e68cd1c20db7ad6a592"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==62.0.0"
+            "version": "==62.1.0"
         },
         "six": {
             "hashes": [
@@ -1357,11 +1352,11 @@
         },
         "twisted": {
             "hashes": [
-                "sha256:4bc4df0b724c0043a16aa4878d4c6bd4916950bb0babc9caceb383eba9d30942",
-                "sha256:650c37c4b1914e6096f6a481eaf3f84bdedaca97ce592252b4046bc04905f43e"
+                "sha256:a047990f57dfae1e0bd2b7df2526d4f16dcdc843774dc108b78c52f2a5f13680",
+                "sha256:f9f7a91f94932477a9fc3b169d57f54f96c6e74a23d78d9ce54039a7f48928a2"
             ],
             "markers": "python_full_version >= '3.6.7'",
-            "version": "==22.4.0rc1"
+            "version": "==22.4.0"
         },
         "txaio": {
             "hashes": [
@@ -1441,57 +1436,57 @@
         },
         "websockets": {
             "hashes": [
-                "sha256:038afef2a05893578d10dadbdbb5f112bd115c46347e1efe99f6a356ff062138",
-                "sha256:05f6e9757017270e7a92a2975e2ae88a9a582ffc4629086fd6039aa80e99cd86",
-                "sha256:0b66421f9f13d4df60cd48ab977ed2c2b6c9147ae1a33caf5a9f46294422fda1",
-                "sha256:0cd02f36d37e503aca88ab23cc0a1a0e92a263d37acf6331521eb38040dcf77b",
-                "sha256:0f73cb2526d6da268e86977b2c4b58f2195994e53070fe567d5487c6436047e6",
-                "sha256:117383d0a17a0dda349f7a8790763dde75c1508ff8e4d6e8328b898b7df48397",
-                "sha256:1c1f3b18c8162e3b09761d0c6a0305fd642934202541cc511ef972cb9463261e",
-                "sha256:1c9031e90ebfc486e9cdad532b94004ade3aa39a31d3c46c105bb0b579cd2490",
-                "sha256:2349fa81b6b959484bb2bda556ccb9eb70ba68987646a0f8a537a1a18319fb03",
-                "sha256:24b879ba7db12bb525d4e58089fcbe6a3df3ce4666523183654170e86d372cbe",
-                "sha256:2aa9b91347ecd0412683f28aabe27f6bad502d89bd363b76e0a3508b1596402e",
-                "sha256:56d48eebe9e39ce0d68701bce3b21df923aa05dcc00f9fd8300de1df31a7c07c",
-                "sha256:5a38a0175ae82e4a8c4bac29fc01b9ee26d7d5a614e5ee11e7813c68a7d938ce",
-                "sha256:5b04270b5613f245ec84bb2c6a482a9d009aefad37c0575f6cda8499125d5d5c",
-                "sha256:6193bbc1ee63aadeb9a4d81de0e19477401d150d506aee772d8380943f118186",
-                "sha256:669e54228a4d9457abafed27cbf0e2b9f401445c4dfefc12bf8e4db9751703b8",
-                "sha256:6a009eb551c46fd79737791c0c833fc0e5b56bcd1c3057498b262d660b92e9cd",
-                "sha256:71a4491cfe7a9f18ee57d41163cb6a8a3fa591e0f0564ca8b0ed86b2a30cced4",
-                "sha256:7b38a5c9112e3dbbe45540f7b60c5204f49b3cb501b40950d6ab34cd202ab1d0",
-                "sha256:7bb9d8a6beca478c7e9bdde0159bd810cc1006ad6a7cb460533bae39da692ca2",
-                "sha256:82bc33db6d8309dc27a3bee11f7da2288ad925fcbabc2a4bb78f7e9c56249baf",
-                "sha256:8351c3c86b08156337b0e4ece0e3c5ec3e01fcd14e8950996832a23c99416098",
-                "sha256:8beac786a388bb99a66c3be4ab0fb38273c0e3bc17f612a4e0a47c4fc8b9c045",
-                "sha256:97950c7c844ec6f8d292440953ae18b99e3a6a09885e09d20d5e7ecd9b914cf8",
-                "sha256:98f57b3120f8331cd7440dbe0e776474f5e3632fdaa474af1f6b754955a47d71",
-                "sha256:9ca2ca05a4c29179f06cf6727b45dba5d228da62623ec9df4184413d8aae6cb9",
-                "sha256:a03a25d95cc7400bd4d61a63460b5d85a7761c12075ee2f51de1ffe73aa593d3",
-                "sha256:a10c0c1ee02164246f90053273a42d72a3b2452a7e7486fdae781138cf7fbe2d",
-                "sha256:a72b92f96e5e540d5dda99ee3346e199ade8df63152fa3c737260da1730c411f",
-                "sha256:ac081aa0307f263d63c5ff0727935c736c8dad51ddf2dc9f5d0c4759842aefaa",
-                "sha256:b22bdc795e62e71118b63e14a08bacfa4f262fd2877de7e5b950f5ac16b0348f",
-                "sha256:b4059e2ccbe6587b6dc9a01db5fc49ead9a884faa4076eea96c5ec62cb32f42a",
-                "sha256:b7fe45ae43ac814beb8ca09d6995b56800676f2cfa8e23f42839dc69bba34a42",
-                "sha256:bef03a51f9657fb03d8da6ccd233fe96e04101a852f0ffd35f5b725b28221ff3",
-                "sha256:bffc65442dd35c473ca9790a3fa3ba06396102a950794f536783f4b8060af8dd",
-                "sha256:c21a67ab9a94bd53e10bba21912556027fea944648a09e6508415ad14e37c325",
-                "sha256:c67d9cacb3f6537ca21e9b224d4fd08481538e43bcac08b3d93181b0816def39",
-                "sha256:c6e56606842bb24e16e36ae7eb308d866b4249cf0be8f63b212f287eeb76b124",
-                "sha256:cb316b87cbe3c0791c2ad92a5a36bf6adc87c457654335810b25048c1daa6fd5",
-                "sha256:cef40a1b183dcf39d23b392e9dd1d9b07ab9c46aadf294fff1350fb79146e72b",
-                "sha256:cf931c33db9c87c53d009856045dd524e4a378445693382a920fa1e0eb77c36c",
-                "sha256:d4d110a84b63c5cfdd22485acc97b8b919aefeecd6300c0c9d551e055b9a88ea",
-                "sha256:d5396710f86a306cf52f87fd8ea594a0e894ba0cc5a36059eaca3a477dc332aa",
-                "sha256:f09f46b1ff6d09b01c7816c50bd1903cf7d02ebbdb63726132717c2fcda835d5",
-                "sha256:f14bd10e170abc01682a9f8b28b16e6f20acf6175945ef38db6ffe31b0c72c3f",
-                "sha256:f5c335dc0e7dc271ef36df3f439868b3c790775f345338c2f61a562f1074187b",
-                "sha256:f8296b8408ec6853b26771599990721a26403e62b9de7e50ac0a056772ac0b5e",
-                "sha256:fa35c5d1830d0fb7b810324e9eeab9aa92e8f273f11fdbdc0741dcded6d72b9f"
+                "sha256:07cdc0a5b2549bcfbadb585ad8471ebdc7bdf91e32e34ae3889001c1c106a6af",
+                "sha256:210aad7fdd381c52e58777560860c7e6110b6174488ef1d4b681c08b68bf7f8c",
+                "sha256:28dd20b938a57c3124028680dc1600c197294da5db4292c76a0b48efb3ed7f76",
+                "sha256:2f94fa3ae454a63ea3a19f73b95deeebc9f02ba2d5617ca16f0bbdae375cda47",
+                "sha256:31564a67c3e4005f27815634343df688b25705cccb22bc1db621c781ddc64c69",
+                "sha256:347974105bbd4ea068106ec65e8e8ebd86f28c19e529d115d89bd8cc5cda3079",
+                "sha256:379e03422178436af4f3abe0aa8f401aa77ae2487843738542a75faf44a31f0c",
+                "sha256:3eda1cb7e9da1b22588cefff09f0951771d6ee9fa8dbe66f5ae04cc5f26b2b55",
+                "sha256:51695d3b199cd03098ae5b42833006a0f43dc5418d3102972addc593a783bc02",
+                "sha256:54c000abeaff6d8771a4e2cef40900919908ea7b6b6a30eae72752607c6db559",
+                "sha256:5b936bf552e4f6357f5727579072ff1e1324717902127ffe60c92d29b67b7be3",
+                "sha256:6075fd24df23133c1b078e08a9b04a3bc40b31a8def4ee0b9f2c8865acce913e",
+                "sha256:661f641b44ed315556a2fa630239adfd77bd1b11cb0b9d96ed8ad90b0b1e4978",
+                "sha256:6ea6b300a6bdd782e49922d690e11c3669828fe36fc2471408c58b93b5535a98",
+                "sha256:6ed1d6f791eabfd9808afea1e068f5e59418e55721db8b7f3bfc39dc831c42ae",
+                "sha256:7934e055fd5cd9dee60f11d16c8d79c4567315824bacb1246d0208a47eca9755",
+                "sha256:7ab36e17af592eec5747c68ef2722a74c1a4a70f3772bc661079baf4ae30e40d",
+                "sha256:7f6d96fdb0975044fdd7953b35d003b03f9e2bcf85f2d2cf86285ece53e9f991",
+                "sha256:83e5ca0d5b743cde3d29fda74ccab37bdd0911f25bd4cdf09ff8b51b7b4f2fa1",
+                "sha256:85506b3328a9e083cc0a0fb3ba27e33c8db78341b3eb12eb72e8afd166c36680",
+                "sha256:8af75085b4bc0b5c40c4a3c0e113fa95e84c60f4ed6786cbb675aeb1ee128247",
+                "sha256:8b1359aba0ff810d5830d5ab8e2c4a02bebf98a60aa0124fb29aa78cfdb8031f",
+                "sha256:8fbd7d77f8aba46d43245e86dd91a8970eac4fb74c473f8e30e9c07581f852b2",
+                "sha256:907e8247480f287aa9bbc9391bd6de23c906d48af54c8c421df84655eef66af7",
+                "sha256:93d5ea0b5da8d66d868b32c614d2b52d14304444e39e13a59566d4acb8d6e2e4",
+                "sha256:97bc9d41e69a7521a358f9b8e44871f6cdeb42af31815c17aed36372d4eec667",
+                "sha256:994cdb1942a7a4c2e10098d9162948c9e7b235df755de91ca33f6e0481366fdb",
+                "sha256:a141de3d5a92188234afa61653ed0bbd2dde46ad47b15c3042ffb89548e77094",
+                "sha256:a1e15b230c3613e8ea82c9fc6941b2093e8eb939dd794c02754d33980ba81e36",
+                "sha256:aad5e300ab32036eb3fdc350ad30877210e2f51bceaca83fb7fef4d2b6c72b79",
+                "sha256:b529fdfa881b69fe563dbd98acce84f3e5a67df13de415e143ef053ff006d500",
+                "sha256:b9c77f0d1436ea4b4dc089ed8335fa141e6a251a92f75f675056dac4ab47a71e",
+                "sha256:bb621ec2dbbbe8df78a27dbd9dd7919f9b7d32a73fafcb4d9252fc4637343582",
+                "sha256:c7250848ce69559756ad0086a37b82c986cd33c2d344ab87fea596c5ac6d9442",
+                "sha256:c8d1d14aa0f600b5be363077b621b1b4d1eb3fbf90af83f9281cda668e6ff7fd",
+                "sha256:d1655a6fc7aecd333b079d00fb3c8132d18988e47f19740c69303bf02e9883c6",
+                "sha256:d6353ba89cfc657a3f5beabb3b69be226adbb5c6c7a66398e17809b0ce3c4731",
+                "sha256:da4377904a3379f0c1b75a965fff23b28315bcd516d27f99a803720dfebd94d4",
+                "sha256:e49ea4c1a9543d2bd8a747ff24411509c29e4bdcde05b5b0895e2120cb1a761d",
+                "sha256:e4e08305bfd76ba8edab08dcc6496f40674f44eb9d5e23153efa0a35750337e8",
+                "sha256:e6fa05a680e35d0fcc1470cb070b10e6fe247af54768f488ed93542e71339d6f",
+                "sha256:e7e6f2d6fd48422071cc8a6f8542016f350b79cc782752de531577d35e9bd677",
+                "sha256:e904c0381c014b914136c492c8fa711ca4cced4e9b3d110e5e7d436d0fc289e8",
+                "sha256:ec2b0ab7edc8cd4b0eb428b38ed89079bdc20c6bdb5f889d353011038caac2f9",
+                "sha256:ef5ce841e102278c1c2e98f043db99d6755b1c58bde475516aef3a008ed7f28e",
+                "sha256:f351c7d7d92f67c0609329ab2735eee0426a03022771b00102816a72715bb00b",
+                "sha256:fab7c640815812ed5f10fbee7abbf58788d602046b7bb3af9b1ac753a6d5e916",
+                "sha256:fc06cc8073c8e87072138ba1e431300e2d408f054b27047d047b549455066ff4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==10.2"
+            "version": "==10.3"
         },
         "werkzeug": {
             "hashes": [
@@ -1578,14 +1573,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==1.7.2"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:56bf8aadb83c24db6c4b577e13de374ccfb67da2078beba1d037c17980bf43ad",
-                "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.8.0"
         },
         "zope.interface": {
             "hashes": [
@@ -1841,11 +1828,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:ca931c5a6414f3f9636fdaf978a216ee9b5c4a6b4415adf628e9d5e5003dcd99",
-                "sha256:de48abb676fc76e4397cd002926e5747cef518570d132221244d27e1075c0bec"
+                "sha256:92b7a7d6f0829d48bc1f87c496dfa601eb9d815549bb12daa601184807733c5b",
+                "sha256:9d17ebf4137e15f6db24793dad7268b8b5afcfc78b770f307c94872f1d96850a"
             ],
             "index": "pypi",
-            "version": "==6.41.0"
+            "version": "==6.45.0"
         },
         "identify": {
             "hashes": [
@@ -1931,11 +1918,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d",
-                "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"
+                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
+                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.1"
+            "version": "==2.5.2"
         },
         "pluggy": {
             "hashes": [
@@ -1979,11 +1966,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954",
+                "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.8"
         },
         "pytest": {
             "hashes": [
@@ -2161,11 +2148,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66",
-                "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"
+                "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a",
+                "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==20.14.0"
+            "version": "==20.14.1"
         }
     }
 }

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,7 +12,7 @@ filelock==3.6.0; python_version >= '3.7'
 gitdb==4.0.9; python_version >= '3.6'
 gitpython==3.1.27; python_version >= '3.7'
 greenlet==2.0.0a2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-hypothesis==6.41.0
+hypothesis==6.45.0
 identify==2.4.12; python_version >= '3.7'
 idna==3.3; python_version >= '3'
 iniconfig==1.1.1
@@ -21,13 +21,13 @@ mypy==0.942
 nodeenv==1.6.0
 packaging==21.3; python_version >= '3.6'
 pbr==5.8.1; python_version >= '2.6'
-platformdirs==2.5.1; python_version >= '3.7'
+platformdirs==2.5.2; python_version >= '3.7'
 pluggy==1.0.0; python_version >= '3.6'
 pre-commit==2.18.1
 py-solc-x==0.10.1
 py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 pyflakes==2.4.0
-pyparsing==3.0.7; python_version >= '3.6'
+pyparsing==3.0.8; python_full_version >= '3.6.8'
 pytest-cov==3.0.0
 pytest-forked==1.4.0; python_version >= '3.6'
 pytest-mock==3.7.0
@@ -46,4 +46,4 @@ toml==0.10.2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 tomli==2.0.1; python_version >= '3.7'
 typing-extensions==3.10.0.2
 urllib3==1.26.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
-virtualenv==20.14.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+virtualenv==20.14.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,7 +2,7 @@
 alabaster==0.7.12
 attrs==21.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 autosemver==0.5.5
-babel==2.9.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+babel==2.10.1; python_version >= '3.6'
 certifi==2021.10.8
 charset-normalizer==2.0.12; python_version >= '3'
 click-default-group==1.2.2
@@ -16,7 +16,7 @@ idna==3.3; python_version >= '3'
 imagesize==1.3.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 incremental==21.3.0
 iniconfig==1.1.1
-isort==5.10.1; python_full_version >= '3.6.1' and python_version < '4.0'
+isort==5.10.1; python_full_version >= '3.6.1' and python_version < '4'
 jinja2==3.0.3
 markupsafe==2.1.1; python_version >= '3.7'
 mock==4.0.3; python_version >= '3.6'
@@ -25,17 +25,17 @@ pep8==1.7.1
 pluggy==1.0.0; python_version >= '3.6'
 py-solc-x==0.10.1
 py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-pygments==2.11.2; python_version >= '3.5'
-pyparsing==3.0.7; python_version >= '3.6'
+pygments==2.12.0; python_version >= '3.6'
+pyparsing==3.0.8; python_full_version >= '3.6.8'
 pytest-cache==1.0
 pytest-cov==3.0.0; python_version >= '3.6'
 pytest-pep8==1.0.6
-pytest==7.1.1; python_version >= '3.7'
+pytest==7.1.2; python_version >= '3.7'
 pytz==2022.1
 pyyaml==6.0; python_version >= '3.6'
 requests==2.27.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 semantic-version==2.9.0; python_version >= '2.7'
-setuptools==62.0.0; python_version >= '3.7'
+setuptools==62.1.0; python_version >= '3.7'
 snowballstemmer==2.2.0
 sphinx-rtd-theme==1.0.0
 sphinx==3.0.1
@@ -47,4 +47,4 @@ sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
 tomli==2.0.1; python_version >= '3.6'
 towncrier==21.9.0
-urllib3==1.26.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'
+urllib3==1.26.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'

--- a/newsfragments/2927.misc.rst
+++ b/newsfragments/2927.misc.rst
@@ -1,0 +1,1 @@
+Bump ``nucypher-core`` dependency to 0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ ecdsa==0.18.0b2; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.
 eth-abi==2.1.1; python_version >= '3.6' and python_version < '4'
 eth-account==0.5.7; python_version >= '3.6' and python_version < '4'
 eth-bloom==1.0.4; python_version >= '3.6' and python_version < '4'
-eth-hash==0.3.2; python_version >= '3.5' and python_version < '4'
+eth-hash[pycryptodome]==0.3.2; python_version >= '3.5' and python_version < '4'
 eth-keyfile==0.5.1
 eth-keys==0.3.4
 eth-rlp==0.2.1; python_version >= '3.6' and python_version < '4'
@@ -39,7 +39,6 @@ hexbytes==0.2.2; python_version >= '3.6' and python_version < '4'
 humanize==4.0.0; python_version >= '3.7'
 hyperlink==21.0.0
 idna==3.3; python_version >= '3'
-importlib-metadata==4.11.3; python_version < '3.10'
 incremental==21.3.0
 ipfshttpclient==0.8.0a2; python_full_version >= '3.6.2' and python_full_version not in '3.7.0, 3.7.1'
 itsdangerous==2.0.1
@@ -59,12 +58,12 @@ multiaddr==0.0.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3
 multidict==6.0.2; python_version >= '3.7'
 mypy-extensions==0.4.3
 netaddr==0.8.0
-nucypher-core==0.1.1
+nucypher-core==0.2.0
 packaging==21.3; python_version >= '3.6'
 parsimonious==0.8.1
 pendulum==2.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 pillow==9.1.0; python_version >= '3.7'
-protobuf==3.20.0; python_version >= '3.7'
+protobuf==3.20.1; python_version >= '3.7'
 py-ecc==5.2.0; python_version >= '3.5' and python_version < '4'
 py-evm==0.5.0a3
 pyasn1-modules==0.2.8
@@ -75,7 +74,7 @@ pycryptodome==3.14.1
 pyethash==0.1.27
 pynacl==1.5.0
 pyopenssl==22.0.0
-pyparsing==3.0.7; python_version >= '3.6'
+pyparsing==3.0.8; python_full_version >= '3.6.8'
 pyrsistent==0.18.1; python_version >= '3.7'
 pysha3==1.0.2
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
@@ -87,7 +86,7 @@ requests==2.27.1
 rlp==2.0.1
 semantic-version==2.9.0; python_version >= '2.7'
 service-identity==21.1.0
-setuptools==62.0.0; python_version >= '3.7'
+setuptools==62.1.0; python_version >= '3.7'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 snaptime==0.2.4
 sortedcontainers==2.4.0
@@ -95,7 +94,7 @@ tabulate==0.8.9
 toolz==0.11.2; python_version >= '3.5'
 trezor==0.13.0
 trie==2.0.0a5; python_version >= '3.6' and python_version < '4'
-twisted==22.4.0rc1; python_full_version >= '3.6.7'
+twisted==22.4.0; python_full_version >= '3.6.7'
 txaio==22.2.1; python_version >= '3.6'
 typing-extensions==3.10.0.2
 tzlocal==2.1
@@ -103,8 +102,7 @@ urllib3==1.26.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.
 varint==1.0.2
 watchdog==2.1.7; python_version >= '3.6'
 web3==6.0.0b1
-websockets==10.2; python_version >= '3.7'
+websockets==10.3; python_version >= '3.7'
 werkzeug==2.1.1; python_version >= '3.7'
 yarl==1.7.2; python_version >= '3.6'
-zipp==3.8.0; python_version >= '3.7'
 zope.interface==5.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 1

**What this does:**
Updates `nucypher-core` to 0.2 to make use of the changed structure of HRACs as soon as possible.
