### PR TITLE
Update darker version that fixes incompatibility with `black` library

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: '3.7'
-      - uses: akaihola/darker@1.5.1
+      - uses: akaihola/darker@1.6.1
         with:
           options: "--check --diff --isort"
-          version: "@3c675b009d747cadd6e8048d2c57a5b1cd54fb3e"
+          version: "1.6.1"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       - id: check-vcs-permalinks
 
   - repo: https://github.com/akaihola/darker
-    rev: 3c675b009d747cadd6e8048d2c57a5b1cd54fb3e
+    rev: 1.6.1
     hooks:
     -   id: darker
         args: [--isort]


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Use latest release of darker that include fix from https://github.com/akaihola/darker/pull/404

**Issues fixed/closed:**
Closes #3038 .