### PR TITLE
Support for nucypher-core v0.4.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=3.4"
 lmdb = "*"
-nucypher-core = "==0.4.0a0"
+nucypher-core = ">=0.4.0"
 # Cryptography
 pyopenssl = "*"
 cryptography = ">=3.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "db35791bc81a734ff80dc7903078f95d93308e703e8dbec8c0f0e6689f9c4dd1"
+            "sha256": "6f95e43da72ec7695f58fcda6c27ef121781c0becd88be8c2d76b7e9d6b814fd"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,81 +18,96 @@
     "default": {
         "aiohttp": {
             "hashes": [
-                "sha256:01d7bdb774a9acc838e6b8f1d114f45303841b89b95984cbb7d80ea41172a9e3",
-                "sha256:03a6d5349c9ee8f79ab3ff3694d6ce1cfc3ced1c9d36200cb8f08ba06bd3b782",
-                "sha256:04d48b8ce6ab3cf2097b1855e1505181bdd05586ca275f2505514a6e274e8e75",
-                "sha256:0770e2806a30e744b4e21c9d73b7bee18a1cfa3c47991ee2e5a65b887c49d5cf",
-                "sha256:07b05cd3305e8a73112103c834e91cd27ce5b4bd07850c4b4dbd1877d3f45be7",
-                "sha256:086f92daf51a032d062ec5f58af5ca6a44d082c35299c96376a41cbb33034675",
-                "sha256:099ebd2c37ac74cce10a3527d2b49af80243e2a4fa39e7bce41617fbc35fa3c1",
-                "sha256:0c7ebbbde809ff4e970824b2b6cb7e4222be6b95a296e46c03cf050878fc1785",
-                "sha256:102e487eeb82afac440581e5d7f8f44560b36cf0bdd11abc51a46c1cd88914d4",
-                "sha256:11691cf4dc5b94236ccc609b70fec991234e7ef8d4c02dd0c9668d1e486f5abf",
-                "sha256:11a67c0d562e07067c4e86bffc1553f2cf5b664d6111c894671b2b8712f3aba5",
-                "sha256:12de6add4038df8f72fac606dff775791a60f113a725c960f2bab01d8b8e6b15",
-                "sha256:13487abd2f761d4be7c8ff9080de2671e53fff69711d46de703c310c4c9317ca",
-                "sha256:15b09b06dae900777833fe7fc4b4aa426556ce95847a3e8d7548e2d19e34edb8",
-                "sha256:1c182cb873bc91b411e184dab7a2b664d4fea2743df0e4d57402f7f3fa644bac",
-                "sha256:1ed0b6477896559f17b9eaeb6d38e07f7f9ffe40b9f0f9627ae8b9926ae260a8",
-                "sha256:28d490af82bc6b7ce53ff31337a18a10498303fe66f701ab65ef27e143c3b0ef",
-                "sha256:2e5d962cf7e1d426aa0e528a7e198658cdc8aa4fe87f781d039ad75dcd52c516",
-                "sha256:2ed076098b171573161eb146afcb9129b5ff63308960aeca4b676d9d3c35e700",
-                "sha256:2f2f69dca064926e79997f45b2f34e202b320fd3782f17a91941f7eb85502ee2",
-                "sha256:31560d268ff62143e92423ef183680b9829b1b482c011713ae941997921eebc8",
-                "sha256:31d1e1c0dbf19ebccbfd62eff461518dcb1e307b195e93bba60c965a4dcf1ba0",
-                "sha256:37951ad2f4a6df6506750a23f7cbabad24c73c65f23f72e95897bb2cecbae676",
-                "sha256:3af642b43ce56c24d063325dd2cf20ee012d2b9ba4c3c008755a301aaea720ad",
-                "sha256:44db35a9e15d6fe5c40d74952e803b1d96e964f683b5a78c3cc64eb177878155",
-                "sha256:473d93d4450880fe278696549f2e7aed8cd23708c3c1997981464475f32137db",
-                "sha256:477c3ea0ba410b2b56b7efb072c36fa91b1e6fc331761798fa3f28bb224830dd",
-                "sha256:4a4a4e30bf1edcad13fb0804300557aedd07a92cabc74382fdd0ba6ca2661091",
-                "sha256:4aed991a28ea3ce320dc8ce655875e1e00a11bdd29fe9444dd4f88c30d558602",
-                "sha256:51467000f3647d519272392f484126aa716f747859794ac9924a7aafa86cd411",
-                "sha256:55c3d1072704d27401c92339144d199d9de7b52627f724a949fc7d5fc56d8b93",
-                "sha256:589c72667a5febd36f1315aa6e5f56dd4aa4862df295cb51c769d16142ddd7cd",
-                "sha256:5bfde62d1d2641a1f5173b8c8c2d96ceb4854f54a44c23102e2ccc7e02f003ec",
-                "sha256:5c23b1ad869653bc818e972b7a3a79852d0e494e9ab7e1a701a3decc49c20d51",
-                "sha256:61bfc23df345d8c9716d03717c2ed5e27374e0fe6f659ea64edcd27b4b044cf7",
-                "sha256:6ae828d3a003f03ae31915c31fa684b9890ea44c9c989056fea96e3d12a9fa17",
-                "sha256:6c7cefb4b0640703eb1069835c02486669312bf2f12b48a748e0a7756d0de33d",
-                "sha256:6d69f36d445c45cda7b3b26afef2fc34ef5ac0cdc75584a87ef307ee3c8c6d00",
-                "sha256:6f0d5f33feb5f69ddd57a4a4bd3d56c719a141080b445cbf18f238973c5c9923",
-                "sha256:6f8b01295e26c68b3a1b90efb7a89029110d3a4139270b24fda961893216c440",
-                "sha256:713ac174a629d39b7c6a3aa757b337599798da4c1157114a314e4e391cd28e32",
-                "sha256:718626a174e7e467f0558954f94af117b7d4695d48eb980146016afa4b580b2e",
-                "sha256:7187a76598bdb895af0adbd2fb7474d7f6025d170bc0a1130242da817ce9e7d1",
-                "sha256:71927042ed6365a09a98a6377501af5c9f0a4d38083652bcd2281a06a5976724",
-                "sha256:7d08744e9bae2ca9c382581f7dce1273fe3c9bae94ff572c3626e8da5b193c6a",
-                "sha256:7dadf3c307b31e0e61689cbf9e06be7a867c563d5a63ce9dca578f956609abf8",
-                "sha256:81e3d8c34c623ca4e36c46524a3530e99c0bc95ed068fd6e9b55cb721d408fb2",
-                "sha256:844a9b460871ee0a0b0b68a64890dae9c415e513db0f4a7e3cab41a0f2fedf33",
-                "sha256:8b7ef7cbd4fec9a1e811a5de813311ed4f7ac7d93e0fda233c9b3e1428f7dd7b",
-                "sha256:97ef77eb6b044134c0b3a96e16abcb05ecce892965a2124c566af0fd60f717e2",
-                "sha256:99b5eeae8e019e7aad8af8bb314fb908dd2e028b3cdaad87ec05095394cce632",
-                "sha256:a25fa703a527158aaf10dafd956f7d42ac6d30ec80e9a70846253dd13e2f067b",
-                "sha256:a2f635ce61a89c5732537a7896b6319a8fcfa23ba09bec36e1b1ac0ab31270d2",
-                "sha256:a79004bb58748f31ae1cbe9fa891054baaa46fb106c2dc7af9f8e3304dc30316",
-                "sha256:a996d01ca39b8dfe77440f3cd600825d05841088fd6bc0144cc6c2ec14cc5f74",
-                "sha256:b0e20cddbd676ab8a64c774fefa0ad787cc506afd844de95da56060348021e96",
-                "sha256:b6613280ccedf24354406caf785db748bebbddcf31408b20c0b48cb86af76866",
-                "sha256:b9d00268fcb9f66fbcc7cd9fe423741d90c75ee029a1d15c09b22d23253c0a44",
-                "sha256:bb01ba6b0d3f6c68b89fce7305080145d4877ad3acaed424bae4d4ee75faa950",
-                "sha256:c2aef4703f1f2ddc6df17519885dbfa3514929149d3ff900b73f45998f2532fa",
-                "sha256:c34dc4958b232ef6188c4318cb7b2c2d80521c9a56c52449f8f93ab7bc2a8a1c",
-                "sha256:c3630c3ef435c0a7c549ba170a0633a56e92629aeed0e707fec832dee313fb7a",
-                "sha256:c3d6a4d0619e09dcd61021debf7059955c2004fa29f48788a3dfaf9c9901a7cd",
-                "sha256:d15367ce87c8e9e09b0f989bfd72dc641bcd04ba091c68cd305312d00962addd",
-                "sha256:d2f9b69293c33aaa53d923032fe227feac867f81682f002ce33ffae978f0a9a9",
-                "sha256:e999f2d0e12eea01caeecb17b653f3713d758f6dcc770417cf29ef08d3931421",
-                "sha256:ea302f34477fda3f85560a06d9ebdc7fa41e82420e892fc50b577e35fc6a50b2",
-                "sha256:eaba923151d9deea315be1f3e2b31cc39a6d1d2f682f942905951f4e40200922",
-                "sha256:ef9612483cb35171d51d9173647eed5d0069eaa2ee812793a75373447d487aa4",
-                "sha256:f5315a2eb0239185af1bddb1abf472d877fede3cc8d143c6cddad37678293237",
-                "sha256:fa0ffcace9b3aa34d205d8130f7873fcfefcb6a4dd3dd705b0dab69af6712642",
-                "sha256:fc5471e1a54de15ef71c1bc6ebe80d4dc681ea600e68bfd1cbce40427f0b7578"
+                "sha256:02f9a2c72fc95d59b881cf38a4b2be9381b9527f9d328771e90f72ac76f31ad8",
+                "sha256:059a91e88f2c00fe40aed9031b3606c3f311414f86a90d696dd982e7aec48142",
+                "sha256:05a3c31c6d7cd08c149e50dc7aa2568317f5844acd745621983380597f027a18",
+                "sha256:08c78317e950e0762c2983f4dd58dc5e6c9ff75c8a0efeae299d363d439c8e34",
+                "sha256:09e28f572b21642128ef31f4e8372adb6888846f32fecb288c8b0457597ba61a",
+                "sha256:0d2c6d8c6872df4a6ec37d2ede71eff62395b9e337b4e18efd2177de883a5033",
+                "sha256:16c121ba0b1ec2b44b73e3a8a171c4f999b33929cd2397124a8c7fcfc8cd9e06",
+                "sha256:1d90043c1882067f1bd26196d5d2db9aa6d268def3293ed5fb317e13c9413ea4",
+                "sha256:1e56b9cafcd6531bab5d9b2e890bb4937f4165109fe98e2b98ef0dcfcb06ee9d",
+                "sha256:20acae4f268317bb975671e375493dbdbc67cddb5f6c71eebdb85b34444ac46b",
+                "sha256:21b30885a63c3f4ff5b77a5d6caf008b037cb521a5f33eab445dc566f6d092cc",
+                "sha256:21d69797eb951f155026651f7e9362877334508d39c2fc37bd04ff55b2007091",
+                "sha256:256deb4b29fe5e47893fa32e1de2d73c3afe7407738bd3c63829874661d4822d",
+                "sha256:25892c92bee6d9449ffac82c2fe257f3a6f297792cdb18ad784737d61e7a9a85",
+                "sha256:2ca9af5f8f5812d475c5259393f52d712f6d5f0d7fdad9acdb1107dd9e3cb7eb",
+                "sha256:2d252771fc85e0cf8da0b823157962d70639e63cb9b578b1dec9868dd1f4f937",
+                "sha256:2dea10edfa1a54098703cb7acaa665c07b4e7568472a47f4e64e6319d3821ccf",
+                "sha256:2df5f139233060578d8c2c975128fb231a89ca0a462b35d4b5fcf7c501ebdbe1",
+                "sha256:2feebbb6074cdbd1ac276dbd737b40e890a1361b3cc30b74ac2f5e24aab41f7b",
+                "sha256:309aa21c1d54b8ef0723181d430347d7452daaff93e8e2363db8e75c72c2fb2d",
+                "sha256:3828fb41b7203176b82fe5d699e0d845435f2374750a44b480ea6b930f6be269",
+                "sha256:398701865e7a9565d49189f6c90868efaca21be65c725fc87fc305906be915da",
+                "sha256:43046a319664a04b146f81b40e1545d4c8ac7b7dd04c47e40bf09f65f2437346",
+                "sha256:437399385f2abcd634865705bdc180c8314124b98299d54fe1d4c8990f2f9494",
+                "sha256:45d88b016c849d74ebc6f2b6e8bc17cabf26e7e40c0661ddd8fae4c00f015697",
+                "sha256:47841407cc89a4b80b0c52276f3cc8138bbbfba4b179ee3acbd7d77ae33f7ac4",
+                "sha256:4a4fbc769ea9b6bd97f4ad0b430a6807f92f0e5eb020f1e42ece59f3ecfc4585",
+                "sha256:4ab94426ddb1ecc6a0b601d832d5d9d421820989b8caa929114811369673235c",
+                "sha256:4b0f30372cef3fdc262f33d06e7b411cd59058ce9174ef159ad938c4a34a89da",
+                "sha256:4e3a23ec214e95c9fe85a58470b660efe6534b83e6cbe38b3ed52b053d7cb6ad",
+                "sha256:512bd5ab136b8dc0ffe3fdf2dfb0c4b4f49c8577f6cae55dca862cd37a4564e2",
+                "sha256:527b3b87b24844ea7865284aabfab08eb0faf599b385b03c2aa91fc6edd6e4b6",
+                "sha256:54d107c89a3ebcd13228278d68f1436d3f33f2dd2af5415e3feaeb1156e1a62c",
+                "sha256:5835f258ca9f7c455493a57ee707b76d2d9634d84d5d7f62e77be984ea80b849",
+                "sha256:598adde339d2cf7d67beaccda3f2ce7c57b3b412702f29c946708f69cf8222aa",
+                "sha256:599418aaaf88a6d02a8c515e656f6faf3d10618d3dd95866eb4436520096c84b",
+                "sha256:5bf651afd22d5f0c4be16cf39d0482ea494f5c88f03e75e5fef3a85177fecdeb",
+                "sha256:5c59fcd80b9049b49acd29bd3598cada4afc8d8d69bd4160cd613246912535d7",
+                "sha256:653acc3880459f82a65e27bd6526e47ddf19e643457d36a2250b85b41a564715",
+                "sha256:66bd5f950344fb2b3dbdd421aaa4e84f4411a1a13fca3aeb2bcbe667f80c9f76",
+                "sha256:6f3553510abdbec67c043ca85727396ceed1272eef029b050677046d3387be8d",
+                "sha256:7018ecc5fe97027214556afbc7c502fbd718d0740e87eb1217b17efd05b3d276",
+                "sha256:713d22cd9643ba9025d33c4af43943c7a1eb8547729228de18d3e02e278472b6",
+                "sha256:73a4131962e6d91109bca6536416aa067cf6c4efb871975df734f8d2fd821b37",
+                "sha256:75880ed07be39beff1881d81e4a907cafb802f306efd6d2d15f2b3c69935f6fb",
+                "sha256:75e14eac916f024305db517e00a9252714fce0abcb10ad327fb6dcdc0d060f1d",
+                "sha256:8135fa153a20d82ffb64f70a1b5c2738684afa197839b34cc3e3c72fa88d302c",
+                "sha256:84b14f36e85295fe69c6b9789b51a0903b774046d5f7df538176516c3e422446",
+                "sha256:86fc24e58ecb32aee09f864cb11bb91bc4c1086615001647dbfc4dc8c32f4008",
+                "sha256:87f44875f2804bc0511a69ce44a9595d5944837a62caecc8490bbdb0e18b1342",
+                "sha256:88c70ed9da9963d5496d38320160e8eb7e5f1886f9290475a881db12f351ab5d",
+                "sha256:88e5be56c231981428f4f506c68b6a46fa25c4123a2e86d156c58a8369d31ab7",
+                "sha256:89d2e02167fa95172c017732ed7725bc8523c598757f08d13c5acca308e1a061",
+                "sha256:8d6aaa4e7155afaf994d7924eb290abbe81a6905b303d8cb61310a2aba1c68ba",
+                "sha256:92a2964319d359f494f16011e23434f6f8ef0434acd3cf154a6b7bec511e2fb7",
+                "sha256:96372fc29471646b9b106ee918c8eeb4cca423fcbf9a34daa1b93767a88a2290",
+                "sha256:978b046ca728073070e9abc074b6299ebf3501e8dee5e26efacb13cec2b2dea0",
+                "sha256:9c7149272fb5834fc186328e2c1fa01dda3e1fa940ce18fded6d412e8f2cf76d",
+                "sha256:a0239da9fbafd9ff82fd67c16704a7d1bccf0d107a300e790587ad05547681c8",
+                "sha256:ad5383a67514e8e76906a06741febd9126fc7c7ff0f599d6fcce3e82b80d026f",
+                "sha256:ad61a9639792fd790523ba072c0555cd6be5a0baf03a49a5dd8cfcf20d56df48",
+                "sha256:b29bfd650ed8e148f9c515474a6ef0ba1090b7a8faeee26b74a8ff3b33617502",
+                "sha256:b97decbb3372d4b69e4d4c8117f44632551c692bb1361b356a02b97b69e18a62",
+                "sha256:ba71c9b4dcbb16212f334126cc3d8beb6af377f6703d9dc2d9fb3874fd667ee9",
+                "sha256:c37c5cce780349d4d51739ae682dec63573847a2a8dcb44381b174c3d9c8d403",
+                "sha256:c971bf3786b5fad82ce5ad570dc6ee420f5b12527157929e830f51c55dc8af77",
+                "sha256:d1fde0f44029e02d02d3993ad55ce93ead9bb9b15c6b7ccd580f90bd7e3de476",
+                "sha256:d24b8bb40d5c61ef2d9b6a8f4528c2f17f1c5d2d31fed62ec860f6006142e83e",
+                "sha256:d5ba88df9aa5e2f806650fcbeedbe4f6e8736e92fc0e73b0400538fd25a4dd96",
+                "sha256:d6f76310355e9fae637c3162936e9504b4767d5c52ca268331e2756e54fd4ca5",
+                "sha256:d737fc67b9a970f3234754974531dc9afeea11c70791dcb7db53b0cf81b79784",
+                "sha256:da22885266bbfb3f78218dc40205fed2671909fbd0720aedba39b4515c038091",
+                "sha256:da37dcfbf4b7f45d80ee386a5f81122501ec75672f475da34784196690762f4b",
+                "sha256:db19d60d846283ee275d0416e2a23493f4e6b6028825b51290ac05afc87a6f97",
+                "sha256:db4c979b0b3e0fa7e9e69ecd11b2b3174c6963cebadeecfb7ad24532ffcdd11a",
+                "sha256:e164e0a98e92d06da343d17d4e9c4da4654f4a4588a20d6c73548a29f176abe2",
+                "sha256:e168a7560b7c61342ae0412997b069753f27ac4862ec7867eff74f0fe4ea2ad9",
+                "sha256:e381581b37db1db7597b62a2e6b8b57c3deec95d93b6d6407c5b61ddc98aca6d",
+                "sha256:e65bc19919c910127c06759a63747ebe14f386cda573d95bcc62b427ca1afc73",
+                "sha256:e7b8813be97cab8cb52b1375f41f8e6804f6507fe4660152e8ca5c48f0436017",
+                "sha256:e8a78079d9a39ca9ca99a8b0ac2fdc0c4d25fc80c8a8a82e5c8211509c523363",
+                "sha256:ebf909ea0a3fc9596e40d55d8000702a85e27fd578ff41a5500f68f20fd32e6c",
+                "sha256:ec40170327d4a404b0d91855d41bfe1fe4b699222b2b93e3d833a27330a87a6d",
+                "sha256:f178d2aadf0166be4df834c4953da2d7eef24719e8aec9a65289483eeea9d618",
+                "sha256:f88df3a83cf9df566f171adba39d5bd52814ac0b94778d2448652fc77f9eb491",
+                "sha256:f973157ffeab5459eefe7b97a804987876dd0a55570b8fa56b4e1954bf11329b",
+                "sha256:ff25f48fc8e623d95eca0670b8cc1469a83783c924a602e0fbd47363bb54aaca"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8.1"
+            "version": "==3.8.3"
         },
         "aiosignal": {
             "hashes": [
@@ -150,9 +165,80 @@
         },
         "bitarray": {
             "hashes": [
-                "sha256:27a69ffcee3b868abab3ce8b17c69e02b63e722d4d64ffd91d659f81e9984954"
+                "sha256:035d3e5ab3c1afa2cd88bbc33af595b4875a24b0d037dfef907b41bc4b0dbe2b",
+                "sha256:0399886ca8ead7d0f16f94545bda800467d6d9c63fbd4866ee7ede7981166ba8",
+                "sha256:049e8f017b5b6d1763ababa156ca5cbdea8a01e20a1e80525b0fbe9fb839d695",
+                "sha256:076a72531bcca99114036c3714bac8124f5529b60fb6a6986067c6f345238c76",
+                "sha256:0b756e5c771cdceb17622b6a0678fa78364e329d875de73a4f26bbacab8915a8",
+                "sha256:11996c4da9c1ca9f97143e939af75c5b24ad0fdc2fa13aeb0007ebfa3c602caf",
+                "sha256:119d503edf09bef37f2d0dc3b4a23c36c3c1e88e17701ab71388eb4780c046c7",
+                "sha256:12c96dedd6e4584fecc2bf5fbffe1c635bd516eee7ade7b839c35aeba84336b4",
+                "sha256:1479f533eaff4080078b6e5d06b467868bd6edd73bb6651a295bf662d40afa62",
+                "sha256:15d2a1c060a11fc5508715fef6177937614f9354dd3afe6a00e261775f8b0e8f",
+                "sha256:1d0a2d896bcbcb5f32f60571ebd48349ec322dee5e137b342483108c5cbd0f03",
+                "sha256:24331bd2f52cd5410e48c132f486ed02a4ca3b96133fb26e3a8f50a57c354be6",
+                "sha256:2cfe1661b614314d67e6884e5e19e36957ff6faea5fcea7f25840dff95288248",
+                "sha256:346d2c5452cc024c41d267ba99e48d38783c1706c50c4632a4484cc57b152d0e",
+                "sha256:36802129a3115023700c07725d981c74e23b0914551898f788e5a41aed2d63bf",
+                "sha256:3f238127789c993de937178c3ff836d0fad4f2da08af9f579668873ac1332a42",
+                "sha256:42a071c9db755f267e5d3b9909ea8c22fb071d27860dd940facfacffbde79de8",
+                "sha256:4d42fee0add2114e572b0cd6edefc4c52207874f58b70043f82faa8bb7141620",
+                "sha256:4ffc076a0e22cda949ccd062f37ecc3dc53856c6e8bdfe07e1e81c411cf31621",
+                "sha256:5276c7247d350819d1dae385d8f78ebfb44ee90ff11a775f981d45cb366573e5",
+                "sha256:565c4334cb410f5eb62280dcfb3a52629e60ce430f31dfa4bbef92ec80de4890",
+                "sha256:56d3f16dd807b1c56732a244ce071c135ee973d3edc9929418c1b24c5439a0fd",
+                "sha256:5a0bb91363041b45523e5bcbc4153a5e1eb1ddb21e46fe1910340c0d095e1a8e",
+                "sha256:5bd315ac63b62de5eefbfa07969162ffbda8e535c3b7b3d41b565d2a88817b71",
+                "sha256:5f5df0377f3e7f1366e506c5295f08d3f8761e4a6381918931fc1d9594aa435e",
+                "sha256:6071d12043300e50a4b7ba9caeeca92aac567bb4ac4a227709e3c77a3d788587",
+                "sha256:67c5822f4bb6a419bc2f2dba9fa07b5646f0cda930bafa9e1130af6822e4bdf3",
+                "sha256:6c3d0a4a6061adc3d3128e1e1146940d17df8cbfe3d77cb66a1df69ddcdf27d5",
+                "sha256:6c46c2ba24a517f391c3ab9e7a214185f95146d0b664b4b0463ab31e5387669f",
+                "sha256:6d8ba8065d1b60da24d94078249cbf24a02d869d7dc9eba12db1fb513a375c79",
+                "sha256:6fa63a86aad0f45a27c7c5a27cd9b787fe9b1aed431f97f49ee8b834fa0780a0",
+                "sha256:7126563c86f6b60d87414124f035ff0d29de02ad9e46ea085de2c772b0be1331",
+                "sha256:71cc3d1da4f682f27728745f21ed3447ee8f6a0019932126c422dd91278eb414",
+                "sha256:742d43cbbc7267caae6379e2156a1fd8532332920a3d919b68c2982d439a98ba",
+                "sha256:763cac57692d07aa950b92c20f55ef66801955b71b4a1f4f48d5422d748c6dda",
+                "sha256:76c4e3261d6370383b02018cb964b5d9260e3c62dea31949910e9cc3a1c802d2",
+                "sha256:7ae3b8b48167579066a17c5ba1631d089f931f4eae8b4359ad123807d5e75c51",
+                "sha256:7f369872d551708d608e50a9ab8748d3d4f32a697dc5c2c37ff16cb8d7060210",
+                "sha256:874a222ece2100b3a3a8f08c57da3267a4e2219d26474a46937552992fcec771",
+                "sha256:878f16daa9c2062e4d29c1928b6f3eb50911726ad6d2006918a29ca6b38b5080",
+                "sha256:8c811e59c86ce0a8515daf47db9c2484fd42e51bdb44581d7bcc9caad6c9a7a1",
+                "sha256:97609495479c5214c7b57173c17206ebb056507a8d26eebc17942d62f8f25944",
+                "sha256:985a937218aa3d1ac7013174bfcbb1cb2f3157e17c6e349e83386f33459be1c0",
+                "sha256:a239313e75da37d1f6548d666d4dd8554c4a92dabed15741612855d186e86e72",
+                "sha256:b080eb25811db46306dfce58b4760df32f40bcf5551ebba3b7c8d3ec90d9b988",
+                "sha256:b0cfca1b5a57b540f4761b57de485196218733153c430d58f9e048e325c98b47",
+                "sha256:b0e4a6f5360e5f6c3a2b250c9e9cd539a9aabf0465dbedbaf364203e74ff101b",
+                "sha256:b849a6cdd46608e7cc108c75e1265304e79488480a822bae7471e628f971a6f0",
+                "sha256:bfda0af4072df6e932ec510b72c461e1ec0ad0820a76df588cdfebf5a07f5b5d",
+                "sha256:c19e900b6f9df13c7f406f827c5643f83c0839a58d007b35a4d7df827601f740",
+                "sha256:c24d4a1b5baa46920b801aa55c0e0a640c6e7683a73a941302e102e2bd11a830",
+                "sha256:c774328057a4b1fc48bee2dd5a60ee1e8e0ec112d29c4e6b9c550e1686b6db5c",
+                "sha256:d34673ebaf562347d004a465e16e2930c6568d196bb79d67fc6358f1213a1ac7",
+                "sha256:d523ffef1927cb686ad787b25b2e98a5bd53e3c40673c394f07bf9b281e69796",
+                "sha256:d53520b54206d8569b81eee56ccd9477af2f1b3ca355df9c48ee615a11e1a637",
+                "sha256:d697cc38cb6fa9bae3b994dd3ce68552ffe69c453a3b6fd6a4f94bb8a8bfd70b",
+                "sha256:d7bec01818c3a9d185f929cd36a82cc7acf13905920f7f595942105c5eef2300",
+                "sha256:e6a4a4bf6fbc42b2674023ca58a47c86ee55c023a8af85420f266e86b10e7065",
+                "sha256:e6bd32e492cdc740ec36b6725457685c9f2aa012dd8cbdae1643fed2b6821895",
+                "sha256:e76642232db8330589ed1ac1cec0e9c3814c708521c336a5c79d39a5d8d8c206",
+                "sha256:e7ba4c964a36fe198a8c4b5d08924709d4ed0337b65ae222b6503ed3442a46e8",
+                "sha256:ec18a0b97ea6b912ea57dc00a3f8f3ce515d774d00951d30e2ae243589d3d021",
+                "sha256:ecce266e24b21615a3ed234869be84bef492f6a34bb650d0e25dc3662c59bce4",
+                "sha256:f0302605b3bbc439083a400cf57d7464f1ac098c722309a03abaa7d97cd420b5",
+                "sha256:f253b9bdf5abd039741a9594a681453c973b09dcb7edac9105961838675b7c6b",
+                "sha256:f263b18fdb8bf42cd7cf9849d5863847d215024c68fe74cf33bcd82641d4376a",
+                "sha256:f37b5282b029d9f51454f8c580eb6a24e5dc140ef5866290afb20e607d2dce5f",
+                "sha256:f4849709571b1a53669798d23cc8430e677dcf0eea88610a0412e1911233899a",
+                "sha256:f853589426920d9bb3683f6b6cd11ce48d9d06a62c0b98ea4b82ebd8db3bddec",
+                "sha256:f9c492644f70f80f8266748c18309a0d73c22c47903f4b62f3fb772a15a8fd5f",
+                "sha256:fc635b27939969d53cac53e8b8f860ea69fc98cc9867cac17dd193f41dc2a57f",
+                "sha256:febaf00e498230ce2e75dac910056f0e3a91c8631b7ceb6385bb39d448960bc5"
             ],
-            "version": "==1.2.2"
+            "version": "==2.6.0"
         },
         "bytestring-splitter": {
             "hashes": [
@@ -171,11 +257,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
-                "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.14"
+            "version": "==2022.9.24"
         },
         "cffi": {
             "hashes": [
@@ -447,11 +533,11 @@
         },
         "eth-account": {
             "hashes": [
-                "sha256:54b0b7d661e73f4cd12d508c9baa5c9a6e8c194aa7bafc39277cd673683ae50e",
-                "sha256:71898127a808d75127a68fa4193aba967489eaf6e62cee1e2e8b08582d01cba8"
+                "sha256:61360e9e514e09e49929ed365ca0e1656758ecbd11248c629ad85b4335c2661a",
+                "sha256:f4d339f031348ba4de2bdd1fa9872019183a7252117f65b6e8019961d5c09ca8"
             ],
             "markers": "python_version >= '3.6' and python_version < '4'",
-            "version": "==0.6.1"
+            "version": "==0.7.0"
         },
         "eth-bloom": {
             "hashes": [
@@ -462,9 +548,6 @@
             "version": "==1.0.4"
         },
         "eth-hash": {
-            "extras": [
-                "pycryptodome"
-            ],
             "hashes": [
                 "sha256:3c884e4f788b38cc92cff05c4e43bc6b82686066f04ecfae0e11cdcbe5a283bd",
                 "sha256:8cde211519ff1a98b46e9057cb909f12ab62e263eb30a0a94e2f7e1f46ac67a0"
@@ -601,19 +684,19 @@
         },
         "hexbytes": {
             "hashes": [
-                "sha256:199daa356aeb14879ee9c43de637acaaa1409febf15151a0e3dbcf1f8df128c0",
-                "sha256:1b33a3f101084763551e0094dbf35104868dfa82ba48787a1ca77f81ce15a44c"
+                "sha256:21c3a5bd00a383097f0369c387174e79839d75c4ccc3a7edda315c9644f4458a",
+                "sha256:afeebfb800f5f15a3ca5bab52e49eabcb4b6dac06ec8ff01a94fdb890c6c0712"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
-            "version": "==0.2.3"
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==0.3.0"
         },
         "humanize": {
             "hashes": [
-                "sha256:0dfac79fe8c1c0c734c14177b07b857bad9ae30dd50daa0a14e2c3d8054ee0c4",
-                "sha256:5dd159c9910cd57b94072e4d7decae097f0eb84c4645153706929a7f127cb2ef"
+                "sha256:8830ebf2d65d0395c1bd4c79189ad71e023f277c2c7ae00f263124432e6f2ffa",
+                "sha256:efb2584565cc86b7ea87a977a15066de34cdedaf341b11c851cfcfd2b964779c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.3.0"
+            "version": "==4.4.0"
         },
         "hyperlink": {
             "hashes": [
@@ -629,14 +712,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
-        },
-        "importlib-metadata": {
-            "hashes": [
-                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
-            ],
-            "markers": "python_version < '3.10'",
-            "version": "==4.12.0"
         },
         "incremental": {
             "hashes": [
@@ -774,11 +849,11 @@
         },
         "mako": {
             "hashes": [
-                "sha256:3724869b363ba630a272a5f89f68c070352137b8fd1757650017b7e06fda163f",
-                "sha256:8efcb8004681b5f71d09c983ad5a9e6f5c40601a6ec469148753292abc0da534"
+                "sha256:7fde96466fcfeedb0eed94f187f20b23d85e4cb41444be0e542e2c8c65c396cd",
+                "sha256:c413a086e38cd885088d5e165305ee8eed04e8b3f8f62df343480da0a385735f"
             ],
             "index": "pypi",
-            "version": "==1.2.2"
+            "version": "==1.2.3"
         },
         "markupsafe": {
             "hashes": [
@@ -828,11 +903,11 @@
         },
         "marshmallow": {
             "hashes": [
-                "sha256:1172ce82765bf26c24a3f9299ed6dbeeca4d213f638eaa39a37772656d7ce408",
-                "sha256:48e2d88d4ab431ad5a17c25556d9da529ea6e966876f2a38d274082e270287f0"
+                "sha256:35e02a3a06899c9119b785c12a22f4cda361745d66a71ab691fd7610202ae104",
+                "sha256:6804c16114f7fce1f5b4dadc31f4674af23317fcc7f075da21e35c1a35d781f7"
             ],
             "index": "pypi",
-            "version": "==3.17.1"
+            "version": "==3.18.0"
         },
         "maya": {
             "hashes": [
@@ -1003,25 +1078,25 @@
         },
         "nucypher-core": {
             "hashes": [
-                "sha256:0c1b8d8c018b51c7c201de070981c47e3ff4a969d86128eef204d50002165c51",
-                "sha256:1830133a5641e4c87203ca9e07c2c6acd162a2f7e4512da5780d9f22f4f9964c",
-                "sha256:1844da5bba3a32bfc6fb5b2219a66287a4a4c373dd7302efb073f6697e608b70",
-                "sha256:19d97226fc0e0e1eb25cdb7fd5d6c386200af3c3b5255089be7d262abf8c2ca0",
-                "sha256:30f88179dbd65d81027098a27df43f78b70c348d246e312e2375c5bc11c1bbcf",
-                "sha256:50c15e0536ca67829ae35d065e1076bd5993cc24a767449e56a12b6fc7275bff",
-                "sha256:6d6bb6047174c28e902e7a84141513f9d4d186799782bd7b438ea4b032f0bef7",
-                "sha256:78663fbe5d5d2cd174424300111efeffd0aad95dc1424c8d78efe85c0da96a36",
-                "sha256:846ea072bacd184044806c6b12587cda3ab22c798e3d9bbf5c50dc51a4dc1dff",
-                "sha256:95cd46e6e1106eb6a93ecc6057f6c62d933fc5286bb344844c5ed12fa407efe0",
-                "sha256:ac77848799fcf42688544aaf29482e795d7dbcecc073160e7c58c8705ba246cd",
-                "sha256:b598807da8921d3ae0e5ababd9ae80a264b84eb1cc29b86ef94f6137cac68748",
-                "sha256:b8ecd6cf3bc7ae5adec437180cbce0b1cb266b42cc42801c6a61acc580efd121",
-                "sha256:b9f6423993a62ee82b2033c8c1198adb1459d6bc89e2262dd87f235fa1064749",
-                "sha256:d1701fec8d3e92b1bc4a841085c225fdc391b589eab9ed9ed7759b9285c15fbb",
-                "sha256:fcc97986d99168cb9ef18e3dd1c592585877899961737b1ef0e56acd895969e7"
+                "sha256:1a66605916ec07e2be97cddba6808361842528d5a29099bc94fb963ca43adf37",
+                "sha256:2348f8b4bdf6f7dbacc0b5a5430163f2294a575684a631d47dc231d6c09c862d",
+                "sha256:267b7661196eb16b973f605627455b0d8576c1283a85ea22efb608408e73175a",
+                "sha256:54d57f5cec7697f33520c12f13fd93de3568a5e2db9bed12b7b02cf8803fb33a",
+                "sha256:8e4de24253c6f3aa63729a04ece89f5b182b3b03d7c71bcc2cf9b310f5b0d2c2",
+                "sha256:961d66d68e64d1ea3267fb43884fdc3acf36ebab11185e66cda56c0ec9056ebf",
+                "sha256:9f03f22571d6e918f4f29cf7b50db09c53bce5c8a6165219c10bd9df6424481c",
+                "sha256:a4683afad8f941f65ea979fd03533e4381ce093e41d1c10ec54d94e6f54a4393",
+                "sha256:bfde47c2598359f32880b00e3226cfad7a031e1e281b4292dddcde93dd8e0fda",
+                "sha256:d149cbf36d4ab184b896d761507de5f0b71eab62ce4a4a0f75a4bd38540611ff",
+                "sha256:dcca694fc755da940da7e04d2ce4a66234617c5314fb3b94c129d2f5eedf0138",
+                "sha256:e3991c6e4c97020ff2f8383c79e74227507064ceece09d0c5442e9759b80bf5b",
+                "sha256:f17f733df7414514f657fa3b585e5e3a903038abb592528f9b781d02e937fc14",
+                "sha256:f39085a9024b3f93fabd51e4e72e828b5e41dfc427e3d41770e8dd7a59b23977",
+                "sha256:f45a2ca0ad3734fa1208f65e2ec864ab39361faa94bfc40813f234e9c09da177",
+                "sha256:f74e8660c27216b16fe4bb8b1298688e0eece74d2334d42c20ecc8a81855fb50"
             ],
             "index": "pypi",
-            "version": "==0.4.0a0"
+            "version": "==0.4.0"
         },
         "packaging": {
             "hashes": [
@@ -1130,32 +1205,33 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:03d76b7bd42ac4a6e109742a4edf81ffe26ffd87c5993126d894fe48a120396a",
-                "sha256:09e25909c4297d71d97612f04f41cea8fa8510096864f2835ad2f3b3df5a5559",
-                "sha256:18e34a10ae10d458b027d7638a599c964b030c1739ebd035a1dfc0e22baa3bfe",
-                "sha256:291fb4307094bf5ccc29f424b42268640e00d5240bf0d9b86bf3079f7576474d",
-                "sha256:2c0b040d0b5d5d207936ca2d02f00f765906622c07d3fa19c23a16a8ca71873f",
-                "sha256:384164994727f274cc34b8abd41a9e7e0562801361ee77437099ff6dfedd024b",
-                "sha256:3cb608e5a0eb61b8e00fe641d9f0282cd0eedb603be372f91f163cbfbca0ded0",
-                "sha256:5d9402bf27d11e37801d1743eada54372f986a372ec9679673bfcc5c60441151",
-                "sha256:712dca319eee507a1e7df3591e639a2b112a2f4a62d40fe7832a16fd19151750",
-                "sha256:7a5037af4e76c975b88c3becdf53922b5ffa3f2cddf657574a4920a3b33b80f3",
-                "sha256:8228e56a865c27163d5d1d1771d94b98194aa6917bcfb6ce139cbfa8e3c27334",
-                "sha256:84a1544252a933ef07bb0b5ef13afe7c36232a774affa673fc3636f7cee1db6c",
-                "sha256:84fe5953b18a383fd4495d375fe16e1e55e0a3afe7b4f7b4d01a3a0649fcda9d",
-                "sha256:9c673c8bfdf52f903081816b9e0e612186684f4eb4c17eeb729133022d6032e3",
-                "sha256:9f876a69ca55aed879b43c295a328970306e8e80a263ec91cf6e9189243c613b",
-                "sha256:a9e5ae5a8e8985c67e8944c23035a0dff2c26b0f5070b2f55b217a1c33bbe8b1",
-                "sha256:b4fdb29c5a7406e3f7ef176b2a7079baa68b5b854f364c21abe327bbeec01cdb",
-                "sha256:c184485e0dfba4dfd451c3bd348c2e685d6523543a0f91b9fd4ae90eb09e8422",
-                "sha256:c9cdf251c582c16fd6a9f5e95836c90828d51b0069ad22f463761d27c6c19019",
-                "sha256:e39cf61bb8582bda88cdfebc0db163b774e7e03364bbf9ce1ead13863e81e359",
-                "sha256:e8fbc522303e09036c752a0afcc5c0603e917222d8bedc02813fd73b4b4ed804",
-                "sha256:f34464ab1207114e73bba0794d1257c150a2b89b7a9faf504e00af7c9fd58978",
-                "sha256:f52dabc96ca99ebd2169dadbe018824ebda08a795c7684a0b7d203a290f3adb0"
+                "sha256:06059eb6953ff01e56a25cd02cca1a9649a75a7e65397b5b9b4e929ed71d10cf",
+                "sha256:097c5d8a9808302fb0da7e20edf0b8d4703274d140fd25c5edabddcde43e081f",
+                "sha256:284f86a6207c897542d7e956eb243a36bb8f9564c1742b253462386e96c6b78f",
+                "sha256:32ca378605b41fd180dfe4e14d3226386d8d1b002ab31c969c366549e66a2bb7",
+                "sha256:3cc797c9d15d7689ed507b165cd05913acb992d78b379f6014e013f9ecb20996",
+                "sha256:62f1b5c4cd6c5402b4e2d63804ba49a327e0c386c99b1675c8a0fefda23b2067",
+                "sha256:69ccfdf3657ba59569c64295b7d51325f91af586f8d5793b734260dfe2e94e2c",
+                "sha256:6f50601512a3d23625d8a85b1638d914a0970f17920ff39cec63aaef80a93fb7",
+                "sha256:7403941f6d0992d40161aa8bb23e12575637008a5a02283a930addc0508982f9",
+                "sha256:755f3aee41354ae395e104d62119cb223339a8f3276a0cd009ffabfcdd46bb0c",
+                "sha256:77053d28427a29987ca9caf7b72ccafee011257561259faba8dd308fda9a8739",
+                "sha256:7e371f10abe57cee5021797126c93479f59fccc9693dafd6bd5633ab67808a91",
+                "sha256:9016d01c91e8e625141d24ec1b20fed584703e527d28512aa8c8707f105a683c",
+                "sha256:9be73ad47579abc26c12024239d3540e6b765182a91dbc88e23658ab71767153",
+                "sha256:adc31566d027f45efe3f44eeb5b1f329da43891634d61c75a5944e9be6dd42c9",
+                "sha256:adfc6cf69c7f8c50fd24c793964eef18f0ac321315439d94945820612849c388",
+                "sha256:af0ebadc74e281a517141daad9d0f2c5d93ab78e9d455113719a45a49da9db4e",
+                "sha256:cb29edb9eab15742d791e1025dd7b6a8f6fcb53802ad2f6e3adcb102051063ab",
+                "sha256:cd68be2559e2a3b84f517fb029ee611546f7812b1fdd0aa2ecc9bc6ec0e4fdde",
+                "sha256:cdee09140e1cd184ba9324ec1df410e7147242b94b5f8b0c64fc89e38a8ba531",
+                "sha256:db977c4ca738dd9ce508557d4fce0f5aebd105e158c725beec86feb1f6bc20d8",
+                "sha256:dd5789b2948ca702c17027c84c2accb552fc30f4622a98ab5c51fcfe8c50d3e7",
+                "sha256:e250a42f15bf9d5b09fe1b293bdba2801cd520a9f5ea2d7fb7536d4441811d20",
+                "sha256:ff8d8fa42675249bb456f5db06c00de6c2f4c27a065955917b28c4f15978b9c3"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.20.2"
+            "version": "==3.20.1"
         },
         "py-ecc": {
             "hashes": [
@@ -1175,39 +1251,19 @@
         },
         "pyasn1": {
             "hashes": [
-                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
-                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
-                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
-                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
-                "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
-                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
-                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
-                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
-                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
-                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
-                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
+                "sha256:760db2dafe04091b000af018c45dff6e3d7a204cd9341b760d72689217a611cc",
+                "sha256:8fcd953d1e34ef6db82a5296bb5ca3762ce4d17f2241c48ac0de2739b2e8fbf2"
             ],
-            "version": "==0.4.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==0.5.0rc2"
         },
         "pyasn1-modules": {
             "hashes": [
-                "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8",
-                "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199",
-                "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811",
-                "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed",
-                "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4",
-                "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e",
-                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74",
-                "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb",
-                "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45",
-                "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd",
-                "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0",
-                "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d",
-                "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
+                "sha256:933b5e50f8070918cb181185a1bdea97e2ea7d4fc353dbe8e501363bd04d197b",
+                "sha256:cbc7a0f2cd7bb1d54541be21410c84ec76ae4b504f5d8f6e5fc412f04981f806"
             ],
-            "version": "==0.2.8"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==0.3.0rc1"
         },
         "pychalk": {
             "hashes": [
@@ -1281,11 +1337,11 @@
         },
         "pyopenssl": {
             "hashes": [
-                "sha256:660b1b1425aac4a1bea1d94168a85d99f0b3144c869dd4390d27629d0087f1bf",
-                "sha256:ea252b38c87425b64116f808355e8da644ef9b07e429398bfece610f893ee2e0"
+                "sha256:7a83b7b272dd595222d672f5ce29aa030f1fb837630ef229f62e72e395ce8968",
+                "sha256:b28437c9773bb6c6958628cf9c3bebe585de661dba6f63df17111966363dd15e"
             ],
             "index": "pypi",
-            "version": "==22.0.0"
+            "version": "==22.1.0"
         },
         "pyparsing": {
             "hashes": [
@@ -1359,10 +1415,10 @@
         },
         "pytz": {
             "hashes": [
-                "sha256:220f481bdafa09c3955dfbdddb7b57780e9a94f5127e35456a48589b9e0c0197",
-                "sha256:cea221417204f2d1a2aa03ddae3e867921971d0d76f14d87abb4414415bbdcf5"
+                "sha256:2c0784747071402c6e99f0bafdb7da0fa22645f06554c7ae06bf6358897e9c91",
+                "sha256:48ce799d83b6f8aab2020e369b627446696619e79645419610b9facd909b3174"
             ],
-            "version": "==2022.2.1"
+            "version": "==2022.4"
         },
         "pytzdata": {
             "hashes": [
@@ -1492,6 +1548,14 @@
             ],
             "version": "==21.1.0"
         },
+        "setuptools": {
+            "hashes": [
+                "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012",
+                "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==65.4.1"
+        },
         "simple-rlp": {
             "hashes": [
                 "sha256:2df1d2b769f0a0177d26231ab8be16e65e3546b17bb0a9a490efd3517c082876"
@@ -1547,11 +1611,11 @@
         },
         "trie": {
             "hashes": [
-                "sha256:103a76d9e7450a7ae5d2014fab69261daa6c1d58089ccf9dd998a0a8d70b99fc",
-                "sha256:54f7c2f7c450354f2ddd4dd15061aeaa0580317a1bb48c8e4d85c86017e4db97"
+                "sha256:8bfc6b82979b7caa6f020a89c9142c7522f017788240487d1c941b0ad82e7132",
+                "sha256:edef6b392f49f80be31c167236c6569aa07d7926138d5fe23d327d65d62b7201"
             ],
             "markers": "python_version >= '3.6' and python_version < '4'",
-            "version": "==2.0.1"
+            "version": "==2.0.2"
         },
         "twisted": {
             "hashes": [
@@ -1632,11 +1696,11 @@
         },
         "web3": {
             "hashes": [
-                "sha256:17f3885bc6466186a69e47ec9690ea6a077dea8361ea96b42c67021d1b543962",
-                "sha256:b310e0de9532e0f2886bf10cfc28b49509213db39ad50484af7fe0e0904c0819"
+                "sha256:1674301b261da529ee6537b970d1a01a1e6d22328b246c16636263f96c2b6df2",
+                "sha256:df74801cb4dff45b175227feb3126ac77480c801ac6412d471520abecf2c8c00"
             ],
             "index": "pypi",
-            "version": "==6.0.0b4"
+            "version": "==6.0.0b6"
         },
         "websockets": {
             "hashes": [
@@ -1765,14 +1829,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.8.1"
         },
-        "zipp": {
-            "hashes": [
-                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.8.1"
-        },
         "zope.interface": {
             "hashes": [
                 "sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192",
@@ -1850,11 +1906,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
-                "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.14"
+            "version": "==2022.9.24"
         },
         "cfgv": {
             "hashes": [
@@ -1873,63 +1929,60 @@
             "version": "==2.1.1"
         },
         "coverage": {
-            "extras": [
-                "toml"
-            ],
             "hashes": [
-                "sha256:01778769097dbd705a24e221f42be885c544bb91251747a8a3efdec6eb4788f2",
-                "sha256:08002f9251f51afdcc5e3adf5d5d66bb490ae893d9e21359b085f0e03390a820",
-                "sha256:1238b08f3576201ebf41f7c20bf59baa0d05da941b123c6656e42cdb668e9827",
-                "sha256:14a32ec68d721c3d714d9b105c7acf8e0f8a4f4734c811eda75ff3718570b5e3",
-                "sha256:15e38d853ee224e92ccc9a851457fb1e1f12d7a5df5ae44544ce7863691c7a0d",
-                "sha256:354df19fefd03b9a13132fa6643527ef7905712109d9c1c1903f2133d3a4e145",
-                "sha256:35ef1f8d8a7a275aa7410d2f2c60fa6443f4a64fae9be671ec0696a68525b875",
-                "sha256:4179502f210ebed3ccfe2f78bf8e2d59e50b297b598b100d6c6e3341053066a2",
-                "sha256:42c499c14efd858b98c4e03595bf914089b98400d30789511577aa44607a1b74",
-                "sha256:4b7101938584d67e6f45f0015b60e24a95bf8dea19836b1709a80342e01b472f",
-                "sha256:564cd0f5b5470094df06fab676c6d77547abfdcb09b6c29c8a97c41ad03b103c",
-                "sha256:5f444627b3664b80d078c05fe6a850dd711beeb90d26731f11d492dcbadb6973",
-                "sha256:6113e4df2fa73b80f77663445be6d567913fb3b82a86ceb64e44ae0e4b695de1",
-                "sha256:61b993f3998ee384935ee423c3d40894e93277f12482f6e777642a0141f55782",
-                "sha256:66e6df3ac4659a435677d8cd40e8eb1ac7219345d27c41145991ee9bf4b806a0",
-                "sha256:67f9346aeebea54e845d29b487eb38ec95f2ecf3558a3cffb26ee3f0dcc3e760",
-                "sha256:6913dddee2deff8ab2512639c5168c3e80b3ebb0f818fed22048ee46f735351a",
-                "sha256:6a864733b22d3081749450466ac80698fe39c91cb6849b2ef8752fd7482011f3",
-                "sha256:7026f5afe0d1a933685d8f2169d7c2d2e624f6255fb584ca99ccca8c0e966fd7",
-                "sha256:783bc7c4ee524039ca13b6d9b4186a67f8e63d91342c713e88c1865a38d0892a",
-                "sha256:7a98d6bf6d4ca5c07a600c7b4e0c5350cd483c85c736c522b786be90ea5bac4f",
-                "sha256:8d032bfc562a52318ae05047a6eb801ff31ccee172dc0d2504614e911d8fa83e",
-                "sha256:98c0b9e9b572893cdb0a00e66cf961a238f8d870d4e1dc8e679eb8bdc2eb1b86",
-                "sha256:9c7b9b498eb0c0d48b4c2abc0e10c2d78912203f972e0e63e3c9dc21f15abdaa",
-                "sha256:9cc4f107009bca5a81caef2fca843dbec4215c05e917a59dec0c8db5cff1d2aa",
-                "sha256:9d6e1f3185cbfd3d91ac77ea065d85d5215d3dfa45b191d14ddfcd952fa53796",
-                "sha256:a095aa0a996ea08b10580908e88fbaf81ecf798e923bbe64fb98d1807db3d68a",
-                "sha256:a3b2752de32c455f2521a51bd3ffb53c5b3ae92736afde67ce83477f5c1dd928",
-                "sha256:ab066f5ab67059d1f1000b5e1aa8bbd75b6ed1fc0014559aea41a9eb66fc2ce0",
-                "sha256:c1328d0c2f194ffda30a45f11058c02410e679456276bfa0bbe0b0ee87225fac",
-                "sha256:c35cca192ba700979d20ac43024a82b9b32a60da2f983bec6c0f5b84aead635c",
-                "sha256:cbbb0e4cd8ddcd5ef47641cfac97d8473ab6b132dd9a46bacb18872828031685",
-                "sha256:cdbb0d89923c80dbd435b9cf8bba0ff55585a3cdb28cbec65f376c041472c60d",
-                "sha256:cf2afe83a53f77aec067033199797832617890e15bed42f4a1a93ea24794ae3e",
-                "sha256:d5dd4b8e9cd0deb60e6fcc7b0647cbc1da6c33b9e786f9c79721fd303994832f",
-                "sha256:dfa0b97eb904255e2ab24166071b27408f1f69c8fbda58e9c0972804851e0558",
-                "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58",
-                "sha256:e1fabd473566fce2cf18ea41171d92814e4ef1495e04471786cbc943b89a3781",
-                "sha256:e3d3c4cc38b2882f9a15bafd30aec079582b819bec1b8afdbde8f7797008108a",
-                "sha256:e431e305a1f3126477abe9a184624a85308da8edf8486a863601d58419d26ffa",
-                "sha256:e7b4da9bafad21ea45a714d3ea6f3e1679099e420c8741c74905b92ee9bfa7cc",
-                "sha256:ee2b2fb6eb4ace35805f434e0f6409444e1466a47f620d1d5763a22600f0f892",
-                "sha256:ee6ae6bbcac0786807295e9687169fba80cb0617852b2fa118a99667e8e6815d",
-                "sha256:ef6f44409ab02e202b31a05dd6666797f9de2aa2b4b3534e9d450e42dea5e817",
-                "sha256:f67cf9f406cf0d2f08a3515ce2db5b82625a7257f88aad87904674def6ddaec1",
-                "sha256:f855b39e4f75abd0dfbcf74a82e84ae3fc260d523fcb3532786bcbbcb158322c",
-                "sha256:fc600f6ec19b273da1d85817eda339fb46ce9eef3e89f220055d8696e0a06908",
-                "sha256:fcbe3d9a53e013f8ab88734d7e517eb2cd06b7e689bedf22c0eb68db5e4a0a19",
-                "sha256:fde17bc42e0716c94bf19d92e4c9f5a00c5feb401f5bc01101fdf2a8b7cacf60",
-                "sha256:ff934ced84054b9018665ca3967fc48e1ac99e811f6cc99ea65978e1d384454b"
+                "sha256:027018943386e7b942fa832372ebc120155fd970837489896099f5cfa2890f79",
+                "sha256:11b990d520ea75e7ee8dcab5bc908072aaada194a794db9f6d7d5cfd19661e5a",
+                "sha256:12adf310e4aafddc58afdb04d686795f33f4d7a6fa67a7a9d4ce7d6ae24d949f",
+                "sha256:1431986dac3923c5945271f169f59c45b8802a114c8f548d611f2015133df77a",
+                "sha256:1ef221513e6f68b69ee9e159506d583d31aa3567e0ae84eaad9d6ec1107dddaa",
+                "sha256:20c8ac5386253717e5ccc827caad43ed66fea0efe255727b1053a8154d952398",
+                "sha256:2198ea6fc548de52adc826f62cb18554caedfb1d26548c1b7c88d8f7faa8f6ba",
+                "sha256:255758a1e3b61db372ec2736c8e2a1fdfaf563977eedbdf131de003ca5779b7d",
+                "sha256:265de0fa6778d07de30bcf4d9dc471c3dc4314a23a3c6603d356a3c9abc2dfcf",
+                "sha256:33a7da4376d5977fbf0a8ed91c4dffaaa8dbf0ddbf4c8eea500a2486d8bc4d7b",
+                "sha256:42eafe6778551cf006a7c43153af1211c3aaab658d4d66fa5fcc021613d02518",
+                "sha256:4433b90fae13f86fafff0b326453dd42fc9a639a0d9e4eec4d366436d1a41b6d",
+                "sha256:4a5375e28c5191ac38cca59b38edd33ef4cc914732c916f2929029b4bfb50795",
+                "sha256:4a8dbc1f0fbb2ae3de73eb0bdbb914180c7abfbf258e90b311dcd4f585d44bd2",
+                "sha256:59f53f1dc5b656cafb1badd0feb428c1e7bc19b867479ff72f7a9dd9b479f10e",
+                "sha256:5dbec3b9095749390c09ab7c89d314727f18800060d8d24e87f01fb9cfb40b32",
+                "sha256:633713d70ad6bfc49b34ead4060531658dc6dfc9b3eb7d8a716d5873377ab745",
+                "sha256:6b07130585d54fe8dff3d97b93b0e20290de974dc8177c320aeaf23459219c0b",
+                "sha256:6c4459b3de97b75e3bd6b7d4b7f0db13f17f504f3d13e2a7c623786289dd670e",
+                "sha256:6d4817234349a80dbf03640cec6109cd90cba068330703fa65ddf56b60223a6d",
+                "sha256:723e8130d4ecc8f56e9a611e73b31219595baa3bb252d539206f7bbbab6ffc1f",
+                "sha256:784f53ebc9f3fd0e2a3f6a78b2be1bd1f5575d7863e10c6e12504f240fd06660",
+                "sha256:7b6be138d61e458e18d8e6ddcddd36dd96215edfe5f1168de0b1b32635839b62",
+                "sha256:7ccf362abd726b0410bf8911c31fbf97f09f8f1061f8c1cf03dfc4b6372848f6",
+                "sha256:83516205e254a0cb77d2d7bb3632ee019d93d9f4005de31dca0a8c3667d5bc04",
+                "sha256:851cf4ff24062c6aec510a454b2584f6e998cada52d4cb58c5e233d07172e50c",
+                "sha256:8f830ed581b45b82451a40faabb89c84e1a998124ee4212d440e9c6cf70083e5",
+                "sha256:94e2565443291bd778421856bc975d351738963071e9b8839ca1fc08b42d4bef",
+                "sha256:95203854f974e07af96358c0b261f1048d8e1083f2de9b1c565e1be4a3a48cfc",
+                "sha256:97117225cdd992a9c2a5515db1f66b59db634f59d0679ca1fa3fe8da32749cae",
+                "sha256:98e8a10b7a314f454d9eff4216a9a94d143a7ee65018dd12442e898ee2310578",
+                "sha256:a1170fa54185845505fbfa672f1c1ab175446c887cce8212c44149581cf2d466",
+                "sha256:a6b7d95969b8845250586f269e81e5dfdd8ff828ddeb8567a4a2eaa7313460c4",
+                "sha256:a8fb6cf131ac4070c9c5a3e21de0f7dc5a0fbe8bc77c9456ced896c12fcdad91",
+                "sha256:af4fffaffc4067232253715065e30c5a7ec6faac36f8fc8d6f64263b15f74db0",
+                "sha256:b4a5be1748d538a710f87542f22c2cad22f80545a847ad91ce45e77417293eb4",
+                "sha256:b5604380f3415ba69de87a289a2b56687faa4fe04dbee0754bfcae433489316b",
+                "sha256:b9023e237f4c02ff739581ef35969c3739445fb059b060ca51771e69101efffe",
+                "sha256:bc8ef5e043a2af066fa8cbfc6e708d58017024dc4345a1f9757b329a249f041b",
+                "sha256:c4ed2820d919351f4167e52425e096af41bfabacb1857186c1ea32ff9983ed75",
+                "sha256:cca4435eebea7962a52bdb216dec27215d0df64cf27fc1dd538415f5d2b9da6b",
+                "sha256:d900bb429fdfd7f511f868cedd03a6bbb142f3f9118c09b99ef8dc9bf9643c3c",
+                "sha256:d9ecf0829c6a62b9b573c7bb6d4dcd6ba8b6f80be9ba4fc7ed50bf4ac9aecd72",
+                "sha256:dbdb91cd8c048c2b09eb17713b0c12a54fbd587d79adcebad543bc0cd9a3410b",
+                "sha256:de3001a203182842a4630e7b8d1a2c7c07ec1b45d3084a83d5d227a3806f530f",
+                "sha256:e07f4a4a9b41583d6eabec04f8b68076ab3cd44c20bd29332c6572dda36f372e",
+                "sha256:ef8674b0ee8cc11e2d574e3e2998aea5df5ab242e012286824ea3c6970580e53",
+                "sha256:f4f05d88d9a80ad3cac6244d36dd89a3c00abc16371769f1340101d3cb899fc3",
+                "sha256:f642e90754ee3e06b0e7e51bce3379590e76b7f76b708e1a71ff043f87025c84",
+                "sha256:fc2af30ed0d5ae0b1abdb4ebdce598eafd5b35397d4d75deb341a614d333d987"
             ],
             "index": "pypi",
-            "version": "==6.4.4"
+            "version": "==6.5.0"
         },
         "decorator": {
             "hashes": [
@@ -1988,71 +2041,71 @@
         },
         "greenlet": {
             "hashes": [
-                "sha256:0118817c9341ef2b0f75f5af79ac377e4da6ff637e5ee4ac91802c0e379dadb4",
-                "sha256:048d2bed76c2aa6de7af500ae0ea51dd2267aec0e0f2a436981159053d0bc7cc",
-                "sha256:07c58e169bbe1e87b8bbf15a5c1b779a7616df9fd3e61cadc9d691740015b4f8",
-                "sha256:095a980288fe05adf3d002fbb180c99bdcf0f930e220aa66fcd56e7914a38202",
-                "sha256:0b181e9aa6cb2f5ec0cacc8cee6e5a3093416c841ba32c185c30c160487f0380",
-                "sha256:1626185d938d7381631e48e6f7713e8d4b964be246073e1a1d15c2f061ac9f08",
-                "sha256:184416e481295832350a4bf731ba619a92f5689bf5d0fa4341e98b98b1265bd7",
-                "sha256:1dd51d2650e70c6c4af37f454737bf4a11e568945b27f74b471e8e2a9fd21268",
-                "sha256:1ec2779774d8e42ed0440cf8bc55540175187e8e934f2be25199bf4ed948cd9e",
-                "sha256:2cf45e339cabea16c07586306a31cfcc5a3b5e1626d365714d283732afed6809",
-                "sha256:2fb0aa7f6996879551fd67461d5d3ab0c3c0245da98be90c89fcb7a18d437403",
-                "sha256:44b4817c34c9272c65550b788913620f1fdc80362b209bc9d7dd2f40d8793080",
-                "sha256:466ce0928e33421ee84ae04c4ac6f253a3a3e6b8d600a79bd43fd4403e0a7a76",
-                "sha256:4f166b4aca8d7d489e82d74627a7069ab34211ef5ebb57c300ec4b9337b60fc0",
-                "sha256:510c3b15587afce9800198b4b142202b323bf4b4b5f9d6c79cb9a35e5e3c30d2",
-                "sha256:5b756e6730ea59b2745072e28ad27f4c837084688e6a6b3633c8b1e509e6ae0e",
-                "sha256:5fbe1ab72b998ca77ceabbae63a9b2e2dc2d963f4299b9b278252ddba142d3f1",
-                "sha256:6200a11f003ec26815f7e3d2ded01b43a3810be3528dd760d2f1fa777490c3cd",
-                "sha256:65ad1a7a463a2a6f863661329a944a5802c7129f7ad33583dcc11069c17e622c",
-                "sha256:694ffa7144fa5cc526c8f4512665003a39fa09ef00d19bbca5c8d3406db72fbe",
-                "sha256:6f5d4b2280ceea76c55c893827961ed0a6eadd5a584a7c4e6e6dd7bc10dfdd96",
-                "sha256:7532a46505470be30cbf1dbadb20379fb481244f1ca54207d7df3bf0bbab6a20",
-                "sha256:76a53bfa10b367ee734b95988bd82a9a5f0038a25030f9f23bbbc005010ca600",
-                "sha256:77e41db75f9958f2083e03e9dd39da12247b3430c92267df3af77c83d8ff9eed",
-                "sha256:7a43bbfa9b6cfdfaeefbd91038dde65ea2c421dc387ed171613df340650874f2",
-                "sha256:7b41d19c0cfe5c259fe6c539fd75051cd39a5d33d05482f885faf43f7f5e7d26",
-                "sha256:7c5227963409551ae4a6938beb70d56bf1918c554a287d3da6853526212fbe0a",
-                "sha256:870a48007872d12e95a996fca3c03a64290d3ea2e61076aa35d3b253cf34cd32",
-                "sha256:88b04e12c9b041a1e0bcb886fec709c488192638a9a7a3677513ac6ba81d8e79",
-                "sha256:8c287ae7ac921dfde88b1c125bd9590b7ec3c900c2d3db5197f1286e144e712b",
-                "sha256:903fa5716b8fbb21019268b44f73f3748c41d1a30d71b4a49c84b642c2fed5fa",
-                "sha256:9537e4baf0db67f382eb29255a03154fcd4984638303ff9baaa738b10371fa57",
-                "sha256:9951dcbd37850da32b2cb6e391f621c1ee456191c6ae5528af4a34afe357c30e",
-                "sha256:9b2f7d0408ddeb8ea1fd43d3db79a8cefaccadd2a812f021333b338ed6b10aba",
-                "sha256:9c88e134d51d5e82315a7c32b914a58751b7353eb5268dbd02eabf020b4c4700",
-                "sha256:9fae214f6c43cd47f7bef98c56919b9222481e833be2915f6857a1e9e8a15318",
-                "sha256:a3a669f11289a8995d24fbfc0e63f8289dd03c9aaa0cc8f1eab31d18ca61a382",
-                "sha256:aa741c1a8a8cc25eb3a3a01a62bdb5095a773d8c6a86470bde7f607a447e7905",
-                "sha256:b0877a9a2129a2c56a2eae2da016743db7d9d6a05d5e1c198f1b7808c602a30e",
-                "sha256:bcb6c6dd1d6be6d38d6db283747d07fda089ff8c559a835236560a4410340455",
-                "sha256:caff52cb5cd7626872d9696aee5b794abe172804beb7db52eed1fd5824b63910",
-                "sha256:cbc1eb55342cbac8f7ec159088d54e2cfdd5ddf61c87b8bbe682d113789331b2",
-                "sha256:cd16a89efe3a003029c87ff19e9fba635864e064da646bc749fc1908a4af18f3",
-                "sha256:ce5b64dfe8d0cca407d88b0ee619d80d4215a2612c1af8c98a92180e7109f4b5",
-                "sha256:d58a5a71c4c37354f9e0c24c9c8321f0185f6945ef027460b809f4bb474bfe41",
-                "sha256:db41f3845eb579b544c962864cce2c2a0257fe30f0f1e18e51b1e8cbb4e0ac6d",
-                "sha256:db5b25265010a1b3dca6a174a443a0ed4c4ab12d5e2883a11c97d6e6d59b12f9",
-                "sha256:dd0404d154084a371e6d2bafc787201612a1359c2dee688ae334f9118aa0bf47",
-                "sha256:de431765bd5fe62119e0bc6bc6e7b17ac53017ae1782acf88fcf6b7eae475a49",
-                "sha256:df02fdec0c533301497acb0bc0f27f479a3a63dcdc3a099ae33a902857f07477",
-                "sha256:e8533f5111704d75de3139bf0b8136d3a6c1642c55c067866fa0a51c2155ee33",
-                "sha256:f2f908239b7098799b8845e5936c2ccb91d8c2323be02e82f8dcb4a80dcf4a25",
-                "sha256:f8bfd36f368efe0ab2a6aa3db7f14598aac454b06849fb633b762ddbede1db90",
-                "sha256:ffe73f9e7aea404722058405ff24041e59d31ca23d1da0895af48050a07b6932"
+                "sha256:004aed447382d80a56ecc354a6d807f305e6c808714ce6ccbca4839c94fae81d",
+                "sha256:068d68fad6bd623e29a2d36e74538c9b9d6dc6464931cd27d93da6cfc6a7f242",
+                "sha256:06fd4075754009c9817c6b4e1dc0af4616de52757b6ca973a81c3c1aadc28257",
+                "sha256:1004cb542451814b12a4f38e835a47734e2b2c683acbf463d5ae76282a3974cf",
+                "sha256:10c358633a8b27bfc32d27114ef2ca2ddc9f1f89f1643d1157b85e1fdd695315",
+                "sha256:115bc25fefbdc692c4483e9ddb9011ccd0251590ed59dbfff0f4eb7050bf99c4",
+                "sha256:1d987a2579336792f73ae6b106c2f087e32afc8573fbf9566f123ac6d8cfb72f",
+                "sha256:2128d727fd1e8afba8e68feb2cdcf88c90163b69ddc9707722a3e491c5280720",
+                "sha256:230132c241fe284f93f2e7b3969e9b22bbd76ef98cf93e382c945d378907f5a4",
+                "sha256:23558f7bd08a663386c032ab8d302d613d2d02ae0c9758ad410bab6035b58d3d",
+                "sha256:255d520d3e4a5f16883b182e1a94219fe455ab4f50aaaf534bfd6d64ee728397",
+                "sha256:2a6bc19a728f6f643cfc89b876159a1a25a8f7d8700c013d48a73691f80b4550",
+                "sha256:379bed346ef8ba0a0e698b3c5975a44d15dd4a5bbff40bbd7fd548b445d5550b",
+                "sha256:3b12d0866759db93b0a893b4e50a7d7d1681519d2346c26695bb8bb2c652230e",
+                "sha256:40d491944f69e350e1e8b25f6ca49459824ede1678ec0cd4b5541f41edc06614",
+                "sha256:471484c7b9d7b7867263051aa81cdeed6e06b455e629a7f05eb91a6cb8bd0836",
+                "sha256:488c557080557bc01aabb3e1bda7225c68455b853733a8652857ac0d810dad1b",
+                "sha256:49c2e76e7aa81ba889b3c183e2341af3cc6161ee38852085110ae49d5b5d9a40",
+                "sha256:52d13ec90236e5935ed6da044e78faa1371d5116cc43fe6d7ca8994dd619ef96",
+                "sha256:57898c69a253d81f487787bdd538629fabd671fab8a9e31b041ca30965fd9556",
+                "sha256:5d577eef5beb5730ef01ab39983eb852a97c359b7a546809adf70c409f4b2ecc",
+                "sha256:6a41987c1474c9158a0c0c96611530a8f299bc547d35bee8add981b8b2534f74",
+                "sha256:6ae67b7df8db3626af8e042e9c6949cfa27d1a3bbbfdff29e45b72bb6673a650",
+                "sha256:6c42c27e9d12e8a481aff469ffe8dd4ce0484c354a418470960f760f6ae41e7c",
+                "sha256:6c4a90c9f6128b4d0905a89930bd325e0491574e5cb453f606bb7094a3197587",
+                "sha256:6e64518e5833ac2d9359b6d9bd4df2c0cf441a0f3a4eca9e735fbea99009fa70",
+                "sha256:6fd3a270c23c5b42d86a9c7c6b0229f23ee4a7a4cabdaaa1693ad7a0982d13cb",
+                "sha256:70db73351e0fcf11a76288c47a0469d9a330bcb2e7618c5eb57432b8caa82403",
+                "sha256:771f401692046845626cbdf1dd0f04e999413ede0ee9ad39033fe30b5fa2e845",
+                "sha256:7935026ec61b967cbc6b746c0ca75c1651ea118d7fee4d259cff9e6866153374",
+                "sha256:7b76b1cac9baac1980210e29145800954e7b42e91ef69c4d695de1cab87ce41f",
+                "sha256:7e3f37c11b6699b1a1e0fcc0e88829dba4f2866546381b05ab8b3f4db645a823",
+                "sha256:8370fa65ad421484894f559055f951843754153b72b9bca2ebdc5288efe2e3f0",
+                "sha256:8ae9c443d44a4e23252632e4d7775f419f992d0df3eff923e23775f5cc551d39",
+                "sha256:8b31d85f2781e44f1ffaaf7ea07f484e7d42317c677c355fa77b4a1a4bea7394",
+                "sha256:8b450336b27f3b375cadc474c6704838eaa8dd3ca312aac3bb69d92264a8e638",
+                "sha256:9ce84357388a76d886febff4e50e321c212ffd3248b590960b2da6e02404a5c9",
+                "sha256:a23e986fb0ba8e7407286add41fa0d4207be44e3dce1b04789f4757800eca1cf",
+                "sha256:a81610ee00d0da9cd2c8679479b7791149365b6dfb3971b01b22ee29b04787ce",
+                "sha256:b4e40444975e5ab0ed3004369209c39a28e084951daaeee4919f164b6b849b14",
+                "sha256:b66600de16702b9dfa74bea34524b55183a2183e5fd92f20fe6c2fcae550a64c",
+                "sha256:ba6ee18694d3673796b7a31b7d21254e87e9e43ca5be56f323fd396111255315",
+                "sha256:bd03837da28293baa39bdfc3cada69e2f8807f423ae06168aa28d2b32c63a6b6",
+                "sha256:bd2192070f88c0778ae1d68a0980fdece3473498c1db37f3794e3454f91e3ecf",
+                "sha256:c1f6f1a3cc013012cd1da913c40b13e6d721046a8c8a0ea0cde94069645a75db",
+                "sha256:ce10a8e7e067bde3c1fbf494d2b8859db510206030b0b67bc3af90b0eb1887b9",
+                "sha256:d31386d208303a5a6cf0819ef9f6db6680bab9e4ca8e48adb3d4b26ead89beb7",
+                "sha256:d83b3af53b201970973c5574b39df226746194063bb248a53fd12b470ac34319",
+                "sha256:df9657b212c054ac6d803290d7c4bcd7790af0b725984fce1eeb0a1e3f2d9798",
+                "sha256:e576e5fd3f129e6b3595dc734ac7f2b8c548f19ef07781194bc538dc9c0cdbbc",
+                "sha256:e7400358558094c1bcedc75f3b3c4f400c53130b44833848890a99968dee6a64",
+                "sha256:eb6a385f8577d30e4cb43dd555fb134ddaae1edeb84205e09dabec332bf49fd0",
+                "sha256:f27f0875e0873f6bf5df09a456bfcac0667824cabac4cad30b43f36e0382ffe7",
+                "sha256:fcd4a6d04995f1d66bc78b503e4e59ae72fd32aaec4f661657fe5ae5c1aa4ce3"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==1.1.3"
+            "version": "==2.0.0a2"
         },
         "hypothesis": {
             "hashes": [
-                "sha256:8a9056825695f415bfad4e808ae719fc01383a9ab659775319724365afcc7ec7",
-                "sha256:d8d2e18139be18e5c95593f1e2d87dbcd21534a32022a1db6e8ac2d458ee1d1a"
+                "sha256:38ac02dba2801e26b964da57950cbc574fb22a3e16951c227150282b986ed002",
+                "sha256:dc3a296f1c23fc402ec50a3d90785fcf4a6290156ad4c97e23b0f972b0c3e32c"
             ],
             "index": "pypi",
-            "version": "==6.54.5"
+            "version": "==6.56.0"
         },
         "identify": {
             "hashes": [
@@ -2079,32 +2132,33 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:02ef476f6dcb86e6f502ae39a16b93285fef97e7f1ff22932b657d1ef1f28655",
-                "sha256:0d054ef16b071149917085f51f89555a576e2618d5d9dd70bd6eea6410af3ac9",
-                "sha256:19830b7dba7d5356d3e26e2427a2ec91c994cd92d983142cbd025ebe81d69cf3",
-                "sha256:1f7656b69974a6933e987ee8ffb951d836272d6c0f81d727f1d0e2696074d9e6",
-                "sha256:23488a14a83bca6e54402c2e6435467a4138785df93ec85aeff64c6170077fb0",
-                "sha256:23c7ff43fff4b0df93a186581885c8512bc50fc4d4910e0f838e35d6bb6b5e58",
-                "sha256:25c5750ba5609a0c7550b73a33deb314ecfb559c350bb050b655505e8aed4103",
-                "sha256:2ad53cf9c3adc43cf3bea0a7d01a2f2e86db9fe7596dfecb4496a5dda63cbb09",
-                "sha256:3fa7a477b9900be9b7dd4bab30a12759e5abe9586574ceb944bc29cddf8f0417",
-                "sha256:40b0f21484238269ae6a57200c807d80debc6459d444c0489a102d7c6a75fa56",
-                "sha256:4b21e5b1a70dfb972490035128f305c39bc4bc253f34e96a4adf9127cf943eb2",
-                "sha256:5a361d92635ad4ada1b1b2d3630fc2f53f2127d51cf2def9db83cba32e47c856",
-                "sha256:77a514ea15d3007d33a9e2157b0ba9c267496acf12a7f2b9b9f8446337aac5b0",
-                "sha256:855048b6feb6dfe09d3353466004490b1872887150c5bb5caad7838b57328cc8",
-                "sha256:9796a2ba7b4b538649caa5cecd398d873f4022ed2333ffde58eaf604c4d2cb27",
-                "sha256:98e02d56ebe93981c41211c05adb630d1d26c14195d04d95e49cd97dbc046dc5",
-                "sha256:b793b899f7cf563b1e7044a5c97361196b938e92f0a4343a5d27966a53d2ec71",
-                "sha256:d1ea5d12c8e2d266b5fb8c7a5d2e9c0219fedfeb493b7ed60cd350322384ac27",
-                "sha256:d2022bfadb7a5c2ef410d6a7c9763188afdb7f3533f22a0a32be10d571ee4bbe",
-                "sha256:d3348e7eb2eea2472db611486846742d5d52d1290576de99d59edeb7cd4a42ca",
-                "sha256:d744f72eb39f69312bc6c2abf8ff6656973120e2eb3f3ec4f758ed47e414a4bf",
-                "sha256:ef943c72a786b0f8d90fd76e9b39ce81fb7171172daf84bf43eaf937e9f220a9",
-                "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"
+                "sha256:06e1eac8d99bd404ed8dd34ca29673c4346e76dd8e612ea507763dccd7e13c7a",
+                "sha256:2ee3dbc53d4df7e6e3b1c68ac6a971d3a4fb2852bf10a05fda228721dd44fae1",
+                "sha256:4bc460e43b7785f78862dab78674e62ec3cd523485baecfdf81a555ed29ecfa0",
+                "sha256:64e1f6af81c003f85f0dfed52db632817dabb51b65c0318ffbf5ff51995bbb08",
+                "sha256:6e35d764784b42c3e256848fb8ed1d4292c9fc0098413adb28d84974c095b279",
+                "sha256:6ee196b1d10b8b215e835f438e06965d7a480f6fe016eddbc285f13955cca659",
+                "sha256:756fad8b263b3ba39e4e204ee53042671b660c36c9017412b43af210ddee7b08",
+                "sha256:77f8fcf7b4b3cc0c74fb33ae54a4cd00bb854d65645c48beccf65fa10b17882c",
+                "sha256:794f385653e2b749387a42afb1e14c2135e18daeb027e0d97162e4b7031210f8",
+                "sha256:8ad21d4c9d3673726cf986ea1d0c9fb66905258709550ddf7944c8f885f208be",
+                "sha256:8e8e49aa9cc23aa4c926dc200ce32959d3501c4905147a66ce032f05cb5ecb92",
+                "sha256:9f362470a3480165c4c6151786b5379351b790d56952005be18bdbdd4c7ce0ae",
+                "sha256:a16a0145d6d7d00fbede2da3a3096dcc9ecea091adfa8da48fa6a7b75d35562d",
+                "sha256:ad77c13037d3402fbeffda07d51e3f228ba078d1c7096a73759c9419ea031bf4",
+                "sha256:b6ede64e52257931315826fdbfc6ea878d89a965580d1a65638ef77cb551f56d",
+                "sha256:c9e0efb95ed6ca1654951bd5ec2f3fa91b295d78bf6527e026529d4aaa1e0c30",
+                "sha256:ce65f70b14a21fdac84c294cde75e6dbdabbcff22975335e20827b3b94bdbf49",
+                "sha256:d1debb09043e1f5ee845fa1e96d180e89115b30e47c5d3ce53bc967bab53f62d",
+                "sha256:e178eaffc3c5cd211a87965c8c0df6da91ed7d258b5fc72b8e047c3771317ddb",
+                "sha256:e1acf62a8c4f7c092462c738aa2c2489e275ed386320c10b2e9bff31f6f7e8d6",
+                "sha256:e53773073c864d5f5cec7f3fc72fbbcef65410cde8cc18d4f7242dea60dac52e",
+                "sha256:eb3978b191b9fa0488524bb4ffedf2c573340e8c2b4206fc191d44c7093abfb7",
+                "sha256:f64d2ce043a209a297df322eb4054dfbaa9de9e8738291706eaafda81ab2b362",
+                "sha256:fa38f82f53e1e7beb45557ff167c177802ba7b387ad017eab1663d567017c8ee"
             ],
             "index": "pypi",
-            "version": "==0.971"
+            "version": "==0.981"
         },
         "mypy-extensions": {
             "hashes": [
@@ -2203,11 +2257,11 @@
         },
         "pytest-cov": {
             "hashes": [
-                "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6",
-                "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"
+                "sha256:2feb1b751d66a8bd934e5edfa2e961d11309dc37b73b0eabe73b5945fee20f6b",
+                "sha256:996b79efde6433cdbd0088872dbc5fb3ed7fe1578b68cdbba634f14bb8dd0470"
             ],
             "index": "pypi",
-            "version": "==3.0.0"
+            "version": "==4.0.0"
         },
         "pytest-forked": {
             "hashes": [
@@ -2219,11 +2273,11 @@
         },
         "pytest-mock": {
             "hashes": [
-                "sha256:77f03f4554392558700295e05aed0b1096a20d4a60a4f3ddcde58b0c31c8fca2",
-                "sha256:8a9e226d6c0ef09fcf20c94eb3405c388af438a90f3e39687f84166da82d5948"
+                "sha256:1a1b9264224d026932d6685a0f9cef3b61d91563c3e74af9fe5afb2767e13812",
+                "sha256:c899a0dcc8a5f22930acd020b500abd5f956911f326864a3b979e4866e14da82"
             ],
             "index": "pypi",
-            "version": "==3.8.2"
+            "version": "==3.9.0"
         },
         "pytest-timeout": {
             "hashes": [
@@ -2310,6 +2364,14 @@
             ],
             "markers": "python_version >= '2.7'",
             "version": "==2.10.0"
+        },
+        "setuptools": {
+            "hashes": [
+                "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012",
+                "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==65.4.1"
         },
         "smmap": {
             "hashes": [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,10 @@
 -i https://pypi.python.org/simple
 attrs==22.1.0; python_version >= '3.5'
 bandit==1.7.4
-certifi==2022.9.14; python_version >= '3.6'
+certifi==2022.9.24; python_version >= '3.6'
 cfgv==3.3.1; python_full_version >= '3.6.1'
 charset-normalizer==2.1.1; python_version >= '3.6'
-coverage[toml]==6.4.4
+coverage==6.5.0
 decorator==5.1.1; python_version >= '3.5'
 distlib==0.3.6
 exceptiongroup==1.0.0rc9; python_version < '3.11'
@@ -12,13 +12,13 @@ execnet==1.9.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2
 filelock==3.8.0; python_version >= '3.7'
 gitdb==4.0.9; python_version >= '3.6'
 gitpython==3.1.27; python_version >= '3.7'
-greenlet==1.1.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-hypothesis==6.54.5
+greenlet==2.0.0a2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+hypothesis==6.56.0
 identify==2.5.5; python_version >= '3.7'
 idna==3.4; python_version >= '3.5'
 iniconfig==1.1.1
 mypy-extensions==0.4.3
-mypy==0.971
+mypy==0.981
 nodeenv==1.7.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
 packaging==21.3; python_version >= '3.6'
 pbr==5.10.0; python_version >= '2.6'
@@ -29,9 +29,9 @@ py-solc-x==0.10.1
 py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 pyflakes==2.5.0
 pyparsing==3.0.9; python_full_version >= '3.6.8'
-pytest-cov==3.0.0
+pytest-cov==4.0.0
 pytest-forked==1.4.0; python_version >= '3.6'
-pytest-mock==3.8.2
+pytest-mock==3.9.0
 pytest-timeout==2.1.0
 pytest-twisted==1.13.4
 pytest-xdist==2.5.0
@@ -39,6 +39,7 @@ pytest==6.2.5
 pyyaml==6.0; python_version >= '3.6'
 requests==2.28.1
 semantic-version==2.10.0; python_version >= '2.7'
+setuptools==65.4.1; python_version >= '3.7'
 smmap==5.0.0; python_version >= '3.6'
 sortedcontainers==2.4.0
 stevedore==4.0.0; python_version >= '3.8'

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -3,11 +3,11 @@ alabaster==0.7.12
 attrs==22.1.0; python_version >= '3.5'
 autosemver==0.5.5
 babel==2.10.3; python_version >= '3.6'
-certifi==2022.9.14; python_version >= '3.6'
+certifi==2022.9.24; python_version >= '3.6'
 charset-normalizer==2.1.1; python_version >= '3.6'
 click-default-group==1.2.2
 click==8.1.3; python_version >= '3.7'
-coverage[toml]==6.4.4; python_version >= '3.7'
+coverage==6.5.0; python_version >= '3.7'
 docutils==0.17.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 dulwich==0.19.16
 execnet==1.9.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
@@ -16,7 +16,7 @@ idna==3.4; python_version >= '3.5'
 imagesize==1.4.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 incremental==21.3.0
 iniconfig==1.1.1
-isort==5.10.1; python_full_version >= '3.6.1' and python_version < '4.0'
+isort==5.10.1; python_full_version >= '3.6.1' and python_version < '4'
 jinja2==3.0.3
 markupsafe==2.1.1; python_version >= '3.7'
 mock==4.0.3; python_version >= '3.6'
@@ -28,13 +28,14 @@ py==1.11.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.
 pygments==2.13.0; python_version >= '3.6'
 pyparsing==3.0.9; python_full_version >= '3.6.8'
 pytest-cache==1.0
-pytest-cov==3.0.0; python_version >= '3.6'
+pytest-cov==4.0.0; python_version >= '3.6'
 pytest-pep8==1.0.6
 pytest==7.1.3; python_version >= '3.7'
-pytz==2022.2.1
+pytz==2022.4
 pyyaml==6.0; python_version >= '3.6'
-requests==2.28.1; python_version >= '3.7' and python_version < '4.0'
+requests==2.28.1; python_version >= '3.7' and python_version < '4'
 semantic-version==2.10.0; python_version >= '2.7'
+setuptools==65.4.1; python_version >= '3.7'
 snowballstemmer==2.2.0
 sphinx-rtd-theme==1.0.0
 sphinx==3.0.1
@@ -46,4 +47,4 @@ sphinxcontrib-qthelp==1.0.3; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5; python_version >= '3.5'
 tomli==2.0.1; python_version >= '3.7'
 towncrier==22.8.0
-urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4.0'
+urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'

--- a/nucypher/blockchain/economics.py
+++ b/nucypher/blockchain/economics.py
@@ -32,7 +32,7 @@ class Economics:
 
     _default_min_authorization = TToken(40_000, 'T').to_units()
     _default_min_operator_seconds = 60 * 60 * 24  # one day in seconds
-    _default_fee_rate = Wei(Web3.toWei(1, 'gwei'))
+    _default_fee_rate = Wei(Web3.to_wei(1, 'gwei'))
 
     # TODO: Reintroduce Adjudicator
     # Slashing parameters

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -110,7 +110,7 @@ class BaseActor:
         """Return this actor's current ETH balance"""
         blockchain = BlockchainInterfaceFactory.get_interface()  # TODO: EthAgent?  #1509
         balance = blockchain.client.get_balance(self.wallet_address)
-        return Web3.fromWei(balance, 'ether')
+        return Web3.from_wei(balance, 'ether')
 
     @property
     def wallet_address(self):
@@ -362,7 +362,7 @@ class Operator(BaseActor):
                 ether_balance = client.get_balance(self.operator_address)
                 if ether_balance:
                     # funds found
-                    funded, balance = True, Web3.fromWei(ether_balance, 'ether')
+                    funded, balance = True, Web3.from_wei(ether_balance, 'ether')
                     emitter.message(f"✓ Operator {self.operator_address} is funded with {balance} ETH", color='green')
                 else:
                     emitter.message(f"! Operator {self.operator_address} is not funded with ETH", color="yellow")

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -227,7 +227,7 @@ class EthereumClient:
 
     @property
     def is_connected(self):
-        return self.w3.isConnected()
+        return self.w3.is_connected()
 
     @property
     def etherbase(self) -> str:

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -308,7 +308,7 @@ class BlockchainInterface:
         configuration_message = f"Using gas strategy '{reported_gas_strategy}'"
 
         if self.max_gas_price:
-            __price = Web3.toWei(self.max_gas_price, 'gwei')  # from gwei to wei
+            __price = Web3.to_wei(self.max_gas_price, 'gwei')  # from gwei to wei
             gas_strategy = max_price_gas_strategy_wrapper(gas_strategy=gas_strategy, max_gas_price_wei=__price)
             configuration_message += f", with a max price of {self.max_gas_price} gwei."
 
@@ -316,7 +316,7 @@ class BlockchainInterface:
 
         # TODO: This line must not be called prior to establishing a connection
         #        Move it down to a lower layer, near the client.
-        # gwei_gas_price = Web3.fromWei(self.client.gas_price_for_transaction(), 'gwei')
+        # gwei_gas_price = Web3.from_wei(self.client.gas_price_for_transaction(), 'gwei')
 
         self.log.info(configuration_message)
         # self.log.debug(f"Gas strategy currently reports a gas price of {gwei_gas_price} gwei.")
@@ -570,9 +570,9 @@ class BlockchainInterface:
             max_unit_price = transaction_dict['gasPrice']
             tx_type = 'Legacy'
 
-        max_price_gwei = Web3.fromWei(max_unit_price, 'gwei')
+        max_price_gwei = Web3.from_wei(max_unit_price, 'gwei')
         max_cost_wei = max_unit_price * transaction_dict['gas']
-        max_cost = Web3.fromWei(max_cost_wei, 'ether')
+        max_cost = Web3.from_wei(max_cost_wei, 'ether')
 
         if transacting_power.is_device:
             emitter.message(f'Confirm transaction {transaction_name} on hardware wallet... '

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -128,11 +128,11 @@ def prettify_eth_amount(amount, original_denomination: str = 'wei') -> str:
     """
     try:
         # First obtain canonical representation in wei. Works for int, float, Decimal and str amounts
-        amount_in_wei = Web3.toWei(Decimal(amount), original_denomination)
+        amount_in_wei = Web3.to_wei(Decimal(amount), original_denomination)
 
         common_denominations = ('wei', 'gwei', 'ether')
 
-        options = [str(Web3.fromWei(amount_in_wei, d)) for d in common_denominations]
+        options = [str(Web3.from_wei(amount_in_wei, d)) for d in common_denominations]
 
         best_option = min(zip(map(len, options), options, common_denominations))
         _length, pretty_amount, denomination = best_option

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1067,7 +1067,7 @@ class Ursula(Teacher, Character, Operator):
             operator_signature = None
         else:
             operator_signature = self.operator_signature
-        payload = NodeMetadataPayload(staking_provider_address=self.canonical_address,
+        payload = NodeMetadataPayload(staking_provider_address=Address(self.canonical_address),
                                       domain=self.domain,
                                       timestamp_epoch=timestamp.epoch,
                                       operator_signature=operator_signature,
@@ -1257,10 +1257,8 @@ class Ursula(Teacher, Character, Operator):
             cfrag = reencrypt(capsule, kfrag)
             cfrags.append(cfrag)
             self.log.info(f"Re-encrypted capsule {capsule} -> made {cfrag}.")
-
-        return ReencryptionResponse(signer=self.stamp.as_umbral_signer(),
-                                    capsules=capsules,
-                                    vcfrags=cfrags)
+        results = list(zip(capsules, cfrags))
+        return ReencryptionResponse(signer=self.stamp.as_umbral_signer(), capsules_and_vcfrags=results)
 
     def status_info(self, omit_known_nodes: bool = False) -> 'LocalUrsulaStatus':
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -52,7 +52,12 @@ from eth_typing.evm import ChecksumAddress
 from eth_utils import to_checksum_address
 from flask import Response, request
 from nucypher_core import (
+<<<<<<< HEAD
     HRAC,
+=======
+    Conditions,
+    MessageKit,
+>>>>>>> 40817db8d (Handle rust-native conditions newtype just-in-time; Co-existing with ConditionsLingo)
     EncryptedKeyFrag,
     EncryptedTreasureMap,
     MessageKit,
@@ -1353,8 +1358,7 @@ class Enrico(Character):
 
     def encrypt_message(self, plaintext: bytes, conditions: Optional[Dict[str, Union[str, int]]] = None) -> MessageKit:
         # TODO: #2107 Rename to "encrypt"
-        if conditions:
-            conditions = json.dumps(conditions).encode()
+        conditions = Conditions(json.dumps(conditions or list()))
         message_kit = MessageKit(policy_encrypting_key=self.policy_pubkey,
                                  plaintext=plaintext,
                                  conditions=conditions)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -52,12 +52,9 @@ from eth_typing.evm import ChecksumAddress
 from eth_utils import to_checksum_address
 from flask import Response, request
 from nucypher_core import (
-<<<<<<< HEAD
+    Address,
     HRAC,
-=======
     Conditions,
-    MessageKit,
->>>>>>> 40817db8d (Handle rust-native conditions newtype just-in-time; Co-existing with ConditionsLingo)
     EncryptedKeyFrag,
     EncryptedTreasureMap,
     MessageKit,

--- a/nucypher/cli/actions/collect.py
+++ b/nucypher/cli/actions/collect.py
@@ -117,7 +117,7 @@ def collect_policy_rate_and_value(alice: Alice, rate: int, value: int, shares: i
         rate = alice.payment_method.rate  # wei
 
         if not force:
-            default_gwei = Web3.fromWei(rate, 'gwei')  # wei -> gwei
+            default_gwei = Web3.from_wei(rate, 'gwei')  # wei -> gwei
             prompt = "Confirm rate of {node_rate} gwei * {shares} nodes ({period_rate} gwei per period)?"
 
             if not click.confirm(prompt.format(node_rate=default_gwei, period_rate=default_gwei * shares, shares=shares), default=True):
@@ -125,7 +125,7 @@ def collect_policy_rate_and_value(alice: Alice, rate: int, value: int, shares: i
                 # TODO: Interactive rate sampling & validation (#1709)
                 interactive_prompt = prompt.format(node_rate=interactive_rate, period_rate=interactive_rate * shares, shares=shares)
                 click.confirm(interactive_prompt, default=True, abort=True)
-                rate = Web3.toWei(interactive_rate, 'gwei')  # gwei -> wei
+                rate = Web3.to_wei(interactive_rate, 'gwei')  # gwei -> wei
 
     return rate, value
 

--- a/nucypher/cli/actions/confirm.py
+++ b/nucypher/cli/actions/confirm.py
@@ -103,7 +103,7 @@ def confirm_staged_grant(emitter, grant_request: Dict, federated: bool, seconds_
         emitter.echo(tabulate(table, tablefmt="simple"))
         return
 
-    period_rate = Web3.fromWei(pretty_request['shares'] * pretty_request['rate'], 'gwei')
+    period_rate = Web3.from_wei(pretty_request['shares'] * pretty_request['rate'], 'gwei')
     pretty_request['rate'] = f"{pretty_request['rate']} wei/period * {pretty_request['shares']} nodes"
 
     expiration = pretty_request['expiration']

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -117,7 +117,7 @@ def select_client_account(emitter,
             is_staking = 'Yes' if bool(staker.stakes) else 'No'
             row.append(is_staking)
         if show_eth_balance:
-            ether_balance = Web3.fromWei(blockchain.client.get_balance(account), 'ether')
+            ether_balance = Web3.from_wei(blockchain.client.get_balance(account), 'ether')
             row.append(f'{ether_balance} ETH')
         if show_nu_balance:
             token_agent = ContractAgency.get_agent(NucypherTokenAgent, registry=registry)

--- a/nucypher/cli/painting/deployment.py
+++ b/nucypher/cli/painting/deployment.py
@@ -114,7 +114,7 @@ Registry  ................ {registry.filepath}
         token_contract_info = f"""
 
 {token_agent.contract_name} ........... {token_agent.contract_address}
-    ~ Ethers ............ {Web3.fromWei(blockchain.client.get_balance(token_agent.contract_address), 'ether')} ETH
+    ~ Ethers ............ {Web3.from_wei(blockchain.client.get_balance(token_agent.contract_address), 'ether')} ETH
     ~ Tokens ............ {NU.from_units(token_agent.get_balance(token_agent.contract_address))}"""
     except BaseContractRegistry.UnknownContract:
         message = f"\n{NucypherTokenAgent.contract_name} is not enrolled in {registry.filepath}"
@@ -146,12 +146,12 @@ Registry  ................ {registry.filepath}
 {agent.contract_name} .... {bare_contract.address}
     ~ Version ............ {bare_contract.version}
     ~ Owner .............. {bare_contract.functions.owner().call()}
-    ~ Ethers ............. {Web3.fromWei(blockchain.client.get_balance(bare_contract.address), 'ether')} ETH
+    ~ Ethers ............. {Web3.from_wei(blockchain.client.get_balance(bare_contract.address), 'ether')} ETH
     ~ Tokens ............. {NU.from_units(token_agent.get_balance(bare_contract.address))}
     ~ Dispatcher ......... {dispatcher_deployer.contract_address}
         ~ Owner .......... {dispatcher_deployer.contract.functions.owner().call()}
         ~ Target ......... {dispatcher_deployer.contract.functions.target().call()}
-        ~ Ethers ......... {Web3.fromWei(blockchain.client.get_balance(dispatcher_deployer.contract_address), 'ether')} ETH
+        ~ Ethers ......... {Web3.from_wei(blockchain.client.get_balance(dispatcher_deployer.contract_address), 'ether')} ETH
         ~ Tokens ......... {NU.from_units(token_agent.get_balance(dispatcher_deployer.contract_address))}"""
             emitter.echo(proxy_payload)
             emitter.echo(sep, nl=False)

--- a/nucypher/cli/painting/status.py
+++ b/nucypher/cli/painting/status.py
@@ -35,7 +35,7 @@ def paint_contract_status(registry, emitter):
 
     blockchain = f"""
 | '{blockchain.client.chain_name}' Blockchain Network |
-Gas Price ................ {Web3.fromWei(blockchain.client.gas_price, 'gwei')} Gwei
+Gas Price ................ {Web3.from_wei(blockchain.client.gas_price, 'gwei')} Gwei
 ETH Provider URI ......... {blockchain.eth_provider_uri}
 Registry ................. {registry.filepath}
     """

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -175,9 +175,9 @@ def _make_rest_app(datastore: Datastore, this_node, log: Logger) -> Flask:
         # TODO: Cache & Optimize
         reenc_request = ReencryptionRequest.from_bytes(request.data)
 
-        json_lingo = json.loads(reenc_request.conditions.decode())
-        lingo = [ConditionLingo.from_json(l) if l else None for l in json_lingo]
-        context = json.loads(reenc_request.context.decode()) or dict()  # user-supplied static input for condition parameters
+        json_lingo = json.loads(str(reenc_request.conditions))
+        lingo = [ConditionLingo.from_list(lingo) if lingo else None for lingo in json_lingo]
+        context = json.loads(str(reenc_request.context)) or dict()  # requester-supplied input
         packets = zip(reenc_request.capsules, lingo)
 
         # TODO: Detect if we are dealing with PRE or tDec here

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -183,11 +183,6 @@ class ConditionLingo:
         data = self.to_json().encode()
         return data
 
-    @classmethod
-    def from_bytes(cls, data: bytes) -> 'ConditionLingo':
-        instance = cls.from_json(data.decode())
-        return instance
-
     def __eval(self, eval_string: str):
         # TODO: Additional protection and/or sanitation here
         result = eval(eval_string)

--- a/nucypher/policy/kits.py
+++ b/nucypher/policy/kits.py
@@ -22,7 +22,7 @@ from eth_typing import ChecksumAddress
 from eth_utils import to_canonical_address
 from nucypher_core.umbral import PublicKey, SecretKey, VerifiedCapsuleFrag
 
-from nucypher_core import MessageKit, RetrievalKit
+from nucypher_core import Address, MessageKit, RetrievalKit
 from nucypher.policy.conditions.lingo import ConditionLingo
 
 
@@ -88,7 +88,7 @@ class RetrievalResult:
 
     def canonical_addresses(self) -> Set[bytes]:
         # TODO (#1995): propagate this to use canonical addresses everywhere
-        return set([to_canonical_address(address) for address in self.cfrags])
+        return set([Address(to_canonical_address(address)) for address in self.cfrags])
 
     def with_result(self, result: 'RetrievalResult') -> 'RetrievalResult':
         """

--- a/nucypher/policy/policies.py
+++ b/nucypher/policy/policies.py
@@ -21,10 +21,9 @@ from typing import Sequence, Optional, Iterable, List, Dict
 
 import maya
 from eth_typing.evm import ChecksumAddress
-from nucypher_core import HRAC, TreasureMap
+from nucypher_core import Address, HRAC, TreasureMap
 from nucypher_core.umbral import PublicKey, VerifiedKeyFrag
 
-from nucypher.blockchain.eth.utils import calculate_period_duration
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.network.middleware import RestMiddleware
 from nucypher.policy.reservoir import (
@@ -171,7 +170,7 @@ class Policy(ABC):
         self._publish(ursulas=ursulas)
 
         assigned_kfrags = {
-            ursula.canonical_address: (ursula.public_keys(DecryptingPower), vkfrag)
+            Address(ursula.canonical_address): (ursula.public_keys(DecryptingPower), vkfrag)
             for ursula, vkfrag in zip(ursulas, self.kfrags)
         }
 

--- a/nucypher/policy/revocation.py
+++ b/nucypher/policy/revocation.py
@@ -15,10 +15,11 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 from eth_typing.evm import ChecksumAddress
 from eth_utils import to_checksum_address, to_canonical_address
 
-from nucypher_core import RevocationOrder
+from nucypher_core import Address, RevocationOrder
 from nucypher.crypto.signing import SignatureStamp
 
 
@@ -29,7 +30,7 @@ class RevocationKit:
         self.revocations = dict()
         for staking_provider_address, encrypted_kfrag in treasure_map.destinations.items():
             self.revocations[staking_provider_address] = RevocationOrder(signer=signer.as_umbral_signer(),
-                                                                         staking_provider_address=staking_provider_address,
+                                                                         staking_provider_address=Address(staking_provider_address),
                                                                          encrypted_kfrag=encrypted_kfrag)
 
     def __iter__(self):

--- a/nucypher/utilities/datafeeds.py
+++ b/nucypher/utilities/datafeeds.py
@@ -112,7 +112,7 @@ class EtherchainGasPriceDatafeed(EthereumGasPriceDatafeed):
 
     def _parse_gas_prices(self):
         self._probe_feed()
-        self.gas_prices = {self.get_canonical_speed(k): int(Web3.toWei(v, 'gwei')) for k, v in self._raw_data.items()}
+        self.gas_prices = {self.get_canonical_speed(k): int(Web3.to_wei(v, 'gwei')) for k, v in self._raw_data.items()}
 
 
 class UpvestGasPriceDatafeed(EthereumGasPriceDatafeed):
@@ -130,7 +130,7 @@ class UpvestGasPriceDatafeed(EthereumGasPriceDatafeed):
 
     def _parse_gas_prices(self):
         self._probe_feed()
-        self.gas_prices = {self.get_canonical_speed(k): int(Web3.toWei(v, 'gwei'))
+        self.gas_prices = {self.get_canonical_speed(k): int(Web3.to_wei(v, 'gwei'))
                            for k, v in self._raw_data['estimates'].items()}
 
 
@@ -152,5 +152,5 @@ class ZoltuGasPriceDatafeed(EthereumGasPriceDatafeed):
         self.gas_prices = dict()
         for canonical_speed_name, zoltu_speed in self._speed_names.items():
             gwei_price = self._raw_data[zoltu_speed].split(" ")[0]
-            wei_price = int(Web3.toWei(gwei_price, 'gwei'))
+            wei_price = int(Web3.to_wei(gwei_price, 'gwei'))
             self.gas_prices[canonical_speed_name] = wei_price

--- a/nucypher/utilities/gas_strategies.py
+++ b/nucypher/utilities/gas_strategies.py
@@ -129,11 +129,11 @@ EXPECTED_CONFIRMATION_TIME_IN_SECONDS = {  # TODO: See #2447
 
 
 def construct_fixed_price_gas_strategy(gas_price, denomination: str = "wei") -> Callable:
-    gas_price_in_wei = Web3.toWei(gas_price, denomination)
+    gas_price_in_wei = Web3.to_wei(gas_price, denomination)
 
     def _fixed_price_strategy(web3: Web3, transaction_params: TxParams = None) -> Wei:
         return gas_price_in_wei
 
-    _fixed_price_strategy.name = f"{round(Web3.fromWei(gas_price_in_wei, 'gwei'))}gwei"
+    _fixed_price_strategy.name = f"{round(Web3.from_wei(gas_price_in_wei, 'gwei'))}gwei"
 
     return _fixed_price_strategy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -i https://pypi.python.org/simple
-aiohttp==3.8.1; python_version >= '3.6'
+aiohttp==3.8.3; python_version >= '3.6'
 aiosignal==1.2.0; python_version >= '3.6'
 appdirs==1.4.4
 async-timeout==4.0.2; python_version >= '3.6'
@@ -7,10 +7,10 @@ attrs==22.1.0; python_version >= '3.5'
 autobahn==22.7.1; python_version >= '3.7'
 automat==20.2.0
 base58==2.1.1; python_version >= '3.5'
-bitarray==1.2.2
+bitarray==2.6.0
 bytestring-splitter==2.4.1
 cached-property==1.5.2
-certifi==2022.9.14; python_version >= '3.6'
+certifi==2022.9.24; python_version >= '3.6'
 cffi==1.15.1
 charset-normalizer==2.1.1; python_version >= '3.6'
 click==8.1.3
@@ -24,9 +24,9 @@ dateparser==1.1.1; python_version >= '3.5'
 ecdsa==0.18.0; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 eip712-structs==1.1.0
 eth-abi==3.0.1; python_version >= '3.7' and python_version < '4'
-eth-account==0.6.1; python_version >= '3.6' and python_version < '4'
+eth-account==0.7.0; python_version >= '3.6' and python_version < '4'
 eth-bloom==1.0.4; python_version >= '3.6' and python_version < '4'
-eth-hash[pycryptodome]==0.3.3; python_version >= '3.5' and python_version < '4'
+eth-hash==0.3.3; python_version >= '3.5' and python_version < '4'
 eth-keyfile==0.6.0
 eth-keys==0.4.0
 eth-rlp==0.3.0; python_version >= '3.7' and python_version < '4'
@@ -36,11 +36,10 @@ eth-utils==2.0.0
 flask==2.2.2
 frozenlist==1.3.1; python_version >= '3.7'
 hendrix==3.4.0
-hexbytes==0.2.3; python_version >= '3.6' and python_version < '4'
-humanize==4.3.0; python_version >= '3.7'
+hexbytes==0.3.0; python_version >= '3.7' and python_version < '4'
+humanize==4.4.0; python_version >= '3.7'
 hyperlink==21.0.0
 idna==3.4; python_version >= '3.5'
-importlib-metadata==4.12.0; python_version < '3.10'
 incremental==21.3.0
 ipfshttpclient==0.8.0a2; python_full_version >= '3.6.2' and python_full_version not in '3.7.0, 3.7.1'
 itsdangerous==2.0.1
@@ -49,9 +48,9 @@ jsonschema==4.16.0; python_version >= '3.7'
 libusb1==3.0.0
 lmdb==1.3.0
 lru-dict==1.1.8
-mako==1.2.2
+mako==1.2.3
 markupsafe==2.1.1; python_version >= '3.7'
-marshmallow==3.17.1
+marshmallow==3.18.0
 maya==0.6.1
 mnemonic==0.20; python_version >= '3.5'
 msgpack-python==0.5.6
@@ -60,27 +59,27 @@ multiaddr==0.0.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3
 multidict==6.0.2; python_version >= '3.7'
 mypy-extensions==0.4.3
 netaddr==0.8.0
-nucypher-core==0.4.0a0
+nucypher-core==0.4.0
 packaging==21.3; python_version >= '3.6'
 parsimonious==0.8.1
 pendulum==2.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 pillow==9.2.0; python_version >= '3.7'
-protobuf==3.20.2; python_version >= '3.7'
+protobuf==3.20.1; python_version >= '3.7'
 py-ecc==6.0.0; python_version >= '3.6' and python_version < '4'
 py-evm==0.6.0a1
-pyasn1-modules==0.2.8
-pyasn1==0.4.8
+pyasn1-modules==0.3.0rc1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+pyasn1==0.5.0rc2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pychalk==2.0.1
 pycparser==2.21
 pycryptodome==3.15.0
 pyethash==0.1.27
 pynacl==1.5.0
-pyopenssl==22.0.0
+pyopenssl==22.1.0
 pyparsing==3.0.9; python_full_version >= '3.6.8'
 pyrsistent==0.18.1; python_version >= '3.7'
 pysha3==1.0.2
 python-dateutil==2.8.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
-pytz==2022.2.1
+pytz==2022.4
 pytzdata==2020.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 qrcode[pil]==7.3.1
 regex==2022.3.2; python_version >= '3.6'
@@ -88,6 +87,7 @@ requests==2.28.1
 rlp==3.0.0
 semantic-version==2.10.0; python_version >= '2.7'
 service-identity==21.1.0
+setuptools==65.4.1; python_version >= '3.7'
 simple-rlp==0.1.3; python_version >= '3.7'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'
 snaptime==0.2.4
@@ -95,7 +95,7 @@ sortedcontainers==2.4.0
 tabulate==0.8.10
 toolz==0.12.0; python_version >= '3.5'
 trezor==0.13.3
-trie==2.0.1; python_version >= '3.6' and python_version < '4'
+trie==2.0.2; python_version >= '3.6' and python_version < '4'
 twisted==22.8.0; python_full_version >= '3.7.1'
 txaio==22.2.1; python_version >= '3.6'
 typing-extensions==4.3.0; python_version >= '3.7'
@@ -103,9 +103,8 @@ tzlocal==2.1
 urllib3==1.26.12; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'
 varint==1.0.2
 watchdog==2.1.9; python_version >= '3.6'
-web3==6.0.0b4
+web3==6.0.0b6
 websockets==10.3; python_version >= '3.7'
 werkzeug==2.2.2; python_version >= '3.7'
 yarl==1.8.1; python_version >= '3.7'
-zipp==3.8.1; python_version >= '3.7'
 zope.interface==5.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/tests/acceptance/blockchain/conditions/conftest.py
+++ b/tests/acceptance/blockchain/conditions/conftest.py
@@ -73,7 +73,7 @@ def rpc_condition():
     condition = RPCCondition(
         method="eth_getBalance",
         chain="testerchain",
-        return_value_test=ReturnValueTest("==", Web3.toWei(1_000_000, "ether")),
+        return_value_test=ReturnValueTest("==", Web3.to_wei(1_000_000, "ether")),
         parameters=[USER_ADDRESS_CONTEXT],
     )
     return condition

--- a/tests/acceptance/blockchain/conditions/test_conditions.py
+++ b/tests/acceptance/blockchain/conditions/test_conditions.py
@@ -148,7 +148,7 @@ def test_rpc_condition_evaluation(get_context_value_mock, testerchain, rpc_condi
         provider=testerchain.provider, **context
     )
     assert condition_result is True
-    assert call_result == Web3.toWei(
+    assert call_result == Web3.to_wei(
         1_000_000, "ether"
     )  # same value used in rpc_condition fixture
 

--- a/tests/acceptance/cli/lifecycle.py
+++ b/tests/acceptance/cli/lifecycle.py
@@ -332,7 +332,7 @@ def run_entire_cli_lifecycle(click_runner,
             grant_args += ('--federated-only',)
         else:
             grant_args += ('--eth-provider', TEST_ETH_PROVIDER_URI,
-                           '--value', Web3.toWei(9, 'gwei'))
+                           '--value', Web3.to_wei(9, 'gwei'))
 
         grant_result = click_runner.invoke(nucypher_cli, grant_args, catch_exceptions=False, env=envvars)
         assert grant_result.exit_code == 0, (grant_result.output, grant_result.exception)

--- a/tests/acceptance/cli/ursula/test_local_keystore_integration.py
+++ b/tests/acceptance/cli/ursula/test_local_keystore_integration.py
@@ -58,7 +58,7 @@ def mock_funded_account_password_keystore(tmp_path_factory, testerchain, thresho
         testerchain.client.w3.eth.send_transaction({
             'to': account.address,
             'from': testerchain.etherbase_account,
-            'value': Web3.toWei('1', 'ether')}))
+            'value': Web3.to_wei('1', 'ether')}))
 
     # initialize threshold stake
     provider_address = testerchain.unassigned_accounts[0]

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -65,7 +65,7 @@ MIN_STAKE_FOR_TESTS = NU(750_000, 'NU').to_units()
 
 BONUS_TOKENS_FOR_TESTS = NU(150_000, 'NU').to_units()
 
-DEVELOPMENT_ETH_AIRDROP_AMOUNT = int(Web3().toWei(100, 'ether'))
+DEVELOPMENT_ETH_AIRDROP_AMOUNT = int(Web3().to_wei(100, 'ether'))
 
 NUMBER_OF_ALLOCATIONS_IN_TESTS = 50  # TODO: Move to constants
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -558,7 +558,7 @@ def testerchain(_testerchain) -> TesterBlockchain:
             txhash = testerchain.w3.eth.send_transaction(tx)
 
             _receipt = testerchain.wait_for_receipt(txhash)
-            eth_amount = Web3().fromWei(spent, 'ether')
+            eth_amount = Web3().from_wei(spent, 'ether')
             testerchain.log.info("Airdropped {} ETH {} -> {}".format(eth_amount, tx['from'], tx['to']))
 
     BlockchainInterfaceFactory.register_interface(interface=testerchain, force=True)
@@ -707,7 +707,7 @@ def blockchain_ursulas(testerchain, staking_providers, ursula_decentralized_test
 
 @pytest.fixture(scope='module')
 def policy_rate():
-    rate = Web3.toWei(21, 'gwei')
+    rate = Web3.to_wei(21, 'gwei')
     return rate
 
 
@@ -766,7 +766,7 @@ def software_stakeholder(testerchain, agency, stakeholder_config_file_location, 
 
     tx = {'to': address,
           'from': testerchain.etherbase_account,
-          'value': Web3.toWei('1', 'ether')}
+          'value': Web3.to_wei('1', 'ether')}
 
     txhash = testerchain.client.w3.eth.send_transaction(tx)
     _receipt = testerchain.wait_for_receipt(txhash)
@@ -809,7 +809,7 @@ def manual_operator(testerchain):
 
     tx = {'to': address,
           'from': testerchain.etherbase_account,
-          'value': Web3.toWei('1', 'ether')}
+          'value': Web3.to_wei('1', 'ether')}
 
     txhash = testerchain.client.w3.eth.send_transaction(tx)
     _receipt = testerchain.wait_for_receipt(txhash)

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -18,7 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 
 import json
 
-from nucypher_core import RetrievalKit, Conditions
+from nucypher_core import Address, RetrievalKit, Conditions
 
 from nucypher.characters.lawful import Enrico
 from tests.utils.middleware import NodeIsDownMiddleware
@@ -48,7 +48,7 @@ def test_retrieval_kit(enacted_federated_policy, federated_ursulas):
     messages, message_kits = _make_message_kits(enacted_federated_policy.public_key)
 
     capsule = message_kits[0].capsule
-    addresses = {ursula.canonical_address for ursula in list(federated_ursulas)[:2]}
+    addresses = {Address(ursula.canonical_address) for ursula in list(federated_ursulas)[:2]}
 
     retrieval_kit = RetrievalKit(capsule, addresses)
     serialized = bytes(retrieval_kit)

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -14,11 +14,13 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 import json
 
+from nucypher_core import RetrievalKit, Conditions
+
 from nucypher.characters.lawful import Enrico
-from nucypher_core import RetrievalKit
-from nucypher.policy.conditions.lingo import ConditionLingo
 from tests.utils.middleware import NodeIsDownMiddleware
 
 
@@ -79,12 +81,13 @@ def test_single_retrieve_with_conditions(enacted_federated_policy, federated_bob
         {'operator': 'and'},
         {'returnValueTest': {'value': '99999999999999999', 'comparator': '<'}, 'method': 'timelock'},
     ]
-
+    json_conditions = json.dumps(conditions)
+    rust_conditions = Conditions(json_conditions)
     message_kits = [
         MessageKit(
             enacted_federated_policy.public_key,
             b'lab',
-            json.dumps(conditions).encode()
+            rust_conditions
         )
     ]
 

--- a/tests/integration/cli/actions/test_select_client_account.py
+++ b/tests/integration/cli/actions/test_select_client_account.py
@@ -207,7 +207,7 @@ def test_select_client_account_with_balance_display(mock_stdin,
 
         if show_eth:
             balance = mock_testerchain.client.get_balance(account=account)
-            assert str(Web3.fromWei(balance, 'ether')) in captured.out
+            assert str(Web3.from_wei(balance, 'ether')) in captured.out
 
         if show_staking:
             if len(stake_info) == 0:

--- a/tests/integration/porter/conftest.py
+++ b/tests/integration/porter/conftest.py
@@ -15,8 +15,9 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+
 import pytest
-from nucypher_core import HRAC, TreasureMap
+from nucypher_core import Address, HRAC, TreasureMap
 
 from nucypher.crypto.powers import DecryptingPower
 
@@ -33,7 +34,7 @@ def random_federated_treasure_map_data(federated_alice, federated_bob, federated
                 label=label)
 
     assigned_kfrags = {
-        ursula.canonical_address: (ursula.public_keys(DecryptingPower), vkfrag)
+        Address(ursula.canonical_address): (ursula.public_keys(DecryptingPower), vkfrag)
         for ursula, vkfrag in zip(list(federated_ursulas)[:shares], kfrags)}
 
     random_treasure_map = TreasureMap(signer=federated_alice.stamp.as_umbral_signer(),

--- a/tests/metrics/grant_availability.py
+++ b/tests/metrics/grant_availability.py
@@ -78,7 +78,7 @@ TEMP_ALICE_DIR: Path = Path('/', 'tmp', 'grant-metrics')
 # Policy Parameters
 THRESHOLD: int = 1
 SHARES: int = 1
-RATE: Wei = Web3.toWei(50, 'gwei')
+RATE: Wei = Web3.to_wei(50, 'gwei')
 DURATION: datetime.timedelta = datetime.timedelta(days=1)
 
 # Tuning

--- a/tests/unit/conditions/conftest.py
+++ b/tests/unit/conditions/conftest.py
@@ -68,7 +68,7 @@ def rpc_condition():
     condition = RPCCondition(
         method="eth_getBalance",
         chain="testerchain",
-        return_value_test=ReturnValueTest("==", Web3.toWei(1_000_000, "ether")),
+        return_value_test=ReturnValueTest("==", Web3.to_wei(1_000_000, "ether")),
         parameters=[USER_ADDRESS_CONTEXT],
     )
     return condition

--- a/tests/unit/conditions/test_evm_condition_serializers.py
+++ b/tests/unit/conditions/test_evm_condition_serializers.py
@@ -60,8 +60,5 @@ def test_conditions_lingo_serialization(lingo):
     lingo_b64 = restored_lingo.to_base64()
     restored_lingo = ConditionLingo.from_base64(lingo_b64)
 
-    lingo_bytes = bytes(restored_lingo)
-    restored_lingo = ConditionLingo.from_bytes(lingo_bytes)
-
     # after all the serialization and transformation the content must remain identical
     assert restored_lingo.to_json() == lingo_json

--- a/tests/unit/test_datafeeds.py
+++ b/tests/unit/test_datafeeds.py
@@ -159,10 +159,10 @@ def test_etherchain():
 
     with patch.object(feed, '_probe_feed'):
         feed._raw_data = etherchain_json
-        assert feed.get_gas_price('safeLow') == Web3.toWei(99.0, 'gwei')
-        assert feed.get_gas_price('standard') == Web3.toWei(105.0, 'gwei')
-        assert feed.get_gas_price('fast') == Web3.toWei(108.0, 'gwei')
-        assert feed.get_gas_price('fastest') == Web3.toWei(119.9, 'gwei')
+        assert feed.get_gas_price('safeLow') == Web3.to_wei(99.0, 'gwei')
+        assert feed.get_gas_price('standard') == Web3.to_wei(105.0, 'gwei')
+        assert feed.get_gas_price('fast') == Web3.to_wei(108.0, 'gwei')
+        assert feed.get_gas_price('fastest') == Web3.to_wei(119.9, 'gwei')
         assert feed.get_gas_price() == feed.get_gas_price('fast')  # Default
         parsed_gas_prices = feed.gas_prices
 
@@ -170,7 +170,7 @@ def test_etherchain():
         EtherchainGasPriceDatafeed.gas_prices = dict()
         with patch.dict(EtherchainGasPriceDatafeed.gas_prices, values=parsed_gas_prices):
             gas_strategy = feed.construct_gas_strategy()
-            assert gas_strategy("web3", "tx") == Web3.toWei(108.0, 'gwei')
+            assert gas_strategy("web3", "tx") == Web3.to_wei(108.0, 'gwei')
 
 
 def test_upvest():
@@ -181,10 +181,10 @@ def test_upvest():
 
     with patch.object(feed, '_probe_feed'):
         feed._raw_data = upvest_json
-        assert feed.get_gas_price('slow') == Web3.toWei(87.19, 'gwei')
-        assert feed.get_gas_price('medium') == Web3.toWei(91.424, 'gwei')
-        assert feed.get_gas_price('fast') == Web3.toWei(97.158, 'gwei')
-        assert feed.get_gas_price('fastest') == Web3.toWei(105.2745, 'gwei')
+        assert feed.get_gas_price('slow') == Web3.to_wei(87.19, 'gwei')
+        assert feed.get_gas_price('medium') == Web3.to_wei(91.424, 'gwei')
+        assert feed.get_gas_price('fast') == Web3.to_wei(97.158, 'gwei')
+        assert feed.get_gas_price('fastest') == Web3.to_wei(105.2745, 'gwei')
         assert feed.get_gas_price() == feed.get_gas_price('fastest')  # Default
         parsed_gas_prices = feed.gas_prices
 
@@ -192,7 +192,7 @@ def test_upvest():
         UpvestGasPriceDatafeed.gas_prices = dict()
         with patch.dict(UpvestGasPriceDatafeed.gas_prices, values=parsed_gas_prices):
             gas_strategy = feed.construct_gas_strategy()
-            assert gas_strategy("web3", "tx") == Web3.toWei(105.2745, 'gwei')
+            assert gas_strategy("web3", "tx") == Web3.to_wei(105.2745, 'gwei')
 
 
 def test_zoltu():
@@ -203,10 +203,10 @@ def test_zoltu():
 
     with patch.object(feed, '_probe_feed'):
         feed._raw_data = zoltu_json
-        assert feed.get_gas_price('slow') == Web3.toWei(41, 'gwei')
-        assert feed.get_gas_price('medium') == Web3.toWei(58, 'gwei')
-        assert feed.get_gas_price('fast') == Web3.toWei(67, 'gwei')
-        assert feed.get_gas_price('fastest') == Web3.toWei(70, 'gwei')
+        assert feed.get_gas_price('slow') == Web3.to_wei(41, 'gwei')
+        assert feed.get_gas_price('medium') == Web3.to_wei(58, 'gwei')
+        assert feed.get_gas_price('fast') == Web3.to_wei(67, 'gwei')
+        assert feed.get_gas_price('fastest') == Web3.to_wei(70, 'gwei')
         assert feed.get_gas_price() == feed.get_gas_price('fast')  # Default
         parsed_gas_prices = feed.gas_prices
 
@@ -214,7 +214,7 @@ def test_zoltu():
         ZoltuGasPriceDatafeed.gas_prices = dict()
         with patch.dict(ZoltuGasPriceDatafeed.gas_prices, values=parsed_gas_prices):
             gas_strategy = feed.construct_gas_strategy()
-            assert gas_strategy("web3", "tx") == Web3.toWei(67, 'gwei')
+            assert gas_strategy("web3", "tx") == Web3.to_wei(67, 'gwei')
 
 
 def test_datafeed_median_gas_price_strategy():

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -14,11 +14,13 @@
  You should have received a copy of the GNU Affero General Public License
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
+
+
 from pathlib import Path
 
 import pytest
 from eth_utils import to_checksum_address
-from nucypher_core import NodeMetadata, NodeMetadataPayload
+from nucypher_core import Address, NodeMetadata, NodeMetadataPayload
 from nucypher_core.umbral import SecretKey, Signer
 
 from nucypher.acumen.perception import FleetSensor
@@ -78,7 +80,7 @@ class Dummy:  # Teacher
         # A dummy signature with the recovery byte
         dummy_signature = bytes(signer.sign(b'whatever')) + b'\x00'
 
-        payload = NodeMetadataPayload(staking_provider_address=self.canonical_address,
+        payload = NodeMetadataPayload(staking_provider_address=Address(self.canonical_address),
                                       domain=':dummy:',
                                       timestamp_epoch=0,
                                       operator_signature=dummy_signature,

--- a/tests/unit/test_gas_strategies.py
+++ b/tests/unit/test_gas_strategies.py
@@ -46,9 +46,9 @@ def test_fixed_price_gas_strategy():
 def test_max_price_gas_strategy(mocker, monkeypatch):
 
     gas_prices_gwei = [10, 100, 999, 1000, 1001, 1_000_000, 1_000_000_000]
-    gas_prices_wei = [Web3.toWei(gwei_price, 'gwei') for gwei_price in gas_prices_gwei]
+    gas_prices_wei = [Web3.to_wei(gwei_price, 'gwei') for gwei_price in gas_prices_gwei]
     max_gas_price_gwei = 1000
-    max_gas_price_wei = Web3.toWei(max_gas_price_gwei, 'gwei')
+    max_gas_price_wei = Web3.to_wei(max_gas_price_gwei, 'gwei')
     mock_gas_strategy = mocker.Mock(side_effect=itertools.cycle(gas_prices_wei))
 
     wrapped_strategy = max_price_gas_strategy_wrapper(gas_strategy=mock_gas_strategy,

--- a/tests/unit/test_porter_unit.py
+++ b/tests/unit/test_porter_unit.py
@@ -21,7 +21,7 @@ from eth_utils import to_canonical_address
 
 import pytest
 
-from nucypher_core import RetrievalKit as RetrievalKitClass, MessageKit
+from nucypher_core import RetrievalKit as RetrievalKitClass, Address, MessageKit
 from nucypher_core.umbral import SecretKey
 
 from nucypher.control.specifications.exceptions import InvalidInputData
@@ -106,7 +106,7 @@ def test_retrieval_kit_field(get_random_checksum_address):
     encrypting_key = SecretKey.random().public_key()
     capsule = MessageKit(encrypting_key, b'testing retrieval kit with 2 ursulas').capsule
     ursulas = [get_random_checksum_address(), get_random_checksum_address()]
-    run_tests_on_kit(kit=RetrievalKitClass(capsule, {to_canonical_address(ursula) for ursula in ursulas}))
+    run_tests_on_kit(kit=RetrievalKitClass(capsule, {Address(to_canonical_address(ursula)) for ursula in ursulas}))
 
     # kit with no ursulas
     encrypting_key = SecretKey.random().public_key()

--- a/tests/unit/test_web3_clients.py
+++ b/tests/unit/test_web3_clients.py
@@ -122,7 +122,7 @@ class SyncedMockWeb3:
         return self.provider.clientVersion
 
     @property
-    def isConnected(self):
+    def is_connected(self):
         return lambda: True
 
 

--- a/tests/utils/blockchain.py
+++ b/tests/utils/blockchain.py
@@ -177,7 +177,7 @@ class TesterBlockchain(BlockchainDeployerInterface):
 
             _receipt = self.wait_for_receipt(txhash)
             tx_hashes.append(txhash)
-            eth_amount = Web3().fromWei(amount, 'ether')
+            eth_amount = Web3().from_wei(amount, 'ether')
             self.log.info("Airdropped {} ETH {} -> {}".format(eth_amount, tx['from'], tx['to']))
 
         return tx_hashes


### PR DESCRIPTION
Co-authored by @KPrasch and @jMyles 

3 approvals please!

##### New Types
- Support the `Condition` type from nucypher-core
- Support the `Context` type from nucypher-core
- Supports the `Address` type from nucypher-core

##### Dependencies
- Updates nucypher-core to v0.4.0
- Updates web3.py
- https://github.com/nucypher/nucypher-core/pull/32
- https://github.com/nucypher/nucypher-core/pull/33
- https://github.com/nucypher/nucypher-core/pull/34
 -https://github.com/nucypher/nucypher-core/pull/35

#####  Why
This PR includes prerequisite work needed to support a backwards-compatible network with co-existing CBD and PRE services.  The protocol version for `MessageKit` has been bumped - this PR exposes the appropriate errors in the client layer as well as integrating a formalized types for `Conditions`, `Context`, and `Address` paving the way for future nucypher-core protocol enhancements.
