### PR TITLE
Update dkg script to use `click` options - exec args were getting complex

### DIFF
--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -58,15 +58,16 @@ emitter = StdoutEmitter(verbosity=2)
     "--ritual-id",
     "ritual_id",
     "-r",
-    help="Ritual ID; existing id or -1 (to initiate a new ritual)",
+    help="Ritual ID; defaults to -1 to initiate a new ritual",
     type=click.INT,
+    default=-1,
     required=True,
 )
 @click.option(
     "--signer",
     "signer_uri",
     "-S",
-    help="Signer URI for initializing new ritual",
+    help="Signer URI for initiating a new ritual with Coordinator contract",
     default=None,
     type=click.STRING,
 )
@@ -82,7 +83,8 @@ def nucypher_dkg(
         raise click.BadOptionUsage(
             option_name="--ritual-id, --signer",
             message=click.style(
-                "--signer must be provided when --ritual-id is -1", fg="red"
+                "--signer must be provided to create new ritual when --ritual-id is not provided",
+                fg="red",
             ),
         )
 

--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -1,21 +1,9 @@
-# Run nucypher dkg on 'lynx'/'mumbai' by running:
-#
-#    python scripts/hooks/nucypher_dkg.py <ETH_PROVIDER_URI> <COORDINATOR_PROVIDER_URI> <RITUAL_ID> <SIGNER_URI_FOR_COORDINATOR_NETWORK>
-#
-# For example:
-#
-# Use existing ritual id (eg. id '0'):
-#    python ./scripts/hooks/nucypher_dkg.py <ETH_PROVIDER_URI> <COORDINATOR_PROVIDER_URI> 0
-#
-# Go through entire process of initiating a ritual, waiting for it to finish, then use for encryption/decryption:
-#    python ./scripts/hooks/nucypher_dkg.py <ETH_PROVIDER_URI> <COORDINATOR_PROVIDER_URI> -1 <SIGNER_URI_FOR_COORDINATOR_NETWORK>
-#
-
 import random
 import sys
 import time
 
 import click
+import maya
 from nucypher_core.ferveo import DkgPublicKey
 from web3 import Web3
 
@@ -36,191 +24,224 @@ GlobalLoggerSettings.start_console_logging()
 
 emitter = StdoutEmitter(verbosity=2)
 
-try:
-    eth_provider_uri = sys.argv[1]
-except IndexError:
-    emitter.message("You must provide a eth (staking) provider URI", color="red")
-    sys.exit(-1)
 
-try:
-    coordinator_provider_uri = sys.argv[2]
-except IndexError:
-    emitter.message("You must provide a coordinator network provider URI", color="red")
-    sys.exit(-1)
-
-try:
-    ritual_id = int(sys.argv[3])
-except IndexError:
-    emitter.message(
-        "You must provide a ritual ID; expected <id> or -1 (to initiate a new ritual)",
-        color="red",
-    )
-    sys.exit(-1)
-
-try:
-    signer_uri = sys.argv[4]
-except IndexError:
-    if ritual_id < 0:
-        emitter.message(
-            "You must provide a signer URI for new ritual transactions if not reusing an existing ritual id",
-            color="red",
-        )
-        sys.exit(-1)
-    signer_uri = None
-
-staking_network = "lynx"
-coordinator_network = "mumbai"
-
-coordinator_agent = ContractAgency.get_agent(
-    agent_class=CoordinatorAgent,
-    registry=InMemoryContractRegistry.from_latest_publication(
-        network=coordinator_network
-    ),
-    provider_uri=coordinator_provider_uri,
-)  # type: CoordinatorAgent
-
-staking_network_registry = InMemoryContractRegistry.from_latest_publication(
-    network=staking_network
+@click.command()
+@click.option(
+    "--eth-provider",
+    "eth_provider_uri",
+    help="ETH staking network provider URI",
+    type=click.STRING,
+    required=True,
 )
-application_agent = ContractAgency.get_agent(
-    agent_class=PREApplicationAgent,
-    registry=staking_network_registry,
-    provider_uri=eth_provider_uri,
-)  # type: PREApplicationAgent
+@click.option(
+    "--eth-staking-network",
+    "eth_staking_network",
+    help="ETH staking network",
+    type=click.Choice(["tapir", "lynx"]),
+    default="lynx",
+)
+@click.option(
+    "--coordinator-provider",
+    "coordinator_provider_uri",
+    help="Coordinator network provider URI",
+    type=click.STRING,
+    required=True,
+)
+@click.option(
+    "--coordinator-network",
+    "coordinator_network",
+    help="Coordinator network",
+    type=click.Choice(["mumbai"]),
+    default="mumbai",
+)
+@click.option(
+    "--ritual-id",
+    "ritual_id",
+    "-r",
+    help="Ritual ID; existing id or -1 (to initiate a new ritual)",
+    type=click.INT,
+    required=True,
+)
+@click.option(
+    "--signer",
+    "signer_uri",
+    "-S",
+    help="Signer URI for initializing new ritual",
+    default=None,
+    type=click.STRING,
+)
+def nucypher_dkg(
+    eth_provider_uri,
+    eth_staking_network,
+    coordinator_provider_uri,
+    coordinator_network,
+    ritual_id,
+    signer_uri,
+):
+    if ritual_id < 0 and signer_uri is None:
+        raise click.BadOptionUsage(
+            option_name="--ritual-id, --signer",
+            message=click.style(
+                "--signer must be provided when --ritual-id is -1", fg="red"
+            ),
+        )
 
+    coordinator_agent = ContractAgency.get_agent(
+        agent_class=CoordinatorAgent,
+        registry=InMemoryContractRegistry.from_latest_publication(
+            network=coordinator_network
+        ),
+        provider_uri=coordinator_provider_uri,
+    )  # type: CoordinatorAgent
 
-#
-# Initial Ritual
-#
-if ritual_id < 0:
-    emitter.echo("--------- Initiating Ritual ---------", color="yellow")
-    # create account from keystore file
-    signer = Signer.from_signer_uri(uri=signer_uri)
-    account_address = signer.accounts[0]
-    emitter.echo(
-        f"Using account {account_address} to initiate DKG Ritual", color="green"
+    staking_network_registry = InMemoryContractRegistry.from_latest_publication(
+        network=eth_staking_network
     )
-
-    password = click.prompt(
-        "Enter your keystore password", confirmation_prompt=False, hide_input=True
-    )
-    signer.unlock_account(account=account_address, password=password)
-    transacting_power = TransactingPower(signer=signer, account=account_address)
-
-    emitter.echo(
-        f"Commencing DKG Ritual on {coordinator_network} using {account_address}",
-        color="green",
-    )
-
-    # find staking addresses
-    _, staking_providers_dict = application_agent.get_all_active_staking_providers()
-    staking_providers = list(staking_providers_dict.keys())
-    staking_providers.remove(
-        "0x7AFDa7e47055CDc597872CA34f9FE75bD083D0Fe"
-    )  # TODO skip Bogdan's node; remove at some point
-
-    # sample then sort
-    dkg_staking_providers = random.sample(staking_providers, 2)
-    dkg_staking_providers.sort()
-    emitter.echo(f"Using staking providers for DKG: {dkg_staking_providers}")
-    receipt = coordinator_agent.initiate_ritual(
-        dkg_staking_providers, transacting_power
-    )
-    start_ritual_event = (
-        coordinator_agent.contract.events.StartRitual().process_receipt(receipt)
-    )
-    ritual_id = start_ritual_event[0]["args"]["ritualId"]
-    ritual_status = coordinator_agent.get_ritual_status(ritual_id)
-    assert (
-        ritual_status != coordinator_agent.Ritual.Status.NON_INITIATED
-    ), "ritual successfully initiated"
-
-    emitter.echo(
-        f"DKG Ritual #{ritual_id} initiated: {Web3.to_hex(receipt['transactionHash'])}",
-        color="green",
-    )
+    application_agent = ContractAgency.get_agent(
+        agent_class=PREApplicationAgent,
+        registry=staking_network_registry,
+        provider_uri=eth_provider_uri,
+    )  # type: PREApplicationAgent
 
     #
-    # Wait for Ritual to complete
-    # TODO perhaps reuse EventActuator here
+    # Initial Ritual
     #
-    start_time = time.time()
-    while True:
-        ritual_status = coordinator_agent.get_ritual_status(ritual_id)
+    if ritual_id < 0:
+        emitter.echo("--------- Initiating Ritual ---------", color="yellow")
+        # create account from keystore file
+        signer = Signer.from_signer_uri(uri=signer_uri)
+        account_address = signer.accounts[0]
+        emitter.echo(
+            f"Using account {account_address} to initiate DKG Ritual", color="green"
+        )
 
-        if ritual_status == coordinator_agent.Ritual.Status.FINALIZED:
-            break
-
-        if (
-            ritual_status == coordinator_agent.Ritual.Status.TIMEOUT
-            or ritual_status == coordinator_agent.Ritual.Status.INVALID
-        ):
-            emitter.error(f"Ritual #{ritual_id} failed with status {ritual_status}")
-            sys.exit(-1)
+        password = click.prompt(
+            "Enter your keystore password", confirmation_prompt=False, hide_input=True
+        )
+        signer.unlock_account(account=account_address, password=password)
+        transacting_power = TransactingPower(signer=signer, account=account_address)
 
         emitter.echo(
-            f"Waiting for Ritual to complete; {time.time() - start_time}s elapsed thus far"
+            f"Commencing DKG Ritual on {coordinator_network} using {account_address}",
+            color="green",
         )
-        time.sleep(10)
 
-    emitter.echo(
-        f"DKG Ritual #{ritual_id} completed after {time.time() - start_time}s",
-        color="green",
+        # find staking addresses
+        _, staking_providers_dict = application_agent.get_all_active_staking_providers()
+        staking_providers = list(staking_providers_dict.keys())
+        staking_providers.remove(
+            "0x7AFDa7e47055CDc597872CA34f9FE75bD083D0Fe"
+        )  # TODO skip Bogdan's node; remove at some point
+
+        # sample then sort
+        dkg_staking_providers = random.sample(staking_providers, 2)
+        dkg_staking_providers.sort()
+        emitter.echo(f"Using staking providers for DKG: {dkg_staking_providers}")
+        receipt = coordinator_agent.initiate_ritual(
+            dkg_staking_providers, transacting_power
+        )
+        start_ritual_event = (
+            coordinator_agent.contract.events.StartRitual().process_receipt(receipt)
+        )
+        ritual_id = start_ritual_event[0]["args"]["ritualId"]
+        ritual_status = coordinator_agent.get_ritual_status(ritual_id)
+        assert (
+            ritual_status != coordinator_agent.Ritual.Status.NON_INITIATED
+        ), "ritual successfully initiated"
+
+        emitter.echo(
+            f"DKG Ritual #{ritual_id} initiated: {Web3.to_hex(receipt['transactionHash'])}",
+            color="green",
+        )
+
+        #
+        # Wait for Ritual to complete
+        # TODO perhaps reuse EventActuator here
+        #
+        start_time = maya.now()
+        while True:
+            ritual_status = coordinator_agent.get_ritual_status(ritual_id)
+
+            if ritual_status == coordinator_agent.Ritual.Status.FINALIZED:
+                break
+
+            if (
+                ritual_status == coordinator_agent.Ritual.Status.TIMEOUT
+                or ritual_status == coordinator_agent.Ritual.Status.INVALID
+            ):
+                emitter.error(f"Ritual #{ritual_id} failed with status {ritual_status}")
+                sys.exit(-1)
+
+            emitter.echo(
+                f"Waiting for Ritual to complete; {(maya.now() - start_time).seconds}s elapsed thus far"
+            )
+            time.sleep(15)
+
+        emitter.echo(
+            f"DKG Ritual #{ritual_id} completed after {(maya.now() - start_time).seconds}s",
+            color="green",
+        )
+    else:
+        # ensure ritual exists
+        _ = coordinator_agent.get_ritual(ritual_id)  # ensure ritual can be found
+        emitter.echo(f"Reusing existing DKG Ritual #{ritual_id}", color="green")
+
+    #
+    # Encrypt some data
+    #
+    emitter.echo("--------- Data Encryption ---------")
+
+    PLAINTEXT = """
+    Those who mistake the unessential to be essential and the essential to be unessential,
+    dwelling in wrong thoughts, never arrive at the essential.
+    
+    Those who know the essential to be essential and the unessential to be unessential,
+    dwelling in right thoughts, do arrive at the essential.
+    """
+    # -- Dhammapada
+
+    CONDITIONS = {
+        "version": ConditionLingo.VERSION,
+        "condition": {
+            "returnValueTest": {"value": "0", "comparator": ">"},
+            "method": "blocktime",
+            "chain": application_agent.blockchain.client.chain_id,
+        },
+    }
+
+    encrypting_key = DkgPublicKey.from_bytes(
+        bytes(coordinator_agent.get_ritual(ritual_id).public_key)
     )
-else:
-    ritual = coordinator_agent.get_ritual(ritual_id)  # ensure ritual can be found
-    emitter.echo(f"Reusing existing DKG Ritual #{ritual_id}", color="green")
 
-#
-# Encrypt some data
-#
-emitter.echo("--------- Data Encryption ---------")
+    enrico = Enrico(encrypting_key=encrypting_key)
+    ciphertext = enrico.encrypt_for_dkg(
+        plaintext=PLAINTEXT.encode(), conditions=CONDITIONS
+    )
 
-PLAINTEXT = """
-Those who mistake the unessential to be essential and the essential to be unessential,
-dwelling in wrong thoughts, never arrive at the essential.
+    emitter.echo("-- Data encrypted --", color="green")
 
-Those who know the essential to be essential and the unessential to be unessential,
-dwelling in right thoughts, do arrive at the essential.
-"""
-# -- Dhammapada
+    #
+    # Get Data Decrypted
+    #
+    emitter.echo("--------- Threshold Decryption ---------")
+    bob = Bob(
+        eth_provider_uri=eth_provider_uri,
+        domain=eth_staking_network,
+        registry=staking_network_registry,
+        coordinator_network=coordinator_network,
+        coordinator_provider_uri=coordinator_provider_uri,
+    )
+    bob.start_learning_loop(now=True)
 
-CONDITIONS = {
-    "version": ConditionLingo.VERSION,
-    "condition": {
-        "returnValueTest": {"value": "0", "comparator": ">"},
-        "method": "blocktime",
-        "chain": application_agent.blockchain.client.chain_id,
-    },
-}
+    cleartext = bob.threshold_decrypt(
+        ritual_id=ritual_id,
+        ciphertext=ciphertext,
+        conditions=CONDITIONS,
+    )
 
-encrypting_key = DkgPublicKey.from_bytes(
-    bytes(coordinator_agent.get_ritual(ritual_id).public_key)
-)
+    emitter.echo(f"\n-- Data decrypted -- \n{bytes(cleartext).decode()}", color="green")
+    assert bytes(cleartext).decode() == PLAINTEXT
 
-enrico = Enrico(encrypting_key=encrypting_key)
-ciphertext = enrico.encrypt_for_dkg(plaintext=PLAINTEXT.encode(), conditions=CONDITIONS)
 
-emitter.echo("-- Data encrypted --", color="green")
-
-#
-# Get Data Decrypted
-#
-emitter.echo("--------- Threshold Decryption ---------")
-bob = Bob(
-    eth_provider_uri=eth_provider_uri,
-    domain=staking_network,
-    registry=staking_network_registry,
-    coordinator_network=coordinator_network,
-    coordinator_provider_uri=coordinator_provider_uri,
-)
-bob.start_learning_loop(now=True)
-
-cleartext = bob.threshold_decrypt(
-    ritual_id=ritual_id,
-    ciphertext=ciphertext,
-    conditions=CONDITIONS,
-)
-
-emitter.echo(f"\n-- Data decrypted -- \n{bytes(cleartext).decode()}", color="green")
-assert bytes(cleartext).decode() == PLAINTEXT
+if __name__ == "__main__":
+    nucypher_dkg()


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Update `nucypher_dkg` script to use `click` instead of exec args.

Successfully created rituals # 14 and # 15 on `lynx` using the script.

```
$ python ./scripts/hooks/nucypher_dkg.py --eth-provider <> --coordinator-provider <> --ritual-id -1 --signer keystore://<>
...
--------- Initiating Ritual ---------
Using account 0xfDd99d58a7D5696c4f757fAFcAc401d5c9AB87A3 to initiate DKG Ritual
Enter your keystore password:
Commencing DKG Ritual on mumbai using 0xfDd99d58a7D5696c4f757fAFcAc401d5c9AB87A3
Using staking providers for DKG: ['0x210eeAC07542F815ebB6FD6689637D8cA2689392', '0xb15d5A4e2be34f4bE154A1b08a94Ab920FfD8A41']
Broadcasting INITIATERITUAL Legacy Transaction (0.00022690050453801 ETH @ 1.50000003 gwei)
TXHASH 0xeb8485c8d4bc2d4fb004aed4a88ee4e0eac5b27752f6020143c763a37f44c6e1
Waiting 600 seconds for receipt
DKG Ritual #15 initiated: 0xeb8485c8d4bc2d4fb004aed4a88ee4e0eac5b27752f6020143c763a37f44c6e1
Waiting for Ritual to complete; 0s elapsed thus far
Waiting for Ritual to complete; 20s elapsed thus far
Waiting for Ritual to complete; 40s elapsed thus far
Waiting for Ritual to complete; 60s elapsed thus far
Waiting for Ritual to complete; 80s elapsed thus far
DKG Ritual #15 completed after 101s
--------- Data Encryption ---------
...
```

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
