### PR TITLE
Update code to handle DkgPublicKey now being 48 bytes instead of 56 bytes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ hendrix = ">=4.0"
 nucypher-core = ">=0.7.0"
 # Cryptography
 cryptography = ">=3.2"
-ferveo = ">=0.1.10"
+ferveo = ">=0.1.11"
 mnemonic = "*"
 pynacl= ">=1.4.0"
 pyopenssl = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -14,7 +14,7 @@ hendrix = ">=4.0"
 nucypher-core = ">=0.7.0"
 # Cryptography
 cryptography = ">=3.2"
-ferveo = ">=0.1.9"
+ferveo = ">=0.1.10"
 mnemonic = "*"
 pynacl= ">=1.4.0"
 pyopenssl = "*"

--- a/newsfragments/3121.dev.rst
+++ b/newsfragments/3121.dev.rst
@@ -1,0 +1,1 @@
+Updates to use ferveo v0.1.10.

--- a/newsfragments/3121.dev.rst
+++ b/newsfragments/3121.dev.rst
@@ -1,1 +1,1 @@
-Updates to use ferveo v0.1.10.
+Updates to use ferveo v0.1.11.

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -557,6 +557,8 @@ class CoordinatorAgent(EthereumContractAgent):
             transcript: bytes = bytes()
 
         class G1Point(NamedTuple):
+            """Coordinator contract representation of DkgPublicKey."""
+
             # TODO validation of these if used directly
             word0: bytes  # 32 bytes
             word1: bytes  # 16 bytes
@@ -567,8 +569,10 @@ class CoordinatorAgent(EthereumContractAgent):
 
             @classmethod
             def from_bytes(cls, data: bytes):
-                if len(data) != 48:
-                    raise ValueError(f"Invalid byte length ({len(data)}) for G1Point")
+                if len(data) != DkgPublicKey.serialized_size():
+                    raise ValueError(
+                        f"Invalid byte length; expected {DkgPublicKey.serialized_size()} bytes but got {len(data)} bytes for G1Point"
+                    )
                 return cls(word0=data[:32], word1=data[32:48])
 
             def to_dkg_public_key(self) -> DkgPublicKey:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -697,7 +697,7 @@ class Bob(Character):
         validators = sorted(validators, key=lambda v: v.address)
         transcripts = [Transcript.from_bytes(t[1]) for t in ritual.transcripts]
         data = list(zip(validators, transcripts))
-        pvss_aggregated, final_key, params = aggregate_transcripts(
+        pvss_aggregated, public_key, params = aggregate_transcripts(
             ritual_id=ritual_id,
             me=validators[0],  # TODO: #3097 this is awkward, but we need to pass "me" here to derive_generator_inverse
             threshold=threshold,
@@ -1326,7 +1326,7 @@ class Enrico:
 
     banner = ENRICO_BANNER
 
-    def __init__(self, encrypting_key: Union[PublicKey, ferveo_py.PublicKey]):
+    def __init__(self, encrypting_key: Union[PublicKey, ferveo_py.DkgPublicKey]):
         self.signing_power = SigningPower()
         self._policy_pubkey = encrypting_key
         self.log = Logger(f'{self.__class__.__name__}-{encrypting_key}')

--- a/nucypher/crypto/ferveo/dkg.py
+++ b/nucypher/crypto/ferveo/dkg.py
@@ -46,7 +46,7 @@ def generate_transcript(*args, **kwargs):
 
 def derive_public_key(*args, **kwargs):
     dkg = _make_dkg(*args, **kwargs)
-    return dkg.final_key
+    return dkg.public_key
 
 
 def aggregate_transcripts(
@@ -56,8 +56,10 @@ def aggregate_transcripts(
     _dkg = _make_dkg(nodes=validators, shares=shares, *args, **kwargs)
     pvss_aggregated = _dkg.aggregate_transcripts(transcripts)
     verify_aggregate(pvss_aggregated, shares, transcripts)
-    LOGGER.debug(f"derived final DKG key {bytes(_dkg.final_key).hex()[:10]} and {keccak(bytes(_dkg.public_params)).hex()[:10]}")
-    return pvss_aggregated, _dkg.final_key, _dkg.public_params
+    LOGGER.debug(
+        f"derived final DKG key {bytes(_dkg.public_key).hex()[:10]} and {keccak(bytes(_dkg.public_params)).hex()[:10]}"
+    )
+    return pvss_aggregated, _dkg.public_key, _dkg.public_params
 
 
 def verify_aggregate(

--- a/nucypher/crypto/ferveo/dkg.py
+++ b/nucypher/crypto/ferveo/dkg.py
@@ -38,20 +38,20 @@ def _make_dkg(
     return dkg
 
 
-def generate_transcript(*args, **kwargs):
+def generate_transcript(*args, **kwargs) -> Transcript:
     dkg = _make_dkg(*args, **kwargs)
     transcript = dkg.generate_transcript()
     return transcript
 
 
-def derive_public_key(*args, **kwargs):
+def derive_public_key(*args, **kwargs) -> DkgPublicKey:
     dkg = _make_dkg(*args, **kwargs)
     return dkg.public_key
 
 
 def aggregate_transcripts(
     transcripts: List[Tuple[Validator, Transcript]], shares: int, *args, **kwargs
-) -> Tuple[AggregatedTranscript, PublicKey, DkgPublicParameters]:
+) -> Tuple[AggregatedTranscript, DkgPublicKey, DkgPublicParameters]:
     validators = [t[0] for t in transcripts]
     _dkg = _make_dkg(nodes=validators, shares=shares, *args, **kwargs)
     pvss_aggregated = _dkg.aggregate_transcripts(transcripts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ eth-rlp==0.3.0 ; python_version >= '3.7' and python_version < '4'
 eth-tester==0.8.0b3
 eth-typing==3.3.0 ; python_version < '4' and python_full_version >= '3.7.2'
 eth-utils==2.1.0
-ferveo==0.1.9
+ferveo==0.1.10
 flask==2.2.5
 frozenlist==1.3.3 ; python_version >= '3.7'
 hendrix==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ eth-rlp==0.3.0 ; python_version >= '3.7' and python_version < '4'
 eth-tester==0.8.0b3
 eth-typing==3.3.0 ; python_version < '4' and python_full_version >= '3.7.2'
 eth-utils==2.1.0
-ferveo==0.1.10
+ferveo==0.1.11
 flask==2.2.5
 frozenlist==1.3.3 ; python_version >= '3.7'
 hendrix==4.0.0

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -89,11 +89,7 @@ def test_ursula_ritualist(testerchain, coordinator_agent, cohort, alice, bob):
         """Encrypts a message and returns the ciphertext and conditions"""
         print("==================== DKG ENCRYPTION ====================")
 
-        # side channel fake-out by using the datastore from the last node in the cohort
-        # alternatively, we could use the coordinator datastore
-        # TODO get from Coordinator contract (when Ferveo version updated)
-        last_node = cohort[-1]
-        encrypting_key = last_node.dkg_storage.get_public_key(RITUAL_ID)
+        encrypting_key = coordinator_agent.get_ritual_public_key(ritual_id=RITUAL_ID)
 
         # prepare message and conditions
         plaintext = PLAINTEXT.encode()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -12,6 +12,7 @@ import pytest
 from click.testing import CliRunner
 from eth_account import Account
 from eth_utils import to_checksum_address
+from ferveo_py.ferveo_py import DkgPublicKey
 from ferveo_py.ferveo_py import Keypair as FerveoKeyPair
 from ferveo_py.ferveo_py import Validator
 from twisted.internet.task import Clock
@@ -699,7 +700,7 @@ def ursulas(testerchain, staking_providers, ursula_test_config):
 
 
 @pytest.fixture(scope="module")
-def dkg_public_key(get_random_checksum_address):
+def dkg_public_key(get_random_checksum_address) -> DkgPublicKey:
     ritual_id = 0
     num_shares = 4
     threshold = 3

--- a/tests/integration/blockchain/test_dkg_ritual.py
+++ b/tests/integration/blockchain/test_dkg_ritual.py
@@ -148,11 +148,9 @@ def test_ursula_ritualist(testerchain, mock_coordinator_agent, cohort, alice, bo
     def encrypt(_):
         """Encrypts a message and returns the ciphertext and conditions"""
         print("==================== DKG ENCRYPTION ====================")
-
-        # side channel fake-out by using the datastore from the last node in the cohort
-        # alternatively, we could use the coordinator datastore
-        last_node = cohort[-1]
-        encrypting_key = last_node.dkg_storage.get_public_key(ritual_id)
+        encrypting_key = mock_coordinator_agent.get_ritual_public_key(
+            ritual_id=ritual_id
+        )
 
         # prepare message and conditions
         plaintext = PLAINTEXT.encode()

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -115,8 +115,7 @@ def test_mock_coordinator_round_2(
 
     assert ritual.aggregated_transcript == aggregated_transcript
 
-    # TODO this key is currently incorrectly padded with 8 bytes (56 bytes instead of 48) - remove when fixed; ferveo #101
-    assert bytes(ritual.public_key) == bytes(dkg_public_key)[8:]
+    assert bytes(ritual.public_key) == bytes(dkg_public_key)
     for p in ritual.participants:
         # unchanged
         assert p.transcript == FAKE_TRANSCRIPT


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Update ferveo version to 0.1.11 which serializes/deserializes DkgPublicKey to/from 48 bytes instead of 56 bytes. 

Related to:
- https://github.com/nucypher/ferveo/pull/109
- https://github.com/nucypher/ferveo/pull/110

Fixes #3120 .

Side note: not the same numbers but reminds me of this song - https://www.youtube.com/watch?v=wNxNwvjzGM0&ab_channel=TootsandTheMaytals-Topic