### PR TITLE
Make the use of string literal type hints compatible with PEP 484

### DIFF
--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -42,7 +42,7 @@ class StateDiff(NamedTuple):
 
 class FleetState:
     """
-    Fleet state as perceived by a local "lawful.Ursula".
+    Fleet state as perceived by a local "Ursula".
 
     Assumptions we're based on:
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -39,7 +39,7 @@ from nucypher.blockchain.eth.registry import (
 )
 from nucypher.blockchain.eth.signers import Signer
 from nucypher.blockchain.eth.token import NU
-from nucypher.blockchain.eth.trackers.dkg import ActiveRitualTracker
+from nucypher.blockchain.eth.trackers import dkg
 from nucypher.blockchain.eth.trackers.pre import WorkTracker
 from nucypher.crypto.ferveo.dkg import DecryptionShareSimple, FerveoVariant, Transcript
 from nucypher.crypto.powers import (
@@ -319,7 +319,7 @@ class Ritualist(BaseActor):
         )
 
         # track active onchain rituals
-        self.ritual_tracker = ActiveRitualTracker(
+        self.ritual_tracker = dkg.ActiveRitualTracker(
             ritualist=self,
         )
 

--- a/nucypher/blockchain/eth/decorators.py
+++ b/nucypher/blockchain/eth/decorators.py
@@ -1,19 +1,20 @@
 
 
-import eth_utils
 import functools
 import inspect
+from datetime import datetime
+from typing import Callable, Optional, TypeVar, Union
+
+import eth_utils
 from constant_sorrow.constants import (
     CONTRACT_ATTRIBUTE,
     CONTRACT_CALL,
+    NO_BLOCKCHAIN_CONNECTION,
     TRANSACTION,
     UNKNOWN_CONTRACT_INTERFACE,
-    NO_BLOCKCHAIN_CONNECTION
 )
-from datetime import datetime
-from typing import Callable, Optional, Union
+from web3.types import TxReceipt, Wei
 
-from nucypher.types import ContractReturnValue
 from nucypher.utilities.logging import Logger
 
 ContractInterfaces = Union[
@@ -22,6 +23,9 @@ ContractInterfaces = Union[
     CONTRACT_ATTRIBUTE,
     UNKNOWN_CONTRACT_INTERFACE
 ]
+ContractReturnValue = TypeVar(
+    "ContractReturnValue", bound=Union[TxReceipt, Wei, int, str, bool]
+)
 
 
 __VERIFIED_ADDRESSES = set()

--- a/nucypher/blockchain/eth/events.py
+++ b/nucypher/blockchain/eth/events.py
@@ -3,6 +3,7 @@ import os
 
 from web3.contract.contract import Contract
 
+from nucypher.blockchain.eth import agents
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.config.constants import NUCYPHER_EVENTS_THROTTLE_MAX_BLOCKS
 
@@ -71,13 +72,15 @@ class ContractEventsThrottler:
     # default to 1000 - smallest default heard about so far (alchemy)
     DEFAULT_MAX_BLOCKS_PER_CALL = int(os.environ.get(NUCYPHER_EVENTS_THROTTLE_MAX_BLOCKS, 1000))
 
-    def __init__(self,
-                 agent: 'EthereumContractAgent',
-                 event_name: str,
-                 from_block: int,
-                 to_block: int = None,  # defaults to latest block
-                 max_blocks_per_call: int = DEFAULT_MAX_BLOCKS_PER_CALL,
-                 **argument_filters):
+    def __init__(
+        self,
+        agent: "agents.EthereumContractAgent",
+        event_name: str,
+        from_block: int,
+        to_block: int = None,  # defaults to latest block
+        max_blocks_per_call: int = DEFAULT_MAX_BLOCKS_PER_CALL,
+        **argument_filters,
+    ):
         self.event_filter = agent.events[event_name]
         self.from_block = from_block
         self.to_block = to_block if to_block is not None else agent.blockchain.client.block_number

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -6,7 +6,7 @@ from twisted.internet import threads
 from web3.contract.contract import ContractEvent
 from web3.datastructures import AttributeDict
 
-from nucypher.blockchain.eth.actors import Ritualist
+from nucypher.blockchain.eth import actors
 from nucypher.policy.conditions.utils import camel_case_to_snake
 from nucypher.utilities.events import EventScanner, JSONifiedState
 from nucypher.utilities.logging import Logger
@@ -67,7 +67,7 @@ class ActiveRitualTracker:
 
     def __init__(
         self,
-        ritualist: Ritualist,
+        ritualist: "actors.Ritualist",
         persistent: bool = False,  # TODO: use persistent storage?
     ):
         self.log = Logger("RitualTracker")

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -6,6 +6,7 @@ from twisted.internet import threads
 from web3.contract.contract import ContractEvent
 from web3.datastructures import AttributeDict
 
+from nucypher.blockchain.eth.actors import Ritualist
 from nucypher.policy.conditions.utils import camel_case_to_snake
 from nucypher.utilities.events import EventScanner, JSONifiedState
 from nucypher.utilities.logging import Logger
@@ -66,7 +67,7 @@ class ActiveRitualTracker:
 
     def __init__(
         self,
-        ritualist: "Ritualist",
+        ritualist: Ritualist,
         persistent: bool = False,  # TODO: use persistent storage?
     ):
         self.log = Logger("RitualTracker")

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -12,8 +12,9 @@ from cryptography.hazmat.backends import default_backend
 from nucypher_core import FleetStateChecksum, MetadataRequest, NodeMetadata
 from requests.exceptions import SSLError
 
+from nucypher import characters
 from nucypher.blockchain.eth.registry import BaseContractRegistry
-from nucypher.config.storages import ForgetfulNodeStorage
+from nucypher.config.storages import ForgetfulNodeStorage, NodeStorage
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.utilities.logging import Logger
 
@@ -29,7 +30,7 @@ class NucypherMiddlewareClient:
         self,
         eth_provider_uri: Optional[str],
         registry: Optional["BaseContractRegistry"] = None,
-        storage: Optional["NodeStorage"] = None,
+        storage: Optional[NodeStorage] = None,
         *args,
         **kwargs,
     ):
@@ -260,7 +261,12 @@ class RestMiddleware:
         )
         return response
 
-    def reencrypt(self, ursula: "Ursula", reencryption_request_bytes: bytes, timeout=8):
+    def reencrypt(
+        self,
+        ursula: "characters.lawful.Ursula",
+        reencryption_request_bytes: bytes,
+        timeout=8,
+    ):
         response = self.client.post(
             node_or_sprout=ursula,
             path="reencrypt",
@@ -270,7 +276,10 @@ class RestMiddleware:
         return response
 
     def get_encrypted_decryption_share(
-        self, ursula: "Ursula", decryption_request_bytes: bytes, timeout=8
+        self,
+        ursula: "characters.lawful.Ursula",
+        decryption_request_bytes: bytes,
+        timeout=8,
     ):
         response = self.client.post(
             node_or_sprout=ursula,

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -29,7 +29,7 @@ class NucypherMiddlewareClient:
     def __init__(
         self,
         eth_provider_uri: Optional[str],
-        registry: Optional["BaseContractRegistry"] = None,
+        registry: Optional[BaseContractRegistry] = None,
         storage: Optional[NodeStorage] = None,
         *args,
         **kwargs,

--- a/nucypher/network/retrieval.py
+++ b/nucypher/network/retrieval.py
@@ -22,6 +22,7 @@ from nucypher_core.umbral import (
     VerifiedCapsuleFrag,
 )
 
+from nucypher.characters import lawful
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.network.client import ThresholdAccessControlClient
 from nucypher.network.exceptions import NodeSeemsToBeDown
@@ -182,13 +183,14 @@ class PRERetrievalClient(ThresholdAccessControlClient):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def _request_reencryption(self,
-                              ursula: 'Ursula',
-                              reencryption_request: ReencryptionRequest,
-                              alice_verifying_key: PublicKey,
-                              policy_encrypting_key: PublicKey,
-                              bob_encrypting_key: PublicKey,
-                              ) -> Dict['Capsule', 'VerifiedCapsuleFrag']:
+    def _request_reencryption(
+        self,
+        ursula: "lawful.Ursula",
+        reencryption_request: ReencryptionRequest,
+        alice_verifying_key: PublicKey,
+        policy_encrypting_key: PublicKey,
+        bob_encrypting_key: PublicKey,
+    ) -> Dict["Capsule", "VerifiedCapsuleFrag"]:
         """
         Sends a reencryption request to a single Ursula and processes the results.
 

--- a/nucypher/network/trackers.py
+++ b/nucypher/network/trackers.py
@@ -8,12 +8,13 @@ from twisted.internet import reactor
 from twisted.internet.task import LoopingCall
 from twisted.python.failure import Failure
 
+from nucypher import characters
 from nucypher.blockchain.eth.agents import ContractAgency, PREApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
-from nucypher.utilities.emitters import StdoutEmitter
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
 from nucypher.network.nodes import NodeSprout
+from nucypher.utilities.emitters import StdoutEmitter
 from nucypher.utilities.logging import Logger
 from nucypher.utilities.task import SimpleTask
 
@@ -263,7 +264,9 @@ class AvailabilityTracker:
                 self.log.debug(f'{ursula_or_sprout} responded to uptime check with {e.__class__.__name__}')
                 continue
 
-    def measure(self, ursula_or_sprout: Union['Ursula', NodeSprout]) -> None:
+    def measure(
+        self, ursula_or_sprout: Union["characters.lawful.Ursula", NodeSprout]
+    ) -> None:
         """Measure self-availability from a single remote node that participates uptime checks."""
         try:
             response = self._ursula.network_middleware.check_availability(initiator=self._ursula, responder=ursula_or_sprout)

--- a/nucypher/policy/payment.py
+++ b/nucypher/policy/payment.py
@@ -10,7 +10,7 @@ from nucypher.blockchain.eth.registry import (
     BaseContractRegistry,
     InMemoryContractRegistry,
 )
-from nucypher.policy.policies import Policy
+from nucypher.policy import policies
 
 
 class PaymentMethod(ABC):
@@ -25,7 +25,7 @@ class PaymentMethod(ABC):
         shares: int
 
     @abstractmethod
-    def pay(self, policy: Policy) -> Dict:
+    def pay(self, policy: "policies.Policy") -> Dict:
         """Carry out payment for the given policy."""
         raise NotImplementedError
 
@@ -101,7 +101,7 @@ class SubscriptionManagerPayment(ContractPayment):
         result = self.agent.is_policy_active(policy_id=bytes(request.hrac))
         return result
 
-    def pay(self, policy: Policy) -> TxReceipt:
+    def pay(self, policy: "policies.Policy") -> TxReceipt:
         """Writes a new policy to the SubscriptionManager contract."""
         receipt = self.agent.create_policy(
             value=policy.value,                   # wei
@@ -176,7 +176,7 @@ class FreeReencryptions(PaymentMethod):
     def verify(self, payee: ChecksumAddress, request: ReencryptionRequest) -> bool:
         return True
 
-    def pay(self, policy: Policy) -> Dict:
+    def pay(self, policy: "policies.Policy") -> Dict:
         receipt = f'Receipt for free policy {bytes(policy.hrac).hex()}.'
         return dict(receipt=receipt.encode())
 

--- a/nucypher/types.py
+++ b/nucypher/types.py
@@ -3,12 +3,16 @@ from typing import NamedTuple, NewType, TypeVar, Union
 from eth_typing.evm import ChecksumAddress
 from web3.types import TxReceipt, Wei
 
+from nucypher.blockchain.eth import agents
+
 ERC20UNits = NewType("ERC20UNits", int)
 NuNits = NewType("NuNits", ERC20UNits)
 TuNits = NewType("TuNits", ERC20UNits)
 
-Agent = TypeVar('Agent', bound='EthereumContractAgent')
-ContractReturnValue = TypeVar('ContractReturnValue', bound=Union[TxReceipt, Wei, int, str, bool])
+Agent = TypeVar("Agent", bound="agents.EthereumContractAgent")
+ContractReturnValue = TypeVar(
+    "ContractReturnValue", bound=Union[TxReceipt, Wei, int, str, bool]
+)
 
 
 class StakingProviderInfo(NamedTuple):

--- a/nucypher/types.py
+++ b/nucypher/types.py
@@ -1,7 +1,7 @@
-from typing import NamedTuple, NewType, TypeVar, Union
+from typing import NamedTuple, NewType, TypeVar
 
 from eth_typing.evm import ChecksumAddress
-from web3.types import TxReceipt, Wei
+from web3.types import Wei
 
 from nucypher.blockchain.eth import agents
 
@@ -10,9 +10,6 @@ NuNits = NewType("NuNits", ERC20UNits)
 TuNits = NewType("TuNits", ERC20UNits)
 
 Agent = TypeVar("Agent", bound="agents.EthereumContractAgent")
-ContractReturnValue = TypeVar(
-    "ContractReturnValue", bound=Union[TxReceipt, Wei, int, str, bool]
-)
 
 
 class StakingProviderInfo(NamedTuple):

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -15,7 +15,7 @@ from typing import Dict, Type
 from eth_typing.evm import ChecksumAddress
 
 import nucypher
-from nucypher.blockchain.eth.actors import NucypherTokenActor
+from nucypher.blockchain.eth import actors
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     EthereumContractAgent,
@@ -23,6 +23,7 @@ from nucypher.blockchain.eth.agents import (
 )
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import BaseContractRegistry
+from nucypher.characters import lawful
 
 
 class MetricsCollector(ABC):
@@ -73,7 +74,8 @@ class BaseMetricsCollector(MetricsCollector):
 
 class UrsulaInfoMetricsCollector(BaseMetricsCollector):
     """Collector for Ursula specific metrics."""
-    def __init__(self, ursula: 'Ursula'):
+
+    def __init__(self, ursula: "lawful.Ursula"):
         super().__init__()
         self.ursula = ursula
 
@@ -210,7 +212,7 @@ class OperatorMetricsCollector(BaseMetricsCollector):
         }
 
     def _collect_internal(self) -> None:
-        operator_token_actor = NucypherTokenActor(
+        operator_token_actor = actors.NucypherTokenActor(
             registry=self.contract_registry,
             domain=self.domain,
             checksum_address=self.operator_address,

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -14,6 +14,7 @@ from typing import List
 from twisted.internet import reactor, task
 from twisted.web.resource import Resource
 
+from nucypher.characters import lawful
 from nucypher.utilities.prometheus.collector import (
     BlockchainMetricsCollector,
     MetricsCollector,
@@ -118,9 +119,11 @@ def collect_prometheus_metrics(metrics_collectors: List[MetricsCollector]) -> No
         collector.collect()
 
 
-def start_prometheus_exporter(ursula: 'Ursula',
-                              prometheus_config: PrometheusMetricsConfig,
-                              registry: CollectorRegistry = REGISTRY) -> None:
+def start_prometheus_exporter(
+    ursula: "lawful.Ursula",
+    prometheus_config: PrometheusMetricsConfig,
+    registry: CollectorRegistry = REGISTRY,
+) -> None:
     """Configure, collect, and serve prometheus metrics."""
     from prometheus_client.twisted import MetricsResource
     from twisted.web.resource import Resource
@@ -148,7 +151,7 @@ def start_prometheus_exporter(ursula: 'Ursula',
     reactor.listenTCP(prometheus_config.port, factory, interface=prometheus_config.listen_address)
 
 
-def create_metrics_collectors(ursula: "Ursula") -> List[MetricsCollector]:
+def create_metrics_collectors(ursula: "lawful.Ursula") -> List[MetricsCollector]:
     """Create collectors used to obtain metrics."""
     collectors: List[MetricsCollector] = [UrsulaInfoMetricsCollector(ursula=ursula)]
 

--- a/tests/mock/agents.py
+++ b/tests/mock/agents.py
@@ -5,9 +5,10 @@ from unittest.mock import Mock
 from constant_sorrow.constants import CONTRACT_ATTRIBUTE, CONTRACT_CALL, TRANSACTION
 
 from nucypher.blockchain.eth import agents
-from nucypher.blockchain.eth.agents import Agent, ContractAgency, EthereumContractAgent
+from nucypher.blockchain.eth.agents import ContractAgency, EthereumContractAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
+from nucypher.types import Agent
 from tests.constants import MOCK_ETH_PROVIDER_URI
 from tests.mock.interfaces import MockBlockchain
 


### PR DESCRIPTION
[Because:
- Not doing so causes F821 linting errors

https://peps.python.org/pep-0484/#forward-references
https://www.flake8rules.com/rules/F821.html

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Removes all but 5 F821 linting errors. Those are genuine undefined name errors rather than type hint issues.


**Notes for reviewers:**
- The relevant section of the PEP484 doc is where it shows an example from Django of using module level imports to avoid circular import problems. I've used that technique several times in this PR.
- To see the remaining F821 issues using [ruff](https://github.com/astral-sh/ruff):
```bash
>>> ruff check --select F821 nucypher
nucypher/blockchain/eth/interfaces.py:523:23: F821 Undefined name `JSONRPCStdoutEmitter`
nucypher/cli/actions/select.py:98:22: F821 Undefined name `Staker`
nucypher/cli/config.py:56:23: F821 Undefined name `JSONRPCStdoutEmitter`
nucypher/cli/painting/deployment.py:119:72: F821 Undefined name `DispatcherDeployer`
nucypher/cli/painting/deployment.py:123:35: F821 Undefined name `DispatcherDeployer`
Found 5 errors.
```