### PR TITLE
Porter Error Handling for `/retrieve_cfrags` endpoint

### DIFF
--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -24,16 +24,27 @@ from http import HTTPStatus
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from queue import Queue
-from typing import Dict, Iterable, List, NamedTuple, Tuple, Union, Optional, Sequence, Set, Any
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 
 import maya
 from constant_sorrow import constants
 from constant_sorrow.constants import (
-    PUBLIC_ONLY,
-    STRANGER_ALICE,
-    READY,
     INVALIDATED,
-    NOT_SIGNED
+    NOT_SIGNED,
+    PUBLIC_ONLY,
+    READY,
+    STRANGER_ALICE,
 )
 from cryptography.hazmat.primitives.serialization import Encoding
 from cryptography.x509 import Certificate, NameOID
@@ -41,35 +52,40 @@ from eth_typing.evm import ChecksumAddress
 from eth_utils import to_checksum_address
 from flask import Response, request
 from nucypher_core import (
-    MessageKit,
+    HRAC,
     EncryptedKeyFrag,
-    TreasureMap,
     EncryptedTreasureMap,
-    ReencryptionResponse,
+    MessageKit,
     NodeMetadata,
     NodeMetadataPayload,
-    HRAC,
+    ReencryptionResponse,
+    TreasureMap,
 )
-from nucypher_core.umbral import (
-    PublicKey, VerifiedKeyFrag, reencrypt,
-
-)
+from nucypher_core.umbral import PublicKey, VerifiedKeyFrag, reencrypt
 from twisted.internet import reactor, stdio
-from twisted.internet.defer import Deferred
 from twisted.logger import Logger
 from web3.types import TxReceipt
 
 import nucypher
 from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import ArchivedFleetState, RemoteUrsulaStatus
-from nucypher.blockchain.eth.actors import Operator, BlockchainPolicyAuthor
+from nucypher.blockchain.eth.actors import BlockchainPolicyAuthor, Operator
 from nucypher.blockchain.eth.agents import ContractAgency, PREApplicationAgent
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.blockchain.eth.signers.software import Web3Signer
-from nucypher.characters.banners import ALICE_BANNER, BOB_BANNER, ENRICO_BANNER, URSULA_BANNER
+from nucypher.characters.banners import (
+    ALICE_BANNER,
+    BOB_BANNER,
+    ENRICO_BANNER,
+    URSULA_BANNER,
+)
 from nucypher.characters.base import Character, Learner
-from nucypher.characters.control.interfaces import AliceInterface, BobInterface, EnricoInterface
+from nucypher.characters.control.interfaces import (
+    AliceInterface,
+    BobInterface,
+    EnricoInterface,
+)
 from nucypher.cli.processes import UrsulaCommandProtocol
 from nucypher.config.storages import NodeStorage
 from nucypher.control.controllers import WebController
@@ -80,19 +96,19 @@ from nucypher.crypto.powers import (
     DelegatingPower,
     PowerUpError,
     SigningPower,
-    TransactingPower,
     TLSHostingPower,
+    TransactingPower,
 )
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
-from nucypher.network.nodes import NodeSprout, TEACHER_NODES, Teacher
+from nucypher.network.nodes import TEACHER_NODES, NodeSprout, Teacher
 from nucypher.network.protocols import parse_node_uri
 from nucypher.network.retrieval import RetrievalClient
 from nucypher.network.server import ProxyRESTServer, make_rest_app
 from nucypher.network.trackers import AvailabilityTracker, OperatorBondedTracker
 from nucypher.policy.kits import PolicyMessageKit
-from nucypher.policy.payment import PaymentMethod, FreeReencryptions
-from nucypher.policy.policies import Policy, BlockchainPolicy, FederatedPolicy
+from nucypher.policy.payment import FreeReencryptions, PaymentMethod
+from nucypher.policy.policies import BlockchainPolicy, FederatedPolicy, Policy
 from nucypher.utilities.logging import Logger
 from nucypher.utilities.networking import validate_operator_ip
 
@@ -598,7 +614,7 @@ class Bob(Character):
 
         # Retrieve capsule frags
         client = RetrievalClient(learner=self)
-        retrieval_results = client.retrieve_cfrags(
+        retrieval_results, _ = client.retrieve_cfrags(
             treasure_map=treasure_map,
             retrieval_kits=retrieval_kits,
             alice_verifying_key=alice_verifying_key,
@@ -955,6 +971,7 @@ class Ursula(Teacher, Character, Operator):
         if prometheus_config:
             # Locally scoped to prevent import without prometheus explicitly installed
             from nucypher.utilities.prometheus.metrics import start_prometheus_exporter
+
             start_prometheus_exporter(ursula=self, prometheus_config=prometheus_config)
             if emitter:
                 emitter.message(f"✓ Prometheus Exporter", color='green')

--- a/nucypher/network/retrieval.py
+++ b/nucypher/network/retrieval.py
@@ -17,7 +17,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import json
 import random
 from collections import defaultdict
-from typing import Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 from eth_typing.evm import ChecksumAddress
 from eth_utils import to_checksum_address
@@ -42,9 +42,8 @@ from nucypher.policy.conditions.lingo import ConditionLingo
 from nucypher.policy.kits import RetrievalResult
 
 
-class RetrievalError:
-    def __init__(self, errors: Dict[ChecksumAddress, str]):
-        self.errors = errors
+class RetrievalError(NamedTuple):
+    errors: Dict[ChecksumAddress, str]
 
 
 class RetrievalPlan:
@@ -155,7 +154,7 @@ class RetrievalPlan:
                     }
                 )
             )
-            errors.append(RetrievalError(self._errors[capsule]))
+            errors.append(RetrievalError(errors=self._errors[capsule]))
 
         return results, errors
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -228,9 +228,6 @@ def _make_rest_app(datastore: Datastore, this_node, log: Logger) -> Flask:
         for capsule, lingo in packets:
             if lingo is not None:
 
-                # TODO: Authenticate these conditions
-                # lingo.verify_signature(reencryption_request, enrico)
-
                 # TODO: Enforce policy expiration as a condition
                 try:
                     # TODO: Can conditions return a useful value?

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -237,9 +237,9 @@ def _make_rest_app(datastore: Datastore, this_node, log: Logger) -> Flask:
                     log.info(f'Evaluating decryption condition')
                     lingo.eval(**context)
                 except RequiredContextVariable as e:
-                    message = f"Missing required inputs - {e}"  # TODO: be more specific and name the missing inputs, etc
-                    # TODO BAD_REQUEST instead of FORBIDDEN?
-                    error = (message, HTTPStatus.FORBIDDEN)
+                    message = f"Missing required inputs - {e}"
+                    # TODO: be more specific and name the missing inputs, etc
+                    error = (message, HTTPStatus.BAD_REQUEST)
                     log.info(message)
                     return Response(str(e), status=error[1])
                 except InvalidContextVariableData as e:

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -74,7 +74,7 @@ def _recover_user_address(**context) -> ChecksumAddress:
     except Exception as e:
         # data could not be processed
         raise InvalidContextVariableData(
-            f'Invalid data provided for "{USER_ADDRESS_CONTEXT}" context variable; {e.__class__.__name__} - {e}'
+            f'Invalid data provided for "{USER_ADDRESS_CONTEXT}"; {e.__class__.__name__} - {e}'
         )
 
     # actual verification
@@ -87,12 +87,12 @@ def _recover_user_address(**context) -> ChecksumAddress:
     except Exception as e:
         # exception during verification
         raise ContextVariableVerificationFailed(
-            f"Invalid signature for associated user address; {e.__class__.__name__} - {e}"
+            f"Could not determine address of signature for '{USER_ADDRESS_CONTEXT}'; {e.__class__.__name__} - {e}"
         )
 
     # verification failed - addresses don't match
     raise ContextVariableVerificationFailed(
-        f"Invalid signature for associated user address; expected {user_address}"
+        f"Signer address for '{USER_ADDRESS_CONTEXT}' signature does not match; expected {user_address}"
     )
 
 

--- a/nucypher/utilities/porter/control/interfaces.py
+++ b/nucypher/utilities/porter/control/interfaces.py
@@ -35,12 +35,14 @@ class PorterInterface(ControlInterface):
     def get_ursulas(self,
                     quantity: int,
                     exclude_ursulas: Optional[List[ChecksumAddress]] = None,
-                    include_ursulas: Optional[List[ChecksumAddress]] = None) -> dict:
-        ursulas_info = self.implementer.get_ursulas(quantity=quantity,
-                                                    exclude_ursulas=exclude_ursulas,
-                                                    include_ursulas=include_ursulas)
+                    include_ursulas: Optional[List[ChecksumAddress]] = None) -> Dict:
+        ursulas_info = self.implementer.get_ursulas(
+            quantity=quantity,
+            exclude_ursulas=exclude_ursulas,
+            include_ursulas=include_ursulas,
+        )
 
-        response_data = {"ursulas": ursulas_info}
+        response_data = {"ursulas": ursulas_info}  # list of UrsulaInfo objects
         return response_data
 
     @attach_schema(porter_schema.AliceRevoke)
@@ -58,8 +60,8 @@ class PorterInterface(ControlInterface):
                         alice_verifying_key: PublicKey,
                         bob_encrypting_key: PublicKey,
                         bob_verifying_key: PublicKey,
-                        context: Optional[Dict] = None) -> dict:
-        retrieval_results = self.implementer.retrieve_cfrags(
+                        context: Optional[Dict] = None) -> Dict:
+        retrieval_outcomes = self.implementer.retrieve_cfrags(
             treasure_map=treasure_map,
             retrieval_kits=retrieval_kits,
             alice_verifying_key=alice_verifying_key,
@@ -67,6 +69,7 @@ class PorterInterface(ControlInterface):
             bob_verifying_key=bob_verifying_key,
             context=context,
         )
-        results = retrieval_results  # list of RetrievalResult objects
-        response_data = {"retrieval_results": results}
+        response_data = {
+            "retrieval_results": retrieval_outcomes
+        }  # list of RetrievalOutcome objects
         return response_data

--- a/nucypher/utilities/porter/control/specifications/fields/retrieve.py
+++ b/nucypher/utilities/porter/control/specifications/fields/retrieve.py
@@ -15,7 +15,7 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 from marshmallow import fields
-
+from marshmallow.fields import String
 from nucypher_core import RetrievalKit as RetrievalKitClass
 from nucypher_core.umbral import CapsuleFrag as CapsuleFragClass
 
@@ -45,9 +45,10 @@ class CapsuleFrag(Base64BytesRepresentation):
             raise InvalidInputData(f"Could not parse {self.name}: {e}")
 
 
-class RetrievalResultSchema(BaseSchema):
-    """Schema for the result of retrieve_cfrags."""
+class RetrievalOutcomeSchema(BaseSchema):
+    """Schema for the result of /retrieve_cfrags endpoint."""
     cfrags = fields.Dict(keys=UrsulaChecksumAddress(), values=CapsuleFrag())
+    errors = fields.Dict(keys=UrsulaChecksumAddress(), values=String())
 
     # maintain field declaration ordering
     class Meta:

--- a/nucypher/utilities/porter/control/specifications/porter_schema.py
+++ b/nucypher/utilities/porter/control/specifications/porter_schema.py
@@ -174,4 +174,6 @@ class BobRetrieveCFrags(BaseSchema):
     )
 
     # output
-    retrieval_results = marshmallow_fields.List(marshmallow_fields.Nested(fields.RetrievalResultSchema), dump_only=True)
+    retrieval_results = marshmallow_fields.List(
+        marshmallow_fields.Nested(fields.RetrievalOutcomeSchema), dump_only=True
+    )

--- a/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
+++ b/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
@@ -26,11 +26,16 @@ from nucypher.control.specifications.fields import JSON
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.policy.kits import PolicyMessageKit, RetrievalResult
 from nucypher.utilities.porter.control.specifications.fields import (
-    RetrievalResultSchema,
     RetrievalKit as RetrievalKitField,
 )
+from nucypher.utilities.porter.control.specifications.fields import (
+    RetrievalOutcomeSchema,
+)
 from tests.utils.middleware import MockRestMiddleware
-from tests.utils.policy import retrieval_request_setup, retrieval_params_decode_from_rest
+from tests.utils.policy import (
+    retrieval_params_decode_from_rest,
+    retrieval_request_setup,
+)
 
 
 def test_get_ursulas(blockchain_porter_web_controller, blockchain_ursulas):
@@ -133,7 +138,7 @@ def test_retrieve_cfrags(blockchain_porter,
                                                            policy_encrypting_key=enacted_policy.public_key,
                                                            threshold=treasure_map.threshold)
     assert len(retrieval_results) == 1
-    field = RetrievalResultSchema()
+    field = RetrievalOutcomeSchema()
     cfrags = field.load(retrieval_results[0])['cfrags']
     verified_cfrags = {}
     for ursula, cfrag in cfrags.items():
@@ -171,6 +176,9 @@ def test_retrieve_cfrags(blockchain_porter,
     retrieval_results = response_data['result']['retrieval_results']
     assert retrieval_results
     assert len(retrieval_results) == 2
+    for i in range(0, 2):
+        assert len(retrieval_results[i]["cfrags"]) > 0
+        assert len(retrieval_results[i]["errors"]) == 0
 
     #
     # Use context

--- a/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
+++ b/tests/acceptance/porter/control/test_porter_web_control_blockchain.py
@@ -111,11 +111,13 @@ def test_retrieve_cfrags(blockchain_porter,
     enacted_policy = random_blockchain_policy.enact(network_middleware=network_middleware)
 
     original_message = b"Those who say it can't be done are usually interrupted by others doing it."  # - James Baldwin
-    retrieve_cfrags_params, message_kit = retrieval_request_setup(enacted_policy,
+    retrieve_cfrags_params, message_kits = retrieval_request_setup(enacted_policy,
                                                                   blockchain_bob,
                                                                   blockchain_alice,
-                                                                  original_message=original_message,
+                                                                  specific_messages=[original_message],
                                                                   encode_for_rest=True)
+    assert len(message_kits) == 1
+    message_kit = message_kits[0]
 
     #
     # Success

--- a/tests/integration/porter/control/test_porter_web_control_federated.py
+++ b/tests/integration/porter/control/test_porter_web_control_federated.py
@@ -108,11 +108,13 @@ def test_retrieve_cfrags(federated_porter,
     original_message = b'The paradox of education is precisely this - that as one begins to become ' \
                        b'conscious one begins to examine the society in which ' \
                        b'he is (they are) being educated.'  # - James Baldwin
-    retrieve_cfrags_params, message_kit = retrieval_request_setup(enacted_federated_policy,
+    retrieve_cfrags_params, message_kits = retrieval_request_setup(enacted_federated_policy,
                                                                   federated_bob,
                                                                   federated_alice,
-                                                                  original_message=original_message,
+                                                                  specific_messages=[original_message],
                                                                   encode_for_rest=True)
+    assert len(message_kits) == 1
+    message_kit = message_kits[0]
 
     #
     # Success

--- a/tests/integration/porter/control/test_porter_web_control_federated.py
+++ b/tests/integration/porter/control/test_porter_web_control_federated.py
@@ -26,10 +26,15 @@ from nucypher.control.specifications.fields import JSON
 from nucypher.crypto.powers import DecryptingPower
 from nucypher.policy.kits import PolicyMessageKit, RetrievalResult
 from nucypher.utilities.porter.control.specifications.fields import (
-    RetrievalResultSchema,
     RetrievalKit as RetrievalKitField,
 )
-from tests.utils.policy import retrieval_request_setup, retrieval_params_decode_from_rest
+from nucypher.utilities.porter.control.specifications.fields import (
+    RetrievalOutcomeSchema,
+)
+from tests.utils.policy import (
+    retrieval_params_decode_from_rest,
+    retrieval_request_setup,
+)
 
 
 def test_get_ursulas(federated_porter_web_controller, federated_ursulas):
@@ -130,7 +135,7 @@ def test_retrieve_cfrags(federated_porter,
                                                            policy_encrypting_key=enacted_federated_policy.public_key,
                                                            threshold=treasure_map.threshold)
     assert len(retrieval_results) == 1
-    field = RetrievalResultSchema()
+    field = RetrievalOutcomeSchema()
     cfrags = field.load(retrieval_results[0])['cfrags']
     verified_cfrags = {}
     for ursula, cfrag in cfrags.items():
@@ -172,6 +177,9 @@ def test_retrieve_cfrags(federated_porter,
     retrieval_results = response_data['result']['retrieval_results']
     assert retrieval_results
     assert len(retrieval_results) == 4
+    for i in range(0, 4):
+        assert len(retrieval_results[i]["cfrags"]) > 0
+        assert len(retrieval_results[i]["errors"]) == 0
 
     #
     # Use context

--- a/tests/utils/policy.py
+++ b/tests/utils/policy.py
@@ -18,7 +18,7 @@ along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 import os
 import random
 import string
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from nucypher_core import MessageKit, RetrievalKit
 
@@ -47,9 +47,22 @@ def generate_random_label() -> bytes:
 def retrieval_request_setup(enacted_policy,
                             bob,
                             alice,
-                            original_message: Optional[bytes] = None,
+                            specific_messages: Optional[List[bytes]] = None,
                             context: Optional[Dict] = None,
-                            encode_for_rest: bool = False) -> Tuple[Dict, MessageKit]:
+                            encode_for_rest: bool = False,
+                            num_random_messages: int = None) -> Tuple[Dict, List[MessageKit]]:
+    """
+    Creates dict of values for a retrieval request. If no specific messages or number
+    of random messages are provided, a single random message is encrypted.
+    """
+    if specific_messages and num_random_messages is not None:
+        raise ValueError(
+            "Provide either original_message or num_random_messages parameter, not both."
+        )
+    if not specific_messages and num_random_messages is None:
+        # default to one random message
+        num_random_messages = 1
+
     treasure_map = bob._decrypt_treasure_map(
         enacted_policy.treasure_map, enacted_policy.publisher_verifying_key
     )
@@ -59,9 +72,16 @@ def retrieval_request_setup(enacted_policy,
 
     # We can pass any number of capsules as args; here we pass just one.
     enrico = Enrico(policy_encrypting_key=enacted_policy.public_key)
-    if not original_message:
-        original_message = ''.join(random.choice(string.ascii_lowercase) for i in range(20)).encode()  # random message
-    message_kit = enrico.encrypt_message(original_message)
+    message_kits = []
+    if specific_messages:
+        for message in specific_messages:
+            message_kits.append(enrico.encrypt_message(message))
+    else:
+        for i in range(num_random_messages):
+            random_message = "".join(
+                random.choice(string.ascii_lowercase) for j in range(20)
+            ).encode()  # random message
+            message_kits.append(enrico.encrypt_message(random_message))
 
     encode_bytes = (lambda field, obj: field()._serialize(value=obj, attr=None, obj=None)) if encode_for_rest else (lambda field, obj: obj)
 
@@ -69,6 +89,7 @@ def retrieval_request_setup(enacted_policy,
         treasure_map=encode_bytes(TreasureMap, treasure_map),
         retrieval_kits=[
             encode_bytes(RetrievalKitField, RetrievalKit.from_message_kit(message_kit))
+            for message_kit in message_kits
         ],
         alice_verifying_key=encode_bytes(Key, alice.stamp.as_umbral_pubkey()),
         bob_encrypting_key=encode_bytes(Key, bob.public_keys(DecryptingPower)),
@@ -78,7 +99,7 @@ def retrieval_request_setup(enacted_policy,
     if context:
         retrieval_params["context"] = encode_bytes(JSON, context)
 
-    return retrieval_params, message_kit
+    return retrieval_params, message_kits
 
 
 def retrieval_params_decode_from_rest(retrieval_params: Dict) -> Dict:


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Initial schema for communicating errors that occur during `/retrieve_cfrags` back to the caller.

**Issues fixed/closed:**
Fixes https://github.com/nucypher/tdec/issues/57
Fixes https://github.com/nucypher/nucypher/issues/2789

**Why it's needed:**
Porter needs to provide better feedback on errors that occur during retrieval.

Initial version looks like:
```json
 "result": {
        "retrieval_results": [
            {
                "cfrags": {
                    // ...
                },
                "errors": {
                    "<ursula_address>": "<error_message>",
                    // category I - network is down, ursulas are wrong, everything is falling apart
                    "<ursula>": "Internal Server Error",
                     // sir, stop breaking the porter plz
                    "<ursula>": "Something wrong with your parameters buddy: ciphertext is undefined",
                    // condition verification on ursula - actionable feedback for the user
                    "<ursula>": "Decryption conditions not satisfied",
                    // auth - actionable feedback for the user; stale auth
                    "<ursula>": "Context variable data could not be verified"
                }
            }
        ]
    }, 
    "version": "6.1.0"
```

**Notes for reviewers:**