### PR TITLE
Restrict return value `index` (previously `key`) to only be an integer

### DIFF
--- a/newsfragments/3032.bugfix.rst
+++ b/newsfragments/3032.bugfix.rst
@@ -1,0 +1,1 @@
+Restrict return value `key` to integer only

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -75,8 +75,6 @@ def _resolve_any_context_variables(
     if is_context_variable(v):
         v = get_context_value(context_variable=v, **context)
     k = return_value_test.key
-    if is_context_variable(k):
-        k = get_context_value(context_variable=k, **context)
     processed_return_value_test = ReturnValueTest(
         return_value_test.comparator, value=v, key=k
     )

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -74,9 +74,9 @@ def _resolve_any_context_variables(
     v = return_value_test.value
     if is_context_variable(v):
         v = get_context_value(context_variable=v, **context)
-    k = return_value_test.key
+    i = return_value_test.index
     processed_return_value_test = ReturnValueTest(
-        return_value_test.comparator, value=v, key=k
+        return_value_test.comparator, value=v, index=i
     )
 
     return processed_parameters, processed_return_value_test

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -93,15 +93,15 @@ class ReturnValueTest:
         def make(self, data, **kwargs):
             return ReturnValueTest(**data)
 
-    def __init__(self, comparator: str, value: Any, key: Optional[Union[int, str]] = None):
+    def __init__(self, comparator: str, value: Any, key: int = None):
         if comparator not in self.COMPARATORS:
             raise self.InvalidExpression(
                 f'"{comparator}" is not a permitted comparator.'
             )
 
-        if not isinstance(key, (int, str)) and key is not None:
+        if not isinstance(key, int) and key is not None:
             raise self.InvalidExpression(
-                f'"{key}" is not a permitted key. Must be a string or integer.'
+                f'"{key}" is not a permitted key. Must be a an integer.'
             )
 
         if not is_context_variable(value):
@@ -122,19 +122,11 @@ class ReturnValueTest:
 
     def _process_data(self, data: Any) -> Any:
         """
-        If a key is specified, return the value at that key in the data if data is a dict or list-like.
-        Otherwise, return the data.
+        Solidity will only return a list
         """
         processed_data = data
         if self.key is not None:
-            if isinstance(data, dict):
-                try:
-                    processed_data = data[self.key]
-                except KeyError:
-                    raise ReturnValueEvaluationError(
-                        f"Key '{self.key}' not found in return data."
-                    )
-            elif isinstance(self.key, int) and isinstance(data, (list, tuple)):
+            if isinstance(self.key, int) and isinstance(data, (list, tuple)):
                 try:
                     processed_data = data[self.key]
                 except IndexError:
@@ -149,10 +141,10 @@ class ReturnValueTest:
         return processed_data
 
     def eval(self, data) -> bool:
-        if is_context_variable(self.value) or is_context_variable(self.key):
+        if is_context_variable(self.value):
             # programming error if we get here
             raise RuntimeError(
-                f"Return value comparator contains an unprocessed context variable (key={self.key}, value={self.value}) and is not valid "
+                f"Return value comparator contains an unprocessed context variable (value={self.value}) and is not valid "
                 f"for condition evaluation."
             )
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -87,21 +87,21 @@ class ReturnValueTest:
         value = fields.Raw(
             allow_none=False, required=True
         )  # any valid type (excludes None)
-        key = fields.Raw(allow_none=True)
+        index = fields.Raw(allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):
             return ReturnValueTest(**data)
 
-    def __init__(self, comparator: str, value: Any, key: int = None):
+    def __init__(self, comparator: str, value: Any, index: int = None):
         if comparator not in self.COMPARATORS:
             raise self.InvalidExpression(
                 f'"{comparator}" is not a permitted comparator.'
             )
 
-        if key is not None and not isinstance(key, int):
+        if index is not None and not isinstance(index, int):
             raise self.InvalidExpression(
-                f'"{key}" is not a permitted key. Must be a an integer.'
+                f'"{index}" is not a permitted index. Must be a an integer.'
             )
 
         if not is_context_variable(value):
@@ -112,7 +112,7 @@ class ReturnValueTest:
 
         self.comparator = comparator
         self.value = value
-        self.key = key
+        self.index = index
 
     def _sanitize_value(self, value):
         try:
@@ -122,21 +122,21 @@ class ReturnValueTest:
 
     def _process_data(self, data: Any) -> Any:
         """
-        If a key is specified, return the value at that key in the data if data is list-like.
+        If an index is specified, return the value at that index in the data if data is list-like.
         Otherwise, return the data.
         """
         processed_data = data
-        if self.key is not None:
-            if isinstance(self.key, int) and isinstance(data, (list, tuple)):
+        if self.index is not None:
+            if isinstance(self.index, int) and isinstance(data, (list, tuple)):
                 try:
-                    processed_data = data[self.key]
+                    processed_data = data[self.index]
                 except IndexError:
                     raise ReturnValueEvaluationError(
-                        f"Index '{self.key}' not found in return data."
+                        f"Index '{self.index}' not found in return data."
                     )
             else:
                 raise ReturnValueEvaluationError(
-                    f"Key: {self.key} and Value: {data} are not compatible types."
+                    f"Index: {self.index} and Value: {data} are not compatible types."
                 )
 
         return processed_data

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -99,7 +99,7 @@ class ReturnValueTest:
                 f'"{comparator}" is not a permitted comparator.'
             )
 
-        if not isinstance(key, int) and key is not None:
+        if key is not None and not isinstance(key, int):
             raise self.InvalidExpression(
                 f'"{key}" is not a permitted key. Must be a an integer.'
             )
@@ -122,7 +122,8 @@ class ReturnValueTest:
 
     def _process_data(self, data: Any) -> Any:
         """
-        Solidity will only return a list
+        If a key is specified, return the value at that key in the data if data is list-like.
+        Otherwise, return the data.
         """
         processed_data = data
         if self.key is not None:

--- a/tests/acceptance/blockchain/conditions/test_conditions.py
+++ b/tests/acceptance/blockchain/conditions/test_conditions.py
@@ -461,24 +461,6 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_context_var
         SubscriptionManagerAgent, registry=test_registry
     )
 
-    # test "sponsor" key (owner is the same as sponsor for this policy)
-    condition = ContractCondition(
-        contract_address=subscription_manager.contract.address,
-        function_abi=subscription_manager.contract.get_function_by_name(
-            "getPolicy"
-        ).abi,
-        method="getPolicy",
-        chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(
-            comparator="==",
-            value=sponsor,  # don't use sponsor context var
-            key=":sponsorIndex",
-        ),
-        parameters=[":hrac"],
-    )
-    condition_result, _ = condition.verify(providers=condition_providers, **context)
-    assert condition_result
-
     # test "sponsor" key not equal to correct value
     condition = ContractCondition(
         contract_address=subscription_manager.contract.address,
@@ -490,7 +472,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_context_var
         return_value_test=ReturnValueTest(
             comparator="!=",
             value=":sponsor",  # use sponsor sponsor context var
-            key=":sponsorIndex",
+            key=0,
         ),
         parameters=[":hrac"],
     )

--- a/tests/acceptance/blockchain/conditions/test_conditions.py
+++ b/tests/acceptance/blockchain/conditions/test_conditions.py
@@ -442,7 +442,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
     assert condition_result
 
 
-def test_subscription_manager_get_policy_policy_struct_condition_key_context_var_evaluation(
+def test_subscription_manager_get_policy_policy_struct_condition_key_and_value_context_var_evaluation(
     testerchain,
     agency,
     test_registry,
@@ -455,7 +455,6 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_context_var
     context = {
         ":hrac": bytes(enacted_blockchain_policy.hrac),
         ":sponsor": sponsor,
-        ":sponsorIndex": 0,
     }  # user-defined context vars
     subscription_manager = ContractAgency.get_agent(
         SubscriptionManagerAgent, registry=test_registry

--- a/tests/acceptance/blockchain/conditions/test_conditions.py
+++ b/tests/acceptance/blockchain/conditions/test_conditions.py
@@ -351,7 +351,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ).abi,
         method="getPolicy",
         chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(comparator="==", value=sponsor, key=0),
+        return_value_test=ReturnValueTest(comparator="==", value=sponsor, index=0),
         parameters=[":hrac"],
     )
     condition_result, _ = condition.verify(providers=condition_providers, **context)
@@ -365,7 +365,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ).abi,
         method="getPolicy",
         chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(comparator="!=", value=sponsor, key=0),
+        return_value_test=ReturnValueTest(comparator="!=", value=sponsor, index=0),
         parameters=[":hrac"],
     )
     condition_result, _ = condition.verify(providers=condition_providers, **context)
@@ -379,7 +379,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ).abi,
         method="getPolicy",
         chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(comparator="==", value=start, key=1),
+        return_value_test=ReturnValueTest(comparator="==", value=start, index=1),
         parameters=[":hrac"],
     )
     condition_result, _ = condition.verify(providers=condition_providers, **context)
@@ -393,13 +393,13 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ).abi,
         method="getPolicy",
         chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(comparator="!=", value=start, key=1),
+        return_value_test=ReturnValueTest(comparator="!=", value=start, index=1),
         parameters=[":hrac"],
     )
     condition_result, _ = condition.verify(providers=condition_providers, **context)
     assert not condition_result
 
-    # test "end" key
+    # test "end" index
     condition = ContractCondition(
         contract_address=subscription_manager.contract.address,
         function_abi=subscription_manager.contract.get_function_by_name(
@@ -407,13 +407,13 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ).abi,
         method="getPolicy",
         chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(comparator="==", value=end, key=2),
+        return_value_test=ReturnValueTest(comparator="==", value=end, index=2),
         parameters=[":hrac"],
     )
     condition_result, _ = condition.verify(providers=condition_providers, **context)
     assert condition_result
 
-    # test "size" key
+    # test "size" index
     condition = ContractCondition(
         contract_address=subscription_manager.contract.address,
         function_abi=subscription_manager.contract.get_function_by_name(
@@ -421,13 +421,13 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ).abi,
         method="getPolicy",
         chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(comparator="==", value=size, key=3),
+        return_value_test=ReturnValueTest(comparator="==", value=size, index=3),
         parameters=[":hrac"],
     )
     condition_result, _ = condition.verify(providers=condition_providers, **context)
     assert condition_result
 
-    # test "owner" key (owner is sponsor, so owner is set to null address)
+    # test "owner" index (owner is sponsor, so owner is set to null address)
     condition = ContractCondition(
         contract_address=subscription_manager.contract.address,
         function_abi=subscription_manager.contract.get_function_by_name(
@@ -435,14 +435,14 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ).abi,
         method="getPolicy",
         chain=TESTERCHAIN_CHAIN_ID,
-        return_value_test=ReturnValueTest(comparator="==", value=NULL_ADDRESS, key=4),
+        return_value_test=ReturnValueTest(comparator="==", value=NULL_ADDRESS, index=4),
         parameters=[":hrac"],
     )
     condition_result, _ = condition.verify(providers=condition_providers, **context)
     assert condition_result
 
 
-def test_subscription_manager_get_policy_policy_struct_condition_key_and_value_context_var_evaluation(
+def test_subscription_manager_get_policy_policy_struct_condition_index_and_value_context_var_evaluation(
     testerchain,
     agency,
     test_registry,
@@ -460,7 +460,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_and_value_c
         SubscriptionManagerAgent, registry=test_registry
     )
 
-    # test "sponsor" key not equal to correct value
+    # test "sponsor" index not equal to correct value
     condition = ContractCondition(
         contract_address=subscription_manager.contract.address,
         function_abi=subscription_manager.contract.get_function_by_name(
@@ -471,7 +471,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_and_value_c
         return_value_test=ReturnValueTest(
             comparator="!=",
             value=":sponsor",  # use sponsor sponsor context var
-            key=0,
+            index=0,
         ),
         parameters=[":hrac"],
     )

--- a/tests/data/test_conditions.json
+++ b/tests/data/test_conditions.json
@@ -108,7 +108,7 @@
       ":userAddress"
     ],
     "returnValueTest": {
-      "key": 0,
+      "index": 0,
       "comparator": ">",
       "value": 0
     }

--- a/tests/data/test_conditions.json
+++ b/tests/data/test_conditions.json
@@ -108,7 +108,7 @@
       ":userAddress"
     ],
     "returnValueTest": {
-      "key": "tStake",
+      "key": 0,
       "comparator": ">",
       "value": 0
     }

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -9,7 +9,7 @@ from nucypher.policy.conditions.lingo import ReturnValueTest
 
 def test_return_value_test_schema():
     schema = ReturnValueTest.ReturnValueTestSchema()
-    return_value_test = ReturnValueTest(comparator=">", value=0, key=1)
+    return_value_test = ReturnValueTest(comparator=">", value=0, index=1)
 
     test_dict = schema.dump(return_value_test)
 
@@ -29,25 +29,25 @@ def test_return_value_test_schema():
     errors = schema.validate(data=test_dict)
     assert errors, f"{errors}"
 
-    # missing key should NOT cause any error since optional
+    # missing index should NOT cause any error since optional
     test_dict = schema.dump(return_value_test)
-    del test_dict["key"]
+    del test_dict["index"]
     errors = schema.validate(data=test_dict)
     assert not errors, f"{errors}"
 
 
-def test_return_value_key():
+def test_return_value_index():
     with pytest.raises(ReturnValueTest.InvalidExpression):
-        _ = ReturnValueTest(comparator=">", value="0", key="james")
+        _ = ReturnValueTest(comparator=">", value="0", index="james")
 
 
 
 def test_return_value_index():
-    test = ReturnValueTest(comparator=">", value="0", key=0)
+    test = ReturnValueTest(comparator=">", value="0", index=0)
     assert test.eval([1])
     assert not test.eval([-1])
 
-    test = ReturnValueTest(comparator="==", value='"james"', key=3)
+    test = ReturnValueTest(comparator="==", value='"james"', index=3)
     assert test.eval([0, 1, 2, '"james"'])
 
     with pytest.raises(ReturnValueEvaluationError):
@@ -55,7 +55,7 @@ def test_return_value_index():
 
 
 def test_return_value_index_tuple():
-    test = ReturnValueTest(comparator=">", value="0", key=0)
+    test = ReturnValueTest(comparator=">", value="0", index=0)
     assert test.eval((1,))
     assert not test.eval((-1,))
 

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -9,8 +9,8 @@ from nucypher.policy.conditions.lingo import ReturnValueTest
 
 def test_return_value_test_schema():
     schema = ReturnValueTest.ReturnValueTestSchema()
+    return_value_test = ReturnValueTest(comparator=">", value=0, key=1)
 
-    return_value_test = ReturnValueTest(comparator=">", value=0, key="tStake")
     test_dict = schema.dump(return_value_test)
 
     # no issues here
@@ -37,19 +37,9 @@ def test_return_value_test_schema():
 
 
 def test_return_value_key():
-    test = ReturnValueTest(comparator=">", value="0", key="james")
-    assert test.eval({"james": 1})
-    assert not test.eval({"james": -1})
+    with pytest.raises(ReturnValueTest.InvalidExpression):
+        _ = ReturnValueTest(comparator=">", value="0", key="james")
 
-    with pytest.raises(ReturnValueEvaluationError):
-        test.eval({"bond": 1})
-
-    test = ReturnValueTest(comparator=">", value="0", key=4)
-    assert test.eval({4: 1})
-    assert not test.eval({4: -1})
-
-    with pytest.raises(ReturnValueEvaluationError):
-        test.eval({5: 1})
 
 
 def test_return_value_index():
@@ -70,11 +60,6 @@ def test_return_value_index_tuple():
     assert not test.eval((-1,))
 
 
-def test_return_value_with_context_variable_key_cant_run_eval():
-    # known context variable
-    test = ReturnValueTest(comparator="==", value="0", key=":userAddress")
-    with pytest.raises(RuntimeError):
-        test.eval({"0xaDD9D957170dF6F33982001E4c22eCCdd5539118": 0})
 
 
 def test_return_value_test_invalid_comparators():


### PR DESCRIPTION
Fixes #3027 