### PR TITLE
Set default ferveo variant to `simple` instead of `precomputed`

### DIFF
--- a/newsfragments/3174.feature.rst
+++ b/newsfragments/3174.feature.rst
@@ -1,0 +1,1 @@
+Reset default ferveo variant to be ``simple``. We can revisit whenever we add logic to properly deal with request failures for the ``precomputed`` variant.

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -199,8 +199,7 @@ class DKGOmniscientDecryptionClient(ThresholdDecryptionClient):
             ciphertext = decrypted_encryption_request.ciphertext
             conditions_bytes = str(decrypted_encryption_request.conditions).encode()
 
-            # Presuming simple for now.  Is this OK?
-            decryption_share = aggregate.create_decryption_share_precomputed(
+            decryption_share = aggregate.create_decryption_share_simple(
                 dkg=dkg,
                 ciphertext=ciphertext,
                 aad=conditions_bytes,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -438,7 +438,7 @@ class Alice(Character, actors.PolicyAuthor):
 
 class Bob(Character):
     banner = BOB_BANNER
-    default_dkg_variant = FerveoVariant.PRECOMPUTED
+    default_dkg_variant = FerveoVariant.SIMPLE
     _default_crypto_powerups = [SigningPower, DecryptingPower]
     _threshold_decryption_client_class = ThresholdDecryptionClient
 
@@ -745,7 +745,7 @@ class Bob(Character):
         conditions: Lingo,
         context: Optional[dict] = None,
         ursulas: Optional[List["Ursula"]] = None,
-        variant: str = "precomputed",
+        variant: str = "simple",
         peering_timeout: int = 60,
     ) -> bytes:
         ritual = self.get_ritual_from_id(ritual_id)
@@ -1510,7 +1510,7 @@ class Enrico:
     """A data source that encrypts data for some policy's public key"""
 
     banner = ENRICO_BANNER
-    default_dkg_variant = FerveoVariant.PRECOMPUTED
+    default_dkg_variant = FerveoVariant.SIMPLE
 
     def __init__(self, encrypting_key: Union[PublicKey, DkgPublicKey]):
         self.signing_power = SigningPower()

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from eth_account._utils.signing import to_standard_signature_bytes
 from eth_typing.evm import ChecksumAddress
@@ -17,6 +17,7 @@ from nucypher_core import (
 from nucypher_core.ferveo import (
     AggregatedTranscript,
     Ciphertext,
+    DecryptionSharePrecomputed,
     DecryptionShareSimple,
     DkgPublicKey,
     Transcript,
@@ -276,7 +277,7 @@ class RitualisticPower(KeyPairBasedPower):
             ciphertext: Ciphertext,
             conditions: bytes,
             variant: FerveoVariant
-    ) -> DecryptionShareSimple:
+    ) -> Union[DecryptionShareSimple, DecryptionSharePrecomputed]:
         decryption_share = dkg.derive_decryption_share(
             ritual_id=ritual_id,
             me=Validator(address=checksum_address, public_key=self.keypair.pubkey),


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Until we get better logic for handling any failures during `precomputed` variant, the `simple` variant should be our default.

**Issues fixed/closed:**
Related to #3143 .

**Why it's needed:**

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
