### PR TITLE
Correctly validate domain/network value provided via `--network` in the CLI

### DIFF
--- a/newsfragments/2952.bugfix.rst
+++ b/newsfragments/2952.bugfix.rst
@@ -1,0 +1,1 @@
+Correctly validate domain/network values provided via the ``--network`` parameter in the CLI.

--- a/newsfragments/2952.misc.rst
+++ b/newsfragments/2952.misc.rst
@@ -1,0 +1,1 @@
+Extends policy probationary period until August 31st, 2022. No policies may be created on the network beyond this date.

--- a/nucypher/blockchain/eth/networks.py
+++ b/nucypher/blockchain/eth/networks.py
@@ -61,4 +61,6 @@ class NetworksInventory:  # TODO: See #1564
     @classmethod
     def validate_network_name(cls, network_name: str):
         if network_name not in cls.NETWORKS:
-            raise cls.UnrecognizedNetwork(f"{network_name} is not a recognized network of NuCypher")
+            raise cls.UnrecognizedNetwork(
+                f"{network_name} is not a recognized network."
+            )

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -30,7 +30,7 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.blockchain.eth.token import NU, TToken
 from nucypher.policy.payment import PAYMENT_METHODS
-from nucypher.utilities.networking import validate_operator_ip, InvalidOperatorIP
+from nucypher.utilities.networking import InvalidOperatorIP, validate_operator_ip
 
 
 class ChecksumAddress(click.ParamType):
@@ -114,8 +114,10 @@ class NuCypherNetworkName(click.ParamType):
     def convert(self, value, param, ctx):
         if self.validate:
             network = str(value).lower()
-            if network not in NetworksInventory.NETWORKS:
-                self.fail(f"'{value}' is not a NuCypher Network. Valid options are: {list(NetworksInventory.NETWORKS)}")
+            if network not in NetworksInventory.ETH_NETWORKS:
+                self.fail(
+                    f"'{value}' is not a recognized network. Valid options are: {list(NetworksInventory.ETH_NETWORKS)}"
+                )
             else:
                 return network
         else:

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -16,12 +16,11 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
 
+import os
 from collections import namedtuple
 from pathlib import Path
 
-import os
 from appdirs import AppDirs
-
 from maya import MayaDT
 
 import nucypher
@@ -75,4 +74,4 @@ TEMPORARY_DOMAIN = ":temporary-domain:"  # for use with `--dev` node runtimes
 NUCYPHER_EVENTS_THROTTLE_MAX_BLOCKS = 'NUCYPHER_EVENTS_THROTTLE_MAX_BLOCKS'
 
 # Probationary period
-END_OF_POLICIES_PROBATIONARY_PERIOD = MayaDT.from_iso8601('2022-6-16T23:59:59.0Z')
+END_OF_POLICIES_PROBATIONARY_PERIOD = MayaDT.from_iso8601("2022-08-31T23:59:59.0Z")

--- a/tests/acceptance/cli/lifecycle.py
+++ b/tests/acceptance/cli/lifecycle.py
@@ -17,19 +17,16 @@
 
 import datetime
 import json
-import os
 import shutil
 from base64 import b64decode
 from collections import namedtuple
 from json import JSONDecodeError
-from pathlib import Path
 
 import maya
 import pytest
+from nucypher_core import MessageKit, EncryptedTreasureMap
 from twisted.internet import threads
 from web3 import Web3
-
-from nucypher_core import MessageKit, EncryptedTreasureMap
 
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import AliceConfiguration, BobConfiguration
@@ -321,8 +318,8 @@ def run_entire_cli_lifecycle(click_runner,
                       '--network', TEMPORARY_DOMAIN,
                       '--teacher', teacher_uri,
                       '--config-file', str(alice_configuration_file_location.absolute()),
-                      '-m', 2,
-                      '-n', 3,
+                      '--threshold', 2,
+                      '--shares', 3,
                       '--expiration', expiration,
                       '--label', random_label,
                       '--bob-encrypting-key', bob_encrypting_key,

--- a/tests/acceptance/cli/test_mixed_configurations.py
+++ b/tests/acceptance/cli/test_mixed_configurations.py
@@ -242,7 +242,7 @@ def test_corrupted_configuration(click_runner,
 
     init_args = ('ursula', 'init',
                  '--eth-provider', TEST_ETH_PROVIDER_URI,
-                '--payment-provider', TEST_POLYGON_PROVIDER_URI,
+                 '--payment-provider', TEST_POLYGON_PROVIDER_URI,
                  '--operator-address', another_ursula,
                  '--network', TEMPORARY_DOMAIN,
                  '--payment-network', TEMPORARY_DOMAIN,

--- a/tests/acceptance/cli/test_porter.py
+++ b/tests/acceptance/cli/test_porter.py
@@ -296,7 +296,7 @@ def test_blockchain_porter_cli_run_network_defaults_to_mainnet(click_runner,
 
     assert result.exit_code != 0
     # there is no 'mainnet' network for decentralized testing
-    assert "'mainnet' is not a NuCypher Network" in result.output
+    assert "'mainnet' is not a recognized network" in result.output
 
 
 def test_blockchain_porter_cli_run_https(click_runner,

--- a/tests/mock/interfaces.py
+++ b/tests/mock/interfaces.py
@@ -56,13 +56,19 @@ def mock_registry_source_manager(test_registry):
             raw_registry_data = json.dumps(registry_data)
             return raw_registry_data
 
-    real_inventory = NetworksInventory.NETWORKS
+    real_networks = NetworksInventory.NETWORKS
+    real_eth_networks = NetworksInventory.ETH_NETWORKS
+    real_poly_networks = NetworksInventory.POLY_NETWORKS
     try:
         RegistrySourceManager._FALLBACK_CHAIN = (MockRegistrySource,)
         NetworksInventory.NETWORKS = (TEMPORARY_DOMAIN,)
-        yield real_inventory
+        NetworksInventory.ETH_NETWORKS = (TEMPORARY_DOMAIN,)
+        NetworksInventory.POLY_NETWORKS = (TEMPORARY_DOMAIN,)
+        yield real_networks
     finally:
-        NetworksInventory.NETWORKS = real_inventory
+        NetworksInventory.POLY_NETWORKS = real_poly_networks
+        NetworksInventory.ETH_NETWORKS = real_eth_networks
+        NetworksInventory.NETWORKS = real_networks
 
 
 class MockBlockchain(TesterBlockchain):


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Related to Discord discussion here - https://discord.com/channels/866378471868727316/870383642751430666/987067366699565056.

Values provided via the `--network` parameter were not correctly validated - it allowed payment network values to be specified.

Additionally tests were failing because we are now past the previous probation period - so extended the probation period to August 31, 2022.