### PR TITLE
Update github action triggers for pull requests

### DIFF
--- a/.github/workflows/contract_tests.yml
+++ b/.github/workflows/contract_tests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, edited, ready_for_review, synchronize]
 
 concurrency:
-  group: ci-tests-${{ github.ref }}-1
+  group: ci-tests-${{ github.ref }}-contracts
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/contract_tests.yml
+++ b/.github/workflows/contract_tests.yml
@@ -1,6 +1,8 @@
 name: '📃 Contract Tests'
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review, synchronize]
 
 concurrency:
   group: ci-tests-${{ github.ref }}-1

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,6 +1,8 @@
 name: '🔎 Python Tests'
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review, synchronize]
 
 concurrency:
   group: ci-tests-${{ github.ref }}-1

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, edited, ready_for_review, synchronize]
 
 concurrency:
-  group: ci-tests-${{ github.ref }}-1
+  group: ci-tests-${{ github.ref }}-pytest
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/run_demo.yml
+++ b/.github/workflows/run_demo.yml
@@ -1,6 +1,8 @@
 name: '👷 Run Demo'
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, reopened, edited, ready_for_review, synchronize]
 
 jobs:
   run-demo:


### PR DESCRIPTION
**Type of PR:**
Ops

**Required reviews:** 
1

**What this does:**
Specified action types for the `pull_request` trigger to include `opened`, `edited`, and `ready_for_review`
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

**Why it's needed:**
Actions are not running when pushing new commits to an existing pull request.
