### PR TITLE
Unfederate Configurations

### DIFF
--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -176,7 +176,7 @@ def select_config_file(emitter: StdoutEmitter,
     # parse configuration files for checksum address values
     for fp in config_files:
         try:
-            config_checksum_address = config_class.checksum_address_from_filepath(fp)
+            config_checksum_address = config_class.address_from_filepath(fp)
             if checksum_address and config_checksum_address == checksum_address:
                 # matching configuration file found, no need to continue - return filepath
                 return fp

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -535,7 +535,7 @@ class CharacterConfiguration(BaseConfiguration):
         self.__keystore = keystore
 
     @classmethod
-    def checksum_address_from_filepath(cls, filepath: Path) -> str:
+    def address_from_filepath(cls, filepath: Path) -> str:
         pattern = re.compile(r'''
                              (^\w+)-
                              (0x{1}           # Then, 0x the start of the string, exactly once

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -1,6 +1,3 @@
-
-
-
 import json
 import re
 from abc import ABC, abstractmethod
@@ -307,7 +304,7 @@ class CharacterConfiguration(BaseConfiguration):
     'Sideways Engagement' of Character classes; a reflection of input parameters.
     """
 
-    VERSION = 4  # bump when static payload scheme changes
+    VERSION = 5  # bump when static payload scheme changes
 
     CHARACTER_CLASS = NotImplemented
     MNEMONIC_KEYSTORE = False

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -62,12 +62,12 @@ class UrsulaConfiguration(CharacterConfiguration):
         super().__init__(dev_mode=dev_mode, keystore_path=keystore_path, *args, **kwargs)
 
     @classmethod
-    def checksum_address_from_filepath(cls, filepath: Path) -> str:
+    def address_from_filepath(cls, filepath: Path) -> str:
         """Extracts worker address by "peeking" inside the ursula configuration file."""
-        checksum_address = cls.peek(filepath=filepath, field='checksum_address')
-        if not is_checksum_address(checksum_address):
+        operator_address = cls.peek(filepath=filepath, field='operator_address')
+        if not is_checksum_address(operator_address):
             raise RuntimeError(f"Invalid checksum address detected in configuration file at '{filepath}'.")
-        return checksum_address
+        return operator_address
 
     def generate_runtime_filepaths(self, config_root: Path) -> dict:
         base_filepaths = super().generate_runtime_filepaths(config_root=config_root)


### PR DESCRIPTION
**Type of PR:**
Bugfix

**Required reviews:** 
1

**What this does:**
- fixes two bugs introduced in #3030 by:
  - bumps the configuration version to follow-up #3030 's changed to ursula config
  - use the operator address to identify and name ursula config files (not the "checksum address")
  
**Note**
- Staged on lynx testnet @ 1b277651a1cdff2fc0d4c6032cbf98b0d6cc7cf9
