### PR TITLE
Initial context variable work (No validation)

### DIFF
--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -27,11 +27,11 @@ from flask import Flask, Response, jsonify, request
 from mako import exceptions as mako_exceptions
 from mako.template import Template
 from nucypher_core import (
-    ReencryptionRequest,
-    RevocationOrder,
     MetadataRequest,
     MetadataResponse,
     MetadataResponsePayload,
+    ReencryptionRequest,
+    RevocationOrder,
 )
 
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
@@ -234,10 +234,15 @@ def _make_rest_app(datastore: Datastore, this_node, log: Logger) -> Flask:
                     lingo.eval(**context)
                 except ReencryptionCondition.RequiredInput as e:
                     message = f'Missing required inputs {e}'  # TODO: be more specific and name the missing inputs, etc
+                    # TODO BAD_REQUEST instead of FORBIDDEN?
                     error = (message, HTTPStatus.FORBIDDEN)
                     log.info(message)
                     return Response(str(e), status=error[1])
-
+                except ReencryptionCondition.InvalidContextVariableData as e:
+                    message = f"Invalid data provided for context variable {e}"
+                    error = (message, HTTPStatus.BAD_REQUEST)
+                    log.info(message)
+                    return Response(str(e), status=error[1])
                 except lingo.Failed as e:
                     # TODO: Better error reporting
                     message = f'Decryption conditions not satisfied {e}'

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -1,8 +1,26 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 import json
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from base64 import b64decode, b64encode
+from typing import Any, Dict, Tuple
+
 from marshmallow import Schema
-from typing import Any, Tuple, Dict
 
 
 class _Serializable:
@@ -47,6 +65,9 @@ class _Serializable:
 class ReencryptionCondition(_Serializable, ABC):
 
     class RequiredInput(Exception):
+        pass
+
+    class InvalidContextVariableData(Exception):
         pass
 
     class Schema(Schema):

--- a/tests/acceptance/blockchain/conditions/conftest.py
+++ b/tests/acceptance/blockchain/conditions/conftest.py
@@ -93,6 +93,20 @@ def evm_condition(test_registry, agency):
 
 
 @pytest.fixture
+def custom_context_variable_evm_condition(test_registry, agency):
+    token = ContractAgency.get_agent(NucypherTokenAgent, registry=test_registry)
+    condition = ContractCondition(
+        contract_address=token.contract.address,
+        method="balanceOf",
+        standard_contract_type="ERC20",
+        chain="testerchain",
+        return_value_test=ReturnValueTest("==", 0),
+        parameters=[":addressToUse"],
+    )
+    return condition
+
+
+@pytest.fixture
 def subscription_manager_condition(test_registry, agency):
     subscription_manager = ContractAgency.get_agent(SubscriptionManagerAgent, registry=test_registry)
     condition = ContractCondition(

--- a/tests/acceptance/blockchain/conditions/test_conditions.py
+++ b/tests/acceptance/blockchain/conditions/test_conditions.py
@@ -33,11 +33,27 @@ def test_erc20_evm_condition_evaluation(testerchain, evm_condition):
     assert result is False
 
 
+def test_erc20_evm_condition_evaluation_with_custom_context_variable(
+    testerchain, custom_context_variable_evm_condition
+):
+    context = {":addressToUse": testerchain.unassigned_accounts[0]}
+    result, value = custom_context_variable_evm_condition.verify(
+        provider=testerchain.provider, **context
+    )
+    assert result is True
+
+    context[":addressToUse"] = testerchain.etherbase_account
+    result, value = custom_context_variable_evm_condition.verify(
+        provider=testerchain.provider, **context
+    )
+    assert result is False
+
+
 @pytest.mark.skip('Need a way to handle user inputs like HRAC as context variables')
 def test_subscription_manager_condition_evaluation(testerchain, subscription_manager_condition):
-    hrac = None  # TODO
+    context = {":hrac": None}
     result, value = subscription_manager_condition.verify(
-        provider=testerchain.provider, hrac=hrac
+        provider=testerchain.provider, **context
     )
     assert result is True
     result, value = subscription_manager_condition.verify(provider=testerchain.provider)

--- a/tests/acceptance/blockchain/conditions/test_conditions.py
+++ b/tests/acceptance/blockchain/conditions/test_conditions.py
@@ -1,4 +1,22 @@
+"""
+ This file is part of nucypher.
+
+ nucypher is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ nucypher is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
 import json
+
 import pytest
 
 from nucypher.policy.conditions.lingo import ConditionLingo
@@ -6,30 +24,35 @@ from tests.integration.characters.test_bob_handles_frags import _make_message_ki
 
 
 def test_erc20_evm_condition_evaluation(testerchain, evm_condition):
-    result, value = evm_condition.verify(provider=testerchain.provider, user_address=testerchain.unassigned_accounts[0])
+    context = {":userAddress": {"address": testerchain.unassigned_accounts[0]}}
+    result, value = evm_condition.verify(provider=testerchain.provider, **context)
     assert result is True
-    result, value = evm_condition.verify(provider=testerchain.provider, user_address=testerchain.etherbase_account)
+
+    context[":userAddress"]["address"] = testerchain.etherbase_account
+    result, value = evm_condition.verify(provider=testerchain.provider, **context)
     assert result is False
 
 
 @pytest.mark.skip('Need a way to handle user inputs like HRAC as context variables')
 def test_subscription_manager_condition_evaluation(testerchain, subscription_manager_condition):
     hrac = None  # TODO
-    result, value = subscription_manager_condition.verify(provider=testerchain.provider, user_address=testerchain.unassigned_accounts[0], hrac=hrac)
+    result, value = subscription_manager_condition.verify(
+        provider=testerchain.provider, hrac=hrac
+    )
     assert result is True
-    result, value = subscription_manager_condition.verify(provider=testerchain.provider, user_address=testerchain.etherbase_account)
+    result, value = subscription_manager_condition.verify(provider=testerchain.provider)
     assert result is False
 
 
 def test_rpc_condition_evaluation(testerchain, rpc_condition):
-    address = testerchain.unassigned_accounts[0]
-    result, value = rpc_condition.verify(provider=testerchain.provider, user_address=address)
+    context = {":userAddress": {"address": testerchain.unassigned_accounts[0]}}
+    result, value = rpc_condition.verify(provider=testerchain.provider, **context)
     assert result is True
 
 
 def test_time_condition_evaluation(testerchain, timelock_condition):
-    address = testerchain.unassigned_accounts[0]
-    result, value = timelock_condition.verify(provider=testerchain.provider, user_address=address)
+    context = {":userAddress": {"address": testerchain.unassigned_accounts[0]}}
+    result, value = timelock_condition.verify(provider=testerchain.provider, **context)
     assert result is True
 
 
@@ -48,8 +71,11 @@ def test_simple_compound_conditions_evaluation(testerchain):
     assert result is True
 
 
-def test_onchain_conditions_lingo_evaluation(testerchain, timelock_condition, rpc_condition, evm_condition, lingo):
-    result = lingo.eval(provider=testerchain.provider, user_address=testerchain.etherbase_account)
+def test_onchain_conditions_lingo_evaluation(
+    testerchain, timelock_condition, rpc_condition, evm_condition, lingo
+):
+    context = {":userAddress": {"address": testerchain.etherbase_account}}
+    result = lingo.eval(provider=testerchain.provider, **context)
     assert result is True
 
 

--- a/tests/acceptance/blockchain/interfaces/test_testerchain.py
+++ b/tests/acceptance/blockchain/interfaces/test_testerchain.py
@@ -22,17 +22,23 @@ from nucypher.blockchain.eth.interfaces import BlockchainDeployerInterface
 from nucypher.blockchain.eth.registry import InMemoryContractRegistry
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.blockchain.eth.sol.compile.compile import multiversion_compile
-from nucypher.blockchain.eth.sol.compile.constants import TEST_MULTIVERSION_CONTRACTS, SOLIDITY_SOURCE_ROOT
+from nucypher.blockchain.eth.sol.compile.constants import (
+    SOLIDITY_SOURCE_ROOT,
+    TEST_MULTIVERSION_CONTRACTS,
+)
 from nucypher.blockchain.eth.sol.compile.types import SourceBundle
 from nucypher.crypto.powers import TransactingPower
 from tests.constants import (
     DEVELOPMENT_ETH_AIRDROP_AMOUNT,
+    INSECURE_DEVELOPMENT_PASSWORD,
     NUMBER_OF_ETH_TEST_ACCOUNTS,
     NUMBER_OF_STAKING_PROVIDERS_IN_BLOCKCHAIN_TESTS,
-    NUMBER_OF_URSULAS_IN_BLOCKCHAIN_TESTS, INSECURE_DEVELOPMENT_PASSWORD
+    NUMBER_OF_URSULAS_IN_BLOCKCHAIN_TESTS,
 )
+
 # Prevents TesterBlockchain to be picked up by py.test as a test class
-from tests.utils.blockchain import TesterBlockchain as _TesterBlockchain, free_gas_price_strategy
+from tests.utils.blockchain import TesterBlockchain as _TesterBlockchain
+from tests.utils.blockchain import free_gas_price_strategy
 
 
 @pytest.fixture()
@@ -54,7 +60,7 @@ def test_testerchain_creation(testerchain, another_testerchain):
 
         # ... and that there are already some blocks mined
         chain.w3.eth.w3.testing.mine(1)
-        assert chain.w3.eth.blockNumber > 0
+        assert chain.w3.eth.block_number > 0
 
         # Check that we have enough test accounts
         assert len(chain.client.accounts) >= NUMBER_OF_ETH_TEST_ACCOUNTS

--- a/tests/data/test_conditions.json
+++ b/tests/data/test_conditions.json
@@ -1,6 +1,6 @@
 {
   "SubscriptionManagerPayment": {
-    "contractAddress": "0xadd9d957170DF6f33982001E4C22eCcDd5539118",
+    "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "chain": "polygon",
     "method": "isValidPolicy",
     "parameters": [
@@ -12,7 +12,7 @@
     }
   },
   "ERC1155_balance": {
-    "contractAddress": "0xadd9d957170DF6f33982001E4C22eCcDd5539118",
+    "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC1155",
     "chain": "ethereum",
     "method": "balanceOf",
@@ -26,7 +26,7 @@
     }
   },
   "ERC1155_balance_batch": {
-    "contractAddress": "0xadd9d957170DF6f33982001E4C22eCcDd5539118",
+    "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC1155",
     "chain": "ethereum",
     "method": "balanceOfBatch",
@@ -40,7 +40,7 @@
     }
   },
   "ERC721_ownership":   {
-    "contractAddress": "0xadd9d957170DF6f33982001E4C22eCcDd5539118",
+    "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC721",
     "chain":  "ethereum",
     "method": "ownerOf",
@@ -53,7 +53,7 @@
     }
   },
   "ERC721_ownership_batch":   {
-    "contractAddress": "0xadd9d957170DF6f33982001E4C22eCcDd5539118",
+    "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC721",
     "chain":  "ethereum",
     "method": "balanceOf",
@@ -66,7 +66,7 @@
     }
   },
   "ERC20_balance":   {
-    "contractAddress": "0xadd9d957170DF6f33982001E4C22eCcDd5539118",
+    "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC20",
     "chain":  "ethereum",
     "method": "balanceOf",
@@ -102,7 +102,7 @@
     ],
     "returnValueTest": {
       "comparator": "=",
-      "value": "0xadd9d957170DF6f33982001E4C22eCcDd5539118"
+      "value": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118"
     }
   },
   "timestamp":   {

--- a/tests/unit/conditions/conftest.py
+++ b/tests/unit/conditions/conftest.py
@@ -78,11 +78,11 @@ def rpc_condition():
 @pytest.fixture
 def evm_condition(test_registry):
     condition = ContractCondition(
-        contract_address='0xadd9d957170DF6f33982001E4C22eCcDd5539118',
-        method='balanceOf',
-        standard_contract_type='ERC20',
-        chain='testerchain',
-        return_value_test=ReturnValueTest('==', 0),
+        contract_address="0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
+        method="balanceOf",
+        standard_contract_type="ERC20",
+        chain="testerchain",
+        return_value_test=ReturnValueTest("==", 0),
         parameters=[
             ':userAddress',
         ]
@@ -92,9 +92,9 @@ def evm_condition(test_registry):
 @pytest.fixture
 def sm_condition(test_registry):
     condition = ContractCondition(
-        contract_address='0xadd9d957170DF6f33982001E4C22eCcDd5539118',
-        method='getPolicy',
-        chain='testerchain',
+        contract_address="0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
+        method="getPolicy",
+        chain="testerchain",
         function_abi=ABI,
         return_value_test=ReturnValueTest('!=', None),
         parameters=[

--- a/tests/unit/conditions/test_evm_condition_serializers.py
+++ b/tests/unit/conditions/test_evm_condition_serializers.py
@@ -26,7 +26,12 @@ def test_evm_condition_json_serializers(ERC1155_balance_condition_data):
     original_data = ERC1155_balance_condition_data
     condition = ContractCondition.from_json(original_data)
     serialized_data = condition.to_json()
-    # assert json.loads(original_data) == json.loads(serialized_data)
+
+    # TODO functionAbi is present in serialized data
+    deserialized_data = json.loads(serialized_data)
+    deserialized_data.pop("functionAbi")
+
+    assert json.loads(original_data) == deserialized_data
 
 
 def test_type_resolution_from_json(timelock_condition, rpc_condition, evm_condition):


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Handle injection of context variable value into condition. Initially starting with `:userAddress` without any signature validation - simply obtain the address from the information provided in the `context`.

**Issues fixed/closed:**
Related to https://github.com/nucypher/tdec/issues/39.

**Why it's needed:**
Allows for simple evaluation of conditions that use the `:userAddress` context variable, and require the user address to be provided dynamically i.e. as part of the `context`.

**Notes for reviewers:**