### PR TITLE
Stop gap measure for limiting operational timeouts

### DIFF
--- a/newsfragments/3153.feature.rst
+++ b/newsfragments/3153.feature.rst
@@ -1,0 +1,1 @@
+Increase default timeout for ``/reencrypt`` requests to limit timeouts when multiple retrieval kits are included in a single request.

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -47,7 +47,9 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
                 node_or_sprout.mature()
                 response = (
                     self._learner.network_middleware.get_encrypted_decryption_share(
-                        node_or_sprout, bytes(encrypted_request)
+                        ursula=node_or_sprout,
+                        decryption_request_bytes=bytes(encrypted_request),
+                        timeout=timeout,
                     )
                 )
                 if response.status_code == 200:

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -253,23 +253,23 @@ class RestMiddleware:
         )
         return response
 
-    def reencrypt(self, ursula: 'Ursula', reencryption_request_bytes: bytes):
+    def reencrypt(self, ursula: "Ursula", reencryption_request_bytes: bytes, timeout=8):
         response = self.client.post(
             node_or_sprout=ursula,
             path=f"reencrypt",
             data=reencryption_request_bytes,
-            timeout=2
+            timeout=timeout,
         )
         return response
 
     def get_encrypted_decryption_share(
-        self, ursula: "Ursula", decryption_request_bytes: bytes
+        self, ursula: "Ursula", decryption_request_bytes: bytes, timeout=8
     ):
         response = self.client.post(
             node_or_sprout=ursula,
             path=f"decrypt",
             data=decryption_request_bytes,
-            timeout=8
+            timeout=timeout,
         )
         return response
 


### PR DESCRIPTION
This is a stop gap measure until we fully address timeouts post 7.0.0. Timeouts could be better configured: 
- An additional Porter request parameter to specify timeouts
- Python API allows timeout to be specified as part of `PRERetrievalClient`. Ideally the `PRERetrievalClient` would use concurrency (i.e. the `WorkerPool` which it currently does not) and an overall timeout used. The `ThresholdDecryptionClient` does this for the cbd `/decrypt` operation.

To prevent scope creep into v7.0.0, we will temporarily solve this problem by extending the hardcoded reencrypt request timeout from middleware.

For the most part, Masterfile has been the only entity encountering this problem and they have been able to work around it, but not lumping many retrieval kits into one `retrieve_cfrags` Porter request, instead issuing multiple Porter requests.

**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
**Issues fixed/closed:**
Resolves https://github.com/nucypher/nucypher-porter/issues/23 in the context of 7.0.0. Full solution will be investigated for `v8.0.0`.

**Why it's needed:**
When many retrieval kits are lumped into a single ReencryptionRequest it can cause timeouts since Ursula would be processing multiple retrieval kits in one request. The next logical question is what should the number be. However, it is tough to provide a fixed number since the timeout should probably be based on the number of kits in the request for an Ursula i.e. configured from the client side (entity making the request). So, we should make it configurable from the request side of things i.e. Porter / Bob Python API. This broader solution will be tackled in v8.0.0.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
