### PR TITLE
Update Ursula Docker build

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -61,7 +61,7 @@ jobs:
         if: matrix.python-version != '3.10'
         run: python -m pytest tests/unit
 
-#       Integration tests
+      # Integration tests
       - name: Integration Tests (Coverage)
         if: matrix.python-version == '3.10'
         run: |

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -7,8 +7,6 @@ WORKDIR /code
 COPY . /code
 
 RUN pip3 install .[ursula]
-RUN pip3 install --force-reinstall nucypher-core@git+https://github.com/KPrasch/nucypher-core.git@b2a56784f41e89b702e74c14a56f461c9b8a233f#subdirectory=nucypher-core-python
-RUN pip3 install --force-reinstall ferveo@git+https://github.com/KPrasch/ferveo.git@7a5c5fc8be49894c0affd0da32b80e29e6e1ee8e#subdirectory=ferveo-python
 RUN export PATH="$HOME/.local/bin:$PATH"
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
The Dockerfile no longer needs to overwrite installations for `nucypher-core` and `ferveo`. The requirements.txt file will take care of this - either by using released versions or git refs.