### PR TITLE
Updates for nucypher-core 0.6 and umbral 0.9

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ python_version = "3"
 constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=4.0"
-nucypher-core = ">=0.4.0"
+nucypher-core = ">=0.6"
 # Cryptography
 cryptography = ">=3.2"
 mnemonic = "*"

--- a/examples/heartbeat_demo/alicia.py
+++ b/examples/heartbeat_demo/alicia.py
@@ -108,8 +108,12 @@ label = label.encode()
 # even before creating any associated policy.
 policy_pubkey = alicia.get_policy_encrypting_key_from_label(label)
 
-print("The policy public key for "
-      "label '{}' is {}".format(label.decode("utf-8"), bytes(policy_pubkey).hex()))
+print(
+    "The policy public key for "
+    "label '{}' is {}".format(
+        label.decode("utf-8"), policy_pubkey.to_compressed_bytes().hex()
+    )
+)
 
 # Data Sources can produce encrypted data for access policies
 # that **don't exist yet**.
@@ -155,7 +159,7 @@ print("Done!")
 # For the demo, we need a way to share with Bob some additional info
 # about the policy, so we store it in a JSON file
 policy_info = {
-    "policy_pubkey": bytes(policy.public_key).hex(),
+    "policy_pubkey": policy.public_key.to_compressed_bytes().hex(),
     "alice_sig_pubkey": bytes(alicia.stamp).hex(),
     "label": label.decode("utf-8"),
     "treasure_map": base64.b64encode(bytes(policy.treasure_map)).decode()

--- a/examples/heartbeat_demo/doctor.py
+++ b/examples/heartbeat_demo/doctor.py
@@ -47,8 +47,12 @@ print("Doctor = ", doctor)
 with open("policy-metadata.json", 'r') as f:
     policy_data = json.load(f)
 
-policy_pubkey = PublicKey.from_bytes(bytes.fromhex(policy_data["policy_pubkey"]))
-alices_sig_pubkey = PublicKey.from_bytes(bytes.fromhex(policy_data["alice_sig_pubkey"]))
+policy_pubkey = PublicKey.from_compressed_bytes(
+    bytes.fromhex(policy_data["policy_pubkey"])
+)
+alices_sig_pubkey = PublicKey.from_compressed_bytes(
+    bytes.fromhex(policy_data["alice_sig_pubkey"])
+)
 label = policy_data["label"].encode()
 treasure_map = EncryptedTreasureMap.from_bytes(base64.b64decode(policy_data["treasure_map"].encode()))
 

--- a/newsfragments/3049.feature.rst
+++ b/newsfragments/3049.feature.rst
@@ -1,0 +1,1 @@
+Bump ``nucypher-core`` to 0.6.

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -237,7 +237,7 @@ class Character(Learner):
 
         for power_up, public_key in powers_and_material.items():
             try:
-                umbral_key = PublicKey.from_bytes(public_key)
+                umbral_key = PublicKey.from_compressed_bytes(public_key)
             except TypeError:
                 umbral_key = public_key
 

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -85,8 +85,10 @@ class Vladimir(Ursula):
 
         # Use our own verifying key
         if substitute_verifying_key:
-            metadata_bytes = metadata_bytes.replace(bytes(metadata.payload.verifying_key),
-                                                    bytes(vladimir.stamp.as_umbral_pubkey()))
+            metadata_bytes = metadata_bytes.replace(
+                metadata.payload.verifying_key.to_compressed_bytes(),
+                vladimir.stamp.as_umbral_pubkey().to_compressed_bytes(),
+            )
 
         fake_metadata = NodeMetadata.from_bytes(metadata_bytes)
 

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -117,7 +117,7 @@ class UmbralPublicKeyHex(click.ParamType):
     def convert(self, value, param, ctx):
         if self.validate:
             try:
-                _key = PublicKey.from_bytes(bytes.fromhex(value))
+                _key = PublicKey.from_compressed_bytes(bytes.fromhex(value))
             except (InternalError, ValueError):
                 self.fail(f"'{value}' is not a valid nucypher public key.")
         return value

--- a/nucypher/crypto/keypairs.py
+++ b/nucypher/crypto/keypairs.py
@@ -68,7 +68,7 @@ class Keypair(object):
 
         :return: Hexdigest fingerprint of key (keccak-256) in bytes
         """
-        return sha3.keccak_256(bytes(self.pubkey)).hexdigest().encode()
+        return sha3.keccak_256(self.pubkey.to_compressed_bytes()).hexdigest().encode()
 
 
 class DecryptingKeypair(Keypair):
@@ -159,7 +159,7 @@ class HostingKeypair(Keypair):
                 message = "If you don't supply a TLS certificate, one will be generated for you." \
                           "But for that, you need to pass a host and checksum address."
                 raise TypeError(message)
-            certificate, private_key = generate_self_signed_certificate(host=host, private_key=private_key)
+            certificate, private_key = generate_self_signed_certificate(host=host)
             super().__init__(private_key=private_key)
 
         else:

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -193,7 +193,7 @@ class KeyPairBasedPower(CryptoPowerUp):
                     public_key = public_key.as_umbral_pubkey()
                 except AttributeError:
                     try:
-                        public_key = PublicKey.from_bytes(public_key)
+                        public_key = PublicKey.from_compressed_bytes(public_key)
                     except TypeError:
                         public_key = public_key
                 self.keypair = self._keypair_class(

--- a/nucypher/crypto/signing.py
+++ b/nucypher/crypto/signing.py
@@ -11,7 +11,7 @@ class SignatureStamp(object):
 
     def __init__(self, verifying_key, signer: Signer = None) -> None:
         self.__signer = signer
-        self._as_bytes = bytes(verifying_key)
+        self._as_bytes = verifying_key.to_compressed_bytes()
         self._as_umbral_pubkey = verifying_key
 
     def __bytes__(self):

--- a/nucypher/crypto/tls.py
+++ b/nucypher/crypto/tls.py
@@ -3,7 +3,7 @@
 import datetime
 from ipaddress import IPv4Address
 from pathlib import Path
-from typing import ClassVar, Tuple
+from typing import ClassVar, Optional, Tuple
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -30,14 +30,14 @@ def _read_tls_certificate(filepath: Path) -> Certificate:
         raise FileNotFoundError("No SSL certificate found at {}".format(filepath))
 
 
-def generate_self_signed_certificate(host: str,
-                                     private_key: SecretKey = None,
-                                     days_valid: int = 365,
-                                     curve: ClassVar[EllipticCurve] = _TLS_CURVE,
-                                     ) -> Tuple[Certificate, _EllipticCurvePrivateKey]:
-
-    if private_key:
-        private_bn = int.from_bytes(private_key.to_secret_bytes(), 'big')
+def generate_self_signed_certificate(
+    host: str,
+    secret_seed: Optional[bytes] = None,
+    days_valid: int = 365,
+    curve: ClassVar[EllipticCurve] = _TLS_CURVE,
+) -> Tuple[Certificate, _EllipticCurvePrivateKey]:
+    if secret_seed:
+        private_bn = int.from_bytes(secret_seed[: _TLS_CURVE.key_size // 8], "big")
         private_key = ec.derive_private_key(private_value=private_bn, curve=curve())
     else:
         private_key = ec.generate_private_key(curve(), default_backend())

--- a/nucypher/crypto/utils.py
+++ b/nucypher/crypto/utils.py
@@ -21,7 +21,7 @@ SYSTEM_RAND = SystemRandom()
 def canonical_address_from_umbral_key(public_key: Union[PublicKey, SignatureStamp]) -> bytes:
     if isinstance(public_key, SignatureStamp):
         public_key = public_key.as_umbral_pubkey()
-    pubkey_compressed_bytes = bytes(public_key)
+    pubkey_compressed_bytes = public_key.to_compressed_bytes()
     eth_pubkey = EthKeyAPI.PublicKey.from_compressed_bytes(pubkey_compressed_bytes)
     canonical_address = eth_pubkey.to_canonical_address()
     return canonical_address

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ multiaddr==0.0.9; python_version >= '2.7' and python_version not in '3.0, 3.1, 3
 multidict==6.0.2; python_version >= '3.7'
 mypy-extensions==0.4.3
 netaddr==0.8.0
-nucypher-core==0.4.1
+nucypher-core==0.6.0
 packaging==21.3; python_version >= '3.6'
 parsimonious==0.8.1
 pendulum==2.1.2; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/tests/contracts/lib/test_umbral_deserializer.py
+++ b/tests/contracts/lib/test_umbral_deserializer.py
@@ -51,7 +51,7 @@ def test_capsule(testerchain, deserializer, fragments):
 
     # Check real capsule
     capsule, _cfrag = fragments
-    capsule_bytes = bytes(capsule)
+    capsule_bytes = capsule.to_bytes_simple()
     result = deserializer.functions.toCapsule(capsule_bytes).call()
     assert b''.join(result) == capsule_bytes
 
@@ -72,7 +72,7 @@ def test_cfrag(testerchain, deserializer, fragments):
 
     # Check real cfrag
     _capsule, cfrag = fragments
-    cfrag_bytes = bytes(cfrag)
+    cfrag_bytes = cfrag.unverify().to_bytes_simple()
     result_frag = deserializer.functions.toCapsuleFrag(cfrag_bytes).call()
     result_proof = deserializer.functions.toCorrectnessProofFromCapsuleFrag(cfrag_bytes).call()
     assert cfrag_bytes == b''.join(result_frag) + b''.join(result_proof)

--- a/tests/metrics/grant_availability.py
+++ b/tests/metrics/grant_availability.py
@@ -123,8 +123,10 @@ def collect(alice: Alice,
             print(f'GRANT FAIL\n{e}')
         else:
             success += 1
-            policies[bytes(policy.public_key).hex()] = policy  # track
-            print(f"PEK:{bytes(policy.public_key).hex()} | {policy.hrac}")
+            policies[policy.public_key.to_compressed_bytes().hex()] = policy  # track
+            print(
+                f"PEK:{policy.public_key.to_compressed_bytes().hex()} | {policy.hrac}"
+            )
 
         # timeit
         end = maya.now()

--- a/tests/mock/performance_mocks.py
+++ b/tests/mock/performance_mocks.py
@@ -37,7 +37,7 @@ class NotAPublicKey:
     _serial_bytes_length = 5
     _serial = 10000
 
-    _umbral_pubkey_from_bytes = PublicKey.from_bytes
+    _umbral_pubkey_from_bytes = PublicKey.from_compressed_bytes
 
     def _tick():
         for serial in good_serials:

--- a/tests/unit/crypto/test_keypairs.py
+++ b/tests/unit/crypto/test_keypairs.py
@@ -26,10 +26,16 @@ def test_keypair_with_umbral_keys():
 
     new_keypair_from_priv = keypairs.Keypair(umbral_privkey)
     assert new_keypair_from_priv._privkey == umbral_privkey
-    assert bytes(new_keypair_from_priv.pubkey) == bytes(umbral_pubkey)
+    assert (
+        new_keypair_from_priv.pubkey.to_compressed_bytes()
+        == umbral_pubkey.to_compressed_bytes()
+    )
 
     new_keypair_from_pub = keypairs.Keypair(public_key=umbral_pubkey)
-    assert bytes(new_keypair_from_pub.pubkey) == bytes(umbral_pubkey)
+    assert (
+        new_keypair_from_pub.pubkey.to_compressed_bytes()
+        == umbral_pubkey.to_compressed_bytes()
+    )
     assert new_keypair_from_pub._privkey == PUBLIC_ONLY
 
 
@@ -37,8 +43,8 @@ def test_keypair_serialization():
     umbral_pubkey = SecretKey.random().public_key()
     new_keypair = keypairs.Keypair(public_key=umbral_pubkey)
 
-    pubkey_bytes = bytes(new_keypair.pubkey)
-    assert pubkey_bytes == bytes(umbral_pubkey)
+    pubkey_bytes = new_keypair.pubkey.to_compressed_bytes()
+    assert pubkey_bytes == umbral_pubkey.to_compressed_bytes()
 
 
 def test_keypair_fingerprint():
@@ -48,7 +54,9 @@ def test_keypair_fingerprint():
     fingerprint = new_keypair.fingerprint()
     assert fingerprint is not None
 
-    umbral_fingerprint = sha3.keccak_256(bytes(umbral_pubkey)).hexdigest().encode()
+    umbral_fingerprint = (
+        sha3.keccak_256(umbral_pubkey.to_compressed_bytes()).hexdigest().encode()
+    )
     assert fingerprint == umbral_fingerprint
 
 

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -232,26 +232,37 @@ def test_restore_keystore_from_mnemonic(tmpdir, mocker):
 
 
 def test_import_custom_keystore(tmpdir):
+    # Too short - 32 bytes is required
+    custom_secret = b"tooshort"
+    with pytest.raises(
+        ValueError,
+        match=f"Entropy bytes bust be exactly {SecretKeyFactory.seed_size()}.",
+    ):
+        _keystore = Keystore.import_secure(
+            key_material=custom_secret,
+            password=INSECURE_DEVELOPMENT_PASSWORD,
+            keystore_dir=tmpdir,
+        )
 
     # Too short - 32 bytes is required
-    custom_secret = b'tooshort'
-    with pytest.raises(ValueError, match=f'Entropy bytes bust be exactly {SecretKey.serialized_size()}.'):
-        _keystore = Keystore.import_secure(key_material=custom_secret,
-                                           password=INSECURE_DEVELOPMENT_PASSWORD,
-                                           keystore_dir=tmpdir)
-
-    # Too short - 32 bytes is required
-    custom_secret = b'thisisabunchofbytesthatisabittoolong'
-    with pytest.raises(ValueError, match=f'Entropy bytes bust be exactly {SecretKey.serialized_size()}.'):
-        _keystore = Keystore.import_secure(key_material=custom_secret,
-                                           password=INSECURE_DEVELOPMENT_PASSWORD,
-                                           keystore_dir=tmpdir)
+    custom_secret = b"thisisabunchofbytesthatisabittoolong"
+    with pytest.raises(
+        ValueError,
+        match=f"Entropy bytes bust be exactly {SecretKeyFactory.seed_size()}.",
+    ):
+        _keystore = Keystore.import_secure(
+            key_material=custom_secret,
+            password=INSECURE_DEVELOPMENT_PASSWORD,
+            keystore_dir=tmpdir,
+        )
 
     # Import private key
-    custom_secret = os.urandom(SecretKey.serialized_size())  # insecure but works
-    keystore = Keystore.import_secure(key_material=custom_secret,
-                                      password=INSECURE_DEVELOPMENT_PASSWORD,
-                                      keystore_dir=tmpdir)
+    custom_secret = os.urandom(SecretKeyFactory.seed_size())  # insecure but works
+    keystore = Keystore.import_secure(
+        key_material=custom_secret,
+        password=INSECURE_DEVELOPMENT_PASSWORD,
+        keystore_dir=tmpdir,
+    )
     keystore.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
     assert keystore._Keystore__secret == custom_secret
     keystore.lock()
@@ -269,7 +280,7 @@ def test_derive_signing_power(tmpdir):
     keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir)
     keystore.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
     signing_power = keystore.derive_crypto_power(power_class=SigningPower)
-    assert bytes(signing_power.public_key()).hex()
+    assert signing_power.public_key().to_compressed_bytes().hex()
     assert signing_power.keypair.fingerprint()
 
 
@@ -277,7 +288,7 @@ def test_derive_decrypting_power(tmpdir):
     keystore = Keystore.generate(INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=tmpdir)
     keystore.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
     decrypting_power = keystore.derive_crypto_power(power_class=DecryptingPower)
-    assert bytes(decrypting_power.public_key()).hex()
+    assert decrypting_power.public_key().to_compressed_bytes().hex()
     assert decrypting_power.keypair.fingerprint()
 
 
@@ -287,8 +298,11 @@ def test_derive_delegating_power(tmpdir):
     delegating_power = keystore.derive_crypto_power(power_class=DelegatingPower)
     parent_skf = SecretKeyFactory.from_secure_randomness(keystore._Keystore__secret)
     child_skf = parent_skf.make_factory(_DELEGATING_INFO)
-    assert delegating_power._DelegatingPower__secret_key_factory.to_secret_bytes() == child_skf.to_secret_bytes()
-    assert delegating_power._get_privkey_from_label(label=b'some-label')
+    ref_pk = child_skf.make_key(b"some-label").public_key()
+    assert (
+        delegating_power._get_privkey_from_label(label=b"some-label").public_key()
+        == ref_pk
+    )
 
 
 def test_derive_hosting_power(tmpdir):

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -1,12 +1,13 @@
 
 
 
+import os
 from pathlib import Path
 
 import pytest
 from eth_utils import to_checksum_address
 from nucypher_core import Address, NodeMetadata, NodeMetadataPayload
-from nucypher_core.umbral import SecretKey, Signer
+from nucypher_core.umbral import RecoverableSignature, SecretKey, Signer
 
 from nucypher.acumen.perception import FleetSensor
 from nucypher.characters.lawful import Ursula
@@ -16,12 +17,12 @@ from nucypher.network.middleware import NucypherMiddlewareClient
 from nucypher.network.nodes import TEACHER_NODES
 from nucypher.network.protocols import InterfaceInfo
 from nucypher.utilities.networking import (
+    CENTRALIZED_IP_ORACLE_URL,
+    UnknownIPAddress,
     determine_external_ip_address,
     get_external_ip_from_centralized_source,
     get_external_ip_from_default_teacher,
     get_external_ip_from_known_nodes,
-    CENTRALIZED_IP_ORACLE_URL,
-    UnknownIPAddress
 )
 from tests.constants import MOCK_IP_ADDRESS
 
@@ -63,7 +64,9 @@ class Dummy:  # Teacher
         signer = Signer(SecretKey.random())
 
         # A dummy signature with the recovery byte
-        dummy_signature = bytes(signer.sign(b'whatever')) + b'\x00'
+        dummy_signature = RecoverableSignature.from_be_bytes(
+            signer.sign(b"whatever").to_be_bytes() + b"\x00"
+        )
 
         payload = NodeMetadataPayload(staking_provider_address=Address(self.canonical_address),
                                       domain=':dummy:',


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
Bumps `nucypher-core` to 0.6 and adjusts the API usage.

In particular, the `nucypher-core` changes are:
- Protocol versions bumped due to some changes in how `umbral-pre` serializes things.
- Public keys are (de)serialized as `to_compressed_bytes()`/`from_compressed_bytes()` instead of `bytes()`/`from_bytes()`
- Signatures are (de)serialized as `to_be_bytes()`/`from_be_bytes()` (the format is r,s pair as 32 bytes + 32 bytes) instead of `bytes()`/`from_bytes()`
- Secret keys are serialized as (de)serialized as `to_be_bytes()`/`from_be_bytes()` instead of `to_secret_bytes()`/`from_secret_bytes()`
- `NodeMetadataPayload.operator_signature` has type `RecoverableSignature` instead of `Optional[bytes]`. 
- Secret seed for the TLS private key is derived with `SecretKeyFactory.secret_seed() -> bytes` instead of `SecretKeyFactory.make_key() -> SecretKey`, and then `SecretKey.to_secret_bytes()`

Notes:
- The current locking scripts don't work with the last `pipenv` (work with `2022.1.8`)
- Even then I wasn't able to relock the deps successfully - the lock creates a weird configuration that either can't be installed on CI or on my machine. So I just bumped the version in `Pipfile` and `requirements.txt`.
- For some reason, even though the federated mode is gone, `Ursula.operator_signature` can still sometimes be `None` in tests. See the note in `Ursula._generate_metadata()`.
