### PR TITLE
Fix weird python chars in exception messages/logging/REST responses

### DIFF
--- a/newsfragments/3042.bugfix.rst
+++ b/newsfragments/3042.bugfix.rst
@@ -1,0 +1,1 @@
+Use decoded text from failed HTTP Responses for exception messages.

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -809,7 +809,11 @@ class Learner:
             self.cycle_teacher_node()
 
         if response.status_code != 200:
-            self.log.info("Bad response from teacher {}: {} - {}".format(current_teacher, response, response.content))
+            self.log.info(
+                "Bad response from teacher {}: {} - {}".format(
+                    current_teacher, response, response.text
+                )
+            )
             return
 
         # TODO: we really should be checking this *before* we ask it for a node list,
@@ -825,7 +829,9 @@ class Learner:
         try:
             metadata = MetadataResponse.from_bytes(response.content)
         except Exception as e:
-            self.log.warn(f"Failed to deserialize MetadataResponse from Teacher {current_teacher} ({e}): {response.content}")
+            self.log.warn(
+                f"Failed to deserialize MetadataResponse from Teacher {current_teacher} ({e}): {response.text}"
+            )
             return
 
         try:
@@ -833,7 +839,8 @@ class Learner:
         except Exception as e:
             # TODO (#567): bucket the node as suspicious
             self.log.warn(
-                f"Failed to verify MetadataResponse from Teacher {current_teacher} ({e}): {response.content}")
+                f"Failed to verify MetadataResponse from Teacher {current_teacher} ({e}): {response.text}"
+            )
             return
 
         # End edge case handling.

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -830,7 +830,7 @@ class Learner:
             metadata = MetadataResponse.from_bytes(response.content)
         except Exception as e:
             self.log.warn(
-                f"Failed to deserialize MetadataResponse from Teacher {current_teacher} ({e}): {response.text}"
+                f"Failed to deserialize MetadataResponse from Teacher {current_teacher} ({e}): {response.content}"
             )
             return
 
@@ -839,7 +839,7 @@ class Learner:
         except Exception as e:
             # TODO (#567): bucket the node as suspicious
             self.log.warn(
-                f"Failed to verify MetadataResponse from Teacher {current_teacher} ({e}): {response.text}"
+                f"Failed to verify MetadataResponse from Teacher {current_teacher} ({e}): {response.content}"
             )
             return
 

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -826,11 +826,12 @@ class Learner:
         #
         # Deserialize
         #
+        response_data = response.content
         try:
-            metadata = MetadataResponse.from_bytes(response.content)
+            metadata = MetadataResponse.from_bytes(response_data)
         except Exception as e:
             self.log.warn(
-                f"Failed to deserialize MetadataResponse from Teacher {current_teacher} ({e}): {response.content}"
+                f"Failed to deserialize MetadataResponse from Teacher {current_teacher} ({e}): hex bytes={response_data.hex()}"
             )
             return
 
@@ -839,7 +840,7 @@ class Learner:
         except Exception as e:
             # TODO (#567): bucket the node as suspicious
             self.log.warn(
-                f"Failed to verify MetadataResponse from Teacher {current_teacher} ({e}): {response.content}"
+                f"Failed to verify MetadataResponse from Teacher {current_teacher} ({e}): hex bytes={response_data.hex()}"
             )
             return
 

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -163,7 +163,7 @@ def evaluate_condition_lingo(
         )
     except NoConnectionToChain as e:
         error = EvalError(
-            f"Node does not have a connection to chain ID {e.chain}: {e}",
+            f"Node does not have a connection to chain ID {e.chain}",
             HTTPStatus.NOT_IMPLEMENTED,
         )
     except ConditionEvaluationFailed as e:

--- a/tests/integration/characters/test_conditional_reencryption.py
+++ b/tests/integration/characters/test_conditional_reencryption.py
@@ -64,4 +64,7 @@ def test_single_retrieve_with_falsy_conditions(enacted_policy, bob, ursulas, moc
         )
 
     reencrypt_spy.assert_not_called()
-    assert isinstance(reencrypt_http_spy.spy_exception, MockRestMiddleware.Unauthorized)
+    actual_exception = reencrypt_http_spy.spy_exception
+    assert isinstance(actual_exception, MockRestMiddleware.Unauthorized)
+    # verify message is not in bytes form
+    assert "Decryption conditions not satisfied" == str(actual_exception)

--- a/tests/integration/characters/test_conditional_reencryption.py
+++ b/tests/integration/characters/test_conditional_reencryption.py
@@ -97,9 +97,8 @@ def test_middleware_handling_of_failed_condition_responses(
     eval_failure_exception_class,
     middleware_exception_class,
     mocker,
-    enacted_federated_policy,
-    federated_bob,
-    federated_ursulas,
+    enacted_policy,
+    bob,
     mock_rest_middleware,
 ):
     # we use a failed condition for reencryption to test conversion of response codes to middleware exceptions
@@ -119,11 +118,9 @@ def test_middleware_handling_of_failed_condition_responses(
         )
     )
 
-    federated_bob.start_learning_loop()
+    bob.start_learning_loop()
 
-    message_kits = [
-        MessageKit(enacted_federated_policy.public_key, b"radio", conditions)
-    ]
+    message_kits = [MessageKit(enacted_policy.public_key, b"radio", conditions)]
 
     # use string message or chain id as exception parameter
     chain_id = 1
@@ -140,10 +137,10 @@ def test_middleware_handling_of_failed_condition_responses(
 
     with pytest.raises(Ursula.NotEnoughUrsulas):
         # failed retrieval because of failed exception
-        federated_bob.retrieve_and_decrypt(
+        bob.retrieve_and_decrypt(
             message_kits=message_kits,
-            encrypted_treasure_map=enacted_federated_policy.treasure_map,
-            alice_verifying_key=enacted_federated_policy.publisher_verifying_key,
+            encrypted_treasure_map=enacted_policy.treasure_map,
+            alice_verifying_key=enacted_policy.publisher_verifying_key,
         )
 
     actual_exception = reencrypt_http_spy.spy_exception

--- a/tests/integration/network/test_middleware.py
+++ b/tests/integration/network/test_middleware.py
@@ -25,9 +25,9 @@ def test_middleware_response_status_code_processing(
     expected_exception_class,
     mocker,
     mock_rest_middleware,
-    federated_ursulas,
+    ursulas,
 ):
-    ursula = list(federated_ursulas)[0]
+    ursula = list(ursulas)[0]
     _original_execute_method = mock_rest_middleware.client._execute_method
 
     def execute_method_side_effect(

--- a/tests/integration/network/test_middleware.py
+++ b/tests/integration/network/test_middleware.py
@@ -1,0 +1,56 @@
+from http import HTTPStatus
+from urllib.parse import urlparse
+
+import pytest
+
+from tests.utils.middleware import MockRestMiddleware
+
+
+@pytest.mark.parametrize(
+    "status_code, expected_exception_class",
+    [
+        (HTTPStatus.BAD_REQUEST, MockRestMiddleware.BadRequest),
+        (HTTPStatus.NOT_FOUND, MockRestMiddleware.NotFound),
+        (HTTPStatus.PAYMENT_REQUIRED, MockRestMiddleware.PaymentRequired),
+        (HTTPStatus.FORBIDDEN, MockRestMiddleware.Unauthorized),
+        # catch alls
+        (HTTPStatus.REQUEST_TIMEOUT, MockRestMiddleware.UnexpectedResponse),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, MockRestMiddleware.UnexpectedResponse),
+        (HTTPStatus.NOT_IMPLEMENTED, MockRestMiddleware.UnexpectedResponse),
+        (HTTPStatus.SERVICE_UNAVAILABLE, MockRestMiddleware.UnexpectedResponse),
+    ],
+)
+def test_middleware_response_status_code_processing(
+    status_code,
+    expected_exception_class,
+    mocker,
+    mock_rest_middleware,
+    federated_ursulas,
+):
+    ursula = list(federated_ursulas)[0]
+    _original_execute_method = mock_rest_middleware.client._execute_method
+
+    def execute_method_side_effect(
+        node_or_sprout, host, port, method, endpoint, *args, **kwargs
+    ):
+        endpoint_url = urlparse(endpoint)
+        if endpoint_url.path == "/reencrypt":
+            response = mocker.MagicMock(
+                text="I have not failed. I've just found 10,000 ways that won't work.",  # -- Thomas Edison
+                status_code=status_code,
+            )
+            return response
+        else:
+            return _original_execute_method(
+                node_or_sprout, host, port, method, endpoint, *args, **kwargs
+            )
+
+    mocker.patch.object(
+        mock_rest_middleware.client,
+        "_execute_method",
+        side_effect=execute_method_side_effect,
+    )
+    with pytest.raises(expected_exception_class):
+        mock_rest_middleware.reencrypt(
+            ursula=ursula, reencryption_request_bytes=b"reencryption_request"
+        )


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
We were using raw content from HTTP responses which is in bytes. Instead, use the decoded text.

Fixes #3041 . 

Need to update ursula nodes and porter (relock deps) on testnet once merged.
