### PR TITLE
Raise error when prometheus CLI option used for now until functionality can be updated/revamped.

### DIFF
--- a/newsfragments/2929.misc.rst
+++ b/newsfragments/2929.misc.rst
@@ -1,0 +1,2 @@
+Show error message when ``--prometheus`` flag is used since functionality not currently supported. Prometheus
+monitoring functionality will be revamped in a subsequent release.

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -405,26 +405,37 @@ def run(general_config, character_options, config_file, interactive, dry_run, pr
         metrics_listen_address, metrics_prefix, metrics_interval, force, ip_checkup):
     """Run an "Ursula" node."""
 
-    operator_address = character_options.config_options.operator_address
     emitter = setup_emitter(general_config)
     dev_mode = character_options.config_options.dev
     lonely = character_options.config_options.lonely
 
-    if prometheus and not metrics_port:
-        # Require metrics port when using prometheus
-        raise click.BadOptionUsage(option_name='metrics-port',
-                                   message=click.style('--metrics-port is required when using --prometheus', fg="red"))
+    # TODO re-add prometheus logic once prometheus functionality is revamped for Threshold (#2928)
+    if prometheus:
+        raise click.BadOptionUsage(
+            option_name="prometheus",
+            message=click.style(
+                "prometheus is not currently supported "
+                "in this version as part of the merge to "
+                "the Threshold Network; it will be in a "
+                "future version",
+                fg="red"
+            )
+        )
+    # if prometheus and not metrics_port:
+    #     # Require metrics port when using prometheus
+    #     raise click.BadOptionUsage(option_name='metrics-port',
+    #                                message=click.style('--metrics-port is required when using --prometheus', fg="red"))
 
     _pre_launch_warnings(emitter, dev=dev_mode, force=None)
 
     prometheus_config: 'PrometheusMetricsConfig' = None
-    if prometheus and not dev_mode:
-        # Locally scoped to prevent import without prometheus explicitly installed
-        from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
-        prometheus_config = PrometheusMetricsConfig(port=metrics_port,
-                                                    metrics_prefix=metrics_prefix,
-                                                    listen_address=metrics_listen_address,
-                                                    collection_interval=metrics_interval)
+    # if prometheus and not dev_mode:
+    #     # Locally scoped to prevent import without prometheus explicitly installed
+    #     from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
+    #     prometheus_config = PrometheusMetricsConfig(port=metrics_port,
+    #                                                 metrics_prefix=metrics_prefix,
+    #                                                 listen_address=metrics_listen_address,
+    #                                                 collection_interval=metrics_interval)
 
     ursula_config, URSULA = character_options.create_character(emitter=emitter,
                                                                config_file=config_file,

--- a/tests/acceptance/cli/ursula/test_run_ursula.py
+++ b/tests/acceptance/cli/ursula/test_run_ursula.py
@@ -26,7 +26,10 @@ from nucypher.characters.base import Learner
 from nucypher.cli.literature import NO_CONFIGURATIONS_ON_DISK
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
-from nucypher.config.constants import NUCYPHER_ENVVAR_KEYSTORE_PASSWORD, TEMPORARY_DOMAIN
+from nucypher.config.constants import (
+    NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
+    TEMPORARY_DOMAIN,
+)
 from nucypher.network.nodes import Teacher
 from nucypher.utilities.networking import LOOPBACK_ADDRESS, UnknownIPAddress
 from tests.constants import (
@@ -34,7 +37,7 @@ from tests.constants import (
     INSECURE_DEVELOPMENT_PASSWORD,
     MOCK_IP_ADDRESS,
     TEST_ETH_PROVIDER_URI,
-    YES_ENTER
+    YES_ENTER,
 )
 from tests.utils.ursula import select_test_port, start_pytest_ursula_services
 
@@ -90,7 +93,9 @@ def test_ursula_run_with_prometheus_but_no_metrics_port(click_runner):
                                          catch_exceptions=False)
 
     assert result.exit_code != 0
-    expected_error = f"Error: --metrics-port is required when using --prometheus"
+    # TODO prometheus not currently supported - follow-up in #2928
+    expected_error = f"prometheus is not currently supported"
+    # expected_error = f"Error: --metrics-port is required when using --prometheus"
     assert expected_error in result.output
 
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Disable the use of the`--prometheus` flag when running Ursula. 

**Issues fixed/closed:**
Fixes #2905 .
Follow-up issue #2928 .

**Why it's needed:**
Underlying functionality for which metrics were collected has significantly changed due to merge to Threshold.