### PR TITLE
[DO NOT MERGE] Temporarily include solidity contract files in package manifest - needed for exported pytest fixtures

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,3 +15,7 @@ recursive-include nucypher/network/templates *.html *.mako
 recursive-include nucypher/utilities/templates *.html *.mako
 recursive-include deploy/ansible/worker *.yml
 recursive-include nucypher/acumen/ *json
+
+# Include solidity contracts since needed for library's exported pytest fixtures
+recursive-include nucypher/blockchain/eth/sol/source *.sol
+recursive-include tests/contracts/contracts *.sol


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Now that federated mode is no more, for external application testing (eg. testing in the `nucypher-porter` repos), since there is no federated mode, the exported testerchain/ursulas (decentralized) fixtures from the nucypher fixtures can be used. However, these rely on `nucypher` contracts needing to be compiled and deployed to the testerchain, and that requires two things:

1. py-solc-x: only installed for the [dev] installation version of nucypher
2. contract solidity source files

1) can be achieved by using the `dev` extra for `nucypher`.  2) is causing some issues since editable support for a dependency is a minefield

This is related to failed tests in https://github.com/nucypher/nucypher-porter/pull/20.

Therefore for 2) the solidity files are now included in the Manifest and therefore included in the distribution. **This is a temporary solution until we rework the exported `nucypher` fixtures from #2993**

**Issues fixed/closed:**
- Related to #2993 .
- https://github.com/nucypher/nucypher/issues/3044 is the follow-up issue to address the temporary nature of this change. 
