### PR TITLE
eval is evil 

### DIFF
--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -62,12 +62,12 @@ class ReturnValueTest:
         def make(self, data, **kwargs):
             return ReturnValueTest(**data)
 
-    def __init__(self, comparator: str, value: Union[int, str]):
-        comparator, value = self.sanitize(comparator, value)
+    def __init__(self, comparator: str, value):
+        comparator, value = self._sanitize(comparator, value)
         self.comparator = comparator
         self.value = value
 
-    def sanitize(self, comparator: str, value: str) -> Tuple[str, str]:
+    def _sanitize(self, comparator: str, value) -> Tuple[str, Any]:
         if comparator not in self.COMPARATORS:
             raise ValueError(f'{comparator} is not a permitted comparator.')
         return comparator, ast.literal_eval(str(value))

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -61,15 +61,13 @@ class ReturnValueTest:
         self.value = value
 
     def sanitize(self, comparator: str, value: str) -> Tuple[str, str]:
-        # Note that we're not sanitizing the value
         if comparator not in self.COMPARATORS:
             raise ValueError(f'{comparator} is not a permitted comparator.')
-        return comparator, value
+        return comparator, ast.literal_eval(str(value))
 
     def eval(self, data) -> bool:
-        # TODO: Sanitize input!!!
         left_operand = ast.literal_eval(str(data))
-        right_operand = ast.literal_eval(str(self.value))
+        right_operand = self.value
         result = eval(f'{left_operand}{self.comparator}{right_operand}')
         return result
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -1,3 +1,4 @@
+import ast
 import base64
 import json
 from typing import Union, Tuple, List, Dict, Any
@@ -60,13 +61,16 @@ class ReturnValueTest:
         self.value = value
 
     def sanitize(self, comparator: str, value: str) -> Tuple[str, str]:
+        # Note that we're not sanitizing the value
         if comparator not in self.COMPARATORS:
             raise ValueError(f'{comparator} is not a permitted comparator.')
         return comparator, value
 
     def eval(self, data) -> bool:
         # TODO: Sanitize input!!!
-        result = eval(f'{data}{self.comparator}{self.value}')
+        left_operand = ast.literal_eval(str(data))
+        right_operand = ast.literal_eval(str(self.value))
+        result = eval(f'{left_operand}{self.comparator}{right_operand}')
         return result
 
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -45,7 +45,14 @@ class Operator:
 
 
 class ReturnValueTest:
-    COMPARATORS = ('==', '>', '<', '<=', '>=')
+    _COMPARATOR_FUNCTIONS = {
+        '==': lambda x, y: x == y,
+        '>': lambda x, y: x > y,
+        '<': lambda x, y: x < y,
+        '<=': lambda x, y: x <= y,
+        '>=': lambda x, y: x >= y,
+    }
+    COMPARATORS = tuple(_COMPARATOR_FUNCTIONS.keys())
 
     class ReturnValueTestSchema(CamelCaseSchema):
         comparator = fields.Str()
@@ -68,7 +75,7 @@ class ReturnValueTest:
     def eval(self, data) -> bool:
         left_operand = ast.literal_eval(str(data))
         right_operand = self.value
-        result = eval(f'{left_operand}{self.comparator}{right_operand}')
+        result = self._COMPARATOR_FUNCTIONS[self.comparator](left_operand, right_operand)
         return result
 
 

--- a/tests/unit/conditions/conftest.py
+++ b/tests/unit/conditions/conftest.py
@@ -88,6 +88,7 @@ def evm_condition(test_registry):
     )
     return condition
 
+
 @pytest.fixture
 def sm_condition(test_registry):
     condition = ContractCondition(

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -1,0 +1,12 @@
+from nucypher.policy.conditions.lingo import ConditionLingo
+
+
+def test_compound_condition_timelock():
+    conditions = [
+        {'returnValueTest': {'value': '0', 'comparator': '>'}, 'method': 'timelock'},
+        {'operator': 'and'},
+        {'returnValueTest': {'value': '99999999999999999', 'comparator': '<'}, 'method': 'timelock'},
+    ]
+
+    clingo = ConditionLingo.from_list(conditions)
+    assert clingo.eval()

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -4,10 +4,20 @@ import pytest
 from nucypher.policy.conditions.lingo import ReturnValueTest
 
 
-def test_return_result_test_simple():
+def test_return_value_test_integer():
     test = ReturnValueTest(comparator='>', value='0')
     assert test.eval('1')
     assert not test.eval('-1')
+
+    test = ReturnValueTest(comparator='>', value=0)
+    assert test.eval(1)
+    assert not test.eval(-1)
+
+
+def test_return_value_test_string():
+    test = ReturnValueTest(comparator='==', value='"foo"')
+    assert test.eval('"foo"')
+    assert not test.eval('"bar"')
 
 
 def test_return_value_sanitization():

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -1,14 +1,23 @@
+import os
 import pytest
 
 from nucypher.policy.conditions.lingo import ReturnValueTest
 
 
 def test_return_result_test_simple():
-    test = ReturnValueTest(comparator='>', value=0)
-    assert test.eval(1)
-    assert not test.eval(-1)
+    test = ReturnValueTest(comparator='>', value='0')
+    assert test.eval('1')
+    assert not test.eval('-1')
 
 
 def test_return_value_sanitization():
     with pytest.raises(ValueError):
         _test = ReturnValueTest('DROP', 'TABLE')
+
+def test_eval_is_evil():
+    file = f"file_{os.urandom(10).hex()}"
+    assert not os.path.isfile(file)
+    test = ReturnValueTest(comparator='>', value=f"(lambda: (42, __import__('os').system('touch {file}'))[0])()")
+    with pytest.raises(ValueError):
+        _ = test.eval('1000')
+    assert not os.path.isfile(file)

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -14,10 +14,9 @@ def test_return_value_sanitization():
     with pytest.raises(ValueError):
         _test = ReturnValueTest('DROP', 'TABLE')
 
+
 def test_eval_is_evil():
     file = f"file_{os.urandom(10).hex()}"
     assert not os.path.isfile(file)
-    test = ReturnValueTest(comparator='>', value=f"(lambda: (42, __import__('os').system('touch {file}'))[0])()")
     with pytest.raises(ValueError):
-        _ = test.eval('1000')
-    assert not os.path.isfile(file)
+        _test = ReturnValueTest(comparator='>', value=f"(lambda: (42, __import__('os').system('touch {file}'))[0])()")


### PR DESCRIPTION
A small fix that reduces the risk of dangerous input that exploit our use of `eval()`, although this PR doesn't remove `eval()` completely.

To solve this once and for all I'd prefer using a different approach, which affects how we define compound conditions (see https://github.com/nucypher/tdec/issues/59)

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
