### PR TITLE
Remove `setuptools-markdown` dependency

### DIFF
--- a/newsfragments/2942.removal.rst
+++ b/newsfragments/2942.removal.rst
@@ -1,0 +1,1 @@
+Remove set up dependency on ``setuptools-markdown`` which is no longer needed, but caused build failures.

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,12 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Dict
 from urllib.parse import urlparse
 
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
-from typing import Dict
-
 
 #
 # Metadata
@@ -163,7 +162,6 @@ setup(
 
     # Requirements
     python_requires='>=3',
-    setup_requires=['setuptools-markdown'],
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS,
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Deprecate the use of `setuptools-markdown` (https://pypi.org/project/setuptools-markdown/) because:
- It depends on `pypandoc` whose latest release, v1.8 on May 10th, deprecated the `convert` function - https://pypi.org/project/pypandoc/1.8/ - but `setuptools-markdown` continues to attempt to use it.
- Fixes the resulting build failure which also affects prior release tags builds:
```
#7 13.95   error: subprocess-exited-with-error
#7 13.95
#7 13.95   × Preparing metadata (pyproject.toml) did not run successfully.
#7 13.95   │ exit code: 1
#7 13.95   ╰─> [32 lines of output]
#7 13.95       long_description_markdown_filename: dist = <setuptools.dist.Distribution object at 0x7f730e355100>; attr = 'long_description_markdown_filename'; value = 'README.md'
#7 13.95       markdown_filename = 'README.md'
#7 13.95       Traceback (most recent call last):
#7 13.95         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 363, in <module>
#7 13.95           main()
#7 13.95         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 345, in main
#7 13.95           json_out['return_val'] = hook(**hook_input['kwargs'])
#7 13.95         File "/usr/local/lib/python3.9/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 164, in prepare_metadata_for_build_wheel
#7 13.95           return hook(metadata_directory, config_settings)
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 188, in prepare_metadata_for_build_wheel
#7 13.95           self.run_setup()
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 281, in run_setup
#7 13.95           super(_BuildMetaLegacyBackend,
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/build_meta.py", line 174, in run_setup
#7 13.95           exec(compile(code, __file__, 'exec'), locals())
#7 13.95         File "setup.py", line 162, in <module>
#7 13.95           setup(
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/__init__.py", line 87, in setup
#7 13.95           return distutils.core.setup(**attrs)
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/_distutils/core.py", line 109, in setup
#7 13.95           _setup_distribution = dist = klass(attrs)
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 472, in __init__
#7 13.95           _Distribution.__init__(
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/_distutils/dist.py", line 293, in __init__
#7 13.95           self.finalize_options()
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 896, in finalize_options
#7 13.95           ep(self)
#7 13.95         File "/tmp/pip-build-env-k112vw8c/overlay/lib/python3.9/site-packages/setuptools/dist.py", line 917, in _finalize_setup_keywords
#7 13.95           ep.load()(self, ep.name, value)
#7 13.95         File "/tmp/pip-build-env-k112vw8c/normal/lib/python3.9/site-packages/setuptools_markdown.py", line 43, in long_description_markdown_filename
#7 13.95           output = pypandoc.convert(markdown_filename, 'rst', format='md')
#7 13.95       AttributeError: module 'pypandoc' has no attribute 'convert'
#7 13.95       [end of output]
#7 13.95
#7 13.95   note: This error originates from a subprocess, and is likely not a problem with pip.
#7 13.96 error: metadata-generation-failed
#7 13.96
#7 13.96 × Encountered error while generating package metadata.
#7 13.96 ╰─
```
- It is deprecated and no longer maintained
- `setuptools` itself has built-in functionality for converting markdown files to rst files

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
