### PR TITLE
Pin web3 version to >= 6.0.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,7 +31,7 @@ requests = "*"
 # Third-Party Ethereum
 py-evm = "*"
 eth-tester = "*"
-web3 = "*"
+web3 = ">=6.0.0"
 eth-utils = "*"
 eip712-structs = "*"
 # CLI / Configuration

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e7853d2a7840c312773bda725183ff5503212278f518f00ef3f1a39c370cf7c6"
+            "sha256": "4a49f106f6f21757ff7657cec43cebdd8f723ca631fd41a4e33e51ad108feb7a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -120,11 +120,11 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
+                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1.0"
         },
         "autobahn": {
             "hashes": [
@@ -365,28 +365,28 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:0a4e3406cfed6b1f6d6e87ed243363652b2586b2d917b0609ca4f97072994405",
-                "sha256:1e0af458515d5e4028aad75f3bb3fe7a31e46ad920648cd59b64d3da842e4356",
-                "sha256:2803f2f8b1e95f614419926c7e6f55d828afc614ca5ed61543877ae668cc3472",
-                "sha256:28d63d75bf7ae4045b10de5413fb1d6338616e79015999ad9cf6fc538f772d41",
-                "sha256:32057d3d0ab7d4453778367ca43e99ddb711770477c4f072a51b3ca69602780a",
-                "sha256:3a4805a4ca729d65570a1b7cac84eac1e431085d40387b7d3bbaa47e39890b88",
-                "sha256:63dac2d25c47f12a7b8aa60e528bfb3c51c5a6c5a9f7c86987909c6c79765554",
-                "sha256:650883cc064297ef3676b1db1b7b1df6081794c4ada96fa457253c4cc40f97db",
-                "sha256:6f2bbd72f717ce33100e6467572abaedc61f1acb87b8d546001328d7f466b778",
-                "sha256:7c872413353c70e0263a9368c4993710070e70ab3e5318d85510cc91cce77e7c",
-                "sha256:918cb89086c7d98b1b86b9fdb70c712e5a9325ba6f7d7cfb509e784e0cfc6917",
-                "sha256:9618a87212cb5200500e304e43691111570e1f10ec3f35569fdfcd17e28fd797",
-                "sha256:a805a7bce4a77d51696410005b3e85ae2839bad9aa38894afc0aa99d8e0c3160",
-                "sha256:cc3a621076d824d75ab1e1e530e66e7e8564e357dd723f2533225d40fe35c60c",
-                "sha256:cd033d74067d8928ef00a6b1327c8ea0452523967ca4463666eeba65ca350d4c",
-                "sha256:cf91e428c51ef692b82ce786583e214f58392399cf65c341bc7301d096fa3ba2",
-                "sha256:d36bbeb99704aabefdca5aee4eba04455d7a27ceabd16f3b3ba9bdcc31da86c4",
-                "sha256:d8aa3609d337ad85e4eb9bb0f8bcf6e4409bfb86e706efa9a027912169e89122",
-                "sha256:f5d7b79fa56bc29580faafc2ff736ce05ba31feaa9d4735048b0de7d9ceb2b94"
+                "sha256:05dc219433b14046c476f6f09d7636b92a1c3e5808b9a6536adf4932b3b2c440",
+                "sha256:0dcca15d3a19a66e63662dc8d30f8036b07be851a8680eda92d079868f106288",
+                "sha256:142bae539ef28a1c76794cca7f49729e7c54423f615cfd9b0b1fa90ebe53244b",
+                "sha256:3daf9b114213f8ba460b829a02896789751626a2a4e7a43a28ee77c04b5e4958",
+                "sha256:48f388d0d153350f378c7f7b41497a54ff1513c816bcbbcafe5b829e59b9ce5b",
+                "sha256:4df2af28d7bedc84fe45bd49bc35d710aede676e2a4cb7fc6d103a2adc8afe4d",
+                "sha256:4f01c9863da784558165f5d4d916093737a75203a5c5286fde60e503e4276c7a",
+                "sha256:7a38250f433cd41df7fcb763caa3ee9362777fdb4dc642b9a349721d2bf47404",
+                "sha256:8f79b5ff5ad9d3218afb1e7e20ea74da5f76943ee5edb7f76e56ec5161ec782b",
+                "sha256:956ba8701b4ffe91ba59665ed170a2ebbdc6fc0e40de5f6059195d9f2b33ca0e",
+                "sha256:a04386fb7bc85fab9cd51b6308633a3c271e3d0d3eae917eebab2fac6219b6d2",
+                "sha256:a95f4802d49faa6a674242e25bfeea6fc2acd915b5e5e29ac90a32b1139cae1c",
+                "sha256:adc0d980fd2760c9e5de537c28935cc32b9353baaf28e0814df417619c6c8c3b",
+                "sha256:aecbb1592b0188e030cb01f82d12556cf72e218280f621deed7d806afd2113f9",
+                "sha256:b12794f01d4cacfbd3177b9042198f3af1c856eedd0a98f10f141385c809a14b",
+                "sha256:c0764e72b36a3dc065c155e5b22f93df465da9c39af65516fe04ed3c68c92636",
+                "sha256:c33c0d32b8594fa647d2e01dbccc303478e16fdd7cf98652d5b3ed11aa5e5c99",
+                "sha256:cbaba590180cba88cb99a5f76f90808a624f18b169b90a4abb40c1fd8c19420e",
+                "sha256:d5a1bd0e9e2031465761dfa920c16b0065ad77321d8a8c1f5ee331021fda65e9"
             ],
             "index": "pypi",
-            "version": "==40.0.1"
+            "version": "==40.0.2"
         },
         "cytoolz": {
             "hashes": [
@@ -587,11 +587,11 @@
         },
         "ferveo": {
             "hashes": [
-                "sha256:17a08a58cc8003270e27b595b3860113f26e243688c68fd2da287ceb85c5675a",
-                "sha256:79c2d73344ba4d03fff487b7bc57037c0a76f644bc63ee55cf0c9ea583e5658c"
+                "sha256:0c0bff40af15e86a6b41d92cfbfd5ca15c344d582c648897e3b38a31659f37f9",
+                "sha256:1ad90b8b5f7cac1e86d23cc05329b2f79ec3e39c5a56cf6cd55f7fc297cdd4b5"
             ],
             "index": "pypi",
-            "version": "==0.1.6"
+            "version": "==0.1.7"
         },
         "flask": {
             "hashes": [
@@ -745,11 +745,11 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:74655a97c41753163c195ac342ceb91168d6b719b123ebc1bbfa3cff6d103481",
-                "sha256:dae26a6aaf4b278b1d1aafd892aee9f16604971497a03c566c365e9ea4dc2c33"
+                "sha256:7f6b40b7501c770ab1465e0f91b0b3737351d9b488331ab39ad0b6aa9869c39e",
+                "sha256:c4abe05b475016459cafb5520fb2062a923adf72aa8ad1319d8a92fa227cf59b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.18.0a3"
+            "version": "==4.18.0a4"
         },
         "jsonschema-specifications": {
             "hashes": [
@@ -1662,79 +1662,79 @@
         },
         "websockets": {
             "hashes": [
-                "sha256:007ed0d62f7e06eeb6e3a848b0d83b9fbd9e14674a59a61326845f27d20d7452",
-                "sha256:07cc20655fb16aeef1a8f03236ba8671c61d332580b996b6396a5b7967ba4b3d",
-                "sha256:0929c2ebdf00cedda77bf77685693e38c269011236e7c62182fee5848c29a4fa",
-                "sha256:12180bc1d72c6a9247472c1dee9dfd7fc2e23786f25feee7204406972d8dab39",
-                "sha256:1cb23597819f68ac6a6d133a002a1b3ef12a22850236b083242c93f81f206d5a",
-                "sha256:25ea5dbd3b00c56b034639dc6fe4d1dd095b8205bab1782d9a47cb020695fdf4",
-                "sha256:2796f097841619acf053245f266a4f66cb27c040f0d9097e5f21301aab95ff43",
-                "sha256:29282631da3bfeb5db497e4d3d94d56ee36222fbebd0b51014e68a2e70736fb1",
-                "sha256:2a58e83f82098d062ae5d4cbe7073b8783999c284d6f079f2fefe87cd8957ac8",
-                "sha256:349dd1fa56a30d530555988be98013688de67809f384671883f8bf8b8c9de984",
-                "sha256:369410925b240b30ef1c1deadbd6331e9cd865ad0b8966bf31e276cc8e0da159",
-                "sha256:385c5391becb9b58e0a4f33345e12762fd857ccf9fbf6fee428669929ba45e4c",
-                "sha256:3a88375b648a2c479532943cc19a018df1e5fcea85d5f31963c0b22794d1bdc1",
-                "sha256:3cf18bbd44b36749b7b66f047a30a40b799b8c0bd9a1b9173cba86a234b4306b",
-                "sha256:3d30cc1a90bcbf9e22e1f667c1c5a7428e2d37362288b4ebfd5118eb0b11afa9",
-                "sha256:42aa05e890fcf1faed8e535c088a1f0f27675827cbacf62d3024eb1e6d4c9e0c",
-                "sha256:43e0de552be624e5c0323ff4fcc9f0b4a9a6dc6e0116b8aa2cbb6e0d3d2baf09",
-                "sha256:45a85dc6b3ff76239379feb4355aadebc18d6e587c8deb866d11060755f4d3ea",
-                "sha256:4fe2aed5963ca267c40a2d29b1ee4e8ab008ac8d5daa284fdda9275201b8a334",
-                "sha256:52ba83ea132390e426f9a7b48848248a2dc0e7120ca8c65d5a8fc1efaa4eb51b",
-                "sha256:53b8e1ee01eb5b8be5c8a69ae26b0820dbc198d092ad50b3451adc3cdd55d455",
-                "sha256:54d084756c50dfc8086dce97b945f210ca43950154e1e04a44a30c6e6a2bcbb1",
-                "sha256:5d4f4b341100d313b08149d7031eb6d12738ac758b0c90d2f9be8675f401b019",
-                "sha256:5d68bd2a3e9fff6f7043c0a711cb1ebba9f202c196a3943d0c885650cd0b6464",
-                "sha256:5d8d5d17371ed9eb9f0e3a8d326bdf8172700164c2e705bc7f1905a719a189be",
-                "sha256:5ffe6fc5e5fe9f2634cdc59b805e4ba1fcccf3a5622f5f36c3c7c287f606e283",
-                "sha256:60a19d4ff5f451254f8623f6aa4169065f73a50ec7b59ab6b9dcddff4aa00267",
-                "sha256:718d19c494637f28e651031b3df6a791b9e86e0097c65ed5e8ec49b400b1210e",
-                "sha256:79b6548e57ab18f071b9bfe3ffe02af7184dd899bc674e2817d8fe7e9e7489ec",
-                "sha256:84e92dbac318a84fef722f38ca57acef19cbb89527aba5d420b96aa2656970ee",
-                "sha256:85b4127f7da332feb932eee833c70e5e1670469e8c9de7ef3874aa2a91a6fbb2",
-                "sha256:87ae582cf2319e45bc457a57232daded27a3c771263cab42fb8864214bbd74ea",
-                "sha256:892959b627eedcdf98ac7022f9f71f050a59624b380b67862da10c32ea3c221a",
-                "sha256:9d91279d57f6546eaf43671d1de50621e0578f13c2f17c96c458a72d170698d7",
-                "sha256:a01c674e0efe0f14aec7e722ed0e0e272fa2f10e8ea8260837e1f4f5dc4b3e53",
-                "sha256:a4667d4e41fa37fa3d836b2603b8b40d6887fa4838496d48791036394f7ace39",
-                "sha256:a797da96d4127e517a5cb0965cd03fd6ec21e02667c1258fa0579501537fbe5c",
-                "sha256:a88815a0c6253ad1312ef186620832fb347706c177730efec34e3efe75e0e248",
-                "sha256:a8d9793f3fb0da16232503df14411dabafed5a81fc9077dc430cfc6f60e71179",
-                "sha256:ac042e8ba9d7f2618e84af27927fdce0f3e03528eb74f343977486c093868389",
-                "sha256:ae59a9f0a77ecb0cbdedea7d206a547ff136e8bfbc7d2d98772fb02d398797bb",
-                "sha256:aedd94422745da60672a901f53de1f50b16e85408b18672b9b210db4a776b5a6",
-                "sha256:aef1602db81096ce3d3847865128c8879635bdad7963fb2b7df290edb9e9150a",
-                "sha256:b0ed24a3aa4213029e100257e5e73c5f912e70ca35630081de94b7f9e2cf4a9b",
-                "sha256:b138f4bf8a64c344e12c76283dac279d11adab89ac62ae4a32ac8490d3c94832",
-                "sha256:b91657b65355954e47f0df874917fa200426b3a7f4e68073326a8cfc2f6deef8",
-                "sha256:c7fdfbed727ce6b4b5e6622d15a6efb2098b2d9e22ba4dc54b2e3ce80f982045",
-                "sha256:c90343fd0774749d23c1891dd8b3e9210f9afd30986673ce0f9d5857f5cb1562",
-                "sha256:ceeef57b9aec8f27e523de4da73c518ece7721aefe7064f18aa28baabfe61b94",
-                "sha256:cfd0b9b18d64c51e5cd322e16b5bf4fe490db65c9f7b18fd5382c824062ead7e",
-                "sha256:d4e0990b6a04b07095c969969da659eecf9069cf8e7b8f49c8f5ee1bb50e3352",
-                "sha256:d5a3022f9291bf2d35ebf65929297d625e68effd3a5647b8eb8b89d51b09394c",
-                "sha256:d5a6fa353b5ef36970c3bd1cd7cecbc08bb8f2f1a3d008b0691208cf34ebf5b0",
-                "sha256:d5f3d0d177b3db3d1d02cce7ba6c0063586499ac28afe0c992be74ffc40d9257",
-                "sha256:db234da3aff01e8483cf0015b75486c04d50dbf90004bd3e5b46d384e1bd6c9e",
-                "sha256:db78535b791840a584c48cf3f4215eae38a7e2f43271ecd27ce4ba8a798beaaa",
-                "sha256:dbeada3b8f1f6d9497840f761906c4236f912a42da4515520168bc7c525b52b0",
-                "sha256:dc77283a7c7b2b24e00fe8c3c4f7cf36bba4f65125777e906aae4d58d06d0460",
-                "sha256:deb0dd98ea4e76b833f0bfd7a6042b51115360d5dfcc7c1daa72dfc417b3327a",
-                "sha256:e039f106d48d3c241f1943bccfb383bd38ec39900d6dcaad0c73cc5fe129f346",
-                "sha256:e2654e94c705ce9b768441d8e3a387a84951ca1056efdc4a26a4a6ee723c01b6",
-                "sha256:e53419201c6c1439148feb99de6b307651a88b8defd41348cc23bbe2a290de1d",
-                "sha256:ec4a887d2236e3878c07033ad5566f6b4d5d954b85f92a219519a1745d0c93e9",
-                "sha256:ec4e87eb9916b481216b1fede7d8913be799915f5216a0c801867cbed8eeb903",
-                "sha256:ef0e6253c36e42f2637cfa3ff9b3903df60d05ec040c718999f6a0644ce1c497",
-                "sha256:ef35cef161f76031f833146f895e7e302196e01c704c00d269c04d8e18f3ac37",
-                "sha256:f7b2544eb3e7bc39ce59812371214cd97762080dab90c3afc857890039384753",
-                "sha256:f888b9565ca1d1c25ab827d184f57f4772ffbfa6baf5710b873b01936cc335ee",
-                "sha256:fa1c23ed3a02732fba906ec337df65d4cc23f9f453635e1a803c285b59c7d987",
-                "sha256:fc0a96a6828bfa6f1ccec62b54630bcdcc205d483f5a8806c0a8abb26101c54b"
+                "sha256:0fb4480556825e4e6bf2eebdbeb130d9474c62705100c90e59f2f56459ddab42",
+                "sha256:13bd5bebcd16a4b5e403061b8b9dcc5c77e7a71e3c57e072d8dff23e33f70fba",
+                "sha256:143782041e95b63083b02107f31cda999f392903ae331de1307441f3a4557d51",
+                "sha256:1b52def56d2a26e0e9c464f90cadb7e628e04f67b0ff3a76a4d9a18dfc35e3dd",
+                "sha256:1df2413266bf48430ef2a752c49b93086c6bf192d708e4a9920544c74cd2baa6",
+                "sha256:2174a75d579d811279855df5824676d851a69f52852edb0e7551e0eeac6f59a4",
+                "sha256:220d5b93764dd70d7617f1663da64256df7e7ea31fc66bc52c0e3750ee134ae3",
+                "sha256:232b6ba974f5d09b1b747ac232f3a3d8f86de401d7b565e837cc86988edf37ac",
+                "sha256:25aae96c1060e85836552a113495db6d857400288161299d77b7b20f2ac569f2",
+                "sha256:25e265686ea385f22a00cc2b719b880797cd1bb53b46dbde969e554fb458bfde",
+                "sha256:2abeeae63154b7f63d9f764685b2d299e9141171b8b896688bd8baec6b3e2303",
+                "sha256:2acdc82099999e44fa7bd8c886f03c70a22b1d53ae74252f389be30d64fd6004",
+                "sha256:2eb042734e710d39e9bc58deab23a65bd2750e161436101488f8af92f183c239",
+                "sha256:3178d965ec204773ab67985a09f5696ca6c3869afeed0bb51703ea404a24e975",
+                "sha256:320ddceefd2364d4afe6576195201a3632a6f2e6d207b0c01333e965b22dbc84",
+                "sha256:34a6f8996964ccaa40da42ee36aa1572adcb1e213665e24aa2f1037da6080909",
+                "sha256:3565a8f8c7bdde7c29ebe46146bd191290413ee6f8e94cf350609720c075b0a1",
+                "sha256:392d409178db1e46d1055e51cc850136d302434e12d412a555e5291ab810f622",
+                "sha256:3a09cce3dacb6ad638fdfa3154d9e54a98efe7c8f68f000e55ca9c716496ca67",
+                "sha256:3a2100b02d1aaf66dc48ff1b2a72f34f6ebc575a02bc0350cc8e9fbb35940166",
+                "sha256:3b87cd302f08ea9e74fdc080470eddbed1e165113c1823fb3ee6328bc40ca1d3",
+                "sha256:3e79065ff6549dd3c765e7916067e12a9c91df2affea0ac51bcd302aaf7ad207",
+                "sha256:3ffe251a31f37e65b9b9aca5d2d67fd091c234e530f13d9dce4a67959d5a3fba",
+                "sha256:46388a050d9e40316e58a3f0838c63caacb72f94129eb621a659a6e49bad27ce",
+                "sha256:46dda4bc2030c335abe192b94e98686615f9274f6b56f32f2dd661fb303d9d12",
+                "sha256:4c54086b2d2aec3c3cb887ad97e9c02c6be9f1d48381c7419a4aa932d31661e4",
+                "sha256:5004c087d17251938a52cce21b3dbdabeecbbe432ce3f5bbbf15d8692c36eac9",
+                "sha256:502683c5dedfc94b9f0f6790efb26aa0591526e8403ad443dce922cd6c0ec83b",
+                "sha256:518ed6782d9916c5721ebd61bb7651d244178b74399028302c8617d0620af291",
+                "sha256:580cc95c58118f8c39106be71e24d0b7e1ad11a155f40a2ee687f99b3e5e432e",
+                "sha256:58477b041099bb504e1a5ddd8aa86302ed1d5c6995bdd3db2b3084ef0135d277",
+                "sha256:5875f623a10b9ba154cb61967f940ab469039f0b5e61c80dd153a65f024d9fb7",
+                "sha256:5c7de298371d913824f71b30f7685bb07ad13969c79679cca5b1f7f94fec012f",
+                "sha256:634239bc844131863762865b75211a913c536817c0da27f691400d49d256df1d",
+                "sha256:6d872c972c87c393e6a49c1afbdc596432df8c06d0ff7cd05aa18e885e7cfb7c",
+                "sha256:752fbf420c71416fb1472fec1b4cb8631c1aa2be7149e0a5ba7e5771d75d2bb9",
+                "sha256:7742cd4524622cc7aa71734b51294644492a961243c4fe67874971c4d3045982",
+                "sha256:808b8a33c961bbd6d33c55908f7c137569b09ea7dd024bce969969aa04ecf07c",
+                "sha256:87c69f50281126dcdaccd64d951fb57fbce272578d24efc59bce72cf264725d0",
+                "sha256:8df63dcd955eb6b2e371d95aacf8b7c535e482192cff1b6ce927d8f43fb4f552",
+                "sha256:8f24cd758cbe1607a91b720537685b64e4d39415649cac9177cd1257317cf30c",
+                "sha256:8f392587eb2767afa8a34e909f2fec779f90b630622adc95d8b5e26ea8823cb8",
+                "sha256:954eb789c960fa5daaed3cfe336abc066941a5d456ff6be8f0e03dd89886bb4c",
+                "sha256:955fcdb304833df2e172ce2492b7b47b4aab5dcc035a10e093d911a1916f2c87",
+                "sha256:95c09427c1c57206fe04277bf871b396476d5a8857fa1b99703283ee497c7a5d",
+                "sha256:a4fe2442091ff71dee0769a10449420fd5d3b606c590f78dd2b97d94b7455640",
+                "sha256:aa7b33c1fb2f7b7b9820f93a5d61ffd47f5a91711bc5fa4583bbe0c0601ec0b2",
+                "sha256:adf6385f677ed2e0b021845b36f55c43f171dab3a9ee0ace94da67302f1bc364",
+                "sha256:b1a69701eb98ed83dd099de4a686dc892c413d974fa31602bc00aca7cb988ac9",
+                "sha256:b2a573c8d71b7af937852b61e7ccb37151d719974146b5dc734aad350ef55a02",
+                "sha256:b444366b605d2885f0034dd889faf91b4b47668dd125591e2c64bfde611ac7e1",
+                "sha256:b985ba2b9e972cf99ddffc07df1a314b893095f62c75bc7c5354a9c4647c6503",
+                "sha256:c78ca3037a954a4209b9f900e0eabbc471fb4ebe96914016281df2c974a93e3e",
+                "sha256:ca9b2dced5cbbc5094678cc1ec62160f7b0fe4defd601cd28a36fde7ee71bbb5",
+                "sha256:cb46d2c7631b2e6f10f7c8bac7854f7c5e5288f024f1c137d4633c79ead1e3c0",
+                "sha256:ce69f5c742eefd039dce8622e99d811ef2135b69d10f9aa79fbf2fdcc1e56cd7",
+                "sha256:cf45d273202b0c1cec0f03a7972c655b93611f2e996669667414557230a87b88",
+                "sha256:d1881518b488a920434a271a6e8a5c9481a67c4f6352ebbdd249b789c0467ddc",
+                "sha256:d3cc3e48b6c9f7df8c3798004b9c4b92abca09eeea5e1b0a39698f05b7a33b9d",
+                "sha256:d6b2bfa1d884c254b841b0ff79373b6b80779088df6704f034858e4d705a4802",
+                "sha256:d70a438ef2a22a581d65ad7648e949d4ccd20e3c8ed7a90bbc46df4e60320891",
+                "sha256:daa1e8ea47507555ed7a34f8b49398d33dff5b8548eae3de1dc0ef0607273a33",
+                "sha256:dca9708eea9f9ed300394d4775beb2667288e998eb6f542cdb6c02027430c599",
+                "sha256:dd906b0cdc417ea7a5f13bb3c6ca3b5fd563338dc596996cb0fdd7872d691c0a",
+                "sha256:e0eeeea3b01c97fd3b5049a46c908823f68b59bf0e18d79b231d8d6764bc81ee",
+                "sha256:e37a76ccd483a6457580077d43bc3dfe1fd784ecb2151fcb9d1c73f424deaeba",
+                "sha256:e8b967a4849db6b567dec3f7dd5d97b15ce653e3497b8ce0814e470d5e074750",
+                "sha256:ec00401846569aaf018700249996143f567d50050c5b7b650148989f956547af",
+                "sha256:ede13a6998ba2568b21825809d96e69a38dc43184bdeebbde3699c8baa21d015",
+                "sha256:f97e03d4d5a4f0dca739ea274be9092822f7430b77d25aa02da6775e490f6846"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==11.0.1"
+            "version": "==11.0.2"
         },
         "werkzeug": {
             "hashes": [
@@ -1869,11 +1869,11 @@
     "develop": {
         "attrs": {
             "hashes": [
-                "sha256:29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836",
-                "sha256:c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"
+                "sha256:1f28b4522cdc2fb4256ac1a020c78acf9cba2c6b461ccd2c126f3aa8e8335d04",
+                "sha256:6279836d581513a26f1bf235f9acd333bc9115683f14f7e8fae46c98fc50e015"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==22.2.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.1.0"
         },
         "certifi": {
             "hashes": [
@@ -1970,14 +1970,6 @@
             ],
             "version": "==0.3.6"
         },
-        "exceptiongroup": {
-            "hashes": [
-                "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
-                "sha256:d484c3090ba2889ae2928419117447a14daf3c1231d5e30d0aae34f354f01785"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==1.1.1"
-        },
         "filelock": {
             "hashes": [
                 "sha256:3618c0da67adcc0506b015fd11ef7faf1b493f0b40d87728e19986b536890c37",
@@ -2054,11 +2046,11 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:06235b8ab3c4090bec96b07dfc2347611c1392e5b4ffa48c069f2c1337968725",
-                "sha256:b2c3bbead72189c0bba6e12848b484ceafadb6e872ac31e40013228239366221"
+                "sha256:12d2a7d72eed477701f66ca48e5b212ea49e2e57ad63903d9bc36f08a5ca2bdb",
+                "sha256:1fb102fe1fdf5c00206507e2719ddfa118d84cf4b9799ef5c28e4aff020964e0"
             ],
             "index": "pypi",
-            "version": "==6.71.0"
+            "version": "==6.72.0"
         },
         "identify": {
             "hashes": [
@@ -2272,13 +2264,6 @@
             ],
             "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "version": "==2.0.1"
         },
         "urllib3": {
             "hashes": [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,15 +1,14 @@
 -i https://pypi.python.org/simple
-attrs==22.2.0 ; python_version >= '3.6'
+attrs==23.1.0 ; python_version >= '3.7'
 certifi==2022.12.7 ; python_version >= '3.6'
 cfgv==3.3.1 ; python_full_version >= '3.6.1'
 charset-normalizer==2.1.1 ; python_full_version >= '3.6.0'
 coverage==6.5.0
 decorator==5.1.1 ; python_version >= '3.5'
 distlib==0.3.6
-exceptiongroup==1.1.1 ; python_version < '3.11'
 filelock==3.11.0 ; python_version >= '3.7'
 greenlet==2.0.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-hypothesis==6.71.0
+hypothesis==6.72.0
 identify==2.5.22 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
 iniconfig==2.0.0 ; python_version >= '3.7'
@@ -32,6 +31,5 @@ semantic-version==2.10.0 ; python_version >= '2.7'
 setuptools==67.6.1 ; python_version >= '3.7'
 sortedcontainers==2.4.0
 toml==0.10.2 ; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
-tomli==2.0.1
 urllib3==1.26.15 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 virtualenv==20.21.0 ; python_version >= '3.7'

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -9,7 +9,6 @@ click-default-group==1.2.2
 coverage==7.2.3 ; python_version >= '3.7'
 docutils==0.18.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 dulwich==0.19.16
-exceptiongroup==1.1.1 ; python_version < '3.11'
 execnet==1.9.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 idna==3.4 ; python_version >= '3.5'
 imagesize==1.4.1 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
@@ -19,13 +18,13 @@ isort==6.0.0b2 ; python_full_version >= '3.7.0'
 jinja2==3.0.3
 git+https://github.com/inspirehep/jsonschema2rst.git@d211d9709046431a6b6a4594c97c22d8713d854b#egg=jsonschema2rst
 markupsafe==2.1.2 ; python_version >= '3.7'
-mock==5.0.1 ; python_version >= '3.6'
+mock==5.0.2 ; python_version >= '3.6'
 packaging==23.1 ; python_version >= '3.7'
 pep8==1.7.1
 pluggy==1.0.0 ; python_version >= '3.6'
 py-solc-x==0.10.1
 pygments==2.15.0 ; python_version >= '3.7'
-pytest==7.3.0 ; python_version >= '3.7'
+pytest==7.3.1 ; python_version >= '3.7'
 pytest-cache==1.0
 pytest-cov==4.0.0 ; python_version >= '3.6'
 pytest-pep8==1.0.6
@@ -43,6 +42,5 @@ sphinxcontrib-jquery==4.1 ; python_version > '3'
 sphinxcontrib-jsmath==1.0.1 ; python_version >= '3.5'
 sphinxcontrib-qthelp==1.0.3 ; python_version >= '3.5'
 sphinxcontrib-serializinghtml==1.1.5 ; python_version >= '3.5'
-tomli==2.0.1 ; python_version < '3.11'
 towncrier==22.12.0
 urllib3==1.26.15 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ aiohttp==3.8.1
 aiosignal==1.3.1 ; python_version >= '3.7'
 appdirs==1.4.4
 async-timeout==4.0.2 ; python_version >= '3.6'
-attrs==22.2.0 ; python_version >= '3.6'
+attrs==23.1.0 ; python_version >= '3.7'
 autobahn==23.1.2 ; python_version >= '3.7'
 automat==22.10.0
 bitarray==2.7.3
@@ -16,7 +16,7 @@ click==8.1.3
 colorama==0.4.6
 constant-sorrow==0.1.0a9
 constantly==15.1.0
-cryptography==40.0.1
+cryptography==40.0.2
 cytoolz==0.12.1 ; implementation_name == 'cpython'
 dateparser==1.1.8 ; python_version >= '3.7'
 eip712-structs==1.1.0
@@ -41,7 +41,7 @@ idna==3.4 ; python_version >= '3.5'
 incremental==22.10.0
 itsdangerous==2.1.2 ; python_version >= '3.7'
 jinja2==3.0.3
-jsonschema==4.18.0a3 ; python_version >= '3.8'
+jsonschema==4.18.0a4 ; python_version >= '3.8'
 jsonschema-specifications==2023.3.6 ; python_version >= '3.8'
 lru-dict==1.1.8
 mako==1.2.4
@@ -94,7 +94,7 @@ tzlocal==5.0b2 ; python_version >= '3.7'
 urllib3==1.26.15 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 watchdog==3.0.0 ; python_version >= '3.7'
 web3==6.2.0
-websockets==11.0.1 ; python_version >= '3.7'
+websockets==11.0.2 ; python_version >= '3.7'
 werkzeug==2.2.3 ; python_version >= '3.7'
 yarl==1.8.2 ; python_version >= '3.7'
 zope.interface==6.1a2 ; python_version >= '3.7'


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 2

**What this does:**
Nucypher code is intended to use v6 of web3 dependency. So this should be a dependency requirement.

**Notes for reviewers:**
relock_dependencies script has been run.
