### PR TITLE
Dependency Hell 🔥 

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.10" ]
+        python-version: [ "3.8", "3.10" ]
 
     steps:
       - uses: actions/checkout@v3

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -155,6 +155,28 @@
             ],
             "version": "==22.10.0"
         },
+        "backports.zoneinfo": {
+            "hashes": [
+                "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf",
+                "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328",
+                "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546",
+                "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6",
+                "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570",
+                "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9",
+                "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7",
+                "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987",
+                "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722",
+                "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582",
+                "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc",
+                "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b",
+                "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1",
+                "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08",
+                "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac",
+                "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '3.9'",
+            "version": "==0.2.1"
+        },
         "bitarray": {
             "hashes": [
                 "sha256:00a6fc4355bd4e6ead54d05187dc4ea39f0af439b336ae113f0194673ed730ae",
@@ -610,11 +632,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:13f6329ddbfff11340939cd11919daf150a01358ded4b7e81c03c055dfecb559",
-                "sha256:77504c4c097f56ac5f29b00f9009213010cf9d2923a288c0e0564a5db2bb53d6"
+                "sha256:58107ed83443e86067e41eff4631b058178191a355886f8e479e347fa1285fdf",
+                "sha256:edee9b0a7ff26621bd5a8c10ff484ae28737a2410d99b0bb9a6850c7fb977aa0"
             ],
             "index": "pypi",
-            "version": "==2.2.4"
+            "version": "==2.2.5"
         },
         "frozenlist": {
             "hashes": [
@@ -734,6 +756,22 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.4"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed",
+                "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==6.6.0"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6",
+                "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==5.12.0"
         },
         "incremental": {
             "hashes": [
@@ -1165,6 +1203,14 @@
             "markers": "python_version >= '3.7' and python_version < '4.0'",
             "version": "==3.0.0a1"
         },
+        "pkgutil-resolve-name": {
+            "hashes": [
+                "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174",
+                "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==1.3.10"
+        },
         "protobuf": {
             "hashes": [
                 "sha256:0a3d1a3f746cc5209163bab06f4f56b77fb9d523beedd42e04e6334bb653fd84",
@@ -1348,69 +1394,97 @@
         },
         "regex": {
             "hashes": [
-                "sha256:086afe222d58b88b62847bdbd92079b4699350b4acab892f88a935db5707c790",
-                "sha256:0b8eb1e3bca6b48dc721818a60ae83b8264d4089a4a41d62be6d05316ec38e15",
-                "sha256:11d00c31aeab9a6e0503bc77e73ed9f4527b3984279d997eb145d7c7be6268fd",
-                "sha256:11d1f2b7a0696dc0310de0efb51b1f4d813ad4401fe368e83c0c62f344429f98",
-                "sha256:1b1fc2632c01f42e06173d8dd9bb2e74ab9b0afa1d698058c867288d2c7a31f3",
-                "sha256:20abe0bdf03630fe92ccafc45a599bca8b3501f48d1de4f7d121153350a2f77d",
-                "sha256:22720024b90a6ba673a725dcc62e10fb1111b889305d7c6b887ac7466b74bedb",
-                "sha256:2472428efc4127374f494e570e36b30bb5e6b37d9a754f7667f7073e43b0abdd",
-                "sha256:25f0532fd0c53e96bad84664171969de9673b4131f2297f1db850d3918d58858",
-                "sha256:2848bf76673c83314068241c8d5b7fa9ad9bed866c979875a0e84039349e8fa7",
-                "sha256:37ae17d3be44c0b3f782c28ae9edd8b47c1f1776d4cabe87edc0b98e1f12b021",
-                "sha256:3cd9f5dd7b821f141d3a6ca0d5d9359b9221e4f051ca3139320adea9f1679691",
-                "sha256:4479f9e2abc03362df4045b1332d4a2b7885b245a30d4f4b051c4083b97d95d8",
-                "sha256:4c49552dc938e3588f63f8a78c86f3c9c75301e813bca0bef13bdb4b87ccf364",
-                "sha256:539dd010dc35af935b32f248099e38447bbffc10b59c2b542bceead2bed5c325",
-                "sha256:54c3fa855a3f7438149de3211738dd9b5f0c733f48b54ae05aa7fce83d48d858",
-                "sha256:55ae114da21b7a790b90255ea52d2aa3a0d121a646deb2d3c6a3194e722fc762",
-                "sha256:5ccfafd98473e007cebf7da10c1411035b7844f0f204015efd050601906dbb53",
-                "sha256:5fc33b27b1d800fc5b78d7f7d0f287e35079ecabe68e83d46930cf45690e1c8c",
-                "sha256:6560776ec19c83f3645bbc5db64a7a5816c9d8fb7ed7201c5bcd269323d88072",
-                "sha256:6572ff287176c0fb96568adb292674b421fa762153ed074d94b1d939ed92c253",
-                "sha256:6b190a339090e6af25f4a5fd9e77591f6d911cc7b96ecbb2114890b061be0ac1",
-                "sha256:7304863f3a652dab5e68e6fb1725d05ebab36ec0390676d1736e0571ebb713ef",
-                "sha256:75f288c60232a5339e0ff2fa05779a5e9c74e9fc085c81e931d4a264501e745b",
-                "sha256:7868b8f218bf69a2a15402fde08b08712213a1f4b85a156d90473a6fb6b12b09",
-                "sha256:787954f541ab95d8195d97b0b8cf1dc304424adb1e07365967e656b92b38a699",
-                "sha256:78ac8dd8e18800bb1f97aad0d73f68916592dddf233b99d2b5cabc562088503a",
-                "sha256:79e29fd62fa2f597a6754b247356bda14b866131a22444d67f907d6d341e10f3",
-                "sha256:845a5e2d84389c4ddada1a9b95c055320070f18bb76512608374aca00d22eca8",
-                "sha256:86b036f401895e854de9fefe061518e78d506d8a919cc250dc3416bca03f6f9a",
-                "sha256:87d9951f5a538dd1d016bdc0dcae59241d15fa94860964833a54d18197fcd134",
-                "sha256:8a9c63cde0eaa345795c0fdeb19dc62d22e378c50b0bc67bf4667cd5b482d98b",
-                "sha256:93f3f1aa608380fe294aa4cb82e2afda07a7598e828d0341e124b8fd9327c715",
-                "sha256:9bf4a5626f2a0ea006bf81e8963f498a57a47d58907eaa58f4b3e13be68759d8",
-                "sha256:9d764514d19b4edcc75fd8cb1423448ef393e8b6cbd94f38cab983ab1b75855d",
-                "sha256:a610e0adfcb0fc84ea25f6ea685e39e74cbcd9245a72a9a7aab85ff755a5ed27",
-                "sha256:a81c9ec59ca2303acd1ccd7b9ac409f1e478e40e96f8f79b943be476c5fdb8bb",
-                "sha256:b7006105b10b59971d3b248ad75acc3651c7e4cf54d81694df5a5130a3c3f7ea",
-                "sha256:c07ce8e9eee878a48ebeb32ee661b49504b85e164b05bebf25420705709fdd31",
-                "sha256:c125a02d22c555e68f7433bac8449992fa1cead525399f14e47c2d98f2f0e467",
-                "sha256:c37df2a060cb476d94c047b18572ee2b37c31f831df126c0da3cd9227b39253d",
-                "sha256:c869260aa62cee21c5eb171a466c0572b5e809213612ef8d495268cd2e34f20d",
-                "sha256:c88e8c226473b5549fe9616980ea7ca09289246cfbdf469241edf4741a620004",
-                "sha256:cd1671e9d5ac05ce6aa86874dd8dfa048824d1dbe73060851b310c6c1a201a96",
-                "sha256:cde09c4fdd070772aa2596d97e942eb775a478b32459e042e1be71b739d08b77",
-                "sha256:cf86b4328c204c3f315074a61bc1c06f8a75a8e102359f18ce99fbcbbf1951f0",
-                "sha256:d5bbe0e1511b844794a3be43d6c145001626ba9a6c1db8f84bdc724e91131d9d",
-                "sha256:d895b4c863059a4934d3e874b90998df774644a41b349ebb330f85f11b4ef2c0",
-                "sha256:db034255e72d2995cf581b14bb3fc9c00bdbe6822b49fcd4eef79e1d5f232618",
-                "sha256:dbb3f87e15d3dd76996d604af8678316ad2d7d20faa394e92d9394dfd621fd0c",
-                "sha256:dc80df325b43ffea5cdea2e3eaa97a44f3dd298262b1c7fe9dbb2a9522b956a7",
-                "sha256:dd7200b4c27b68cf9c9646da01647141c6db09f48cc5b51bc588deaf8e98a797",
-                "sha256:df45fac182ebc3c494460c644e853515cc24f5ad9da05f8ffb91da891bfee879",
-                "sha256:e152461e9a0aedec7d37fc66ec0fa635eca984777d3d3c3e36f53bf3d3ceb16e",
-                "sha256:e2396e0678167f2d0c197da942b0b3fb48fee2f0b5915a0feb84d11b6686afe6",
-                "sha256:e76b6fc0d8e9efa39100369a9b3379ce35e20f6c75365653cf58d282ad290f6f",
-                "sha256:ea3c0cb56eadbf4ab2277e7a095676370b3e46dbfc74d5c383bd87b0d6317910",
-                "sha256:ef3f528fe1cc3d139508fe1b22523745aa77b9d6cb5b0bf277f48788ee0b993f",
-                "sha256:fdf7ad455f1916b8ea5cdbc482d379f6daf93f3867b4232d14699867a5a13af7",
-                "sha256:fffe57312a358be6ec6baeb43d253c36e5790e436b7bf5b7a38df360363e88e9"
+                "sha256:00f6f26e748c797a041ab6957f4cacc66a7fbd5dc5f627760985f5c5b7de2af6",
+                "sha256:0130a2fdd6f033c3e3710d0b950cc6abd3133c5af88c40c78e77641cb6f6cf8a",
+                "sha256:027d4962340dbd84979fd1c40bfd7ca8362030abfbbff25f1327bbf4867f047c",
+                "sha256:037f4be6a240a11a6d3397e932ef5d3ec5855858910792a0ab7d351bd0333533",
+                "sha256:04a825fd9f5931263eccd0cbdbf171a9792fa1bf2642ca62800b57689ca1b660",
+                "sha256:06fe9870165d4975a8a3e27a83919b9014b35dd2ee7061a5f2be8e579294cedc",
+                "sha256:0a664857dd9b1076942c4d73c54a031066ee0ae88a438e7a1e0e79c1c5ddf47a",
+                "sha256:0c731522eaf74166066fcf91fe7fe3c3617cc5e8df0c150132282d0dd5225afc",
+                "sha256:0d5a0edefdf800aeef6cf559af75e614fb2eb2d0388f0b132af805fdefcf8ec6",
+                "sha256:0eee66c4ce6ced2e9d5d4497a569bab6257a6d118eb43dd57cceb61ba00b62d8",
+                "sha256:12be293d718e05f7304f715980b1a25b16e34a1ff2121740592559d066f91e67",
+                "sha256:1ad00c9aae6090d052c0ee16a2737a7154031793e6c7b58a629eed8d8aa77e31",
+                "sha256:1d98e4748a60c9902ad504e862756c43cc707404fc3025f82ef5bbe50bee3b9e",
+                "sha256:1dc5e9a847613679ac8bd0386a0e54f2958441a0fcc123778637e433041aa763",
+                "sha256:1ef51012493837263236781ac9598f059dc4e5a4d72627bd3ac85cbd5d1b0ee1",
+                "sha256:2095acff95df0bf6ec3dee672a03d3d78606b4ca419d53fbd606c559cebedf45",
+                "sha256:21b653c1538cbbc1c58f6d6f3ccb4a5ce56491f0ab370ec057c1c64a152eb48c",
+                "sha256:24db1c0fc20850db47977824a99fdae81d6764adaf8192dd874185d9e7166dbb",
+                "sha256:2762750332f57820c0f38ade87ce4ebe671b178892faed0112f574f0b42801cf",
+                "sha256:336fb3f585e239362d4f26dd6f904b15d91febfc980f47ed706858f5cee20ce6",
+                "sha256:3633a07ffeabc14f3cd531f11794bb603267d86e4109cb811a34aee020622d3f",
+                "sha256:376fa2ef6a02a004b6fe4ebaa5ba370e7532ec6915efd12e33aa434517f8bbee",
+                "sha256:3965a9ab13f1bf3e4af021c7dbe9678dd9f8dc5cc9097b3d3cbbf3ad00574b5d",
+                "sha256:3d8cc797f87c07372e7d300198e1423c2b7bd35b68f375cc6700e26158940c9a",
+                "sha256:460672c6ec94997755bd37b00302853b9d85a5a433121c198359958e8c10ced5",
+                "sha256:49a77f0b62a4122cf578d1194658973c435e6d2a9611013be11b6750056a5930",
+                "sha256:4c2ae89c92a04b057b412f88a3359e77600ce966a740e2da212667ce795e1bdc",
+                "sha256:50e00ab84396bfbeb1bede61eff6641f957b6532e74e02be480d71914e20e2ac",
+                "sha256:5a7ab3440f0c653dee8b42af858da6e07615c64ba86a6b3509a0ecf44eabdb11",
+                "sha256:5a98814d42282153c30d674ee34ea114a03ea8d32fd5d9b924d46fbeb2c7eb15",
+                "sha256:5cc67b3562aada6682ae45f2ea40819baa6bffe38155883100f8779c22c8c087",
+                "sha256:5d321dd059fd00482537aaba919e29189ea4ab6a03528881267982bb7707f610",
+                "sha256:5f82d4e0725788787216c9ae53116e6e477b2d97f29ec1e5086f5afbab5716b0",
+                "sha256:5fda1fc36dd923aee070d7aab3a85b448c8b62930900c615bb67db829281103b",
+                "sha256:63a92f28a3f285dae06aae83227cb66cc87256db040aaf26c1c48ae5221eccde",
+                "sha256:6469c2baf450fd1e648752b113a1fc1d67dfbad359f6171be954bacf7b09d126",
+                "sha256:6686256d1d435ed782ff12ef11e074705911a40d3907b986e53ca9a996e88489",
+                "sha256:6ccd0d7557c4e76303a6429ec9de55cd87334809cda66c0f101831e2ce9073c1",
+                "sha256:6f02105d4a511f550dcd63f750937d1607a1f6dc253c798c4adf36aba89215a3",
+                "sha256:70bd0c121b3c4e641e5c4e633c4581059acad774a1a62bcb15fea3470c2a61cc",
+                "sha256:770f825c7751ce43aae2088fee94f2e60f95e181223642a0bb35cbaeea92001c",
+                "sha256:77b3333a6cd1161b81bcf018a9bdb3cc567074a913aa69b98b9c8c79be28565c",
+                "sha256:797bab57e1317c940030f3c15d48c01e1f16d12ba0f6a807ee0bebdc1cfe3f2d",
+                "sha256:8418b0ee315555ca9786daab00ec8aaf47dfb2698a5be689676e83e88b949f22",
+                "sha256:861ed1249302664f96b2e968216486a02af0a143e0f3cc6fd92b78f11aa18579",
+                "sha256:89f54d4bbd452a5ee01dc31ec918f7b1f32483f13d3598af1acf5ea82ad82ad3",
+                "sha256:8c704e7062c59d2f7e2eebda2c0c0b69bd807ca6579c3a21fc4b1d8505cfc090",
+                "sha256:8d5bc5035989852a4ae7dacf8dc99db7c4f21c852486777a98b8efe37af4d8d7",
+                "sha256:91f47522688955cb33190f8354ccaa1cc058d05e73f99afe9ace40db36c159e8",
+                "sha256:9322797fddd51ec0312a8b649d9a3ebfabf4826a204ef8e1cc11801013005323",
+                "sha256:953ba37dd83c424c2cf699c64a8477645fc7c7403ffd2eb1417189eddbbfb4a7",
+                "sha256:97fd2885df308edcdf96baa632192a4291f3ed5b072c0bc3f29dc1e6de40ffa4",
+                "sha256:99780a0880d3dab2bb6f863492d38ab90ffdc9daf4fbefb505524f6f3a1c9dbe",
+                "sha256:9b887d87188489859411d0c7e741f7dfe8a3ca5946b0db8b3c9e5daecc089b62",
+                "sha256:9e1b4b0b4baff934ef3c0ac56578a6b773f7f90ad1db3ff843ee40d83bdae09f",
+                "sha256:a419384c6c80d58532016c3cf6a3aca009bfb7661f33e119ba7f77ec0e28222a",
+                "sha256:aa92f9ad481108a7e4c5a5234608f7c718f8b67003ce4719a4d2735d82b54167",
+                "sha256:ac402ac165f42f41b3aef9e8a9c6fb204dac31faad65b3b0ae6bff4bc9d0dad2",
+                "sha256:ad84e1d4be3504e7dcd6370b3e847eaf05d5d35cb0818d0bd2d1a26b58c0abd2",
+                "sha256:b132e4507c6404faece005329de7b2b97653ddfeeaf84f058fe820791160dcda",
+                "sha256:b365b8fa0d5fd0208db5b0e94582edb796dde07d1f99c5a9c1ff6be172c374ee",
+                "sha256:b48820071a49b68ca8734e8b2bd1f26632512154816b261b614e62cc724d9f8a",
+                "sha256:b7eb07d60c385aec906b82d48447907a2bbf454d0e9ead62168de111accabaf8",
+                "sha256:b87d38717ed855583ae1693f6095fc9c06b7dde4ddec782b41aa92931dd60e7c",
+                "sha256:bda905e040e6c2875a7dde9652a9e0c426aaac6058568cc064f8128b061439ee",
+                "sha256:c10b1388106447db0cdb8e340d06fa2d49b822368a049c36928d3c24296c2e37",
+                "sha256:c1155571edd498b6274f969517db6781500fbb24fc91ff740ea5a37c4735b3ba",
+                "sha256:c1fa9651141caaafa0d6048695a4a04bc4bf39c75f250a36b1a05c9588a403a9",
+                "sha256:c300461ed8159f61d979971ba51f1acd1e6f9907d86888e9275165e06ea90f06",
+                "sha256:c40f7e8c02b287550166a3e36dbb89f9387db86a71101f6242668e3ef979cd2a",
+                "sha256:c455d886838dd5a248e7f06e5573275fc854febd206eb937cf632082a06a939f",
+                "sha256:cb22580ce5e2eee138a78df40444151ff51c91acd11be546216a046677c75593",
+                "sha256:ccd0c918971f79bd9a883f13f91343dd2eaefbafd4344aadfe5134a65fb821c3",
+                "sha256:d0ac14c36d91b191d1cb073fb5ac49937d88a5c8b051ced3875321a525202c34",
+                "sha256:d28933aa1242814ed737b569b2baf96e4d236c52be454b5dc17afd36bf893c12",
+                "sha256:db5d5c9c7bbcf9cbc541f8adba8c92a7a7abd0de4f0343da4e96fb78ffe9d1a1",
+                "sha256:dbc47670e0424a566084e15af9a253b85f90fa26e60fa07e1b10c90df4c8fd07",
+                "sha256:dbcb49036a6a6065035ac2acc1ad6a918f9e09ef2d0f9392dc90b8756f789f95",
+                "sha256:e708e69c4d3bc41df29efb94aadc5578c841b2cd02f8cbb1bcfbf280f2801238",
+                "sha256:e87450db3c444f41e3ac6a09b7a10ddfe54fa1e98bf60ee299fe6d11097540cd",
+                "sha256:ea2d66c1fd898d81b8ce0f95afab9ba0ab522cf08810f11fa28ad958706cd2b2",
+                "sha256:eaff21326bc5d9be0c2f400931d39274105bd5d06650f0b0215392d1b050d404",
+                "sha256:ebf0776fdc7a5e0ac11b6db2d69ac77479411b627a96119ffa4427ba32f3bb66",
+                "sha256:f2bc7249840faacfff6196e5b5ffeb3fdaf078986521a1cda34e9be5607e773b",
+                "sha256:f3e20cf2575b1330687d3dd6242f82278b3bdc09a9f36cc7ac4d45b7dd63c1f5",
+                "sha256:f576b8dec95456ba0157943a57f5f88c076cf96cc363ef1bf5027c2976fd487a",
+                "sha256:fbc5b23b569d96b8c831574c93098b68c6d7ff2509f31268c968152ca4f2ecd0",
+                "sha256:ff8fef88029d0420315935041db517855ea022889fa8d54959943e39fffebf59"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2023.3.23"
+            "markers": "python_version >= '3.6'",
+            "version": "==2023.5.4"
         },
         "requests": {
             "hashes": [
@@ -1837,6 +1911,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.9.2"
         },
+        "zipp": {
+            "hashes": [
+                "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+                "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.15.0"
+        },
         "zope.interface": {
             "hashes": [
                 "sha256:0326cc72f232167498eb4814232c960881bd8eb5e1f7e92ed07ea7afbf21dbb0",
@@ -1988,6 +2070,14 @@
             ],
             "index": "pypi",
             "version": "==0.6.3"
+        },
+        "appnope": {
+            "hashes": [
+                "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24",
+                "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.3"
         },
         "asttokens": {
             "hashes": [
@@ -2546,11 +2636,11 @@
         },
         "ethpm-types": {
             "hashes": [
-                "sha256:02ad8a63da2c9e3aec643bd7aeb8a940cf8e8be18a6b2cac0326348d85b60d90",
-                "sha256:30d08a1da87dc87fe97112198d4a4f385d38cc122a867d0102fa54f97e8559d8"
+                "sha256:8923693a673862d74ab0ac0f0bd1072e4017e27262f189ec9b9b2007db53360b",
+                "sha256:b48a83bc4b21ef066ed4f405a357ec2770ab171eed233c25804aec423d798703"
             ],
-            "markers": "python_version < '3.11' and python_version >= '3.8'",
-            "version": "==0.4.4"
+            "markers": "python_version >= '3.8' and python_version < '4'",
+            "version": "==0.4.5"
         },
         "evm-trace": {
             "hashes": [
@@ -2849,8 +2939,16 @@
                 "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed",
                 "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.10'",
             "version": "==6.6.0"
+        },
+        "importlib-resources": {
+            "hashes": [
+                "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6",
+                "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==5.12.0"
         },
         "iniconfig": {
             "hashes": [
@@ -2862,11 +2960,11 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:1c80d08f04144a1994cda25569eab07fbdc4989bd8d8793e3a4ff643065ccb51",
-                "sha256:9c8487ac18f330c8a683fc50ab6d7bc0fcf9ef1d7a9f6ce7926938261067b81f"
+                "sha256:2442915417763b62181009259782975fa50bb5eedb97ae97fb614204bf6ecc21",
+                "sha256:e3015a1a4aa09b3984fb81b9cef4f0772af5a549878b81efb094cda8bb121993"
             ],
-            "markers": "python_version >= '3.9'",
-            "version": "==8.13.1"
+            "markers": "python_version >= '3.8'",
+            "version": "==8.12.1"
         },
         "jedi": {
             "hashes": [
@@ -3118,7 +3216,7 @@
                 "sha256:ecde0f8adef7dfdec993fd54b0f78183051b6580f606111a6d789cd14c61ea0c",
                 "sha256:f21c442fdd2805e91799fbe044a7b999b8571bb0ab0f7850d0cb9641a687092b"
             ],
-            "markers": "python_version >= '3.10'",
+            "markers": "python_version < '3.10'",
             "version": "==1.24.3"
         },
         "packaging": {
@@ -3191,6 +3289,14 @@
             ],
             "version": "==0.7.5"
         },
+        "pkgutil-resolve-name": {
+            "hashes": [
+                "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174",
+                "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e"
+            ],
+            "markers": "python_version < '3.9'",
+            "version": "==1.3.10"
+        },
         "platformdirs": {
             "hashes": [
                 "sha256:47692bc24c1958e8b0f13dd727307cff1db103fca36399f457da8e05f222fdc4",
@@ -3209,11 +3315,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:06acda43a7b6b63fdcc29aa90bf1228cf4d4029a4e4d70971347a9d2593c94d4",
-                "sha256:7577a012399334d9f001873b5553f9fabc1ccc5b3e2b29e0793f84ce18e9d042"
+                "sha256:218e9e3f7f7f3271ebc355a15598a4d3893ad9fc7b57fe446db75644543323b9",
+                "sha256:733f78c9a056cdd169baa6cd4272d51ecfda95346ef8a89bf93712706021b907"
             ],
             "index": "pypi",
-            "version": "==3.3.0"
+            "version": "==3.3.1"
         },
         "prompt-toolkit": {
             "hashes": [
@@ -3460,6 +3566,32 @@
             "index": "pypi",
             "version": "==1.5.0"
         },
+        "pysha3": {
+            "hashes": [
+                "sha256:0060a66be16665d90c432f55a0ba1f6480590cfb7d2ad389e688a399183474f0",
+                "sha256:11a2ba7a2e1d9669d0052fc8fb30f5661caed5512586ecbeeaf6bf9478ab5c48",
+                "sha256:386998ee83e313b6911327174e088021f9f2061cbfa1651b97629b761e9ef5c4",
+                "sha256:41be70b06c8775a9e4d4eeb52f2f6a3f356f17539a54eac61f43a29e42fd453d",
+                "sha256:4416f16b0f1605c25f627966f76873e432971824778b369bd9ce1bb63d6566d9",
+                "sha256:571a246308a7b63f15f5aa9651f99cf30f2a6acba18eddf28f1510935968b603",
+                "sha256:59111c08b8f34495575d12e5f2ce3bafb98bea470bc81e70c8b6df99aef0dd2f",
+                "sha256:5ec8da7c5c70a53b5fa99094af3ba8d343955b212bc346a0d25f6ff75853999f",
+                "sha256:684cb01d87ed6ff466c135f1c83e7e4042d0fc668fa20619f581e6add1d38d77",
+                "sha256:68c3a60a39f9179b263d29e221c1bd6e01353178b14323c39cc70593c30f21c5",
+                "sha256:6e6a84efb7856f5d760ee55cd2b446972cb7b835676065f6c4f694913ea8f8d9",
+                "sha256:827b308dc025efe9b6b7bae36c2e09ed0118a81f792d888548188e97b9bf9a3d",
+                "sha256:93abd775dac570cb9951c4e423bcb2bc6303a9d1dc0dc2b7afa2dd401d195b24",
+                "sha256:9c778fa8b161dc9348dc5cc361e94d54aa5ff18413788f4641f6600d4893a608",
+                "sha256:9fdd28884c5d0b4edfed269b12badfa07f1c89dbc5c9c66dd279833894a9896b",
+                "sha256:c7c2adcc43836223680ebdf91f1d3373543dc32747c182c8ca2e02d1b69ce030",
+                "sha256:c93a2676e6588abcfaecb73eb14485c81c63b94fca2000a811a7b4fb5937b8e8",
+                "sha256:cd5c961b603bd2e6c2b5ef9976f3238a561c58569945d4165efb9b9383b050ef",
+                "sha256:f9046d59b3e72aa84f6dae83a040bd1184ebd7fef4e822d38186a8158c89e3cf",
+                "sha256:fd7e66999060d079e9c0e8893e78d8017dad4f59721f6fe0be6307cd32127a07",
+                "sha256:fe988e73f2ce6d947220624f04d467faf05f1bbdbc64b0a201296bb3af92739e"
+            ],
+            "version": "==1.0.2"
+        },
         "pytest": {
             "hashes": [
                 "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89",
@@ -3577,69 +3709,97 @@
         },
         "regex": {
             "hashes": [
-                "sha256:086afe222d58b88b62847bdbd92079b4699350b4acab892f88a935db5707c790",
-                "sha256:0b8eb1e3bca6b48dc721818a60ae83b8264d4089a4a41d62be6d05316ec38e15",
-                "sha256:11d00c31aeab9a6e0503bc77e73ed9f4527b3984279d997eb145d7c7be6268fd",
-                "sha256:11d1f2b7a0696dc0310de0efb51b1f4d813ad4401fe368e83c0c62f344429f98",
-                "sha256:1b1fc2632c01f42e06173d8dd9bb2e74ab9b0afa1d698058c867288d2c7a31f3",
-                "sha256:20abe0bdf03630fe92ccafc45a599bca8b3501f48d1de4f7d121153350a2f77d",
-                "sha256:22720024b90a6ba673a725dcc62e10fb1111b889305d7c6b887ac7466b74bedb",
-                "sha256:2472428efc4127374f494e570e36b30bb5e6b37d9a754f7667f7073e43b0abdd",
-                "sha256:25f0532fd0c53e96bad84664171969de9673b4131f2297f1db850d3918d58858",
-                "sha256:2848bf76673c83314068241c8d5b7fa9ad9bed866c979875a0e84039349e8fa7",
-                "sha256:37ae17d3be44c0b3f782c28ae9edd8b47c1f1776d4cabe87edc0b98e1f12b021",
-                "sha256:3cd9f5dd7b821f141d3a6ca0d5d9359b9221e4f051ca3139320adea9f1679691",
-                "sha256:4479f9e2abc03362df4045b1332d4a2b7885b245a30d4f4b051c4083b97d95d8",
-                "sha256:4c49552dc938e3588f63f8a78c86f3c9c75301e813bca0bef13bdb4b87ccf364",
-                "sha256:539dd010dc35af935b32f248099e38447bbffc10b59c2b542bceead2bed5c325",
-                "sha256:54c3fa855a3f7438149de3211738dd9b5f0c733f48b54ae05aa7fce83d48d858",
-                "sha256:55ae114da21b7a790b90255ea52d2aa3a0d121a646deb2d3c6a3194e722fc762",
-                "sha256:5ccfafd98473e007cebf7da10c1411035b7844f0f204015efd050601906dbb53",
-                "sha256:5fc33b27b1d800fc5b78d7f7d0f287e35079ecabe68e83d46930cf45690e1c8c",
-                "sha256:6560776ec19c83f3645bbc5db64a7a5816c9d8fb7ed7201c5bcd269323d88072",
-                "sha256:6572ff287176c0fb96568adb292674b421fa762153ed074d94b1d939ed92c253",
-                "sha256:6b190a339090e6af25f4a5fd9e77591f6d911cc7b96ecbb2114890b061be0ac1",
-                "sha256:7304863f3a652dab5e68e6fb1725d05ebab36ec0390676d1736e0571ebb713ef",
-                "sha256:75f288c60232a5339e0ff2fa05779a5e9c74e9fc085c81e931d4a264501e745b",
-                "sha256:7868b8f218bf69a2a15402fde08b08712213a1f4b85a156d90473a6fb6b12b09",
-                "sha256:787954f541ab95d8195d97b0b8cf1dc304424adb1e07365967e656b92b38a699",
-                "sha256:78ac8dd8e18800bb1f97aad0d73f68916592dddf233b99d2b5cabc562088503a",
-                "sha256:79e29fd62fa2f597a6754b247356bda14b866131a22444d67f907d6d341e10f3",
-                "sha256:845a5e2d84389c4ddada1a9b95c055320070f18bb76512608374aca00d22eca8",
-                "sha256:86b036f401895e854de9fefe061518e78d506d8a919cc250dc3416bca03f6f9a",
-                "sha256:87d9951f5a538dd1d016bdc0dcae59241d15fa94860964833a54d18197fcd134",
-                "sha256:8a9c63cde0eaa345795c0fdeb19dc62d22e378c50b0bc67bf4667cd5b482d98b",
-                "sha256:93f3f1aa608380fe294aa4cb82e2afda07a7598e828d0341e124b8fd9327c715",
-                "sha256:9bf4a5626f2a0ea006bf81e8963f498a57a47d58907eaa58f4b3e13be68759d8",
-                "sha256:9d764514d19b4edcc75fd8cb1423448ef393e8b6cbd94f38cab983ab1b75855d",
-                "sha256:a610e0adfcb0fc84ea25f6ea685e39e74cbcd9245a72a9a7aab85ff755a5ed27",
-                "sha256:a81c9ec59ca2303acd1ccd7b9ac409f1e478e40e96f8f79b943be476c5fdb8bb",
-                "sha256:b7006105b10b59971d3b248ad75acc3651c7e4cf54d81694df5a5130a3c3f7ea",
-                "sha256:c07ce8e9eee878a48ebeb32ee661b49504b85e164b05bebf25420705709fdd31",
-                "sha256:c125a02d22c555e68f7433bac8449992fa1cead525399f14e47c2d98f2f0e467",
-                "sha256:c37df2a060cb476d94c047b18572ee2b37c31f831df126c0da3cd9227b39253d",
-                "sha256:c869260aa62cee21c5eb171a466c0572b5e809213612ef8d495268cd2e34f20d",
-                "sha256:c88e8c226473b5549fe9616980ea7ca09289246cfbdf469241edf4741a620004",
-                "sha256:cd1671e9d5ac05ce6aa86874dd8dfa048824d1dbe73060851b310c6c1a201a96",
-                "sha256:cde09c4fdd070772aa2596d97e942eb775a478b32459e042e1be71b739d08b77",
-                "sha256:cf86b4328c204c3f315074a61bc1c06f8a75a8e102359f18ce99fbcbbf1951f0",
-                "sha256:d5bbe0e1511b844794a3be43d6c145001626ba9a6c1db8f84bdc724e91131d9d",
-                "sha256:d895b4c863059a4934d3e874b90998df774644a41b349ebb330f85f11b4ef2c0",
-                "sha256:db034255e72d2995cf581b14bb3fc9c00bdbe6822b49fcd4eef79e1d5f232618",
-                "sha256:dbb3f87e15d3dd76996d604af8678316ad2d7d20faa394e92d9394dfd621fd0c",
-                "sha256:dc80df325b43ffea5cdea2e3eaa97a44f3dd298262b1c7fe9dbb2a9522b956a7",
-                "sha256:dd7200b4c27b68cf9c9646da01647141c6db09f48cc5b51bc588deaf8e98a797",
-                "sha256:df45fac182ebc3c494460c644e853515cc24f5ad9da05f8ffb91da891bfee879",
-                "sha256:e152461e9a0aedec7d37fc66ec0fa635eca984777d3d3c3e36f53bf3d3ceb16e",
-                "sha256:e2396e0678167f2d0c197da942b0b3fb48fee2f0b5915a0feb84d11b6686afe6",
-                "sha256:e76b6fc0d8e9efa39100369a9b3379ce35e20f6c75365653cf58d282ad290f6f",
-                "sha256:ea3c0cb56eadbf4ab2277e7a095676370b3e46dbfc74d5c383bd87b0d6317910",
-                "sha256:ef3f528fe1cc3d139508fe1b22523745aa77b9d6cb5b0bf277f48788ee0b993f",
-                "sha256:fdf7ad455f1916b8ea5cdbc482d379f6daf93f3867b4232d14699867a5a13af7",
-                "sha256:fffe57312a358be6ec6baeb43d253c36e5790e436b7bf5b7a38df360363e88e9"
+                "sha256:00f6f26e748c797a041ab6957f4cacc66a7fbd5dc5f627760985f5c5b7de2af6",
+                "sha256:0130a2fdd6f033c3e3710d0b950cc6abd3133c5af88c40c78e77641cb6f6cf8a",
+                "sha256:027d4962340dbd84979fd1c40bfd7ca8362030abfbbff25f1327bbf4867f047c",
+                "sha256:037f4be6a240a11a6d3397e932ef5d3ec5855858910792a0ab7d351bd0333533",
+                "sha256:04a825fd9f5931263eccd0cbdbf171a9792fa1bf2642ca62800b57689ca1b660",
+                "sha256:06fe9870165d4975a8a3e27a83919b9014b35dd2ee7061a5f2be8e579294cedc",
+                "sha256:0a664857dd9b1076942c4d73c54a031066ee0ae88a438e7a1e0e79c1c5ddf47a",
+                "sha256:0c731522eaf74166066fcf91fe7fe3c3617cc5e8df0c150132282d0dd5225afc",
+                "sha256:0d5a0edefdf800aeef6cf559af75e614fb2eb2d0388f0b132af805fdefcf8ec6",
+                "sha256:0eee66c4ce6ced2e9d5d4497a569bab6257a6d118eb43dd57cceb61ba00b62d8",
+                "sha256:12be293d718e05f7304f715980b1a25b16e34a1ff2121740592559d066f91e67",
+                "sha256:1ad00c9aae6090d052c0ee16a2737a7154031793e6c7b58a629eed8d8aa77e31",
+                "sha256:1d98e4748a60c9902ad504e862756c43cc707404fc3025f82ef5bbe50bee3b9e",
+                "sha256:1dc5e9a847613679ac8bd0386a0e54f2958441a0fcc123778637e433041aa763",
+                "sha256:1ef51012493837263236781ac9598f059dc4e5a4d72627bd3ac85cbd5d1b0ee1",
+                "sha256:2095acff95df0bf6ec3dee672a03d3d78606b4ca419d53fbd606c559cebedf45",
+                "sha256:21b653c1538cbbc1c58f6d6f3ccb4a5ce56491f0ab370ec057c1c64a152eb48c",
+                "sha256:24db1c0fc20850db47977824a99fdae81d6764adaf8192dd874185d9e7166dbb",
+                "sha256:2762750332f57820c0f38ade87ce4ebe671b178892faed0112f574f0b42801cf",
+                "sha256:336fb3f585e239362d4f26dd6f904b15d91febfc980f47ed706858f5cee20ce6",
+                "sha256:3633a07ffeabc14f3cd531f11794bb603267d86e4109cb811a34aee020622d3f",
+                "sha256:376fa2ef6a02a004b6fe4ebaa5ba370e7532ec6915efd12e33aa434517f8bbee",
+                "sha256:3965a9ab13f1bf3e4af021c7dbe9678dd9f8dc5cc9097b3d3cbbf3ad00574b5d",
+                "sha256:3d8cc797f87c07372e7d300198e1423c2b7bd35b68f375cc6700e26158940c9a",
+                "sha256:460672c6ec94997755bd37b00302853b9d85a5a433121c198359958e8c10ced5",
+                "sha256:49a77f0b62a4122cf578d1194658973c435e6d2a9611013be11b6750056a5930",
+                "sha256:4c2ae89c92a04b057b412f88a3359e77600ce966a740e2da212667ce795e1bdc",
+                "sha256:50e00ab84396bfbeb1bede61eff6641f957b6532e74e02be480d71914e20e2ac",
+                "sha256:5a7ab3440f0c653dee8b42af858da6e07615c64ba86a6b3509a0ecf44eabdb11",
+                "sha256:5a98814d42282153c30d674ee34ea114a03ea8d32fd5d9b924d46fbeb2c7eb15",
+                "sha256:5cc67b3562aada6682ae45f2ea40819baa6bffe38155883100f8779c22c8c087",
+                "sha256:5d321dd059fd00482537aaba919e29189ea4ab6a03528881267982bb7707f610",
+                "sha256:5f82d4e0725788787216c9ae53116e6e477b2d97f29ec1e5086f5afbab5716b0",
+                "sha256:5fda1fc36dd923aee070d7aab3a85b448c8b62930900c615bb67db829281103b",
+                "sha256:63a92f28a3f285dae06aae83227cb66cc87256db040aaf26c1c48ae5221eccde",
+                "sha256:6469c2baf450fd1e648752b113a1fc1d67dfbad359f6171be954bacf7b09d126",
+                "sha256:6686256d1d435ed782ff12ef11e074705911a40d3907b986e53ca9a996e88489",
+                "sha256:6ccd0d7557c4e76303a6429ec9de55cd87334809cda66c0f101831e2ce9073c1",
+                "sha256:6f02105d4a511f550dcd63f750937d1607a1f6dc253c798c4adf36aba89215a3",
+                "sha256:70bd0c121b3c4e641e5c4e633c4581059acad774a1a62bcb15fea3470c2a61cc",
+                "sha256:770f825c7751ce43aae2088fee94f2e60f95e181223642a0bb35cbaeea92001c",
+                "sha256:77b3333a6cd1161b81bcf018a9bdb3cc567074a913aa69b98b9c8c79be28565c",
+                "sha256:797bab57e1317c940030f3c15d48c01e1f16d12ba0f6a807ee0bebdc1cfe3f2d",
+                "sha256:8418b0ee315555ca9786daab00ec8aaf47dfb2698a5be689676e83e88b949f22",
+                "sha256:861ed1249302664f96b2e968216486a02af0a143e0f3cc6fd92b78f11aa18579",
+                "sha256:89f54d4bbd452a5ee01dc31ec918f7b1f32483f13d3598af1acf5ea82ad82ad3",
+                "sha256:8c704e7062c59d2f7e2eebda2c0c0b69bd807ca6579c3a21fc4b1d8505cfc090",
+                "sha256:8d5bc5035989852a4ae7dacf8dc99db7c4f21c852486777a98b8efe37af4d8d7",
+                "sha256:91f47522688955cb33190f8354ccaa1cc058d05e73f99afe9ace40db36c159e8",
+                "sha256:9322797fddd51ec0312a8b649d9a3ebfabf4826a204ef8e1cc11801013005323",
+                "sha256:953ba37dd83c424c2cf699c64a8477645fc7c7403ffd2eb1417189eddbbfb4a7",
+                "sha256:97fd2885df308edcdf96baa632192a4291f3ed5b072c0bc3f29dc1e6de40ffa4",
+                "sha256:99780a0880d3dab2bb6f863492d38ab90ffdc9daf4fbefb505524f6f3a1c9dbe",
+                "sha256:9b887d87188489859411d0c7e741f7dfe8a3ca5946b0db8b3c9e5daecc089b62",
+                "sha256:9e1b4b0b4baff934ef3c0ac56578a6b773f7f90ad1db3ff843ee40d83bdae09f",
+                "sha256:a419384c6c80d58532016c3cf6a3aca009bfb7661f33e119ba7f77ec0e28222a",
+                "sha256:aa92f9ad481108a7e4c5a5234608f7c718f8b67003ce4719a4d2735d82b54167",
+                "sha256:ac402ac165f42f41b3aef9e8a9c6fb204dac31faad65b3b0ae6bff4bc9d0dad2",
+                "sha256:ad84e1d4be3504e7dcd6370b3e847eaf05d5d35cb0818d0bd2d1a26b58c0abd2",
+                "sha256:b132e4507c6404faece005329de7b2b97653ddfeeaf84f058fe820791160dcda",
+                "sha256:b365b8fa0d5fd0208db5b0e94582edb796dde07d1f99c5a9c1ff6be172c374ee",
+                "sha256:b48820071a49b68ca8734e8b2bd1f26632512154816b261b614e62cc724d9f8a",
+                "sha256:b7eb07d60c385aec906b82d48447907a2bbf454d0e9ead62168de111accabaf8",
+                "sha256:b87d38717ed855583ae1693f6095fc9c06b7dde4ddec782b41aa92931dd60e7c",
+                "sha256:bda905e040e6c2875a7dde9652a9e0c426aaac6058568cc064f8128b061439ee",
+                "sha256:c10b1388106447db0cdb8e340d06fa2d49b822368a049c36928d3c24296c2e37",
+                "sha256:c1155571edd498b6274f969517db6781500fbb24fc91ff740ea5a37c4735b3ba",
+                "sha256:c1fa9651141caaafa0d6048695a4a04bc4bf39c75f250a36b1a05c9588a403a9",
+                "sha256:c300461ed8159f61d979971ba51f1acd1e6f9907d86888e9275165e06ea90f06",
+                "sha256:c40f7e8c02b287550166a3e36dbb89f9387db86a71101f6242668e3ef979cd2a",
+                "sha256:c455d886838dd5a248e7f06e5573275fc854febd206eb937cf632082a06a939f",
+                "sha256:cb22580ce5e2eee138a78df40444151ff51c91acd11be546216a046677c75593",
+                "sha256:ccd0c918971f79bd9a883f13f91343dd2eaefbafd4344aadfe5134a65fb821c3",
+                "sha256:d0ac14c36d91b191d1cb073fb5ac49937d88a5c8b051ced3875321a525202c34",
+                "sha256:d28933aa1242814ed737b569b2baf96e4d236c52be454b5dc17afd36bf893c12",
+                "sha256:db5d5c9c7bbcf9cbc541f8adba8c92a7a7abd0de4f0343da4e96fb78ffe9d1a1",
+                "sha256:dbc47670e0424a566084e15af9a253b85f90fa26e60fa07e1b10c90df4c8fd07",
+                "sha256:dbcb49036a6a6065035ac2acc1ad6a918f9e09ef2d0f9392dc90b8756f789f95",
+                "sha256:e708e69c4d3bc41df29efb94aadc5578c841b2cd02f8cbb1bcfbf280f2801238",
+                "sha256:e87450db3c444f41e3ac6a09b7a10ddfe54fa1e98bf60ee299fe6d11097540cd",
+                "sha256:ea2d66c1fd898d81b8ce0f95afab9ba0ab522cf08810f11fa28ad958706cd2b2",
+                "sha256:eaff21326bc5d9be0c2f400931d39274105bd5d06650f0b0215392d1b050d404",
+                "sha256:ebf0776fdc7a5e0ac11b6db2d69ac77479411b627a96119ffa4427ba32f3bb66",
+                "sha256:f2bc7249840faacfff6196e5b5ffeb3fdaf078986521a1cda34e9be5607e773b",
+                "sha256:f3e20cf2575b1330687d3dd6242f82278b3bdc09a9f36cc7ac4d45b7dd63c1f5",
+                "sha256:f576b8dec95456ba0157943a57f5f88c076cf96cc363ef1bf5027c2976fd487a",
+                "sha256:fbc5b23b569d96b8c831574c93098b68c6d7ff2509f31268c968152ca4f2ecd0",
+                "sha256:ff8fef88029d0420315935041db517855ea022889fa8d54959943e39fffebf59"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2023.3.23"
+            "markers": "python_version >= '3.6'",
+            "version": "==2023.5.4"
         },
         "requests": {
             "hashes": [
@@ -3692,15 +3852,6 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.7.1"
-        },
-        "safe-pysha3": {
-            "hashes": [
-                "sha256:29dfa56fdb799decb9d01bdd7dbc0f2806f4468d2c296f83b6e37d86531917c2",
-                "sha256:6bc9d3b2d127521a50ebf3a58e01feaeae19c94184a140b62780ce019bb5b1f0",
-                "sha256:a0ba257f66291b281f4c3259ae2391d19445a6bdf18e8b79f2405257a8db0394",
-                "sha256:ddc10fc2eb491a5105c0deb1cbf4a6eabd5719256b65585b9b721d9d521eda96"
-            ],
-            "version": "==1.0.3"
         },
         "semantic-version": {
             "hashes": [

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -34,7 +34,7 @@ eth-rlp==0.3.0 ; python_version >= '3.7' and python_version < '4'
 eth-tester==0.8.0b3
 eth-typing==3.3.0 ; python_full_version >= '3.7.2' and python_version < '4'
 eth-utils==2.1.0
-ethpm-types==0.4.4 ; python_version < '3.11' and python_version >= '3.8'
+ethpm-types==0.4.5 ; python_version >= '3.8' and python_version < '4'
 evm-trace==0.1.0a18 ; python_version >= '3.8' and python_version < '4'
 exceptiongroup==1.1.1 ; python_version < '3.11'
 executing==1.2.0
@@ -46,9 +46,10 @@ hypothesis==6.75.1
 identify==2.5.23 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
 ijson==3.2.0.post0
-importlib-metadata==6.6.0 ; python_version >= '3.7'
+importlib-metadata==6.6.0 ; python_version < '3.10'
+importlib-resources==5.12.0 ; python_version < '3.9'
 iniconfig==2.0.0 ; python_version >= '3.7'
-ipython==8.13.1 ; python_version >= '3.9'
+ipython==8.12.1 ; python_version >= '3.8'
 jedi==0.18.2 ; python_version >= '3.6'
 jsonschema==4.18.0a6 ; python_version >= '3.8'
 jsonschema-specifications==2023.3.6 ; python_version >= '3.8'
@@ -59,16 +60,17 @@ msgspec==0.14.2 ; python_version >= '3.8'
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
 nodeenv==1.7.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5, 3.6'
-numpy==1.24.3 ; python_version >= '3.10'
+numpy==1.24.3 ; python_version < '3.10'
 packaging==23.1 ; python_version >= '3.7'
 pandas==1.5.3 ; python_version >= '3.8'
 parsimonious==0.9.0
 parso==0.8.3 ; python_version >= '3.6'
 pexpect==4.8.0 ; sys_platform != 'win32'
 pickleshare==0.7.5
+pkgutil-resolve-name==1.3.10 ; python_version < '3.9'
 platformdirs==3.5.0 ; python_version >= '3.7'
 pluggy==1.0.0 ; python_version >= '3.6'
-pre-commit==3.3.0
+pre-commit==3.3.1
 prompt-toolkit==3.0.38 ; python_full_version >= '3.7.0'
 protobuf==4.23.0rc2 ; python_version >= '3.7'
 ptyprocess==0.7.0
@@ -90,6 +92,7 @@ pygithub==1.58.1 ; python_version >= '3.7'
 pygments==2.15.1 ; python_version >= '3.7'
 pyjwt[crypto]==2.6.0 ; python_version >= '3.7'
 pynacl==1.5.0
+pysha3==1.0.2
 pytest==6.2.5
 pytest-cov==4.0.0
 pytest-mock==3.10.0
@@ -100,12 +103,11 @@ python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0,
 pytz==2023.3
 pyyaml==6.0 ; python_version >= '3.6'
 referencing==0.28.0 ; python_version >= '3.8'
-regex==2023.3.23 ; python_version >= '3.8'
+regex==2023.5.4 ; python_version >= '3.6'
 requests==2.29.0
 rich==12.6.0 ; python_full_version >= '3.6.3' and python_full_version < '4.0.0'
 rlp==3.0.0
 rpds-py==0.7.1 ; python_version >= '3.8'
-safe-pysha3==1.0.3
 semantic-version==2.10.0 ; python_version >= '2.7'
 setuptools==67.7.2 ; python_version >= '3.7'
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -13,6 +13,7 @@ jinja2==3.0.3
 markupsafe==2.1.2 ; python_version >= '3.7'
 packaging==23.1 ; python_version >= '3.7'
 pygments==2.15.1 ; python_version >= '3.7'
+pytz==2023.3 ; python_version < '3.9'
 requests==2.29.0 ; python_version >= '3.7'
 setuptools==67.7.2 ; python_version >= '3.7'
 snowballstemmer==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ async-timeout==4.0.2 ; python_version >= '3.6'
 attrs==23.1.0 ; python_version >= '3.7'
 autobahn==23.1.2 ; python_version >= '3.7'
 automat==22.10.0
+backports.zoneinfo==0.2.1 ; python_version >= '3.7' and python_version < '3.9'
 bitarray==2.7.3
 bytestring-splitter==2.4.1
 cached-property==1.5.2
@@ -31,13 +32,15 @@ eth-tester==0.8.0b3
 eth-typing==3.3.0 ; python_version < '4' and python_full_version >= '3.7.2'
 eth-utils==2.1.0
 ferveo @ git+https://github.com/KPrasch/ferveo.git@7a5c5fc8be49894c0affd0da32b80e29e6e1ee8e#subdirectory=ferveo-python
-flask==2.2.4
+flask==2.2.5
 frozenlist==1.3.3 ; python_version >= '3.7'
 hendrix==4.0.0
 hexbytes==0.3.0 ; python_version >= '3.7' and python_version < '4'
 humanize==4.6.0 ; python_version >= '3.7'
 hyperlink==21.0.0
 idna==3.4 ; python_version >= '3.5'
+importlib-metadata==6.6.0 ; python_version < '3.10'
+importlib-resources==5.12.0 ; python_version < '3.9'
 incremental==22.10.0
 itsdangerous==2.1.2 ; python_version >= '3.7'
 jinja2==3.0.3
@@ -57,6 +60,7 @@ nucypher-core==0.7.0
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'
+pkgutil-resolve-name==1.3.10 ; python_version < '3.9'
 protobuf==4.23.0rc2 ; python_version >= '3.7'
 py-ecc==6.0.0 ; python_version >= '3.6' and python_version < '4'
 py-evm==0.6.1a2
@@ -72,7 +76,7 @@ pysha3==1.0.2
 python-dateutil==2.8.2 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pytz==2023.3
 referencing==0.28.0 ; python_version >= '3.8'
-regex==2023.3.23 ; python_version >= '3.8'
+regex==2023.5.4 ; python_version >= '3.6'
 requests==2.29.0
 rlp==3.0.0
 rpds-py==0.7.1 ; python_version >= '3.8'
@@ -97,4 +101,5 @@ web3==6.2.0
 websockets==11.0.2 ; python_version >= '3.7'
 werkzeug==2.3.3 ; python_version >= '3.8'
 yarl==1.9.2 ; python_version >= '3.7'
+zipp==3.15.0 ; python_version >= '3.7'
 zope.interface==6.1a2 ; python_version >= '3.7'

--- a/scripts/dependencies/relock_dependencies.sh
+++ b/scripts/dependencies/relock_dependencies.sh
@@ -35,18 +35,18 @@ set -e
 
 echo "Building Documentation Requirements"
 pushd ./scripts/dependencies/docs
-pipenv lock --clear --pre
+pipenv --python 3.8 lock --clear --pre
 pipenv requirements > ../../../docs-$PREFIX.txt
 rm -f Pipfile.lock
 pipenv --rm
 popd
 
 echo "Building Development Requirements"
-pipenv lock --clear --pre --dev-only
+pipenv --python 3.8 lock --clear --pre --dev-only
 pipenv requirements --dev-only > dev-$PREFIX.txt
 
 echo "Building Standard Requirements"
-pipenv lock --clear --pre
+pipenv --python 3.8 lock --clear --pre
 pipenv requirements > $PREFIX.txt
 
 echo "OK!"

--- a/setup.py
+++ b/setup.py
@@ -38,18 +38,17 @@ from setuptools.command.install import install
 PACKAGE_NAME = 'nucypher'
 BASE_DIR = Path(__file__).parent
 PYPI_CLASSIFIERS = [
-      "Development Status :: 3 - Alpha",
-      "Intended Audience :: Developers",
-      "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
-      "Natural Language :: English",
-      "Operating System :: OS Independent",
-      "Programming Language :: Python",
-      "Programming Language :: Python :: 3 :: Only",
-      "Programming Language :: Python :: 3.6",
-      "Programming Language :: Python :: 3.7",
-      "Programming Language :: Python :: 3.8",
-      "Programming Language :: Python :: 3.9",
-      "Topic :: Security"
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Topic :: Security",
 ]
 
 ABOUT: Dict[str, str] = dict()


### PR DESCRIPTION
Existing dependencies in `tdec` EPIC do not work for python 3.8, 3.9.

Relocking dependencies using python 3.8. Tested that `pip install -e .[dev]` works and sanity tested with unit tests and a the `test/integration/blockchain` integration test. The virtual env worked with 3.8, 3.9, 3.10 but not 3.11, failing with the following during pip install.
```
ERROR: Could not find a version that satisfies the requirement eth-ape==0.6.8; extra == "dev" (from nucypher[dev]) (from versions: 0.0.0a0, 0.1.0a0, 0.1.0a1, 0.1.0a2)
ERROR: No matching distribution found for eth-ape==0.6.8; extra == "dev"
```

Also:
- Updated github action for python tests to use python 3.8 instead of 3.7. 
- Updated pypi classifiers to not include python 3.6 and 3.7
- Updated relock deps script to specifically use python 3.8 when relocking deps.