### PR TITLE
Fixes #2903 - Corrects the circleCI context name for porter publication.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,7 +187,7 @@ workflows:
             branches:
               ignore: /.*/
       - publish_porter_docker:
-          context: "NuCypher Porter Docker"
+          context: "NuCypher Docker"  # This name much match the organization's context name on circleCI.
           requires:
             - request_publication_approval
           filters:


### PR DESCRIPTION
**Type of PR:**
Bugfix (Ops)

**Required reviews:** 
1

**Issues fixed/closed:**
- Fixes #2903 
