### PR TITLE
Integrate `ferveo` through bindings exposed in `nucypher-core`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ python_version = "3"
 constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=4.0"
-nucypher-core = ">=0.8.0"
+nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="main", subdirectory="nucypher-core-python"}
 # Cryptography
 cryptography = ">=3.2"
 ferveo = ">=0.1.11"

--- a/examples/tdec/simple_tdec.py
+++ b/examples/tdec/simple_tdec.py
@@ -1,13 +1,12 @@
 import os
-from ferveo_py.ferveo_py import DkgPublicKey
 from pathlib import Path
+
+from nucypher_core.ferveo import DkgPublicKey
 
 import nucypher
 from nucypher.blockchain.eth.agents import CoordinatorAgent
 from nucypher.blockchain.eth.registry import LocalContractRegistry
-from nucypher.characters.lawful import Bob
-from nucypher.characters.lawful import Enrico as Enrico
-from nucypher.characters.lawful import Ursula
+from nucypher.characters.lawful import Bob, Enrico as Enrico, Ursula
 from nucypher.utilities.logging import GlobalLoggerSettings
 
 ######################

--- a/examples/tdec/simple_tdec.py
+++ b/examples/tdec/simple_tdec.py
@@ -6,7 +6,7 @@ from nucypher_core.ferveo import DkgPublicKey
 import nucypher
 from nucypher.blockchain.eth.agents import CoordinatorAgent
 from nucypher.blockchain.eth.registry import LocalContractRegistry
-from nucypher.characters.lawful import Bob, Enrico as Enrico, Ursula
+from nucypher.characters.lawful import Bob, Enrico, Ursula
 from nucypher.utilities.logging import GlobalLoggerSettings
 
 ######################

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -4,13 +4,16 @@ from typing import List, Optional, Tuple, Union
 
 import maya
 from eth_typing import ChecksumAddress
-from ferveo_py import AggregatedTranscript, Ciphertext
-from ferveo_py import DkgPublicKey as FerveoPublicKey
-from ferveo_py import Validator
 from hexbytes import HexBytes
 from nucypher_core import (
     EncryptedThresholdDecryptionRequest,
     ThresholdDecryptionRequest,
+)
+from nucypher_core.ferveo import (
+    AggregatedTranscript,
+    Ciphertext,
+    FerveoPublicKey,
+    Validator,
 )
 from nucypher_core.umbral import PublicKey
 from web3 import Web3

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -10,7 +10,7 @@ from constant_sorrow.constants import CONTRACT_ATTRIBUTE  # type: ignore
 from constant_sorrow.constants import CONTRACT_CALL, TRANSACTION
 from eth_typing.evm import ChecksumAddress
 from eth_utils.address import to_checksum_address
-from ferveo_py.ferveo_py import AggregatedTranscript, DkgPublicKey, Transcript
+from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Transcript
 from nucypher_core.umbral import PublicKey
 from web3.contract.contract import Contract, ContractFunction
 from web3.types import Timestamp, TxParams, TxReceipt, Wei

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -47,8 +47,8 @@ from nucypher_core.ferveo import (
     Ciphertext,
     DecryptionSharePrecomputed,
     DecryptionShareSimple,
-    DkgPublicParameters,
     DkgPublicKey,
+    DkgPublicParameters,
     Transcript,
     Validator,
     combine_decryption_shares_precomputed,
@@ -578,7 +578,7 @@ class Bob(Character):
         decryption_request = ThresholdDecryptionRequest(
             ritual_id=ritual_id,
             variant=int(variant.value),
-            ciphertext=bytes(ciphertext),
+            ciphertext=ciphertext,
             conditions=conditions,
             context=context,
         )
@@ -1420,7 +1420,7 @@ class Enrico:
                                           conditions=conditions)
         tdr = ThresholdDecryptionRequest(
             ritual_id=ritual_id,
-            ciphertext=bytes(ciphertext),
+            ciphertext=ciphertext,
             conditions=Conditions(json.dumps(conditions)),
             context=context,
             variant=variant_id,

--- a/nucypher/crypto/ferveo/dkg.py
+++ b/nucypher/crypto/ferveo/dkg.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Tuple, Union
 
 from eth_utils import keccak
-from ferveo_py.ferveo_py import *
+from nucypher_core.ferveo import *
 
 from nucypher.utilities.logging import Logger
 

--- a/nucypher/crypto/keypairs.py
+++ b/nucypher/crypto/keypairs.py
@@ -1,8 +1,6 @@
 from pathlib import Path
 from typing import Optional, Union
 
-from OpenSSL.SSL import TLSv1_2_METHOD
-from OpenSSL.crypto import X509
 from constant_sorrow import constants
 from cryptography.hazmat.primitives.asymmetric import ec
 from hendrix.deploy.tls import HendrixDeployTLS
@@ -22,6 +20,8 @@ from nucypher_core.umbral import (
     Signer,
     VerifiedKeyFrag,
 )
+from OpenSSL.crypto import X509
+from OpenSSL.SSL import TLSv1_2_METHOD
 
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
 from nucypher.crypto.signing import SignatureStamp, StrangerStamp
@@ -112,10 +112,10 @@ class RitualisticKeypair(Keypair):
     @classmethod
     def from_secure_randomness(cls, randomness: bytes) -> 'RitualisticKeypair':
         """Create a keypair from a precomputed secure source of randomness"""
-        size = Keypair.secure_randomness_size()
+        size = FerveoKeypair.secure_randomness_size()
         if len(randomness) != size:
             raise ValueError(f"precomputed randomness must be {size} bytes long")
-        keypair = Keypair.from_secure_randomness(randomness)
+        keypair = FerveoKeypair.from_secure_randomness(randomness)
         return cls(private_key=keypair)
 
 

--- a/nucypher/crypto/keypairs.py
+++ b/nucypher/crypto/keypairs.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 from typing import Optional, Union
 
-import ferveo_py
+from OpenSSL.SSL import TLSv1_2_METHOD
+from OpenSSL.crypto import X509
 from constant_sorrow import constants
 from cryptography.hazmat.primitives.asymmetric import ec
-from ferveo_py.ferveo_py import Keypair as FerveoKeypair
 from hendrix.deploy.tls import HendrixDeployTLS
 from hendrix.facilities.services import ExistingKeyTLSContextFactory
 from nucypher_core import (
@@ -14,6 +14,7 @@ from nucypher_core import (
     MessageKit,
     TreasureMap,
 )
+from nucypher_core.ferveo import Keypair as FerveoKeypair
 from nucypher_core.umbral import (
     PublicKey,
     SecretKey,
@@ -21,8 +22,6 @@ from nucypher_core.umbral import (
     Signer,
     VerifiedKeyFrag,
 )
-from OpenSSL.crypto import X509
-from OpenSSL.SSL import TLSv1_2_METHOD
 
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
 from nucypher.crypto.signing import SignatureStamp, StrangerStamp
@@ -107,16 +106,16 @@ class DecryptingKeypair(Keypair):
 class RitualisticKeypair(Keypair):
     """A keypair for Ferveo DKG"""
 
-    _private_key_source = ferveo_py.Keypair.random
+    _private_key_source = FerveoKeypair.random
     _public_key_method = "public_key"
 
     @classmethod
     def from_secure_randomness(cls, randomness: bytes) -> 'RitualisticKeypair':
         """Create a keypair from a precomputed secure source of randomness"""
-        size = FerveoKeypair.secure_randomness_size()
+        size = Keypair.secure_randomness_size()
         if len(randomness) != size:
             raise ValueError(f"precomputed randomness must be {size} bytes long")
-        keypair = FerveoKeypair.from_secure_randomness(randomness)
+        keypair = Keypair.from_secure_randomness(randomness)
         return cls(private_key=keypair)
 
 

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -11,8 +11,8 @@ from typing import Callable, ClassVar, Dict, List, Optional, Tuple, Union
 
 import click
 from constant_sorrow.constants import KEYSTORE_LOCKED
-from ferveo_py import ferveo_py
 from mnemonic.mnemonic import Mnemonic
+from nucypher_core.ferveo import Keypair
 from nucypher_core.umbral import SecretKeyFactory
 
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT
@@ -425,7 +425,7 @@ class Keystore:
 
         elif issubclass(power_class, RitualisticPower):
             keypair_class: RitualisticKeypair = power_class._keypair_class
-            size = ferveo_py.Keypair.secure_randomness_size()
+            size = Keypair.secure_randomness_size()
             blob = __skf.make_secret(info)[:size]
             keypair = keypair_class.from_secure_randomness(blob)
             power = power_class(keypair=keypair, *power_args, **power_kwargs)

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -12,6 +12,7 @@ from nucypher_core.ferveo import (
     AggregatedTranscript,
     Ciphertext,
     DecryptionShareSimple,
+    DkgPublicKey,
     Keypair,
     Transcript,
     Validator,
@@ -205,20 +206,11 @@ class KeyPairBasedPower(CryptoPowerUp):
 
     def __init__(self, public_key: PublicKey = None, keypair: keypairs.Keypair = None):
         if keypair and public_key:
-            raise ValueError("Pass keypair or pubkey_bytes (or neither), but not both.")
+            raise ValueError("Pass keypair or public key (or neither), but not both.")
         elif keypair:
             self.keypair = keypair
         else:
-            # They didn't pass a keypair; we'll make one with the bytes or
-            # Umbral PublicKey if they provided such a thing.
             if public_key:
-                try:
-                    public_key = public_key.as_umbral_pubkey()
-                except AttributeError:
-                    try:
-                        public_key = PublicKey.from_compressed_bytes(public_key)
-                    except TypeError:
-                        public_key = public_key
                 self.keypair = self._keypair_class(
                     public_key=public_key)
             else:
@@ -308,15 +300,15 @@ class RitualisticPower(KeyPairBasedPower):
             shares: int,
             threshold: int,
             transcripts: list
-    ) -> Tuple[AggregatedTranscript, PublicKey, Any]:
-        aggregated_transcript, public_key, params = dkg.aggregate_transcripts(
+    ) -> Tuple[AggregatedTranscript, DkgPublicKey, Any]:
+        aggregated_transcript, dkg_public_key, params = dkg.aggregate_transcripts(
             ritual_id=ritual_id,
             me=Validator(address=checksum_address, public_key=self.keypair.pubkey),
             shares=shares,
             threshold=threshold,
             transcripts=transcripts
         )
-        return aggregated_transcript, public_key, params
+        return aggregated_transcript, dkg_public_key, params
 
 
 class DerivedKeyBasedPower(CryptoPowerUp):

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -1,20 +1,20 @@
 import inspect
 from typing import Any, List, Optional, Tuple
 
-import ferveo_py
 from eth_account._utils.signing import to_standard_signature_bytes
 from eth_typing.evm import ChecksumAddress
-from ferveo_py import (
-    AggregatedTranscript,
-    Ciphertext,
-    DecryptionShareSimple,
-    Transcript,
-    Validator,
-)
 from hexbytes import HexBytes
 from nucypher_core import (
     EncryptedThresholdDecryptionRequest,
     ThresholdDecryptionRequest,
+)
+from nucypher_core.ferveo import (
+    AggregatedTranscript,
+    Ciphertext,
+    DecryptionShareSimple,
+    Keypair,
+    Transcript,
+    Validator,
 )
 from nucypher_core.umbral import PublicKey, SecretKey, SecretKeyFactory, generate_kfrags
 
@@ -253,7 +253,7 @@ class DecryptingPower(KeyPairBasedPower):
 
 class RitualisticPower(KeyPairBasedPower):
     _keypair_class = RitualisticKeypair
-    _default_private_key_class = ferveo_py.Keypair
+    _default_private_key_class = Keypair
 
     not_found_error = NoRitualisticPower
     provides = ("derive_decryption_share", "generate_transcript")

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from ferveo_py.ferveo_py import AggregatedTranscript, Transcript
+from nucypher_core.ferveo import AggregatedTranscript, Transcript
 from web3.types import TxReceipt
 
 

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -13,7 +13,7 @@ class DKGStorage:
     def store_transcript(self, ritual_id: int, transcript: Transcript) -> None:
         self.data["transcripts"][ritual_id] = bytes(transcript)
 
-    def get_transcript(self, ritual_id: int) -> AggregatedTranscript:
+    def get_transcript(self, ritual_id: int) -> Transcript:
         data = self.data["transcripts"][ritual_id]
         transcript = Transcript.from_bytes(data)
         return transcript

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from queue import Queue
 from typing import Callable, List, Optional, Set, Tuple, Union
 
-import ferveo_py
 import maya
 import requests
 from constant_sorrow.constants import (
@@ -19,6 +18,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import Certificate, load_der_x509_certificate
 from eth_utils import to_checksum_address
 from nucypher_core import MetadataResponse, MetadataResponsePayload, NodeMetadata
+from nucypher_core.ferveo import FerveoPublicKey
 from nucypher_core.umbral import Signature
 from requests.exceptions import SSLError
 from twisted.internet import reactor, task
@@ -157,7 +157,7 @@ class NodeSprout:
         crypto_power = CryptoPower()
         crypto_power.consume_power_up(SigningPower(public_key=self._metadata_payload.verifying_key))
         crypto_power.consume_power_up(DecryptingPower(public_key=self._metadata_payload.encrypting_key))
-        crypto_power.consume_power_up(RitualisticPower(public_key=ferveo_py.PublicKey.from_bytes((self._metadata_payload.ferveo_public_key))))
+        crypto_power.consume_power_up(RitualisticPower(public_key=FerveoPublicKey.from_bytes((self._metadata_payload.ferveo_public_key))))
         tls_certificate = load_der_x509_certificate(self._metadata_payload.certificate_der, backend=default_backend())
 
         return Ursula(is_me=False,

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -18,7 +18,6 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import Certificate, load_der_x509_certificate
 from eth_utils import to_checksum_address
 from nucypher_core import MetadataResponse, MetadataResponsePayload, NodeMetadata
-from nucypher_core.ferveo import FerveoPublicKey
 from nucypher_core.umbral import Signature
 from requests.exceptions import SSLError
 from twisted.internet import reactor, task
@@ -155,10 +154,18 @@ class NodeSprout:
 
         # Remote node cryptographic material
         crypto_power = CryptoPower()
-        crypto_power.consume_power_up(SigningPower(public_key=self._metadata_payload.verifying_key))
-        crypto_power.consume_power_up(DecryptingPower(public_key=self._metadata_payload.encrypting_key))
-        crypto_power.consume_power_up(RitualisticPower(public_key=FerveoPublicKey.from_bytes((self._metadata_payload.ferveo_public_key))))
-        tls_certificate = load_der_x509_certificate(self._metadata_payload.certificate_der, backend=default_backend())
+        crypto_power.consume_power_up(
+            SigningPower(public_key=self._metadata_payload.verifying_key)
+        )
+        crypto_power.consume_power_up(
+            DecryptingPower(public_key=self._metadata_payload.encrypting_key)
+        )
+        crypto_power.consume_power_up(
+            RitualisticPower(public_key=self._metadata_payload.ferveo_public_key)
+        )
+        tls_certificate = load_der_x509_certificate(
+            self._metadata_payload.certificate_der, backend=default_backend()
+        )
 
         return Ursula(is_me=False,
                       crypto_power=crypto_power,

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from constant_sorrow import constants
 from constant_sorrow.constants import RELAX
-from ferveo_py.ferveo_py import Ciphertext
 from flask import Flask, Response, jsonify, request
 from mako import exceptions as mako_exceptions
 from mako.template import Template
@@ -16,9 +15,9 @@ from nucypher_core import (
     MetadataResponsePayload,
     ReencryptionRequest,
     RevocationOrder,
-    ThresholdDecryptionRequest,
     ThresholdDecryptionResponse,
 )
+from nucypher_core.ferveo import Ciphertext
 
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
 from nucypher.crypto.ferveo.dkg import FerveoVariant

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -192,10 +192,9 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             )
 
         # derive the decryption share
-        ciphertext = Ciphertext.from_bytes(decryption_request.ciphertext)
         decryption_share = this_node.derive_decryption_share(
             ritual_id=decryption_request.ritual_id,
-            ciphertext=ciphertext,
+            ciphertext=decryption_request.ciphertext,
             conditions=decryption_request.conditions,
             variant=FerveoVariant(decryption_request.variant),
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@17aeb3f36074321a4936d7731aa4ce7303471147#subdirectory=nucypher-core-python
+nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@573432ba608cfdd0cc57f12dec190c85af014d20#subdirectory=nucypher-core-python
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core==0.8.0
+nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@17aeb3f36074321a4936d7731aa4ce7303471147#subdirectory=nucypher-core-python
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@573432ba608cfdd0cc57f12dec190c85af014d20#subdirectory=nucypher-core-python
+nucypher-core @ git+https://github.com/nucypher/nucypher-core.git@a037b066a7469bccea3b91aee3f092f8de161929#subdirectory=nucypher-core-python
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'

--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -17,7 +17,7 @@ import time
 
 import click
 from constant_sorrow.constants import NO_BLOCKCHAIN_CONNECTION
-from ferveo_py.ferveo_py import DkgPublicKey
+from nucypher_core.ferveo import DkgPublicKey
 from web3 import Web3
 
 from nucypher.blockchain.eth.agents import (

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -5,7 +5,6 @@ from twisted.internet.threads import deferToThread
 from nucypher.blockchain.eth.agents import ContractAgency, CoordinatorAgent
 from nucypher.blockchain.eth.trackers.dkg import EventScannerTask
 from nucypher.characters.lawful import Enrico
-from tests.utils.ursula import start_pytest_ursula_services
 
 # constants
 DKG_SIZE = 4

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,8 +17,8 @@ from nucypher_core.ferveo import (
     AggregatedTranscript,
     DkgPublicKey,
     DkgPublicParameters,
+    Keypair,
     Validator,
-    Keypair
 )
 from twisted.internet.task import Clock
 from web3 import Web3

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -13,9 +13,13 @@ import pytest
 from click.testing import CliRunner
 from eth_account import Account
 from eth_utils import to_checksum_address
-from ferveo_py.ferveo_py import AggregatedTranscript, DkgPublicKey, DkgPublicParameters
-from ferveo_py.ferveo_py import Keypair as FerveoKeyPair
-from ferveo_py.ferveo_py import Transcript, Validator
+from nucypher_core.ferveo import (
+    AggregatedTranscript,
+    DkgPublicKey,
+    DkgPublicParameters,
+    Validator,
+    Keypair
+)
 from twisted.internet.task import Clock
 from web3 import Web3
 
@@ -712,7 +716,7 @@ def dkg_public_key_data(
         validators.append(
             Validator(
                 address=get_random_checksum_address(),
-                public_key=FerveoKeyPair.random().public_key(),
+                public_key=Keypair.random().public_key(),
             )
         )
 

--- a/tests/integration/blockchain/test_dkg_ritual.py
+++ b/tests/integration/blockchain/test_dkg_ritual.py
@@ -11,7 +11,6 @@ from nucypher.blockchain.eth.agents import CoordinatorAgent
 from nucypher.characters.lawful import Enrico, Ursula
 from tests.mock.coordinator import MockCoordinatorAgent
 from tests.mock.interfaces import MockBlockchain
-from tests.utils.ursula import make_ursulas
 
 # The message to encrypt and its conditions
 PLAINTEXT = "peace at dawn"

--- a/tests/integration/config/test_keystore_integration.py
+++ b/tests/integration/config/test_keystore_integration.py
@@ -171,7 +171,7 @@ def test_ritualist(temp_dir_path, testerchain, dkg_public_key):
     decryption_request = ThresholdDecryptionRequest(
         ritual_id=ritual_id,
         variant=0,
-        ciphertext=bytes(ciphertext),
+        ciphertext=ciphertext,
         conditions=Conditions(json.dumps(CONDITIONS)),
     )
 

--- a/tests/mock/coordinator.py
+++ b/tests/mock/coordinator.py
@@ -4,7 +4,7 @@ from typing import Dict, List
 
 from eth_typing import ChecksumAddress
 from eth_utils import keccak
-from ferveo_py.ferveo_py import AggregatedTranscript, DkgPublicKey, Transcript
+from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Transcript
 from nucypher_core.umbral import PublicKey
 from web3.types import TxReceipt
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,6 +1,5 @@
 import pytest
-from ferveo_py.ferveo_py import Keypair as FerveoKeyPair
-from ferveo_py.ferveo_py import Validator
+from nucypher_core.ferveo import Keypair, Validator
 
 from nucypher.blockchain.economics import EconomicsFactory
 from nucypher.blockchain.eth.actors import Operator
@@ -103,7 +102,7 @@ def random_transcript(get_random_checksum_address):
         validators.append(
             Validator(
                 address=get_random_checksum_address(),
-                public_key=FerveoKeyPair.random().public_key(),
+                public_key=Keypair.random().public_key(),
             )
         )
 

--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import pytest
 from eth_utils import to_checksum_address
-from ferveo_py.ferveo_py import Keypair
 from nucypher_core import Address, NodeMetadata, NodeMetadataPayload
+from nucypher_core.ferveo import Keypair
 from nucypher_core.umbral import RecoverableSignature, SecretKey, Signer
 
 from nucypher.acumen.perception import FleetSensor
@@ -72,7 +72,7 @@ class Dummy:  # Teacher
             operator_signature=dummy_signature,
             verifying_key=signer.verifying_key(),
             encrypting_key=SecretKey.random().public_key(),
-            ferveo_public_key=bytes(Keypair.random().public_key()),
+            ferveo_public_key=Keypair.random().public_key(),
             certificate_der=b"not a certificate",
             host=MOCK_IP_ADDRESS,
             port=MOCK_PORT,


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Integrates pre-release version of `nucypher-core` with `nucypher`
- Replaces `ferveo_py` with Ferveo module exposed from `nucypher.ferveo` 
- Based on changes in https://github.com/nucypher/nucypher-core/pull/53 

**Issues fixed/closed:**
- ...

**Why it's needed:**
- To remove dependency on `ferveo_py` module
- To iron out any issues with `nucypher-core` and `ferveo` before releasing their new versions

**Notes for reviewers:**
- **Please don't merge**
- Are there any other changes that should go into this PR?
- This is a multi-repository effort. Please consider reviewing PRs in other repos:
  - https://github.com/nucypher/ferveo/pull/125
  - https://github.com/nucypher/ferveo/pull/119
  - https://github.com/nucypher/nucypher-core/pull/58
