### PR TITLE
Simplify simplified tooling - remove return of TDR when encrypting

### DIFF
--- a/examples/tdec/simple_tdec_local.py
+++ b/examples/tdec/simple_tdec_local.py
@@ -19,30 +19,18 @@ before_the_beginning_of_time = {
     },
 }
 
-ciphertext, tdr = enrico.encrypt_for_dkg_and_produce_decryption_request(
+ciphertext = enrico.encrypt_for_dkg(
     plaintext=plaintext,
     conditions=before_the_beginning_of_time,
-    ritual_id=ANYTHING_CAN_BE_PASSED_AS_RITUAL_ID,
 )
 
-cleartest_from_tdr = bob.threshold_decrypt(
+cleartext_from_ciphertext = bob.threshold_decrypt(
     ciphertext=ciphertext,
     ritual_id=ANYTHING_CAN_BE_PASSED_AS_RITUAL_ID,
     conditions=before_the_beginning_of_time,
 )
 
-cohort = bob._dkg_insight.fake_ritual.fake_nodes
-
-cleartext_from_ciphertext = bob.decrypt_using_existing_decryption_request(
-    tdr,
-    participant_public_keys=bob._dkg_insight.fake_ritual.participant_public_keys,
-    cohort=cohort,
-    threshold=1,
-)
-
 decoded_cleartext_from_ciphertext = bytes(cleartext_from_ciphertext)
-decoded_cleartext_from_tdr = bytes(cleartest_from_tdr)
 
 assert decoded_cleartext_from_ciphertext == plaintext
-assert plaintext == decoded_cleartext_from_tdr
 print(f"Decrypted cleartext: {decoded_cleartext_from_ciphertext}")

--- a/newsfragments/3174.feature.rst
+++ b/newsfragments/3174.feature.rst
@@ -1,0 +1,1 @@
+Reset default ferveo variant to be ``simple``. We can revisit whenever we add logic to properly deal with request failures for the ``precomputed`` variant.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -15,7 +15,10 @@ from nucypher_core import (
 from nucypher_core.ferveo import (
     AggregatedTranscript,
     Ciphertext,
+    DecryptionSharePrecomputed,
+    DecryptionShareSimple,
     FerveoPublicKey,
+    Transcript,
     Validator,
 )
 from web3 import Web3
@@ -41,7 +44,7 @@ from nucypher.blockchain.eth.signers import Signer
 from nucypher.blockchain.eth.token import NU
 from nucypher.blockchain.eth.trackers import dkg
 from nucypher.blockchain.eth.trackers.pre import WorkTracker
-from nucypher.crypto.ferveo.dkg import DecryptionShareSimple, FerveoVariant, Transcript
+from nucypher.crypto.ferveo.dkg import FerveoVariant
 from nucypher.crypto.powers import (
     CryptoPower,
     RitualisticPower,
@@ -571,7 +574,7 @@ class Ritualist(BaseActor):
         ciphertext: Ciphertext,
         conditions: ConditionLingo,
         variant: FerveoVariant
-    ) -> DecryptionShareSimple:
+    ) -> Union[DecryptionShareSimple, DecryptionSharePrecomputed]:
         ritual = self.coordinator_agent.get_ritual(ritual_id)
         status = self.coordinator_agent.get_ritual_status(ritual_id=ritual_id)
         if status != CoordinatorAgent.Ritual.Status.FINALIZED:

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -199,8 +199,7 @@ class DKGOmniscientDecryptionClient(ThresholdDecryptionClient):
             ciphertext = decrypted_encryption_request.ciphertext
             conditions_bytes = str(decrypted_encryption_request.conditions).encode()
 
-            # Presuming simple for now.  Is this OK?
-            decryption_share = aggregate.create_decryption_share_precomputed(
+            decryption_share = aggregate.create_decryption_share_simple(
                 dkg=dkg,
                 ciphertext=ciphertext,
                 aad=conditions_bytes,

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -182,7 +182,7 @@ class DKGOmniscientDecryptionClient(ThresholdDecryptionClient):
         aggregate = ferveo.AggregatedTranscript(validator_messages)
         assert aggregate.verify(
             self._learner._dkg_insight.shares_num,
-            # TODO this list should have to be passed again (either make `verify` static or use list
+            # TODO this list should not have to be passed again (either make `verify` static or use list
             #  provided in constructor
             validator_messages,
         )

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -438,7 +438,7 @@ class Alice(Character, actors.PolicyAuthor):
 
 class Bob(Character):
     banner = BOB_BANNER
-    default_dkg_variant = FerveoVariant.PRECOMPUTED
+    default_dkg_variant = FerveoVariant.SIMPLE
     _default_crypto_powerups = [SigningPower, DecryptingPower]
     _threshold_decryption_client_class = ThresholdDecryptionClient
 
@@ -745,7 +745,7 @@ class Bob(Character):
         conditions: Lingo,
         context: Optional[dict] = None,
         ursulas: Optional[List["Ursula"]] = None,
-        variant: str = "precomputed",
+        variant: str = "simple",
         peering_timeout: int = 60,
     ) -> bytes:
         ritual = self.get_ritual_from_id(ritual_id)
@@ -1510,7 +1510,7 @@ class Enrico:
     """A data source that encrypts data for some policy's public key"""
 
     banner = ENRICO_BANNER
-    default_dkg_variant = FerveoVariant.PRECOMPUTED
+    default_dkg_variant = FerveoVariant.SIMPLE
 
     def __init__(self, encrypting_key: Union[PublicKey, DkgPublicKey]):
         self.signing_power = SigningPower()

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -1,5 +1,5 @@
 import inspect
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from eth_account._utils.signing import to_standard_signature_bytes
 from eth_typing.evm import ChecksumAddress
@@ -17,6 +17,7 @@ from nucypher_core import (
 from nucypher_core.ferveo import (
     AggregatedTranscript,
     Ciphertext,
+    DecryptionSharePrecomputed,
     DecryptionShareSimple,
     DkgPublicKey,
     Transcript,
@@ -276,7 +277,7 @@ class RitualisticPower(KeyPairBasedPower):
             ciphertext: Ciphertext,
             conditions: bytes,
             variant: FerveoVariant
-    ) -> DecryptionShareSimple:
+    ) -> Union[DecryptionShareSimple, DecryptionSharePrecomputed]:
         decryption_share = dkg.derive_decryption_share(
             ritual_id=ritual_id,
             me=Validator(address=checksum_address, public_key=self.keypair.pubkey),

--- a/tests/integration/characters/test_dkg_and_testnet_bypass.py
+++ b/tests/integration/characters/test_dkg_and_testnet_bypass.py
@@ -35,19 +35,18 @@ def _attempt_decryption(BobClass, plaintext):
         },
     }
 
-    ciphertext, tdr = enrico.encrypt_for_dkg_and_produce_decryption_request(
+    ciphertext = enrico.encrypt_for_dkg(
         plaintext=plaintext,
         conditions=definitely_false_condition,
-        ritual_id=ANYTHING_CAN_BE_PASSED_AS_RITUAL_DATA,
     )
 
-    decrypted_cleartext_from_ciphertext_list = bob.threshold_decrypt(
-        ciphertext=ciphertext,
+    decrypted_cleartext = bob.threshold_decrypt(
         ritual_id=ANYTHING_CAN_BE_PASSED_AS_RITUAL_DATA,
+        ciphertext=ciphertext,
         conditions=definitely_false_condition,
     )
 
-    return decrypted_cleartext_from_ciphertext_list
+    return decrypted_cleartext
 
 
 def test_user_controls_success():
@@ -65,4 +64,4 @@ def test_user_controls_success():
 def test_user_controls_failure():
     plaintext = b"ever thus to deadbeats"
     with pytest.raises(Ursula.NotEnoughUrsulas) as e:
-        result = _attempt_decryption(ThisBobAlwaysFails, plaintext)
+        _ = _attempt_decryption(ThisBobAlwaysFails, plaintext)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Removes the ThresholdDecryptionRequest being returned by Enrico.

**Issues fixed/closed:**
Based over #3174 .

Related to #3143 

**Why it's needed:**
Threshold Decryption Requests should not be returned by Enrico. It is really a decryption object that Bob populates because it contains `variant` and the `context` dictionary (think Bob signing to prove ownership of a wallet). Therefore, the TDR should only be constructed by Bob and not Enrico.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
