### PR TITLE
Prevent network port reuse in tests

### DIFF
--- a/tests/acceptance/cli/ursula/test_federated_ursula.py
+++ b/tests/acceptance/cli/ursula/test_federated_ursula.py
@@ -1,26 +1,29 @@
-
-
 import json
 from json import JSONDecodeError
-
-import os
 from pathlib import Path
-
 from unittest.mock import PropertyMock
 
 import pytest
 
-from nucypher.cli.literature import SUCCESSFUL_DESTRUCTION, COLLECT_NUCYPHER_PASSWORD
+from nucypher.cli.literature import COLLECT_NUCYPHER_PASSWORD, SUCCESSFUL_DESTRUCTION
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.base import CharacterConfiguration
 from nucypher.config.characters import UrsulaConfiguration
-from nucypher.config.constants import APP_DIR, DEFAULT_CONFIG_ROOT, NUCYPHER_ENVVAR_KEYSTORE_PASSWORD, TEMPORARY_DOMAIN
+from nucypher.config.constants import (
+    APP_DIR,
+    DEFAULT_CONFIG_ROOT,
+    NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
+    TEMPORARY_DOMAIN,
+)
 from nucypher.crypto.keystore import Keystore
 from tests.constants import (
-    FAKE_PASSWORD_CONFIRMED, INSECURE_DEVELOPMENT_PASSWORD,
+    FAKE_PASSWORD_CONFIRMED,
+    INSECURE_DEVELOPMENT_PASSWORD,
     MOCK_CUSTOM_INSTALLATION_PATH,
-    MOCK_IP_ADDRESS, YES_ENTER)
-from tests.utils.ursula import MOCK_URSULA_STARTING_PORT, select_test_port
+    MOCK_IP_ADDRESS,
+    YES_ENTER,
+)
+from tests.utils.ursula import select_test_port
 
 
 def test_initialize_ursula_defaults(click_runner, mocker, tmpdir):

--- a/tests/contracts/main/application/conftest.py
+++ b/tests/contracts/main/application/conftest.py
@@ -1,15 +1,4 @@
-
-
-
 import pytest
-from web3.contract import Contract
-
-from tests.constants import (
-    TEST_ETH_PROVIDER_URI,
-)
-from tests.utils.ursula import MOCK_URSULA_STARTING_PORT
-from tests.utils.config import make_ursula_test_configuration
-from nucypher.blockchain.eth.registry import InMemoryContractRegistry
 
 # @pytest.fixture()
 # def token(deploy_contract, token_economics):

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -24,8 +24,6 @@ from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     NucypherTokenAgent,
-)
-from nucypher.blockchain.eth.agents import (
     PREApplicationAgent,
 )
 from nucypher.blockchain.eth.deployers import (
@@ -50,7 +48,6 @@ from nucypher.crypto.keystore import Keystore
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import TEACHER_NODES
 from nucypher.policy.conditions.context import USER_ADDRESS_CONTEXT
-from nucypher.policy.conditions.context import USER_ADDRESS_CONTEXT
 from nucypher.policy.conditions.evm import ContractCondition, RPCCondition
 from nucypher.policy.conditions.lingo import ReturnValueTest
 from nucypher.policy.conditions.time import TimeCondition
@@ -71,8 +68,9 @@ from tests.constants import (
     MOCK_REGISTRY_FILEPATH,
     NUMBER_OF_URSULAS_IN_DEVELOPMENT_NETWORK,
     TEST_ETH_PROVIDER_URI,
-    TEST_GAS_LIMIT, )
-from tests.constants import TESTERCHAIN_CHAIN_ID
+    TEST_GAS_LIMIT,
+    TESTERCHAIN_CHAIN_ID,
+)
 from tests.mock.interfaces import MockBlockchain, mock_registry_source_manager
 from tests.mock.performance_mocks import (
     mock_cert_generation,
@@ -98,9 +96,9 @@ from tests.utils.middleware import (
 from tests.utils.policy import generate_random_label
 from tests.utils.ursula import (
     MOCK_KNOWN_URSULAS_CACHE,
-    MOCK_URSULA_STARTING_PORT,
     make_decentralized_ursulas,
     make_federated_ursulas,
+    select_test_port,
 )
 
 test_logger = Logger("test-logger")
@@ -144,7 +142,9 @@ def certificates_tempdir():
 
 @pytest.fixture(scope="module")
 def ursula_federated_test_config(test_registry):
-    config = make_ursula_test_configuration(federated=True, rest_port=MOCK_URSULA_STARTING_PORT)
+    config = make_ursula_test_configuration(
+        federated=True, rest_port=select_test_port()
+    )
     yield config
     config.cleanup()
 
@@ -170,11 +170,13 @@ def bob_federated_test_config():
 
 @pytest.fixture(scope="module")
 def ursula_decentralized_test_config(test_registry, temp_dir_path):
-    config = make_ursula_test_configuration(federated=False,
-                                            eth_provider_uri=TEST_ETH_PROVIDER_URI,
-                                            payment_provider=TEST_ETH_PROVIDER_URI,
-                                            test_registry=test_registry,
-                                            rest_port=MOCK_URSULA_STARTING_PORT)
+    config = make_ursula_test_configuration(
+        federated=False,
+        eth_provider_uri=TEST_ETH_PROVIDER_URI,
+        payment_provider=TEST_ETH_PROVIDER_URI,
+        test_registry=test_registry,
+        rest_port=select_test_port(),
+    )
     yield config
     config.cleanup()
     for k in list(MOCK_KNOWN_URSULAS_CACHE.keys()):
@@ -1012,4 +1014,3 @@ def valid_user_address_context():
             },
         }
     }
-

--- a/tests/integration/config/test_storages.py
+++ b/tests/integration/config/test_storages.py
@@ -1,7 +1,3 @@
-
-
-import tempfile
-
 import pytest
 
 from nucypher.characters.lawful import Ursula
@@ -9,7 +5,7 @@ from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.config.storages import ForgetfulNodeStorage, TemporaryFileBasedNodeStorage
 from nucypher.policy.payment import FreeReencryptions
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
-from tests.utils.ursula import MOCK_URSULA_STARTING_PORT
+from tests.utils.ursula import select_test_port
 
 ADDITIONAL_NODES_TO_LEARN_ABOUT = 10
 
@@ -27,11 +23,13 @@ class BaseTestNodeStorageBackends:
 
     @pytest.fixture(scope='class')
     def light_ursula(temp_dir_path):
-        node = Ursula(rest_host=LOOPBACK_ADDRESS,
-                      rest_port=MOCK_URSULA_STARTING_PORT,
-                      federated_only=True,
-                      domain=TEMPORARY_DOMAIN,
-                      payment_method=FreeReencryptions())
+        node = Ursula(
+            rest_host=LOOPBACK_ADDRESS,
+            rest_port=select_test_port(),
+            federated_only=True,
+            domain=TEMPORARY_DOMAIN,
+            payment_method=FreeReencryptions(),
+        )
         yield node
 
     character_class = Ursula
@@ -49,12 +47,14 @@ class BaseTestNodeStorageBackends:
 
         # Save more nodes
         all_known_nodes = set()
-        for port in range(MOCK_URSULA_STARTING_PORT, MOCK_URSULA_STARTING_PORT + ADDITIONAL_NODES_TO_LEARN_ABOUT):
-            node = Ursula(rest_host=LOOPBACK_ADDRESS,
-                          rest_port=port,
-                          federated_only=True,
-                          domain=TEMPORARY_DOMAIN,
-                          payment_method=FreeReencryptions())
+        for i in range(ADDITIONAL_NODES_TO_LEARN_ABOUT):
+            node = Ursula(
+                rest_host=LOOPBACK_ADDRESS,
+                rest_port=select_test_port(),
+                federated_only=True,
+                domain=TEMPORARY_DOMAIN,
+                payment_method=FreeReencryptions(),
+            )
             node_storage.store_node_metadata(node=node)
             all_known_nodes.add(node)
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,3 @@
-
-
-
 from pathlib import Path
 
 import pytest
@@ -10,7 +7,7 @@ from nucypher.blockchain.economics import EconomicsFactory
 from nucypher.blockchain.eth.agents import (
     AdjudicatorAgent,
     ContractAgency,
-    PREApplicationAgent
+    PREApplicationAgent,
 )
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.blockchain.eth.registry import InMemoryContractRegistry
@@ -18,9 +15,9 @@ from nucypher.blockchain.eth.signers import KeystoreSigner
 from nucypher.config.characters import UrsulaConfiguration
 from tests.constants import (
     KEYFILE_NAME_TEMPLATE,
-    MOCK_KEYSTORE_PATH,
     MOCK_ETH_PROVIDER_URI,
-    NUMBER_OF_MOCK_KEYSTORE_ACCOUNTS
+    MOCK_KEYSTORE_PATH,
+    NUMBER_OF_MOCK_KEYSTORE_ACCOUNTS,
 )
 from tests.mock.agents import MockContractAgency, MockContractAgent
 from tests.mock.interfaces import MockBlockchain, mock_registry_source_manager
@@ -28,9 +25,9 @@ from tests.mock.io import MockStdinWrapper
 from tests.utils.config import (
     make_alice_test_configuration,
     make_bob_test_configuration,
-    make_ursula_test_configuration
+    make_ursula_test_configuration,
 )
-from tests.utils.ursula import MOCK_URSULA_STARTING_PORT
+from tests.utils.ursula import select_test_port
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -201,11 +198,13 @@ def bob_blockchain_test_config(mock_testerchain, test_registry):
 
 @pytest.fixture(scope="module")
 def ursula_decentralized_test_config(mock_testerchain, test_registry):
-    config = make_ursula_test_configuration(federated=False,
-                                            eth_provider_uri=MOCK_ETH_PROVIDER_URI,  # L1
-                                            payment_provider=MOCK_ETH_PROVIDER_URI,  # L1/L2
-                                            test_registry=test_registry,
-                                            rest_port=MOCK_URSULA_STARTING_PORT,
-                                            checksum_address=mock_testerchain.ursula_account(index=0))
+    config = make_ursula_test_configuration(
+        federated=False,
+        eth_provider_uri=MOCK_ETH_PROVIDER_URI,  # L1
+        payment_provider=MOCK_ETH_PROVIDER_URI,  # L1/L2
+        test_registry=test_registry,
+        rest_port=select_test_port(),
+        checksum_address=mock_testerchain.ursula_account(index=0),
+    )
     yield config
     config.cleanup()

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -1,12 +1,15 @@
-
 from typing import List
 
 from nucypher.blockchain.eth.registry import BaseContractRegistry
 from nucypher.characters.lawful import Ursula
-from nucypher.config.characters import AliceConfiguration, BobConfiguration, UrsulaConfiguration
+from nucypher.config.characters import (
+    AliceConfiguration,
+    BobConfiguration,
+    UrsulaConfiguration,
+)
 from nucypher.config.constants import TEMPORARY_DOMAIN
 from tests.utils.middleware import MockRestMiddleware
-from tests.utils.ursula import MOCK_URSULA_STARTING_PORT
+from tests.utils.ursula import select_test_port
 
 TEST_CHARACTER_CONFIG_BASE_PARAMS = dict(
     dev_mode=True,
@@ -48,10 +51,9 @@ def assemble(federated: bool,
     return base_test_params
 
 
-def make_ursula_test_configuration(rest_port: int = MOCK_URSULA_STARTING_PORT,
-                                   payment_provider: str = None,
-                                   **assemble_kwargs
-                                   ) -> UrsulaConfiguration:
+def make_ursula_test_configuration(
+    rest_port: int = select_test_port(), payment_provider: str = None, **assemble_kwargs
+) -> UrsulaConfiguration:
     test_params = assemble(**assemble_kwargs)
     federated = test_params['federated_only']
     payment_provider = payment_provider if not federated else None


### PR DESCRIPTION
**Type of PR:**
Bugfix (tests)

**Required reviews:** 
1

**Notes**

This error is still occurring occasionally, even with the changes in this PR:
```
tests/acceptance/cli/ursula/test_run_ursula.py .....F
...
twisted.internet.error.CannotListenError: Couldn't listen on any:60998: [Errno 98] Address already in use.
 ```