### PR TITLE
Use ritual_id properly as a seed

### DIFF
--- a/newsfragments/3178.bugfix.rst
+++ b/newsfragments/3178.bugfix.rst
@@ -1,0 +1,1 @@
+Properly convert ritual id to bytes when being used as a seed for generating a session key.

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -346,7 +346,7 @@ class ThresholdRequestDecryptingPower(DerivedKeyBasedPower):
         self.__request_key_factory = session_secret_factory
 
     def _get_static_secret_from_ritual_id(self, ritual_id: int) -> SessionStaticSecret:
-        return self.__request_key_factory.make_key(bytes(ritual_id))
+        return self.__request_key_factory.make_key(bytes(ritual_id.to_bytes(4, "big")))
 
     def get_pubkey_from_ritual_id(self, ritual_id: int) -> SessionStaticKey:
         return self._get_static_secret_from_ritual_id(ritual_id).public_key()


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Ritual id was not being used correctly as a seed when generating a key for dkg decryption sessions.

**Issues fixed/closed:**

Fixes #3175 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
