### PR TITLE
Fix code coverage to only focus on files in `nucypher` subfolder

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -9,3 +9,5 @@ coverage:
           - unit
           - integration
           - acceptance
+        paths:
+          - "nucypher"


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Related to https://github.com/nucypher/nucypher/pull/3046#issuecomment-1375285804.

I think code coverage needs to be configured to focus on files in `nucypher` subfolder.