### PR TITLE
Show fleet state checksums as hex instead of an escaped bytestring

### DIFF
--- a/newsfragments/2946.bugfix.rst
+++ b/newsfragments/2946.bugfix.rst
@@ -1,0 +1,1 @@
+Show fleet state checksums as hex instead of an escaped bytestring

--- a/nucypher/network/templates/basic_status.mako
+++ b/nucypher/network/templates/basic_status.mako
@@ -35,7 +35,7 @@ def character_span(character):
         <td>
             <span>${state.population} nodes</span>
             <br/>
-            <span class="checksum">${bytes(state.checksum)[0:8]}</span>
+            <span class="checksum">0x${bytes(state.checksum)[0:8].hex()}</span>
         </td>
     </tr>
 </table>


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
Turns
<img width="263" alt="Screen Shot 2022-05-25 at 18 23 47" src="https://user-images.githubusercontent.com/30720/170396007-c9b5bc2a-f211-4c90-af94-b0e1cbed039a.png">
into
<img width="183" alt="Screen Shot 2022-05-25 at 18 26 19" src="https://user-images.githubusercontent.com/30720/170396137-58dc3e73-5c8b-48c3-9b98-2c24081129b6.png">

This has been bothering me for a while, and since it was originally my fault...
