### PR TITLE
Dev newsfragments will show up in release notes but under its own section

### DIFF
--- a/newsfragments/README.md
+++ b/newsfragments/README.md
@@ -13,6 +13,7 @@ should be named `<PR_NUMBER>.<TYPE>.rst`, where `<TYPE>` is one of:
 * `doc` - documentation
 * `removal` - deprecations and removals
 * `misc` - other
+* `dev` - internal development tasks
 
 For example: `123.feature.rst`, `456.bugfix.rst`, `789.doc.rst`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,5 @@
 
     [[tool.towncrier.type]]
         directory = "dev"
-        name = "Internal development tasks"
-        showcontent = false  # don't include development changes in release notes
+        name = "Internal Development Tasks"
+        showcontent = true


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

Related to #3022 - don't hide dev newsfragments (not possible with towncrier), but instead just keep it in its own section - tucked away for people who care to look for it. No use including with other release notes section since mostly internal changes eg. gh actions, builds etc.

This is how it look:

```
...

Misc
~~~~
...


Internal Development Tasks
~~~~~~~~~~~~~~~~~~~~~~~~~~

-  (`#3022 <https://github.com/nucypher/nucypher/issues/3022>`__, `#3024 <https://github.com/nucypher/nucypher/issues/3024>`__)
```