### PR TITLE
Configure oryx contract registry to point to the correct contract address.

### DIFF
--- a/nucypher/blockchain/eth/contract_registry/oryx/contract_registry.json
+++ b/nucypher/blockchain/eth/contract_registry/oryx/contract_registry.json
@@ -2,7 +2,7 @@
     [
       "SimplePREApplication",
       "v0.0.0",
-      "0xaF96aa6000ec2B6CF0Fe6B505B6C33fa246967Ca",
+      "0x9BA321B30173b433c68767961D6e53e420AEa382",
       [
         {
           "inputs": [


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Oryx contract registry not pointing to the correct contract address (it points to `tapir`'s).