### PR TITLE
Dev newsfragment

### DIFF
--- a/.github/workflows/pr_release_note_entry.yml
+++ b/.github/workflows/pr_release_note_entry.yml
@@ -14,5 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - run: |
-          ls -l ${{ github.workspace }}/newsfragments/${{ github.event.number }}.*.rst
+      - run: ls -l ${{ github.workspace }}/newsfragments/ | grep -E '${{ github.event.number }}\.(feature|bugfix|doc|removal|misc|dev)\.rst'

--- a/newsfragments/validate_files.py
+++ b/newsfragments/validate_files.py
@@ -28,11 +28,12 @@ class InvalidNewsFragment(RuntimeError):
 
 
 ALLOWED_EXTENSIONS = {
-    '.feature.rst',
-    '.bugfix.rst',
-    '.doc.rst',
-    '.removal.rst',
-    '.misc.rst',
+    ".feature.rst",
+    ".bugfix.rst",
+    ".doc.rst",
+    ".removal.rst",
+    ".misc.rst",
+    ".dev.rst",
 }
 
 ALLOWED_FILES = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,8 @@
         directory = "misc"
         name = "Misc"
         showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "dev"
+        name = "Internal development tasks"
+        showcontent = false  # don't include development changes in release notes


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Allow for dev newsfragment to be provided so that the release note GitHub action doesn't have to fail for dev-specific work that we don't want included in the release notes.

Also more specific newsfragment naming check. Noticed this as part of https://github.com/nucypher/nucypher/pull/3014#discussion_r1022891325