### PR TITLE
Fix issue with darker during failed darker gh action

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -14,7 +14,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4
-      - uses: akaihola/darker@1.4.2
+        with:
+          python-version: '3.7'
+      - uses: akaihola/darker@1.5.1
         with:
           options: "--check --diff --isort"
-          version: "1.4.2"
+          version: "@3c675b009d747cadd6e8048d2c57a5b1cd54fb3e"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: check-vcs-permalinks
 
   - repo: https://github.com/akaihola/darker
-    rev: 1.4.2
+    rev: 3c675b009d747cadd6e8048d2c57a5b1cd54fb3e
     hooks:
     -   id: darker
         args: [--isort]


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

Update version of darker from 1.4.2 to a specific unreleased sha commit to resolve the issue. Related to https://github.com/akaihola/darker/issues/403 and https://github.com/akaihola/darker/pull/404.

Also added a python version to the darker gh action, because it fails when running locally without it.

Once the unreleased code is included in a release we can revert back to using release versions.


Failed darker gh action.
```
Run akaihola/darker@[1](https://github.com/nucypher/nucypher/actions/runs/3659069522/jobs/6185481806#step:4:1).4.2
Run akaihola/darker/.github/actions/commit-range@1.4.2
Run if [ "${GITHUB_EVENT_NAME}" == "push" ]
 COMMIT_RANGE = 91bb4a4ce39d370b90b4dff4b9db04c1f05c1e34...5[6](https://github.com/nucypher/nucypher/actions/runs/3659069522/jobs/6185481806#step:4:7)0aee2eafdf253580a83a0b2[7](https://github.com/nucypher/nucypher/actions/runs/3659069522/jobs/6185481806#step:4:9)2e82baa2ec9d65 
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
Run # Exists since using github.action_path + path to main script doesn't
Traceback (most recent call last):
  File "/home/runner/work/_actions/akaihola/darker/1.4.2/.darker-env/bin/darker", line 8, in <module>
    sys.exit(main_with_error_handling())
  File "/home/runner/work/_actions/akaihola/darker/1.4.2/.darker-env/lib/python3.10/site-packages/darker/__main__.py", line 416, in main_with_error_handling
    return main()
  File "/home/runner/work/_actions/akaihola/darker/1.4.2/.darker-env/lib/python3.10/site-packages/darker/__main__.py", line [36](https://github.com/nucypher/nucypher/actions/runs/3659069522/jobs/6185481806#step:4:39)2, in main
    files_to_process = filter_python_files(paths, root, {})
  File "/home/runner/work/_actions/akaihola/darker/1.4.2/.darker-env/lib/python3.10/site-packages/darker/black_diff.py", line 142, in filter_python_files
    gen_python_files(
TypeError: gen_python_files() got an unexpected keyword argument 'gitignore'
Error: Process completed with exit code 1.
```
