### PR TITLE
work around for failure to estimate gas occuring on Ropsten

### DIFF
--- a/newsfragments/2943.bugfix.rst
+++ b/newsfragments/2943.bugfix.rst
@@ -1,0 +1,1 @@
+temp workaround for Ropsten/oryx gas estimation issue

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -562,9 +562,14 @@ class BlockchainInterface:
         #
 
         # TODO: Show the USD Price:  https://api.coinmarketcap.com/v1/ticker/ethereum/
-        max_tx_price = transaction_dict['maxFeePerGas']
-        max_priority_price = transaction_dict['maxPriorityFeePerGas']
-        max_price = max_tx_price + max_priority_price
+        
+        if transaction_dict.get('maxFeePerGas') and transaction_dict.get('maxPriorityFeePerGas'):
+            # TODO:  this probably only needs to be here to support Ropsten?
+            max_tx_price = transaction_dict['maxFeePerGas']
+            max_priority_price = transaction_dict['maxPriorityFeePerGas']
+            max_price = max_tx_price + max_priority_price
+        else:
+            max_price = transaction_dict['gasPrice']
         max_price_gwei = Web3.fromWei(max_price, 'gwei')
         max_cost_wei = max_price * transaction_dict['gas']
         max_cost = Web3.fromWei(max_cost_wei, 'ether')

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -564,10 +564,12 @@ class BlockchainInterface:
         try:
             # post-london fork transactions (Type 2)
             max_unit_price = transaction_dict['maxFeePerGas']
+            tx_type = 'EIP-1559'
         except KeyError:
             # pre-london fork "legacy" transactions (Type 0)
             max_unit_price = transaction_dict['gasPrice']
-            
+            tx_type = 'Legacy'
+
         max_price_gwei = Web3.fromWei(max_unit_price, 'gwei')
         max_cost_wei = max_unit_price * transaction_dict['gas']
         max_cost = Web3.fromWei(max_cost_wei, 'ether')
@@ -581,7 +583,7 @@ class BlockchainInterface:
         #
         # Broadcast
         #
-        emitter.message(f'Broadcasting {transaction_name} Transaction ({max_cost} ETH @ {max_price_gwei} gwei)',
+        emitter.message(f'Broadcasting {transaction_name} {tx_type} Transaction ({max_cost} ETH @ {max_price_gwei} gwei)',
                         color='yellow')
         try:
             txhash = self.client.send_raw_transaction(signed_raw_transaction)  # <--- BROADCAST

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -468,9 +468,7 @@ class BlockchainInterface:
                       ) -> dict:
 
         nonce = self.client.get_transaction_count(account=sender_address, pending=use_pending_nonce)
-        base_payload = {
-                        'nonce': nonce,
-                        'from': sender_address}
+        base_payload = {'nonce': nonce, 'from': sender_address}
 
         # Aggregate
         if not payload:
@@ -563,15 +561,15 @@ class BlockchainInterface:
 
         # TODO: Show the USD Price:  https://api.coinmarketcap.com/v1/ticker/ethereum/
         
-        if transaction_dict.get('maxFeePerGas') and transaction_dict.get('maxPriorityFeePerGas'):
-            # TODO:  this probably only needs to be here to support Ropsten?
-            max_tx_price = transaction_dict['maxFeePerGas']
-            max_priority_price = transaction_dict['maxPriorityFeePerGas']
-            max_price = max_tx_price + max_priority_price
-        else:
-            max_price = transaction_dict['gasPrice']
-        max_price_gwei = Web3.fromWei(max_price, 'gwei')
-        max_cost_wei = max_price * transaction_dict['gas']
+        try:
+            # post-london fork transactions (Type 2)
+            max_unit_price = transaction_dict['maxFeePerGas']
+        except KeyError:
+            # pre-london fork "legacy" transactions (Type 0)
+            max_unit_price = transaction_dict['gasPrice']
+            
+        max_price_gwei = Web3.fromWei(max_unit_price, 'gwei')
+        max_cost_wei = max_unit_price * transaction_dict['gas']
         max_cost = Web3.fromWei(max_cost_wei, 'ether')
 
         if transacting_power.is_device:


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Fixes the KeyError occurring on Ropsten/Oryx when node attempts to confirm worker address
