### PR TITLE
Allow Porter to provide `context` for re-encryption conditions

### DIFF
--- a/docs/source/application_development/web_development.rst
+++ b/docs/source/application_development/web_development.rst
@@ -674,9 +674,9 @@ Parameters
 +-------------------------------------------+---------------+----------------------------------------+
 | ``bob_verifying_key``                     | String        | Bob's verifying key encoded as hex.    |
 +-------------------------------------------+---------------+----------------------------------------+
-| ``context`` *(Optional)*                  | String        | | Associated data required during      |
+| ``context`` *(Optional)*                  | String        | | Associated JSON data required during |
 |                                           |               | | re-encryption e.g. data to satisfy   |
-|                                           |               | | conditions.                          |
+|                                           |               | | re-encryption conditions.            |
 +-------------------------------------------+---------------+----------------------------------------+
 
 
@@ -703,7 +703,7 @@ Parameters
         because some Ursulas may have experienced a blip in connectivity. This is an optional optimization that provides
         retry functionality that skips previously successful reencryption operations.
 
-    * A *context* is associated data required during re-encryption. One such example is when a condition for re-encryption
+    * A *context* is associated JSON data required during re-encryption. One such example is when a condition for re-encryption
       requires proof of ownership of a wallet address; the *context* is used to provide the data and signature required for proof.
 
 

--- a/docs/source/application_development/web_development.rst
+++ b/docs/source/application_development/web_development.rst
@@ -674,9 +674,9 @@ Parameters
 +-------------------------------------------+---------------+----------------------------------------+
 | ``bob_verifying_key``                     | String        | Bob's verifying key encoded as hex.    |
 +-------------------------------------------+---------------+----------------------------------------+
-| ``context`` *(Optional)*                  | String        | | Associated JSON data required during |
-|                                           |               | | re-encryption e.g. data to satisfy   |
-|                                           |               | | re-encryption conditions.            |
+| ``context`` *(Optional)*                  | String        | | Associated JSON dictionary required  |
+|                                           |               | | during re-encryption e.g. data to    |
+|                                           |               | | satisfy re-encryption conditions.    |
 +-------------------------------------------+---------------+----------------------------------------+
 
 
@@ -703,8 +703,8 @@ Parameters
         because some Ursulas may have experienced a blip in connectivity. This is an optional optimization that provides
         retry functionality that skips previously successful reencryption operations.
 
-    * A *context* is associated JSON data required during re-encryption. One such example is when a condition for re-encryption
-      requires proof of ownership of a wallet address; the *context* is used to provide the data and signature required for proof.
+    * A *context* is an associated JSON dictionary of data required during re-encryption. One such example is when a condition for re-encryption
+      requires proof of ownership of a wallet address; the *context* is used to provide the data and signature required for the proof.
 
 
 Returns
@@ -728,12 +728,6 @@ Example Request
              "bob_encrypting_key": "03d41cb7aa2df98cb9fb1591b5556363862a367faae6d0e4874a860321141788cb",
              "bob_verifying_key": "039c19e5d44b016af126d89488c4ae5599e0fde9ea30047754d1fe173d05eee468",
              "policy_encrypting_key": "02cdb2cec70b568c0624b72450c2043836aa831b06b196a50db461e87acddb791e"}'
-
-OR
-
-.. code:: bash
-
-    curl -X POST "<PORTER URI>/retrieve_crags?retrieval_kits=%5B%27gANDYgMKitDPd%2FQttLGy%2Bs7Oacnm8pfbl3Qs2UD3IS1d9wF3awJsXnjFq7OkRQE45DV4%2BMa2lDSJ5SeKEBqJK5GdPMB6CRwJ1hX7Y5SYgzpZtr%2FZ5%2FS3DHgVKn%2B8fWX92FaqEXIGcQBjYnVpbHRpbnMKc2V0CnEBXXEChXEDUnEEhnEFLg%3D%3D%27%5D&alice_verifying_key=02d3389864e9e7206ae1d18301bbd67ad8e0bdf257b3085c9aa13e9438ff9133f2&bob_encrypting_key=03d41cb7aa2df98cb9fb1591b5556363862a367faae6d0e4874a860321141788cb&bob_verifying_key=039c19e5d44b016af126d89488c4ae5599e0fde9ea30047754d1fe173d05eee468&policy_encrypting_key=02cdb2cec70b568c0624b72450c2043836aa831b06b196a50db461e87acddb791e&treasure_map=ivOS2%2FMarBpkLAksM0O%2BpgLUHAV%2F0ceIBarBKwqUpAXARhpvuwAAAm0DoDAtioScWJSHWNGzQd9pMGW2dRF4IvJX%2FExALF6AcLICLCBP%2Btte8QR4l0GLNy3YwK4oO8f8Ht0Ij%2Bv0feWWwgeo3R7FVeC4ExDuYvgdsV6jCP3vqZnLphIPk8LQeo1XVAABAtM4mGTp5yBq4dGDAbvWetjgvfJXswhcmqE%2BlDj%2FkTPyAAAB5H0rD40N1u5Ct455sh4SicbHTGsXcRSt%2FadeHVl3zylNpWDsFbeon7VI5fGGmWLAKmCJ5ARU1Mgfwg0pfsXDgHTky6XOeXnNw630z9muBE4NMUiESOQm%2FRAsphMR%2FDEIMRaCgjhaE2diVdVAm15JjRXV9JN5gAp58Y1ecPcWR2lMcgAMHBFMX60bpbgjySha94Hwb0kR2SKIFkPQnuMljoQxutTDAyh55eE2sHf9ZOAVZkpKQu8NkaWy7adx%2F1QefezNbngX9c2yYml133Al4oGrLWYA3fnbod2Y6F1oeG5As5ZIW%2FO8k7Rf%2B3i9a%2BDS1i%2BKbgETHQGxOkQSpNPUmwJjtzDJQ1xFMmKkxgwUtXenfyrzDDPU6EQloWK2PmyTD%2FhSKHLpkLyzYp95gadzDiS8RlOnNw%2FuP8vfMPSrXYGZSKXvHvlrQxKOjnF7FrheauwwRPjM0yYTftPs3jNkZwCTl%2BEwn6NdLur927SeGyAB3gHCjHenje%2B3hU1jsn%2FmwfwLJwSMT7V0rbXV6I0NYhjQy2Ajj%2B7ev%2FNSvRdeneeYTU3iHoO6nIhWHBLVExWafu59B6hhsm261kvXw718eiUcL%2B1X1eZ5WApplCuXGQV7L6DZxlQPanRJy7BZZQmFwEUoMCnx9mGbOKmNbeCADx3vwKY5nrbTDAAAAm0Cccv5a3jS2QiICCzCyA0Ot3U7VT1F3d%2BB3cHcmv8DaCwDODb8IadnsiVK%2BdfbPLn3ne%2Blm8d9yqhh6bLi6KNDb6yiWrjWnd4Irnnh3amMwik00vdyQKYvdsaSEJqtVLmtcQABAtM4mGTp5yBq4dGDAbvWetjgvfJXswhcmqE%2BlDj%2FkTPyAAAB5Do%2Feww%2BG709VPQwkxd0tRFyJh97Wcb5uSGs%2B4fK9O%2B5CTf5rDQSO3ueWLRF4ytRzd3QjK6%2B8FlXsJQM5n5pGLUNNWpUlimk2MmPaLehC9uGBfQzoTfQof%2BU8CBXkTTnRi0IeAYMq8eiuEnNR%2FoOJjpjuwgZH4gue%2FsSDF8FyhFU4SwF%2FWdjLg0FgmZzRlqABNXeE8vOofydEMYgUMPd8qxjimAGhkYlBUNjlme4BUdA2AqndMttpc3y9ILTobaGSnjgWfq9Ztw%2Fn72scPI11T%2BYMaaXd33dacNPx%2BpVzcgqi358PT8WQ6U3n%2B1be8mhF8VGEO7%2F5zLFHECRCv06erER8ChTZvr4rb8Y0xRCz%2FpatllLqvWZkGSmotmsi9qAptgG%2FXkozOZIqmBuM2AuQTwaePyuJzelc5xD51OlkQRahV6%2Bok3CokckwtOXtC6dzq4dmh03Uj5ZeKj8IgITDPN6jCf5TwLmXSuEGl5W%2FxmrEUeNlrthlJm7Cdd1NpLn3RZNCgSS4%2BPw9cpY6fj%2FmF8yR0erf9Tkrxr7FXzSe%2FUWkfeB3aQPulP4U3nM7vJIz9DBcJxtdozfqHchZ%2FK%2BVnaW%2F7IlNhvu3Cwk%2BN3D9sUwf%2FuHQuE%2FQSsYZ0fjUCnB1UgJMjho5Sd4CHLNoCFroNj71YtnpdXjUQAAAm0D5ITdM1U28%2B6%2FLU%2B%2BJw%2FUTMOefScVULkEyaojkyJK574Dc96zie3HtMN0ahALfOg5yn2z2zZpwqsLk9mpT23GD8AYR55RcvLHGIjJTubtuMINy7ZBgbZmisPDt5DvHVKj1wABAtM4mGTp5yBq4dGDAbvWetjgvfJXswhcmqE%2BlDj%2FkTPyAAAB5B9Wn5rfJ8LS81DIkZj6By39KZPYLoNSpR%2BVEZsLaSEo%2FHTMG43Q%2FgG%2FYjZMQHBEZwleE1H35P3EuDlWOriEQxveH7ihmHVSDfj8R%2B6xo%2F263QCLqtg9djSFPW7h6QRx5JBM%2BWABcmIZQrAvMDe1q7F8VOGRDMf8tW%2F7sySMFn9pQ7735kasw8iNsGPX9gVNcncSuh8hmgWGzwciUU%2FY5SYmQvl0Oc15G5%2FkFhIA9nDVfZR4sMBRB9ApYbnNYsxtH12wWhTo04hPEGfzsqKK10muLy%2Bqpo3VBhX24HPTBAvYm68f0UVD%2Ba0cZWmgYKypmMqApJ87RnPvXbE3rmKepJM8u02O4X1OBlfDZBrTsbCbMxeniS6bzE6VPE62jOW6GIuyV6%2BNQS3PZTuTWG%2Fp7T5n2EC%2FPf%2FCvGLq41gQDU9VT2aCbHkbr9C0klVJfUwqdE%2F51zLmcY8wpx3P%2BOS%2BlrIjxQzOpWSKQfsNyt1DhKpKb5Y1wWrUGm6s0sBEG7FQK2SmWMhpjB36ZRdmtQ8%2Fmvh20KELR6W%2BocGosR20TXdGINzJEnobbTkkGNz2sqzePvL7Ql5Utc%2FGCaZYC2yIvJEGBOSBVtKvwqTOaMOFTaCIx4R5f3X17umkMD1YCvir39cREkU%3D"
 
 
 Example Response

--- a/docs/source/application_development/web_development.rst
+++ b/docs/source/application_development/web_development.rst
@@ -649,7 +649,7 @@ Example Response
              }
           ]
        },
-       "version": "6.0.0"
+       "version": "6.1.0"
     }
 
 
@@ -674,6 +674,11 @@ Parameters
 +-------------------------------------------+---------------+----------------------------------------+
 | ``bob_verifying_key``                     | String        | Bob's verifying key encoded as hex.    |
 +-------------------------------------------+---------------+----------------------------------------+
+| ``context`` *(Optional)*                  | String        | | Associated data required during      |
+|                                           |               | | re-encryption e.g. data to satisfy   |
+|                                           |               | | conditions.                          |
++-------------------------------------------+---------------+----------------------------------------+
+
 
     * A single *retrieval kit* is an encapsulation of the information necessary to obtain cfrags from Ursulas.
       It contains a capsule and the checksum addresses of the Ursulas from which the requester has
@@ -697,6 +702,10 @@ Parameters
         previous ``/retrieve_cfrags`` call; for example, retrying after receiving less than a threshold of cfrags
         because some Ursulas may have experienced a blip in connectivity. This is an optional optimization that provides
         retry functionality that skips previously successful reencryption operations.
+
+    * A *context* is associated data required during re-encryption. One such example is when a condition for re-encryption
+      requires proof of ownership of a wallet address; the *context* is used to provide the data and signature required for proof.
+
 
 Returns
 ^^^^^^^
@@ -747,7 +756,7 @@ Example Response
              }
           ]
        },
-       "version": "6.0.0"
+       "version": "6.1.0"
     }
 
 

--- a/nucypher/control/specifications/fields/base.py
+++ b/nucypher/control/specifications/fields/base.py
@@ -87,25 +87,20 @@ class Base64BytesRepresentation(BaseField, fields.Field):
             raise InvalidInputData(f"Could not parse {self.name}: {e}")
 
 
-class Base64JSON(Base64BytesRepresentation):
-    """Serializes/Deserializes JSON objects as base64 byte representation."""
-
+class JSON(BaseField, fields.Field):
+    """Serializes/Deserializes objects to/from JSON strings."""
     def _serialize(self, value, attr, obj, **kwargs):
         try:
             value_json = json.dumps(value)
+            return value_json
         except Exception as e:
             raise InvalidInputData(
                 f"Provided object type, {type(value)}, is not JSON serializable: {e}"
             )
-        else:
-            json_base64_bytes = super()._serialize(
-                value_json.encode(), attr, obj, **kwargs
-            )
-            return json_base64_bytes
 
     def _deserialize(self, value, attr, data, **kwargs):
-        json_bytes = super()._deserialize(value, attr, data, **kwargs)
         try:
-            return json.loads(json_bytes)
+            result = json.loads(value)
+            return result
         except Exception as e:
-            raise InvalidInputData(f"Invalid JSON bytes: {e}")
+            raise InvalidInputData(f"Invalid JSON: {e}")

--- a/nucypher/utilities/porter/control/interfaces.py
+++ b/nucypher/utilities/porter/control/interfaces.py
@@ -14,11 +14,10 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from eth_typing import ChecksumAddress
-
-from nucypher_core import TreasureMap, RetrievalKit
+from nucypher_core import RetrievalKit, TreasureMap
 from nucypher_core.umbral import PublicKey
 
 from nucypher.control.interfaces import ControlInterface, attach_schema
@@ -59,12 +58,15 @@ class PorterInterface(ControlInterface):
                         alice_verifying_key: PublicKey,
                         bob_encrypting_key: PublicKey,
                         bob_verifying_key: PublicKey,
-                        ) -> dict:
-        retrieval_results = self.implementer.retrieve_cfrags(treasure_map=treasure_map,
-                                                             retrieval_kits=retrieval_kits,
-                                                             alice_verifying_key=alice_verifying_key,
-                                                             bob_encrypting_key=bob_encrypting_key,
-                                                             bob_verifying_key=bob_verifying_key)
-        results = retrieval_results   # list of RetrievalResult objects
-        response_data = {'retrieval_results': results}
+                        context: Optional[Dict] = None) -> dict:
+        retrieval_results = self.implementer.retrieve_cfrags(
+            treasure_map=treasure_map,
+            retrieval_kits=retrieval_kits,
+            alice_verifying_key=alice_verifying_key,
+            bob_encrypting_key=bob_encrypting_key,
+            bob_verifying_key=bob_verifying_key,
+            context=context,
+        )
+        results = retrieval_results  # list of RetrievalResult objects
+        response_data = {"retrieval_results": results}
         return response_data

--- a/nucypher/utilities/porter/control/specifications/porter_schema.py
+++ b/nucypher/utilities/porter/control/specifications/porter_schema.py
@@ -159,5 +159,18 @@ class BobRetrieveCFrags(BaseSchema):
             type=click.STRING,
             required=True))
 
+    # optional
+    context = base_fields.Base64JSON(
+        required=False,
+        load_only=True,
+        click=click.option(
+            "--context",
+            "-ctx",
+            help="Context data for retrieval conditions",
+            type=click.STRING,
+            required=False,
+        ),
+    )
+
     # output
     retrieval_results = marshmallow_fields.List(marshmallow_fields.Nested(fields.RetrievalResultSchema), dump_only=True)

--- a/nucypher/utilities/porter/control/specifications/porter_schema.py
+++ b/nucypher/utilities/porter/control/specifications/porter_schema.py
@@ -160,7 +160,7 @@ class BobRetrieveCFrags(BaseSchema):
             required=True))
 
     # optional
-    context = base_fields.Base64JSON(
+    context = base_fields.JSON(
         required=False,
         load_only=True,
         click=click.option(

--- a/nucypher/utilities/porter/control/specifications/porter_schema.py
+++ b/nucypher/utilities/porter/control/specifications/porter_schema.py
@@ -161,6 +161,7 @@ class BobRetrieveCFrags(BaseSchema):
 
     # optional
     context = base_fields.JSON(
+        expected_type=dict,
         required=False,
         load_only=True,
         click=click.option(

--- a/nucypher/utilities/porter/porter.py
+++ b/nucypher/utilities/porter/porter.py
@@ -17,18 +17,21 @@
 
 
 from pathlib import Path
-from typing import List, NamedTuple, Optional, Sequence
+from typing import Dict, List, NamedTuple, Optional, Sequence
 
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION, NO_CONTROL_PROTOCOL
 from eth_typing import ChecksumAddress
 from eth_utils import to_checksum_address
-from flask import request, Response
-from nucypher_core import TreasureMap, RetrievalKit
+from flask import Response, request
+from nucypher_core import RetrievalKit, TreasureMap
 from nucypher_core.umbral import PublicKey
 
 from nucypher.blockchain.eth.agents import ContractAgency, PREApplicationAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
-from nucypher.blockchain.eth.registry import BaseContractRegistry, InMemoryContractRegistry
+from nucypher.blockchain.eth.registry import (
+    BaseContractRegistry,
+    InMemoryContractRegistry,
+)
 from nucypher.characters.lawful import Ursula
 from nucypher.control.controllers import JSONRPCController, WebController
 from nucypher.crypto.powers import DecryptingPower
@@ -36,9 +39,9 @@ from nucypher.network.nodes import Learner
 from nucypher.network.retrieval import RetrievalClient
 from nucypher.policy.kits import RetrievalResult
 from nucypher.policy.reservoir import (
-    make_federated_staker_reservoir,
+    PrefetchStrategy,
     make_decentralized_staking_provider_reservoir,
-    PrefetchStrategy
+    make_federated_staker_reservoir,
 )
 from nucypher.utilities.concurrency import WorkerPool
 from nucypher.utilities.logging import Logger
@@ -164,10 +167,17 @@ the Pipe for PRE Application network operations
                         alice_verifying_key: PublicKey,
                         bob_encrypting_key: PublicKey,
                         bob_verifying_key: PublicKey,
-                        ) -> List[RetrievalResult]:
+                        context: Optional[Dict] = None) -> List[RetrievalResult]:
         client = RetrievalClient(self)
-        return client.retrieve_cfrags(treasure_map, retrieval_kits,
-            alice_verifying_key, bob_encrypting_key, bob_verifying_key)
+        context = context or dict()  # must not be None
+        return client.retrieve_cfrags(
+            treasure_map,
+            retrieval_kits,
+            alice_verifying_key,
+            bob_encrypting_key,
+            bob_verifying_key,
+            **context,
+        )
 
     def _make_reservoir(self,
                         quantity: int,

--- a/tests/acceptance/blockchain/conditions/conftest.py
+++ b/tests/acceptance/blockchain/conditions/conftest.py
@@ -1,12 +1,34 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 import json
-import pytest
 from pathlib import Path
+
+import pytest
 from web3 import Web3
 
 import tests.data
-from nucypher.blockchain.eth.agents import ContractAgency, NucypherTokenAgent, SubscriptionManagerAgent
+from nucypher.blockchain.eth.agents import (
+    ContractAgency,
+    NucypherTokenAgent,
+    SubscriptionManagerAgent,
+)
 from nucypher.policy.conditions.evm import ContractCondition, RPCCondition
-from nucypher.policy.conditions.lingo import ReturnValueTest, ConditionLingo, OR, AND
+from nucypher.policy.conditions.lingo import AND, OR, ConditionLingo, ReturnValueTest
 from nucypher.policy.conditions.time import TimeCondition
 
 VECTORS_FILE = Path(tests.__file__).parent / "data" / "test_conditions.json"
@@ -95,11 +117,7 @@ def timelock_condition():
 
 @pytest.fixture()
 def lingo(timelock_condition, rpc_condition, evm_condition):
-    lingo = ConditionLingo(conditions=(
-        timelock_condition,
-        OR,
-        rpc_condition,
-        AND,
-        evm_condition)
+    lingo = ConditionLingo(
+        conditions=[timelock_condition, OR, rpc_condition, AND, evm_condition]
     )
     return lingo

--- a/tests/acceptance/blockchain/interfaces/test_testerchain.py
+++ b/tests/acceptance/blockchain/interfaces/test_testerchain.py
@@ -53,7 +53,7 @@ def test_testerchain_creation(testerchain, another_testerchain):
         assert 'tester' in chain.eth_provider_uri
 
         # ... and that there are already some blocks mined
-        chain.w3.eth.web3.testing.mine(1)
+        chain.w3.eth.w3.testing.mine(1)
         assert chain.w3.eth.blockNumber > 0
 
         # Check that we have enough test accounts

--- a/tests/acceptance/porter/control/test_porter_rpc_control_blockchain.py
+++ b/tests/acceptance/porter/control/test_porter_rpc_control_blockchain.py
@@ -77,7 +77,8 @@ def test_retrieve_cfrags(blockchain_porter,
                          blockchain_porter_rpc_controller,
                          random_blockchain_policy,
                          blockchain_bob,
-                         blockchain_alice):
+                         blockchain_alice,
+                         random_context):
     method = 'retrieve_cfrags'
 
     # Setup
@@ -101,6 +102,19 @@ def test_retrieve_cfrags(blockchain_porter,
     retrieve_args = retrieval_params_decode_from_rest(retrieve_cfrags_params)
     expected_results = blockchain_porter.retrieve_cfrags(**retrieve_args)
     assert len(retrieval_results) == len(expected_results)
+
+    # Use context
+    retrieve_cfrags_params_with_context, _ = retrieval_request_setup(enacted_policy,
+                                                                     blockchain_bob,
+                                                                     blockchain_alice,
+                                                                     context=random_context,
+                                                                     encode_for_rest=True)
+    request_data = {'method': method, 'params': retrieve_cfrags_params_with_context}
+    response = blockchain_porter_rpc_controller.send(request_data)
+    assert response.success
+
+    retrieval_results = response.data['result']['retrieval_results']
+    assert retrieval_results
 
     # Failure - use encrypted treasure map
     failure_retrieve_cfrags_params = dict(retrieve_cfrags_params)

--- a/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
+++ b/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
@@ -18,15 +18,17 @@
 import json
 import os
 from base64 import b64encode
-from urllib.parse import urlencode
 
 from nucypher_core import RetrievalKit
 
 from nucypher.characters.lawful import Enrico
-from nucypher.control.specifications.fields import Base64JSON
+from nucypher.control.specifications.fields import JSON
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.policy.kits import PolicyMessageKit, RetrievalResult
-from nucypher.utilities.porter.control.specifications.fields import RetrievalResultSchema, RetrievalKit as RetrievalKitField
+from nucypher.utilities.porter.control.specifications.fields import (
+    RetrievalResultSchema,
+    RetrievalKit as RetrievalKitField,
+)
 from tests.utils.middleware import MockRestMiddleware
 from tests.utils.policy import retrieval_request_setup, retrieval_params_decode_from_rest
 
@@ -173,27 +175,13 @@ def test_retrieve_cfrags(blockchain_porter,
     #
     # Use context
     #
-    context_field = Base64JSON()
+    context_field = JSON()
     multiple_retrieval_kits_params['context'] = context_field._serialize(random_context, attr=None, obj=None)
 
     response = blockchain_porter_web_controller.post('/retrieve_cfrags', data=json.dumps(
         multiple_retrieval_kits_params))
     assert response.status_code == 200
 
-    response_data = json.loads(response.data)
-    retrieval_results = response_data['result']['retrieval_results']
-    assert retrieval_results
-    assert len(retrieval_results) == 2
-
-    #
-    # Try same retrieval (with multiple retrieval kits) using query parameters
-    #
-    url_retrieve_params = dict(multiple_retrieval_kits_params)  # use multiple kit params from above
-    # adjust parameter for url query parameter list format
-    url_retrieve_params['retrieval_kits'] = ",".join(url_retrieve_params['retrieval_kits'])   # adjust for list
-    response = blockchain_porter_web_controller.post(f'/retrieve_cfrags'
-                                                     f'?{urlencode(url_retrieve_params)}')
-    assert response.status_code == 200
     response_data = json.loads(response.data)
     retrieval_results = response_data['result']['retrieval_results']
     assert retrieval_results

--- a/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
+++ b/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
@@ -23,6 +23,7 @@ from urllib.parse import urlencode
 from nucypher_core import RetrievalKit
 
 from nucypher.characters.lawful import Enrico
+from nucypher.control.specifications.fields import Base64JSON
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.policy.kits import PolicyMessageKit, RetrievalResult
 from nucypher.utilities.porter.control.specifications.fields import RetrievalResultSchema, RetrievalKit as RetrievalKitField
@@ -91,7 +92,8 @@ def test_retrieve_cfrags(blockchain_porter,
                          blockchain_porter_web_controller,
                          random_blockchain_policy,
                          blockchain_bob,
-                         blockchain_alice):
+                         blockchain_alice,
+                         random_context):
     # Send bad data to assert error return
     response = blockchain_porter_web_controller.post('/retrieve_cfrags', data=json.dumps({'bad': 'input'}))
     assert response.status_code == 400
@@ -161,6 +163,21 @@ def test_retrieve_cfrags(blockchain_porter,
         retrieval_kit_field._serialize(value=retrieval_kit_2, attr=None, obj=None)
     ]
     response = blockchain_porter_web_controller.post('/retrieve_cfrags', data=json.dumps(multiple_retrieval_kits_params))
+    assert response.status_code == 200
+
+    response_data = json.loads(response.data)
+    retrieval_results = response_data['result']['retrieval_results']
+    assert retrieval_results
+    assert len(retrieval_results) == 2
+
+    #
+    # Use context
+    #
+    context_field = Base64JSON()
+    multiple_retrieval_kits_params['context'] = context_field._serialize(random_context, attr=None, obj=None)
+
+    response = blockchain_porter_web_controller.post('/retrieve_cfrags', data=json.dumps(
+        multiple_retrieval_kits_params))
     assert response.status_code == 200
 
     response_data = json.loads(response.data)

--- a/tests/acceptance/porter/test_decentralized_porter.py
+++ b/tests/acceptance/porter/test_decentralized_porter.py
@@ -76,3 +76,22 @@ def test_retrieve_cfrags(blockchain_porter,
     # use porter
     result = blockchain_porter.retrieve_cfrags(**retrieval_args)
     assert result
+
+
+def test_retrieve_cfrags_with_context(blockchain_porter,
+                                      random_blockchain_policy,
+                                      blockchain_bob,
+                                      blockchain_alice,
+                                      random_context):
+    # Setup
+    network_middleware = MockRestMiddleware()
+    # enact new random policy since idle_blockchain_policy/enacted_blockchain_policy already modified in previous tests
+    enacted_policy = random_blockchain_policy.enact(network_middleware=network_middleware)
+    retrieval_args, _ = retrieval_request_setup(enacted_policy,
+                                                blockchain_bob,
+                                                blockchain_alice,
+                                                context=random_context)
+
+    # use porter
+    result = blockchain_porter.retrieve_cfrags(**retrieval_args)
+    assert result

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -21,6 +21,7 @@ import os
 import random
 import shutil
 import tempfile
+from base64 import b64encode
 from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
@@ -1034,3 +1035,23 @@ def basic_auth_file(temp_dir_path):
         f.write("admin:$apr1$hlEpWVoI$0qjykXrvdZ0yO2TnBggQO0\n")
     yield basic_auth
     basic_auth.unlink()
+
+
+#
+# Condition Context
+#
+@pytest.fixture(scope='module')
+def random_context():
+    context = {
+        "domain": {"name": "tdec", "version": 1, "chainId": 1, "salt": "blahblahblah"},
+        "message": {
+            "address": "0x03e75d7dd38cce2e20ffee35ec914c57780a8e29",
+            "conditions": b64encode(
+                "random condition for reencryption".encode()
+            ).decode(),
+            "blockNumber": 15440685,
+            "blockHash": "0x2220da8b777767df526acffd5375ebb340fc98e53c1040b25ad1a8119829e3bd",
+        },
+    }
+
+    return context

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -37,20 +37,28 @@ from web3.types import TxReceipt
 
 from nucypher.blockchain.economics import Economics
 from nucypher.blockchain.eth.actors import Operator
-from nucypher.blockchain.eth.agents import ContractAgency, NucypherTokenAgent, PREApplicationAgent
+from nucypher.blockchain.eth.agents import (
+    ContractAgency,
+    NucypherTokenAgent,
+    PREApplicationAgent,
+)
 from nucypher.blockchain.eth.deployers import (
+    NucypherTokenDeployer,
     PREApplicationDeployer,
-    SubscriptionManagerDeployer, NucypherTokenDeployer
+    SubscriptionManagerDeployer,
 )
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
-from nucypher.blockchain.eth.registry import InMemoryContractRegistry, LocalContractRegistry
+from nucypher.blockchain.eth.registry import (
+    InMemoryContractRegistry,
+    LocalContractRegistry,
+)
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.blockchain.eth.token import NU
 from nucypher.characters.lawful import Enrico
 from nucypher.config.characters import (
     AliceConfiguration,
     BobConfiguration,
-    UrsulaConfiguration
+    UrsulaConfiguration,
 )
 from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.control.emitters import StdoutEmitter
@@ -74,8 +82,8 @@ from tests.constants import (
     MOCK_POLICY_DEFAULT_THRESHOLD,
     MOCK_REGISTRY_FILEPATH,
     NUMBER_OF_URSULAS_IN_DEVELOPMENT_NETWORK,
+    TEST_ETH_PROVIDER_URI,
     TEST_GAS_LIMIT,
-    TEST_ETH_PROVIDER_URI
 )
 from tests.mock.interfaces import MockBlockchain, mock_registry_source_manager
 from tests.mock.performance_mocks import (
@@ -87,21 +95,24 @@ from tests.mock.performance_mocks import (
     mock_record_fleet_state,
     mock_remember_node,
     mock_rest_app_creation,
-    mock_verify_node
+    mock_verify_node,
 )
 from tests.utils.blockchain import TesterBlockchain, token_airdrop
 from tests.utils.config import (
     make_alice_test_configuration,
     make_bob_test_configuration,
-    make_ursula_test_configuration
+    make_ursula_test_configuration,
 )
-from tests.utils.middleware import MockRestMiddleware, MockRestMiddlewareForLargeFleetTests
+from tests.utils.middleware import (
+    MockRestMiddleware,
+    MockRestMiddlewareForLargeFleetTests,
+)
 from tests.utils.policy import generate_random_label
 from tests.utils.ursula import (
     MOCK_KNOWN_URSULAS_CACHE,
     MOCK_URSULA_STARTING_PORT,
     make_decentralized_ursulas,
-    make_federated_ursulas
+    make_federated_ursulas,
 )
 
 test_logger = Logger("test-logger")
@@ -1043,15 +1054,26 @@ def basic_auth_file(temp_dir_path):
 @pytest.fixture(scope='module')
 def random_context():
     context = {
-        "domain": {"name": "tdec", "version": 1, "chainId": 1, "salt": "blahblahblah"},
-        "message": {
+        ":userAddress": {
+            "signature": "16b15f88bbd2e0a22d1d0084b8b7080f2003ea83eab1a00f80d8c18446c9c1b6224f17aa09eaf167717ca4f355bb6dc94356e037edf3adf6735a86fc3741f5231b",
             "address": "0x03e75d7dd38cce2e20ffee35ec914c57780a8e29",
-            "conditions": b64encode(
-                "random condition for reencryption".encode()
-            ).decode(),
-            "blockNumber": 15440685,
-            "blockHash": "0x2220da8b777767df526acffd5375ebb340fc98e53c1040b25ad1a8119829e3bd",
-        },
+            "typedMessage": {
+                "domain": {
+                    "name": "tdec",
+                    "version": 1,
+                    "chainId": 1,
+                    "salt": "0xf2d857f4a3edcb9b78b4d503bfe733db1e3f6cdc2b7971ee739626c97e86a558",
+                },
+                "message": {
+                    "address": "0x03e75d7dd38cce2e20ffee35ec914c57780a8e29",
+                    "conditions": b64encode(
+                        "random condition for reencryption".encode()
+                    ).decode(),
+                    "blockNumber": 15440685,
+                    "blockHash": "0x2220da8b777767df526acffd5375ebb340fc98e53c1040b25ad1a8119829e3bd",
+                },
+            },
+        }
     }
 
     return context

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1066,9 +1066,6 @@ def random_context():
                 },
                 "message": {
                     "address": "0x03e75d7dd38cce2e20ffee35ec914c57780a8e29",
-                    "conditions": b64encode(
-                        "random condition for reencryption".encode()
-                    ).decode(),
                     "blockNumber": 15440685,
                     "blockHash": "0x2220da8b777767df526acffd5375ebb340fc98e53c1040b25ad1a8119829e3bd",
                 },

--- a/tests/integration/porter/conftest.py
+++ b/tests/integration/porter/conftest.py
@@ -14,10 +14,8 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
-from base64 import b64decode
 
 import pytest
-
 from nucypher_core import HRAC, TreasureMap
 
 from nucypher.crypto.powers import DecryptingPower

--- a/tests/integration/porter/control/test_porter_rpc_control_federated.py
+++ b/tests/integration/porter/control/test_porter_rpc_control_federated.py
@@ -75,7 +75,8 @@ def test_retrieve_cfrags(federated_porter,
                          enacted_federated_policy,
                          federated_bob,
                          federated_alice,
-                         random_federated_treasure_map_data):
+                         random_federated_treasure_map_data,
+                         random_context):
     method = 'retrieve_cfrags'
 
     # Setup
@@ -96,6 +97,19 @@ def test_retrieve_cfrags(federated_porter,
     retrieve_args = retrieval_params_decode_from_rest(retrieve_cfrags_params)
     expected_results = federated_porter.retrieve_cfrags(**retrieve_args)
     assert len(retrieval_results) == len(expected_results)
+
+    # Use context
+    retrieve_cfrags_params_with_context, _ = retrieval_request_setup(enacted_federated_policy,
+                                                                     federated_bob,
+                                                                     federated_alice,
+                                                                     context=random_context,
+                                                                     encode_for_rest=True)
+    request_data = {'method': method, 'params': retrieve_cfrags_params_with_context}
+    response = federated_porter_rpc_controller.send(request_data)
+    assert response.success
+
+    retrieval_results = response.data['result']['retrieval_results']
+    assert retrieval_results
 
     # Failure - use encrypted treasure map
     failure_retrieve_cfrags_params = dict(retrieve_cfrags_params)

--- a/tests/integration/porter/control/test_porter_web_control_federated.py
+++ b/tests/integration/porter/control/test_porter_web_control_federated.py
@@ -18,15 +18,17 @@
 
 import json
 from base64 import b64encode
-from urllib.parse import urlencode
 
 from nucypher_core import RetrievalKit
 
 from nucypher.characters.lawful import Enrico
-from nucypher.control.specifications.fields import Base64JSON
+from nucypher.control.specifications.fields import JSON
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.policy.kits import PolicyMessageKit, RetrievalResult
-from nucypher.utilities.porter.control.specifications.fields import RetrievalResultSchema, RetrievalKit as RetrievalKitField
+from nucypher.utilities.porter.control.specifications.fields import (
+    RetrievalResultSchema,
+    RetrievalKit as RetrievalKitField,
+)
 from tests.utils.policy import retrieval_request_setup, retrieval_params_decode_from_rest
 
 
@@ -174,25 +176,11 @@ def test_retrieve_cfrags(federated_porter,
     #
     # Use context
     #
-    context_field = Base64JSON()
+    context_field = JSON()
     multiple_retrieval_kits_params['context'] = context_field._serialize(random_context, attr=None, obj=None)
     response = federated_porter_web_controller.post('/retrieve_cfrags', data=json.dumps(multiple_retrieval_kits_params))
     assert response.status_code == 200
 
-    response_data = json.loads(response.data)
-    retrieval_results = response_data['result']['retrieval_results']
-    assert retrieval_results
-    assert len(retrieval_results) == 4
-
-    #
-    # Try same retrieval (with multiple retrieval kits) using query parameters
-    #
-    url_retrieve_params = dict(multiple_retrieval_kits_params)  # use multiple kit params from above
-    # adjust parameter for url query parameter list format
-    url_retrieve_params['retrieval_kits'] = ",".join(url_retrieve_params['retrieval_kits'])
-    response = federated_porter_web_controller.post(f'/retrieve_cfrags'
-                                                    f'?{urlencode(url_retrieve_params)}')
-    assert response.status_code == 200
     response_data = json.loads(response.data)
     retrieval_results = response_data['result']['retrieval_results']
     assert retrieval_results

--- a/tests/integration/porter/control/test_porter_web_control_federated.py
+++ b/tests/integration/porter/control/test_porter_web_control_federated.py
@@ -23,6 +23,7 @@ from urllib.parse import urlencode
 from nucypher_core import RetrievalKit
 
 from nucypher.characters.lawful import Enrico
+from nucypher.control.specifications.fields import Base64JSON
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.policy.kits import PolicyMessageKit, RetrievalResult
 from nucypher.utilities.porter.control.specifications.fields import RetrievalResultSchema, RetrievalKit as RetrievalKitField
@@ -90,7 +91,8 @@ def test_retrieve_cfrags(federated_porter,
                          enacted_federated_policy,
                          federated_bob,
                          federated_alice,
-                         random_federated_treasure_map_data):
+                         random_federated_treasure_map_data,
+                         random_context):
     # Send bad data to assert error return
     response = federated_porter_web_controller.post('/retrieve_cfrags', data=json.dumps({'bad': 'input'}))
     assert response.status_code == 400
@@ -161,6 +163,19 @@ def test_retrieve_cfrags(federated_porter,
         retrieval_kit_field._serialize(value=retrieval_kit_3, attr=None, obj=None),
         retrieval_kit_field._serialize(value=retrieval_kit_4, attr=None, obj=None)
     ]
+    response = federated_porter_web_controller.post('/retrieve_cfrags', data=json.dumps(multiple_retrieval_kits_params))
+    assert response.status_code == 200
+
+    response_data = json.loads(response.data)
+    retrieval_results = response_data['result']['retrieval_results']
+    assert retrieval_results
+    assert len(retrieval_results) == 4
+
+    #
+    # Use context
+    #
+    context_field = Base64JSON()
+    multiple_retrieval_kits_params['context'] = context_field._serialize(random_context, attr=None, obj=None)
     response = federated_porter_web_controller.post('/retrieve_cfrags', data=json.dumps(multiple_retrieval_kits_params))
     assert response.status_code == 200
 

--- a/tests/integration/porter/test_federated_porter.py
+++ b/tests/integration/porter/test_federated_porter.py
@@ -74,3 +74,18 @@ def test_retrieve_cfrags(federated_porter,
     result = federated_porter.retrieve_cfrags(**retrieval_args)
 
     assert result, "valid result returned"
+
+
+def test_retrieve_cfrags_with_context(federated_porter,
+                                      federated_bob,
+                                      federated_alice,
+                                      enacted_federated_policy,
+                                      random_context):
+    # Setup
+    retrieval_args, _ = retrieval_request_setup(enacted_federated_policy,
+                                                federated_bob,
+                                                federated_alice,
+                                                context=random_context)
+
+    result = federated_porter.retrieve_cfrags(**retrieval_args)
+    assert result, "valid result returned"

--- a/tests/integration/porter/test_porter_specifications.py
+++ b/tests/integration/porter/test_porter_specifications.py
@@ -194,6 +194,18 @@ def test_bob_retrieve_cfrags(federated_porter,
     )
     bob_retrieve_cfrags_schema.load(retrieval_args)
 
+    # invalid context specified
+    retrieval_args, _ = retrieval_request_setup(
+        enacted_federated_policy,
+        federated_bob,
+        federated_alice,
+        encode_for_rest=True,
+        context=[1, 2, 3],  # list instead of dict
+    )
+    with pytest.raises(InvalidInputData):
+        # invalid context type
+        bob_retrieve_cfrags_schema.load(retrieval_args)
+
     # missing required argument
     updated_data = dict(retrieval_args)
     key_to_remove = random.choice(list(updated_data.keys()))

--- a/tests/integration/porter/test_porter_specifications.py
+++ b/tests/integration/porter/test_porter_specifications.py
@@ -169,7 +169,8 @@ def test_alice_revoke():
 def test_bob_retrieve_cfrags(federated_porter,
                              enacted_federated_policy,
                              federated_bob,
-                             federated_alice):
+                             federated_alice,
+                             random_context):
     bob_retrieve_cfrags_schema = BobRetrieveCFrags()
 
     # no args
@@ -184,23 +185,12 @@ def test_bob_retrieve_cfrags(federated_porter,
     bob_retrieve_cfrags_schema.load(retrieval_args)
 
     # simple schema load w/ optional context
-    context = {
-        "domain": {"name": "tdec", "version": 1, "chainId": 1, "salt": "blahblahblah"},
-        "message": {
-            "address": "0x03e75d7dd38cce2e20ffee35ec914c57780a8e29",
-            "conditions": b64encode(
-                "random condition for reencryption".encode()
-            ).decode(),
-            "blockNumber": 15440685,
-            "blockHash": "0x2220da8b777767df526acffd5375ebb340fc98e53c1040b25ad1a8119829e3bd",
-        },
-    }
     retrieval_args, _ = retrieval_request_setup(
         enacted_federated_policy,
         federated_bob,
         federated_alice,
         encode_for_rest=True,
-        context=context,
+        context=random_context,
     )
     bob_retrieve_cfrags_schema.load(retrieval_args)
 
@@ -220,7 +210,7 @@ def test_bob_retrieve_cfrags(federated_porter,
         federated_bob,
         federated_alice,
         encode_for_rest=False,
-        context=context,
+        context=random_context,
     )
     retrieval_results = federated_porter.retrieve_cfrags(**non_encoded_retrieval_args)
     expected_retrieval_results_json = []

--- a/tests/integration/porter/test_porter_specifications.py
+++ b/tests/integration/porter/test_porter_specifications.py
@@ -208,6 +208,7 @@ def test_bob_retrieve_cfrags(federated_porter,
 
     # missing required argument
     updated_data = dict(retrieval_args)
+    updated_data.pop("context")  # context is not a required param
     key_to_remove = random.choice(list(updated_data.keys()))
     del updated_data[key_to_remove]
     with pytest.raises(InvalidInputData):

--- a/tests/unit/conditions/conftest.py
+++ b/tests/unit/conditions/conftest.py
@@ -1,11 +1,29 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 import json
-import pytest
 from pathlib import Path
+
+import pytest
 from web3 import Web3
 
 import tests
 from nucypher.policy.conditions.evm import ContractCondition, RPCCondition
-from nucypher.policy.conditions.lingo import ReturnValueTest, ConditionLingo, OR, AND
+from nucypher.policy.conditions.lingo import AND, OR, ConditionLingo, ReturnValueTest
 from nucypher.policy.conditions.time import TimeCondition
 
 VECTORS_FILE = Path(tests.__file__).parent / "data" / "test_conditions.json"
@@ -96,11 +114,7 @@ def timelock_condition():
 
 @pytest.fixture()
 def lingo(timelock_condition, rpc_condition, evm_condition):
-    lingo = ConditionLingo(conditions=(
-        timelock_condition,
-        OR,
-        rpc_condition,
-        AND,
-        evm_condition)
+    lingo = ConditionLingo(
+        conditions=[timelock_condition, OR, rpc_condition, AND, evm_condition]
     )
     return lingo

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -21,8 +21,8 @@ import pytest
 
 from nucypher.control.specifications.exceptions import InvalidInputData
 from nucypher.control.specifications.fields import (
-    Base64BytesRepresentation,
     JSON,
+    Base64BytesRepresentation,
     PositiveInteger,
     String,
     StringList,
@@ -80,9 +80,6 @@ def test_json_field():
         "domain": {"name": "tdec", "version": 1, "chainId": 1, "salt": "blahblahblah"},
         "message": {
             "address": "0x03e75d7dd38cce2e20ffee35ec914c57780a8e29",
-            "conditions": b64encode(
-                "random condition for reencryption".encode()
-            ).decode(),
             "blockNumber": 15440685,
             "blockHash": "0x2220da8b777767df526acffd5375ebb340fc98e53c1040b25ad1a8119829e3bd",
         },

--- a/tests/unit/test_control.py
+++ b/tests/unit/test_control.py
@@ -22,7 +22,7 @@ import pytest
 from nucypher.control.specifications.exceptions import InvalidInputData
 from nucypher.control.specifications.fields import (
     Base64BytesRepresentation,
-    Base64JSON,
+    JSON,
     PositiveInteger,
     String,
     StringList,
@@ -74,7 +74,7 @@ def test_base64_representation_field():
         field._deserialize(value=b"raw bytes with non base64 chars ?&^%", attr=None, data=None)
 
 
-def test_base64_json_field():
+def test_json_field():
     # test data
     dict_data = {
         "domain": {"name": "tdec", "version": 1, "chainId": 1, "salt": "blahblahblah"},
@@ -94,10 +94,10 @@ def test_base64_json_field():
 
     # test serialization/deserialization of data
     test_data = [dict_data, list_data, str_data, num_data, bool_data]
-    field = Base64JSON()
+    field = JSON()
     for d in test_data:
         serialized = field._serialize(value=d, attr=None, obj=None)
-        assert serialized == b64encode(json.dumps(d).encode()).decode()
+        assert serialized == json.dumps(d)
 
         deserialized = field._deserialize(value=serialized, attr=None, data=None)
         assert deserialized == d
@@ -109,5 +109,5 @@ def test_base64_json_field():
     with pytest.raises(InvalidInputData):
         # attempt to deserialize invalid data
         field._deserialize(
-            value=b"raw bytes with non base64 chars ?&^%", attr=None, data=None
+            value=b"raw bytes", attr=None, data=None
         )

--- a/tests/utils/policy.py
+++ b/tests/utils/policy.py
@@ -18,14 +18,17 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import os
 import random
 import string
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from nucypher_core import MessageKit, RetrievalKit
 
 from nucypher.characters.control.specifications.fields import Key, TreasureMap
 from nucypher.characters.lawful import Enrico
+from nucypher.control.specifications.fields import Base64JSON
 from nucypher.crypto.powers import DecryptingPower
-from nucypher.utilities.porter.control.specifications.fields import RetrievalKit as RetrievalKitField
+from nucypher.utilities.porter.control.specifications.fields import (
+    RetrievalKit as RetrievalKitField,
+)
 
 
 def generate_random_label() -> bytes:
@@ -41,9 +44,15 @@ def generate_random_label() -> bytes:
     return bytes(random_label, encoding='utf-8')
 
 
-def retrieval_request_setup(enacted_policy, bob, alice,  original_message: bytes = None, encode_for_rest: bool = False) -> Tuple[Dict, MessageKit]:
-    treasure_map = bob._decrypt_treasure_map(enacted_policy.treasure_map,
-                                             enacted_policy.publisher_verifying_key)
+def retrieval_request_setup(enacted_policy,
+                            bob,
+                            alice,
+                            original_message: Optional[bytes] = None,
+                            context: Optional[Dict] = None,
+                            encode_for_rest: bool = False) -> Tuple[Dict, MessageKit]:
+    treasure_map = bob._decrypt_treasure_map(
+        enacted_policy.treasure_map, enacted_policy.publisher_verifying_key
+    )
 
     # We pick up our story with Bob already having followed the treasure map above, ie:
     bob.start_learning_loop()
@@ -56,18 +65,40 @@ def retrieval_request_setup(enacted_policy, bob, alice,  original_message: bytes
 
     encode_bytes = (lambda field, obj: field()._serialize(value=obj, attr=None, obj=None)) if encode_for_rest else (lambda field, obj: obj)
 
-    return (dict(treasure_map=encode_bytes(TreasureMap, treasure_map),
-                 retrieval_kits=[encode_bytes(RetrievalKitField, RetrievalKit.from_message_kit(message_kit))],
-                 alice_verifying_key=encode_bytes(Key, alice.stamp.as_umbral_pubkey()),
-                 bob_encrypting_key=encode_bytes(Key, bob.public_keys(DecryptingPower)),
-                 bob_verifying_key=encode_bytes(Key, bob.stamp.as_umbral_pubkey())),
-            message_kit)
+    retrieval_params = dict(
+        treasure_map=encode_bytes(TreasureMap, treasure_map),
+        retrieval_kits=[
+            encode_bytes(RetrievalKitField, RetrievalKit.from_message_kit(message_kit))
+        ],
+        alice_verifying_key=encode_bytes(Key, alice.stamp.as_umbral_pubkey()),
+        bob_encrypting_key=encode_bytes(Key, bob.public_keys(DecryptingPower)),
+        bob_verifying_key=encode_bytes(Key, bob.stamp.as_umbral_pubkey()),
+    )
+    # context is optional
+    if context:
+        retrieval_params["context"] = encode_bytes(Base64JSON, context)
+
+    return retrieval_params, message_kit
 
 
 def retrieval_params_decode_from_rest(retrieval_params: Dict) -> Dict:
-    decode_bytes = (lambda field, data: field()._deserialize(value=data, attr=None, data=None))
-    return dict(treasure_map=decode_bytes(TreasureMap, retrieval_params['treasure_map']),
-                retrieval_kits=[decode_bytes(RetrievalKitField, kit) for kit in retrieval_params['retrieval_kits']],
-                alice_verifying_key=decode_bytes(Key, retrieval_params['alice_verifying_key']),
-                bob_encrypting_key=decode_bytes(Key, retrieval_params['bob_encrypting_key']),
-                bob_verifying_key=decode_bytes(Key, retrieval_params['bob_verifying_key']))
+    decode_bytes = lambda field, data: field()._deserialize(
+        value=data, attr=None, data=None
+    )
+    decoded_params = dict(
+        treasure_map=decode_bytes(TreasureMap, retrieval_params["treasure_map"]),
+        retrieval_kits=[
+            decode_bytes(RetrievalKitField, kit)
+            for kit in retrieval_params["retrieval_kits"]
+        ],
+        alice_verifying_key=decode_bytes(Key, retrieval_params["alice_verifying_key"]),
+        bob_encrypting_key=decode_bytes(Key, retrieval_params["bob_encrypting_key"]),
+        bob_verifying_key=decode_bytes(Key, retrieval_params["bob_verifying_key"]),
+    )
+    # context is optional
+    if "context" in retrieval_params:
+        decoded_params["context"] = decode_bytes(
+            Base64JSON, retrieval_params["context"]
+        )
+
+    return decoded_params

--- a/tests/utils/policy.py
+++ b/tests/utils/policy.py
@@ -24,7 +24,7 @@ from nucypher_core import MessageKit, RetrievalKit
 
 from nucypher.characters.control.specifications.fields import Key, TreasureMap
 from nucypher.characters.lawful import Enrico
-from nucypher.control.specifications.fields import Base64JSON
+from nucypher.control.specifications.fields import JSON
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.utilities.porter.control.specifications.fields import (
     RetrievalKit as RetrievalKitField,
@@ -76,7 +76,7 @@ def retrieval_request_setup(enacted_policy,
     )
     # context is optional
     if context:
-        retrieval_params["context"] = encode_bytes(Base64JSON, context)
+        retrieval_params["context"] = encode_bytes(JSON, context)
 
     return retrieval_params, message_kit
 
@@ -98,7 +98,7 @@ def retrieval_params_decode_from_rest(retrieval_params: Dict) -> Dict:
     # context is optional
     if "context" in retrieval_params:
         decoded_params["context"] = decode_bytes(
-            Base64JSON, retrieval_params["context"]
+            JSON, retrieval_params["context"]
         )
 
     return decoded_params


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Based over #2961 .
Related to https://github.com/nucypher/nucypher-ts/pull/82.
Related to https://github.com/nucypher/tdec/issues/39.


**Issues fixed/closed:**
Allows an optional `context` parameter to be provided as part of the retrieval flow.


**Why it's needed:**
`Context` is needed to provide the necessary information to determine whether the recipient satisfies the relevant conditions for getting data re-encrypted/decrypted.

**Notes for reviewers:**
CI tests will continue to fail until an updated version of `nucypher-core` is used.
