### PR TITLE
Remove dependency on deprecated `DkgPublicParams`

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ python_version = "3"
 constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=4.0"
-nucypher-core = ">=0.9.0"
+nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="49144396dfa291491b62fe0a05c71de8d1adcd42", subdirectory="nucypher-core-python"}
 # Cryptography
 cryptography = ">=3.2"
 mnemonic = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ python_version = "3"
 constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=4.0"
-nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="704a2ea5b5d0ed29c55bd0d57db7cdd9e4fe26ea", subdirectory="nucypher-core-python"}
+nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="b1bf17756ad1961a31afd5ddb943f0c3841909e6", subdirectory="nucypher-core-python"}
 # Cryptography
 cryptography = ">=3.2"
 mnemonic = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ python_version = "3"
 constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=4.0"
-nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="b1bf17756ad1961a31afd5ddb943f0c3841909e6", subdirectory="nucypher-core-python"}
+nucypher-core = ">=0.10.0"
 # Cryptography
 cryptography = ">=3.2"
 mnemonic = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ python_version = "3"
 constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=4.0"
-nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="49144396dfa291491b62fe0a05c71de8d1adcd42", subdirectory="nucypher-core-python"}
+nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="704a2ea5b5d0ed29c55bd0d57db7cdd9e4fe26ea", subdirectory="nucypher-core-python"}
 # Cryptography
 cryptography = ">=3.2"
 mnemonic = "*"

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -534,11 +534,10 @@ class Ritualist(BaseActor):
             self.log.debug(f"Failed to aggregate transcripts for ritual #{ritual_id}: {str(e)}")
             raise e
         else:
-            aggregated_transcript, dkg_public_key, params = result
+            aggregated_transcript, dkg_public_key = result
 
         # Store the DKG artifacts for later us
         self.dkg_storage.store_aggregated_transcript(ritual_id=ritual_id, aggregated_transcript=aggregated_transcript)
-        self.dkg_storage.store_dkg_params(ritual_id=ritual_id, public_params=params)
         self.dkg_storage.store_public_key(ritual_id=ritual_id, public_key=dkg_public_key)
 
         # publish the transcript and store the receipt

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -50,7 +50,6 @@ from nucypher_core.ferveo import (
     DecryptionSharePrecomputed,
     DecryptionShareSimple,
     DkgPublicKey,
-    Transcript,
     Validator,
     combine_decryption_shares_precomputed,
     combine_decryption_shares_simple,
@@ -87,7 +86,7 @@ from nucypher.characters.banners import (
 )
 from nucypher.characters.base import Character, Learner
 from nucypher.config.storages import NodeStorage
-from nucypher.crypto.ferveo.dkg import FerveoVariant, aggregate_transcripts
+from nucypher.crypto.ferveo.dkg import FerveoVariant
 from nucypher.crypto.keypairs import HostingKeypair
 from nucypher.crypto.powers import (
     DecryptingPower,

--- a/nucypher/crypto/ferveo/dkg.py
+++ b/nucypher/crypto/ferveo/dkg.py
@@ -56,9 +56,7 @@ def aggregate_transcripts(
     _dkg = _make_dkg(nodes=validators, shares=shares, *args, **kwargs)
     pvss_aggregated = _dkg.aggregate_transcripts(transcripts)
     verify_aggregate(pvss_aggregated, shares, transcripts)
-    LOGGER.debug(
-        f"derived final DKG key {bytes(_dkg.public_key).hex()[:10]}"
-    )
+    LOGGER.debug(f"derived final DKG key {bytes(_dkg.public_key).hex()[:10]}")
     return pvss_aggregated, _dkg.public_key
 
 

--- a/nucypher/crypto/ferveo/dkg.py
+++ b/nucypher/crypto/ferveo/dkg.py
@@ -51,15 +51,15 @@ def derive_public_key(*args, **kwargs) -> DkgPublicKey:
 
 def aggregate_transcripts(
     transcripts: List[Tuple[Validator, Transcript]], shares: int, *args, **kwargs
-) -> Tuple[AggregatedTranscript, DkgPublicKey, DkgPublicParameters]:
+) -> Tuple[AggregatedTranscript, DkgPublicKey]:
     validators = [t[0] for t in transcripts]
     _dkg = _make_dkg(nodes=validators, shares=shares, *args, **kwargs)
     pvss_aggregated = _dkg.aggregate_transcripts(transcripts)
     verify_aggregate(pvss_aggregated, shares, transcripts)
     LOGGER.debug(
-        f"derived final DKG key {bytes(_dkg.public_key).hex()[:10]} and {keccak(bytes(_dkg.public_params)).hex()[:10]}"
+        f"derived final DKG key {bytes(_dkg.public_key).hex()[:10]}"
     )
-    return pvss_aggregated, _dkg.public_key, _dkg.public_params
+    return pvss_aggregated, _dkg.public_key
 
 
 def verify_aggregate(

--- a/nucypher/crypto/ferveo/dkg.py
+++ b/nucypher/crypto/ferveo/dkg.py
@@ -54,8 +54,9 @@ def aggregate_transcripts(
 ) -> Tuple[AggregatedTranscript, DkgPublicKey]:
     validators = [t[0] for t in transcripts]
     _dkg = _make_dkg(nodes=validators, shares=shares, *args, **kwargs)
-    pvss_aggregated = _dkg.aggregate_transcripts(transcripts)
-    verify_aggregate(pvss_aggregated, shares, transcripts)
+    validator_msgs = [ValidatorMessage(v[0], v[1]) for v in transcripts]
+    pvss_aggregated = _dkg.aggregate_transcripts(validator_msgs)
+    verify_aggregate(pvss_aggregated, shares, validator_msgs)
     LOGGER.debug(f"derived final DKG key {bytes(_dkg.public_key).hex()[:10]}")
     return pvss_aggregated, _dkg.public_key
 
@@ -63,7 +64,7 @@ def aggregate_transcripts(
 def verify_aggregate(
     pvss_aggregated: AggregatedTranscript,
     shares: int,
-    transcripts: List[Tuple[Validator, Transcript]],
+    transcripts: List[ValidatorMessage],
 ):
     pvss_aggregated.verify(shares, transcripts)
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -315,15 +315,15 @@ class RitualisticPower(KeyPairBasedPower):
             shares: int,
             threshold: int,
             transcripts: list
-    ) -> Tuple[AggregatedTranscript, DkgPublicKey, Any]:
-        aggregated_transcript, dkg_public_key, params = dkg.aggregate_transcripts(
+    ) -> Tuple[AggregatedTranscript, DkgPublicKey]:
+        aggregated_transcript, dkg_public_key = dkg.aggregate_transcripts(
             ritual_id=ritual_id,
             me=Validator(address=checksum_address, public_key=self.keypair.pubkey),
             shares=shares,
             threshold=threshold,
             transcripts=transcripts
         )
-        return aggregated_transcript, dkg_public_key, params
+        return aggregated_transcript, dkg_public_key
 
 
 class DerivedKeyBasedPower(CryptoPowerUp):

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -36,12 +36,6 @@ class DKGStorage:
     def get_aggregated_transcript_receipt(self, ritual_id: int) -> TxReceipt:
         return self.data["aggregated_transcript_receipts"][ritual_id]
 
-    def store_dkg_params(self, ritual_id: int, public_params) -> None:
-        self.data["public_params"][ritual_id] = public_params
-
-    def get_dkg_params(self, ritual_id: int) -> int:
-        return self.data["public_params"][ritual_id]
-
     def store_public_key(self, ritual_id: int, public_key: bytes) -> None:
         self.data["public_keys"][ritual_id] = public_key
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core@git+https://github.com/nucypher/nucypher-core.git@49144396dfa291491b62fe0a05c71de8d1adcd42#subdirectory=nucypher-core-python
+nucypher-core@git+https://github.com/nucypher/nucypher-core.git@704a2ea5b5d0ed29c55bd0d57db7cdd9e4fe26ea#subdirectory=nucypher-core-python
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core==0.9.0
+nucypher-core@git+https://github.com/nucypher/nucypher-core.git@49144396dfa291491b62fe0a05c71de8d1adcd42#subdirectory=nucypher-core-python
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core@git+https://github.com/nucypher/nucypher-core.git@b1bf17756ad1961a31afd5ddb943f0c3841909e6#subdirectory=nucypher-core-python
+nucypher-core==0.10.0
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core@git+https://github.com/nucypher/nucypher-core.git@704a2ea5b5d0ed29c55bd0d57db7cdd9e4fe26ea#subdirectory=nucypher-core-python
+nucypher-core@git+https://github.com/nucypher/nucypher-core.git@b1bf17756ad1961a31afd5ddb943f0c3841909e6#subdirectory=nucypher-core-python
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -752,14 +752,14 @@ def dkg_public_key_data(
             threshold=threshold,
             nodes=validators,
         )
-        transcripts.append(transcript)
+        transcripts.append((validator, transcript))
 
     aggregate_transcript, public_key = dkg.aggregate_transcripts(
         ritual_id=ritual_id,
         me=validators[0],
         shares=num_shares,
         threshold=threshold,
-        transcripts=list(zip(validators, transcripts)),
+        transcripts=transcripts,
     )
 
     return aggregate_transcript, public_key

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,7 +16,6 @@ from eth_utils import to_checksum_address
 from nucypher_core.ferveo import (
     AggregatedTranscript,
     DkgPublicKey,
-    DkgPublicParameters,
     Keypair,
     Validator,
 )
@@ -729,7 +728,7 @@ def ursulas(
 @pytest.fixture(scope="session")
 def dkg_public_key_data(
     get_random_checksum_address,
-) -> Tuple[AggregatedTranscript, DkgPublicKey, DkgPublicParameters]:
+) -> Tuple[AggregatedTranscript, DkgPublicKey]:
     ritual_id = 0
     num_shares = 4
     threshold = 3
@@ -755,7 +754,7 @@ def dkg_public_key_data(
         )
         transcripts.append(transcript)
 
-    aggregate_transcript, public_key, params = dkg.aggregate_transcripts(
+    aggregate_transcript, public_key = dkg.aggregate_transcripts(
         ritual_id=ritual_id,
         me=validators[0],
         shares=num_shares,
@@ -763,16 +762,16 @@ def dkg_public_key_data(
         transcripts=list(zip(validators, transcripts)),
     )
 
-    return aggregate_transcript, public_key, params
+    return aggregate_transcript, public_key
 
 
 @pytest.fixture(scope="session")
 def dkg_public_key(dkg_public_key_data) -> DkgPublicKey:
-    _, dkg_public_key, _ = dkg_public_key_data
+    _, dkg_public_key = dkg_public_key_data
     return dkg_public_key
 
 
 @pytest.fixture(scope="session")
 def aggregated_transcript(dkg_public_key_data) -> AggregatedTranscript:
-    aggregated_transcript, _, _ = dkg_public_key_data
+    aggregated_transcript, _ = dkg_public_key_data
     return aggregated_transcript

--- a/tests/integration/blockchain/test_dkg_ritual.py
+++ b/tests/integration/blockchain/test_dkg_ritual.py
@@ -175,14 +175,10 @@ def test_ursula_ritualist(testerchain, mock_coordinator_agent, cohort, alice, bo
         print("==================== DKG DECRYPTION ====================")
         bob.start_learning_loop(now=True)
 
-        # ritual_id, ciphertext, conditions, and params are obtained from the side channel
-        params = cohort[0].dkg_storage.get_dkg_params(ritual_id)
-
         cleartext = bob.threshold_decrypt(
             ritual_id=ritual_id,
             ciphertext=ciphertext,
             conditions=CONDITIONS,
-            params=params,
             peering_timeout=0,
             variant=variant
         )


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
-  2

**What this does:**
- Removes dependency on `DkgPublicParams` which is now replaced with a default value
- Introduces `ValidatorMessage` type where necessary

**Why it's needed:**
- To implement downstream changes from https://github.com/nucypher/nucypher-core/issues/62

**Notes for reviewers:**
- Uses an [unreleased `ferveo` version](https://github.com/nucypher/ferveo/pull/127/commits/0d4e973e007b16cff34d649ae107608c809349af)
