### PR TITLE
Fix status events

### DIFF
--- a/newsfragments/2934.bugfix.rst
+++ b/newsfragments/2934.bugfix.rst
@@ -1,0 +1,3 @@
+Properly support event retrieval for the PREApplication contract.
+Remove invalid support for SubscriptionManager contract - proper support will be
+added in a future release.

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -595,6 +595,8 @@ class ContractAgency:
         if name == NUCYPHER_TOKEN_CONTRACT_NAME:
             # TODO: Perhaps rename NucypherTokenAgent
             name = "NucypherToken"
+        if name == PRE_APPLICATION_CONTRACT_NAME:
+            name = "PREApplication"  # TODO not needed once full PRE Application is used
         agent_name = f"{name}Agent"
         return agent_name
 

--- a/nucypher/cli/commands/status.py
+++ b/nucypher/cli/commands/status.py
@@ -23,8 +23,8 @@ import click
 
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
+    NucypherTokenAgent,
     PREApplicationAgent,
-    SubscriptionManagerAgent,
     EthereumContractAgent
 )
 from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS
@@ -57,7 +57,7 @@ POLICY_MANAGER = 'PolicyManager'
 
 CONTRACT_NAMES = [
     PREApplicationAgent.contract_name,
-    SubscriptionManagerAgent.contract_name,
+    NucypherTokenAgent.contract_name,
     STAKING_ESCROW,
     POLICY_MANAGER
 ]
@@ -147,7 +147,7 @@ def staking_providers(general_config, registry_options, staking_provider_address
 @status.command()
 @group_registry_options
 @group_general_config
-@option_contract_name(required=False)
+@option_contract_name(required=False, valid_options=CONTRACT_NAMES)
 @option_event_name
 @option_from_block
 @option_to_block
@@ -175,6 +175,8 @@ def events(general_config, registry_options, contract_name, from_block, to_block
         if event_name:
             raise click.BadOptionUsage(option_name='--event-name', message=click.style('--event-name requires --contract-name', fg="red"))
         # FIXME should we force a contract name to be specified?
+        # default to PREApplication contract
+        contract_names = [PREApplicationAgent.contract_name]
     else:
         contract_names = [contract_name]
 
@@ -209,7 +211,7 @@ def events(general_config, registry_options, contract_name, from_block, to_block
     if legacy and contract_name in LEGACY_CONTRACT_VERSIONS:
         contract_version = LEGACY_CONTRACT_VERSIONS[contract_name]
 
-    for contract_name in CONTRACT_NAMES:
+    for contract_name in contract_names:
         if legacy:
             versioned_contract = blockchain.get_contract_by_name(
                 registry=registry,

--- a/nucypher/cli/options.py
+++ b/nucypher/cli/options.py
@@ -19,6 +19,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import functools
 from collections import namedtuple
 from pathlib import Path
+from typing import Sequence
 
 import click
 
@@ -89,11 +90,12 @@ def option_alice_verifying_key(required: bool = False):
         required=required)
 
 
-def option_contract_name(required: bool = False):
+def option_contract_name(required: bool = False,
+                         valid_options: Sequence[str] = NUCYPHER_CONTRACT_NAMES):
     return click.option(
         '--contract-name',
         help="Specify a single contract by name",
-        type=click.Choice(NUCYPHER_CONTRACT_NAMES),
+        type=click.Choice(valid_options),
         required=required
     )
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
- Properly support events from the PREApplication. Currently SimplePREApplication uses the PREApplicationAgent, which is special use. usually the agent's name is the application name with "Agent" appended the end. There is no "SimplePREApplicationAgent", so a special case for the mapping must be added.
- SuscriptionManager needs more work to be supported because it exists in a separate registry.  Support for event retrieval of SubscriptionManager events was therefore always faulty, and is current removed. Support can be added in a follow-up issue/PR (#2935 ).
- Allow NuCypherToken events to be supported.

**Issues fixed/closed:**
Fixes #2931 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
