### PR TITLE
Node DKG Ritual event handling robustness

### DIFF
--- a/newsfragments/3183.misc.rst
+++ b/newsfragments/3183.misc.rst
@@ -1,0 +1,1 @@
+Ensure that nodes can be more resilient when handling events related to rituals.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -396,7 +396,8 @@ class Ritualist(BaseActor):
         receipt = self.coordinator_agent.post_transcript(
             ritual_id=ritual_id,
             transcript=transcript,
-            transacting_power=self.transacting_power
+            transacting_power=self.transacting_power,
+            fire_and_forget=True,
         )
         return receipt
 
@@ -416,7 +417,8 @@ class Ritualist(BaseActor):
             aggregated_transcript=aggregated_transcript,
             public_key=public_key,
             participant_public_key=participant_public_key,
-            transacting_power=self.transacting_power
+            transacting_power=self.transacting_power,
+            fire_and_forget=True,
         )
         return receipt
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -339,13 +339,6 @@ class Ritualist(BaseActor):
             ThresholdRequestDecryptingPower
         )  # used for secure decryption request channel
 
-    def get_ritual(self, ritual_id: int) -> CoordinatorAgent.Ritual:
-        try:
-            ritual = self.ritual_tracker.rituals[ritual_id]
-        except KeyError:
-            raise self.ActorError(f"{ritual_id} is not in the local cache")
-        return ritual
-
     def _resolve_validators(
             self,
             ritual: CoordinatorAgent.Ritual,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -329,9 +329,8 @@ class Ritualist(BaseActor):
         self.publish_finalization = (
             publish_finalization  # publish the DKG final key if True
         )
-        self.dkg_storage = (
-            DKGStorage()
-        )  # TODO: #3052 stores locally generated public DKG artifacts (is this still needed?)
+        # TODO: #3052 stores locally generated public DKG artifacts
+        self.dkg_storage = DKGStorage()
         self.ritual_power = crypto_power.power_ups(
             RitualisticPower
         )  # ferveo material contained within

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -452,6 +452,14 @@ class Ritualist(BaseActor):
             )
             return None
 
+        # pending tx
+        pending_tx = self.dkg_storage.get_transcript_receipt(ritual_id=ritual_id)
+        if pending_tx:
+            self.log.debug(
+                f"Node {self.transacting_power.account} has pending tx {pending_tx} for posting transcript for ritual {ritual_id}; skipping execution"
+            )
+            return None
+
         # TODO - process pending receipts before submitting a new tx (perhaps tx already submitted, but not finalized
         self.log.debug(f"performing round 1 of DKG ritual #{ritual_id} from blocktime {timestamp}")
 
@@ -513,6 +521,16 @@ class Ritualist(BaseActor):
         if participant.aggregated:
             self.log.debug(
                 f"Node {self.transacting_power.account} has already posted an aggregated transcript for ritual {ritual_id}; skipping execution"
+            )
+            return None
+
+        # has pending tx
+        pending_tx = self.dkg_storage.get_aggregated_transcript_receipt(
+            ritual_id=ritual_id
+        )
+        if pending_tx:
+            self.log.debug(
+                f"Node {self.transacting_power.account} has pending tx {pending_tx} for posting aggregated transcript for ritual {ritual_id}; skipping execution"
             )
             return None
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -421,7 +421,7 @@ class Ritualist(BaseActor):
         initiator: ChecksumAddress,
         participants: List[ChecksumAddress],
         timestamp: int,
-    ):
+    ) -> HexBytes:
         """Perform round 1 of the DKG protocol for a given ritual ID on this node."""
         if self.checksum_address not in participants:
             # should never get here
@@ -441,7 +441,7 @@ class Ritualist(BaseActor):
             self.log.debug(
                 f"ritual #{ritual_id} is not waiting for transcripts; status={status}; skipping execution"
             )
-            return
+            return None
 
         # validate the active ritual tracker state
         participant = self.coordinator_agent.get_participant_from_provider(
@@ -451,7 +451,7 @@ class Ritualist(BaseActor):
             self.log.debug(
                 f"Node {self.transacting_power.account} has already posted a transcript for ritual {ritual_id}; skipping execution"
             )
-            return
+            return None
 
         # TODO - process pending receipts before submitting a new tx (perhaps tx already submitted, but not finalized
         self.log.debug(f"performing round 1 of DKG ritual #{ritual_id} from blocktime {timestamp}")
@@ -494,7 +494,7 @@ class Ritualist(BaseActor):
         )
         return tx_hash
 
-    def perform_round_2(self, ritual_id: int, timestamp: int):
+    def perform_round_2(self, ritual_id: int, timestamp: int) -> HexBytes:
         """Perform round 2 of the DKG protocol for the given ritual ID on this node."""
 
         # Get the ritual and check the status from the blockchain
@@ -505,7 +505,7 @@ class Ritualist(BaseActor):
             self.log.debug(
                 f"ritual #{ritual_id} is not waiting for aggregations; status={status}; skipping execution"
             )
-            return
+            return None
 
         # validate the active ritual tracker state
         participant = self.coordinator_agent.get_participant_from_provider(
@@ -515,7 +515,7 @@ class Ritualist(BaseActor):
             self.log.debug(
                 f"Node {self.transacting_power.account} has already posted an aggregated transcript for ritual {ritual_id}; skipping execution"
             )
-            return
+            return None
 
         # TODO - process pending receipts before submitting a new tx (perhaps tx already submitted, but not finalized
         self.log.debug(

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -17,7 +17,7 @@ from nucypher_core.ferveo import (
     Ciphertext,
     DecryptionSharePrecomputed,
     DecryptionShareSimple,
-    FerveoPublicKey,
+    DkgPublicKey,
     Transcript,
     Validator,
 )
@@ -404,7 +404,7 @@ class Ritualist(BaseActor):
         self,
         ritual_id: int,
         aggregated_transcript: AggregatedTranscript,
-        public_key: FerveoPublicKey,
+        public_key: DkgPublicKey,
     ) -> TxReceipt:
         """Publish an aggregated transcript to publicly available storage."""
         # look up the node index for this node on the blockchain

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -431,8 +431,7 @@ class Ritualist(BaseActor):
                 f"Not part of ritual {ritual_id}; don't post transcript"
             )
 
-        # get the ritual and check its status from the blockchain
-        ritual = self.coordinator_agent.get_ritual(ritual_id, with_participants=True)
+        # check ritual status from the blockchain
         status = self.coordinator_agent.get_ritual_status(ritual_id=ritual_id)
 
         # validate the status
@@ -464,6 +463,7 @@ class Ritualist(BaseActor):
         self.log.debug(f"performing round 1 of DKG ritual #{ritual_id} from blocktime {timestamp}")
 
         # gather the cohort
+        ritual = self.coordinator_agent.get_ritual(ritual_id, with_participants=True)
         nodes, transcripts = list(zip(*self._resolve_validators(ritual)))
         nodes = sorted(nodes, key=lambda n: n.address)
         if any(transcripts):
@@ -506,7 +506,6 @@ class Ritualist(BaseActor):
 
         # Get the ritual and check the status from the blockchain
         # TODO Optimize local cache of ritual participants (#3052)
-        ritual = self.coordinator_agent.get_ritual(ritual_id, with_participants=True)
         status = self.coordinator_agent.get_ritual_status(ritual_id=ritual_id)
         if status != CoordinatorAgent.Ritual.Status.AWAITING_AGGREGATIONS:
             self.log.debug(
@@ -539,6 +538,7 @@ class Ritualist(BaseActor):
             f"{self.transacting_power.account[:8]} performing round 2 of DKG ritual #{ritual_id} from blocktime {timestamp}"
         )
 
+        ritual = self.coordinator_agent.get_ritual(ritual_id, with_participants=True)
         transcripts = self._resolve_validators(ritual)
         if not all([t for _, t in transcripts]):
             raise self.ActorError(

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -729,12 +729,16 @@ class CoordinatorAgent(EthereumContractAgent):
         ritual_id: int,
         transcript: Transcript,
         transacting_power: TransactingPower,
+        fire_and_forget: bool = False,
     ) -> TxReceipt:
         contract_function: ContractFunction = self.contract.functions.postTranscript(
             ritualId=ritual_id, transcript=bytes(transcript)
         )
-        receipt = self.blockchain.send_transaction(contract_function=contract_function,
-                                                   transacting_power=transacting_power)
+        receipt = self.blockchain.send_transaction(
+            contract_function=contract_function,
+            transacting_power=transacting_power,
+            fire_and_forget=fire_and_forget,
+        )
         return receipt
 
     @contract_api(TRANSACTION)
@@ -745,6 +749,7 @@ class CoordinatorAgent(EthereumContractAgent):
         public_key: DkgPublicKey,
         participant_public_key: SessionStaticKey,
         transacting_power: TransactingPower,
+        fire_and_forget: bool = False,
     ) -> TxReceipt:
         contract_function: ContractFunction = self.contract.functions.postAggregation(
             ritualId=ritual_id,
@@ -754,7 +759,8 @@ class CoordinatorAgent(EthereumContractAgent):
         )
         receipt = self.blockchain.send_transaction(
             contract_function=contract_function,
-            transacting_power=transacting_power
+            transacting_power=transacting_power,
+            fire_and_forget=fire_and_forget,
         )
         return receipt
 

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -4,7 +4,18 @@ import sys
 from bisect import bisect_right
 from dataclasses import dataclass, field
 from itertools import accumulate
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Type, cast
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
 
 from constant_sorrow.constants import (
     CONTRACT_ATTRIBUTE,  # type: ignore
@@ -13,6 +24,7 @@ from constant_sorrow.constants import (
 )
 from eth_typing.evm import ChecksumAddress
 from eth_utils.address import to_checksum_address
+from hexbytes import HexBytes
 from nucypher_core import SessionStaticKey
 from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Transcript
 from web3.contract.contract import Contract, ContractFunction
@@ -730,7 +742,7 @@ class CoordinatorAgent(EthereumContractAgent):
         transcript: Transcript,
         transacting_power: TransactingPower,
         fire_and_forget: bool = False,
-    ) -> TxReceipt:
+    ) -> Union[TxReceipt, HexBytes]:
         contract_function: ContractFunction = self.contract.functions.postTranscript(
             ritualId=ritual_id, transcript=bytes(transcript)
         )
@@ -750,7 +762,7 @@ class CoordinatorAgent(EthereumContractAgent):
         participant_public_key: SessionStaticKey,
         transacting_power: TransactingPower,
         fire_and_forget: bool = False,
-    ) -> TxReceipt:
+    ) -> Union[TxReceipt, HexBytes]:
         contract_function: ContractFunction = self.contract.functions.postAggregation(
             ritualId=ritual_id,
             aggregatedTranscript=bytes(aggregated_transcript),

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -126,7 +126,7 @@ class ActiveRitualTracker:
         )
 
         self.task = EventScannerTask(scanner=self.scan)
-        self.participation_states = dict()  # { ritual_id -> ParticipationState }
+        self._participation_states = dict()  # { ritual_id -> ParticipationState }
 
     @property
     def provider(self):
@@ -241,11 +241,11 @@ class ActiveRitualTracker:
                 f"Unexpected event type: '{event_type}'; no ritual id as argument"
             )
 
-        participation_state = self.participation_states.get(ritual_id)
+        participation_state = self._participation_states.get(ritual_id)
         if not participation_state:
             # not previously tracked
             participation_state = self.ParticipationState()
-            self.participation_states[ritual_id] = participation_state
+            self._participation_states[ritual_id] = participation_state
             state_already_tracked = False
         else:
             state_already_tracked = True
@@ -255,7 +255,7 @@ class ActiveRitualTracker:
             if event_type == self.contract.events.EndRitual:
                 # be sure to remove for EndRitual before returning
                 # since not participating we don't care about setting the other state values
-                self.participation_states.pop(ritual_id)
+                self._participation_states.pop(ritual_id)
 
             return participation_state
 
@@ -296,7 +296,7 @@ class ActiveRitualTracker:
             # previously tracked
 
             # ritual is over no need to track the state anymore
-            self.participation_states.pop(ritual_id)
+            self._participation_states.pop(ritual_id)
 
             # gather state information
             if state_already_tracked:

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -183,7 +183,7 @@ class ActiveRitualTracker:
         """Stop the event scanner task."""
         return self.task.stop()
 
-    def _action_required(self, ritual_event: AttributeDict):
+    def _action_required(self, ritual_event: AttributeDict) -> bool:
         """Check if an action is required for a given ritual event."""
         # establish participation state first
         participation_state = self._get_participation_state(ritual_event)

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -320,7 +320,7 @@ class ActiveRitualTracker:
                 # not successful - and unsure of state values
                 # obtain information from contract
                 (
-                    _,
+                    _,  # participating ignored - we know we are participating
                     posted_transcript,
                     posted_aggregate,
                 ) = self._get_participation_state_values_from_contract(

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -212,9 +212,14 @@ class ActiveRitualTracker:
         args = event.args
 
         # check for participation
-        participation_state = self.participation_states.get(args.ritualId)
+        try:
+            participation_state = self.participation_states.get(args.ritualId)
+        except AttributeError:
+            raise ValueError(f"Unexpected event type: {event_type}")
+
         if not participation_state:
-            # unsure about anything; create bare-bones state (default values); need to do more processing
+            # not previously tracked
+            # create bare-bones state (default values) and do more processing
             participation_state = self.ParticipationState()
             self.participation_states[args.ritualId] = participation_state
             state_already_tracked = False
@@ -262,7 +267,9 @@ class ActiveRitualTracker:
             # ritual is over no need to track the state anymore
             self.participation_states.pop(args.ritualId, None)
         else:
-            raise ValueError(f"unprocessed event type: {event_type}")
+            # should never happen since we specify the list of events we
+            # want to receive (1st level of filtering)
+            raise ValueError(f"Unexpected event type: {event_type}")
 
         # what did we learn
         if not participation_state.participating:

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -89,8 +89,6 @@ class ActiveRitualTracker:
         self.ritualist = ritualist
         self.coordinator_agent = ritualist.coordinator_agent
 
-        self.rituals = dict()  # TODO: use persistent storage?
-
         # Restore/create persistent event scanner state
         self.persistent = persistent
         self.state = JSONifiedState(persistent=persistent)
@@ -309,9 +307,6 @@ class ActiveRitualTracker:
         #  do not use abbreviations in event names (e.g. "DKG" -> "d_k_g")
         formatted_kwargs = {camel_case_to_snake(k): v for k, v in event.args.items()}
         timestamp = int(get_block_when(event.blockNumber).timestamp())
-        ritual_id = event.args.ritualId
-        ritual = self.coordinator_agent.get_ritual(ritual_id=ritual_id)
-        self.add_ritual(ritual_id=ritual_id, ritual=ritual)
         d = self.__execute_action(
             event_type=event_type, timestamp=timestamp, **formatted_kwargs
         )
@@ -349,27 +344,3 @@ class ActiveRitualTracker:
         self.__scan(
             suggested_start_block, end_block, self.ritualist.transacting_power.account
         )
-
-    def add_ritual(self, ritual_id, ritual):
-        self.rituals[ritual_id] = ritual
-        return ritual
-
-    def track_ritual(self, ritual_id: int, ritual=None, transcript=None, confirmations=None, checkin_timestamp=None):
-        try:
-            _ritual = self.rituals[ritual_id]
-        except KeyError:
-            if not ritual:
-                raise ValueError("Ritual not found and no new ritual provided")
-            _ritual = self.add_ritual(ritual_id=ritual_id, ritual=ritual)
-        if ritual_id and ritual:
-            # replace the whole ritual
-            self.rituals[ritual_id] = ritual
-        if transcript:
-            # update the transcript
-            _ritual.transcript = transcript
-        if confirmations:
-            # update the confirmations
-            _ritual.confirmations = confirmations
-        if checkin_timestamp:
-            # update the checkin timestamp
-            _ritual.checkin_timestamp = checkin_timestamp

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -193,18 +193,22 @@ class ActiveRitualTracker:
 
         # does event have an associated action
         event_type = getattr(self.contract.events, ritual_event.event)
-        if event_type not in self.actions:
-            return False
 
-        if (
+        event_has_associated_action = event_type in self.actions
+        already_posted_transcript = (
             event_type == self.contract.events.StartRitual
             and participation_state.already_posted_transcript
-        ):
-            return False
-
-        if (
+        )
+        already_posted_aggregate = (
             event_type == self.contract.events.StartAggregationRound
             and participation_state.already_posted_aggregate
+        )
+        if any(
+            [
+                not event_has_associated_action,
+                already_posted_transcript,
+                already_posted_aggregate,
+            ]
         ):
             return False
 

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -53,7 +53,7 @@ class Uncoordinated:
             FakeNode(checksum_address) for checksum_address in checksum_addresses
         ]
         self.checksum_addresses = checksum_addresses
-        if session_seed == None:
+        if session_seed is None:
             session_seed = b"ABytestringOf32BytesIsNeededHere"
         secret_factory = SessionSecretFactory.from_secure_randomness(session_seed)
         self.threshold_request_decrypting_power = ThresholdRequestDecryptingPower(
@@ -243,7 +243,7 @@ class DoomedDecryptionClient(ThresholdDecryptionClient):
             # TODO: Dehydrate this logic in a single failure flow.
             try:
                 raise RestMiddleware.Unauthorized("Decryption conditions not satisfied")
-            except RestMiddleware.Unauthorized as e:
+            except RestMiddleware.Unauthorized:
                 failures[checksum_address] = sys.exc_info()
 
         return NO_SUCCESSES, failures

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Union
+from typing import Optional, Union
 
 from hexbytes import HexBytes
 from nucypher_core.ferveo import AggregatedTranscript, Transcript
@@ -15,7 +15,7 @@ class DKGStorage:
     def store_transcript(self, ritual_id: int, transcript: Transcript) -> None:
         self.data["transcripts"][ritual_id] = bytes(transcript)
 
-    def get_transcript(self, ritual_id: int) -> Transcript:
+    def get_transcript(self, ritual_id: int) -> Optional[Transcript]:
         data = self.data["transcripts"][ritual_id]
         transcript = Transcript.from_bytes(data)
         return transcript
@@ -25,14 +25,18 @@ class DKGStorage:
     ) -> None:
         self.data["transcript_receipts"][ritual_id] = txhash_or_receipt
 
-    def get_transcript_receipt(self, ritual_id: int) -> Union[TxReceipt, HexBytes]:
-        return self.data["transcript_receipts"][ritual_id]
+    def get_transcript_receipt(
+        self, ritual_id: int
+    ) -> Optional[Union[TxReceipt, HexBytes]]:
+        return self.data["transcript_receipts"].get(ritual_id)
 
     def store_aggregated_transcript(self, ritual_id: int, aggregated_transcript: AggregatedTranscript) -> None:
         self.data["aggregated_transcripts"][ritual_id] = bytes(aggregated_transcript)
 
-    def get_aggregated_transcript(self, ritual_id: int) -> AggregatedTranscript:
-        return self.data["aggregated_transcripts"][ritual_id]
+    def get_aggregated_transcript(
+        self, ritual_id: int
+    ) -> Optional[AggregatedTranscript]:
+        return self.data["aggregated_transcripts"].get(ritual_id)
 
     def store_aggregated_transcript_receipt(
         self, ritual_id: int, txhash_or_receipt: Union[TxReceipt, HexBytes]
@@ -41,11 +45,11 @@ class DKGStorage:
 
     def get_aggregated_transcript_receipt(
         self, ritual_id: int
-    ) -> Union[TxReceipt, HexBytes]:
-        return self.data["aggregated_transcript_receipts"][ritual_id]
+    ) -> Optional[Union[TxReceipt, HexBytes]]:
+        return self.data["aggregated_transcript_receipts"].get(ritual_id)
 
     def store_public_key(self, ritual_id: int, public_key: bytes) -> None:
         self.data["public_keys"][ritual_id] = public_key
 
-    def get_public_key(self, ritual_id: int) -> bytes:
-        return self.data["public_keys"][ritual_id]
+    def get_public_key(self, ritual_id: int) -> Optional[bytes]:
+        return self.data["public_keys"].get(ritual_id)

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -16,7 +16,10 @@ class DKGStorage:
         self.data["transcripts"][ritual_id] = bytes(transcript)
 
     def get_transcript(self, ritual_id: int) -> Optional[Transcript]:
-        data = self.data["transcripts"][ritual_id]
+        data = self.data["transcripts"].get(ritual_id)
+        if not data:
+            return None
+
         transcript = Transcript.from_bytes(data)
         return transcript
 
@@ -36,7 +39,12 @@ class DKGStorage:
     def get_aggregated_transcript(
         self, ritual_id: int
     ) -> Optional[AggregatedTranscript]:
-        return self.data["aggregated_transcripts"].get(ritual_id)
+        data = self.data["aggregated_transcripts"].get(ritual_id)
+        if not data:
+            return None
+
+        aggregated_transcript = AggregatedTranscript.from_bytes(data)
+        return aggregated_transcript
 
     def store_aggregated_transcript_receipt(
         self, ritual_id: int, txhash_or_receipt: Union[TxReceipt, HexBytes]

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
+from typing import Union
 
+from hexbytes import HexBytes
 from nucypher_core.ferveo import AggregatedTranscript, Transcript
 from web3.types import TxReceipt
 
@@ -18,10 +20,12 @@ class DKGStorage:
         transcript = Transcript.from_bytes(data)
         return transcript
 
-    def store_transcript_receipt(self, ritual_id: int, receipt: TxReceipt) -> None:
-        self.data["transcript_receipts"][ritual_id] = receipt
+    def store_transcript_receipt(
+        self, ritual_id: int, txhash_or_receipt: Union[TxReceipt, HexBytes]
+    ) -> None:
+        self.data["transcript_receipts"][ritual_id] = txhash_or_receipt
 
-    def get_transcript_receipt(self, ritual_id: int) -> TxReceipt:
+    def get_transcript_receipt(self, ritual_id: int) -> Union[TxReceipt, HexBytes]:
         return self.data["transcript_receipts"][ritual_id]
 
     def store_aggregated_transcript(self, ritual_id: int, aggregated_transcript: AggregatedTranscript) -> None:
@@ -30,10 +34,14 @@ class DKGStorage:
     def get_aggregated_transcript(self, ritual_id: int) -> AggregatedTranscript:
         return self.data["aggregated_transcripts"][ritual_id]
 
-    def store_aggregated_transcript_receipt(self, ritual_id: int, receipt: TxReceipt) -> None:
-        self.data["aggregated_transcript_receipts"][ritual_id] = receipt
+    def store_aggregated_transcript_receipt(
+        self, ritual_id: int, txhash_or_receipt: Union[TxReceipt, HexBytes]
+    ) -> None:
+        self.data["aggregated_transcript_receipts"][ritual_id] = txhash_or_receipt
 
-    def get_aggregated_transcript_receipt(self, ritual_id: int) -> TxReceipt:
+    def get_aggregated_transcript_receipt(
+        self, ritual_id: int
+    ) -> Union[TxReceipt, HexBytes]:
         return self.data["aggregated_transcript_receipts"][ritual_id]
 
     def store_public_key(self, ritual_id: int, public_key: bytes) -> None:

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -16,7 +16,7 @@ import time
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
 
 import maya
 from eth_abi.codec import ABICodec
@@ -98,7 +98,9 @@ class EventScannerState(ABC):
         """
 
     @abstractmethod
-    def process_event(self, block_when: datetime.datetime, event: AttributeDict) -> object:
+    def process_event(
+        self, block_when: datetime.datetime, event: AttributeDict
+    ) -> object:
         """Process incoming events.
 
         This function takes raw events from Web3, transforms them to your application internal
@@ -227,7 +229,7 @@ class EventScanner:
 
         # Cache block timestamps to reduce some RPC overhead
         # Real solution might include smarter models around block
-        def get_block_when(block_num):
+        def get_block_when(block_num) -> datetime.datetime:
             if block_num not in block_timestamps:
                 block_timestamps[block_num] = get_block_timestamp(block_num)
             return block_timestamps[block_num]
@@ -250,7 +252,9 @@ class EventScanner:
         end_block_timestamp = get_block_when(end_block)
         return end_block, end_block_timestamp, all_processed
 
-    def process_event(self, event, get_block_when):
+    def process_event(
+        self, event: AttributeDict, get_block_when: Callable[[int], datetime.datetime]
+    ):
         """Process events and update internal state"""
         idx = event["logIndex"]  # Integer of the log index position in the block, null when its pending
 

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -98,6 +98,10 @@ def test_ursula_ritualist(testerchain, coordinator_agent, cohort, alice, bob):
                 ursula.ritual_tracker.task.run()
             testerchain.time_travel(seconds=TIME_TRAVEL_INTERVAL)
 
+        # Ensure that all events processed, including EndRitual
+        for ursula in cohort:
+            ursula.ritual_tracker.task.run()
+
     def test_finality(_):
         """Checks the finality of the DKG"""
         print("==================== CHECKING DKG FINALITY ====================")

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -74,13 +74,19 @@ def test_ursula_ritualist(testerchain, coordinator_agent, cohort, alice, bob):
         # TODO is there a better strategy
         testerchain.time_travel(seconds=1)
 
-        # check that the ritual is being tracked locally upon initialization for each node
         for ursula in cohort:
             # this is a testing hack to make the event scanner work
             # normally it's called by the reactor clock in a loop
             ursula.ritual_tracker.task.run()
-            # check that the ritual was created locally for this node
-            assert len(ursula.ritual_tracker.rituals) == RITUAL_ID + 1
+            # nodes received `StartRitual` and submitted their transcripts
+            assert (
+                len(
+                    coordinator_agent.get_participant_from_provider(
+                        ritual_id=RITUAL_ID, provider=ursula.checksum_address
+                    ).transcript
+                )
+                > 0
+            ), "ursula posted transcript to Coordinator"
 
     def block_until_dkg_finalized(_):
         """simulates the passage of time and the execution of the event scanner"""

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -106,7 +106,7 @@ def test_get_participation_state_start_ritual(cohort, get_random_checksum_addres
     #
     # clear prior information
     #
-    active_ritual_tracker.participation_states.clear()
+    active_ritual_tracker._participation_states.clear()
 
     #
     # actually participating now
@@ -155,7 +155,7 @@ def test_get_participation_state_transcript_posted(cohort, get_random_checksum_a
     #
     # clear prior information
     #
-    active_ritual_tracker.participation_states.clear()
+    active_ritual_tracker._participation_states.clear()
 
     #
     # actually participating now
@@ -203,7 +203,7 @@ def test_get_participation_state_aggregation_posted(
     #
     # clear prior information
     #
-    active_ritual_tracker.participation_states.clear()
+    active_ritual_tracker._participation_states.clear()
 
     #
     # actually participating now
@@ -257,7 +257,7 @@ def test_get_participation_state_start_aggregation_round_participation_not_alrea
     #
     # clear prior information
     #
-    active_ritual_tracker.participation_states.clear()
+    active_ritual_tracker._participation_states.clear()
 
     #
     # actually participating now
@@ -305,7 +305,7 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     #
 
     # mimic already tracked prior state: not participating
-    active_ritual_tracker.participation_states[
+    active_ritual_tracker._participation_states[
         ritual_id
     ] = active_ritual_tracker.ParticipationState(False, False, False)
     verify_non_participation_flow(active_ritual_tracker, event_data, event_type)
@@ -315,7 +315,7 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     #
 
     # mimic already tracked prior state: participating
-    active_ritual_tracker.participation_states[
+    active_ritual_tracker._participation_states[
         ritual_id
     ] = active_ritual_tracker.ParticipationState(True, False, False)
 
@@ -329,8 +329,8 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     )
 
     # new state stored
-    assert len(active_ritual_tracker.participation_states) == 1
-    assert active_ritual_tracker.participation_states[ritual_id] == participation_state
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
 
     # check again
     participation_state = active_ritual_tracker._get_participation_state(
@@ -343,8 +343,8 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     )
 
     # no new state information
-    assert len(active_ritual_tracker.participation_states) == 1
-    assert active_ritual_tracker.participation_states[ritual_id] == participation_state
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
 
 
 def test_get_participation_state_end_ritual_participation_not_already_tracked(
@@ -386,12 +386,12 @@ def test_get_participation_state_end_ritual_participation_not_already_tracked(
         )
         check_participation_state(participation_state)
         # no state stored
-        assert len(active_ritual_tracker.participation_states) == 0
+        assert len(active_ritual_tracker._participation_states) == 0
 
     #
     # clear prior information
     #
-    active_ritual_tracker.participation_states.clear()
+    active_ritual_tracker._participation_states.clear()
 
     #
     # actually participating now: successful
@@ -420,7 +420,7 @@ def test_get_participation_state_end_ritual_participation_not_already_tracked(
             expected_already_posted_aggregate=True,
         )
         # no state stored
-        assert len(active_ritual_tracker.participation_states) == 0
+        assert len(active_ritual_tracker._participation_states) == 0
 
     #
     # actually participating now: not successful - transcript not posted
@@ -451,7 +451,7 @@ def test_get_participation_state_end_ritual_participation_not_already_tracked(
             expected_already_posted_aggregate=False,
         )
         # no state stored
-        assert len(active_ritual_tracker.participation_states) == 0
+        assert len(active_ritual_tracker._participation_states) == 0
 
     #
     # actually participating now: not successful - aggregate not posted
@@ -482,7 +482,7 @@ def test_get_participation_state_end_ritual_participation_not_already_tracked(
             expected_already_posted_aggregate=False,
         )
         # no state stored
-        assert len(active_ritual_tracker.participation_states) == 0
+        assert len(active_ritual_tracker._participation_states) == 0
 
 
 def test_get_participation_state_end_ritual_participation_already_tracked(
@@ -514,7 +514,7 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
     #
 
     # mimic already tracked prior state: not participating
-    active_ritual_tracker.participation_states[
+    active_ritual_tracker._participation_states[
         ritual_id
     ] = active_ritual_tracker.ParticipationState(False, False, False)
     participation_state = active_ritual_tracker._get_participation_state(
@@ -523,14 +523,14 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
     check_participation_state(participation_state, expected_participating=False)
 
     # state is removed
-    assert len(active_ritual_tracker.participation_states) == 0
+    assert len(active_ritual_tracker._participation_states) == 0
 
     #
     # actually participating now
     #
 
     # mimic already tracked prior state: participating
-    active_ritual_tracker.participation_states[
+    active_ritual_tracker._participation_states[
         ritual_id
     ] = active_ritual_tracker.ParticipationState(True, False, False)
 
@@ -545,7 +545,7 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
     )
 
     # state is removed
-    assert len(active_ritual_tracker.participation_states) == 0
+    assert len(active_ritual_tracker._participation_states) == 0
 
 
 def test_get_participation_state_unexpected_event_without_ritual_id_arg(cohort):
@@ -648,8 +648,8 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
         d = active_ritual_tracker._handle_ritual_event(event_data, get_block_when)
         yield d
 
-        assert len(active_ritual_tracker.participation_states) == (i + 1)
-        participation_state = active_ritual_tracker.participation_states[r_id]
+        assert len(active_ritual_tracker._participation_states) == (i + 1)
+        participation_state = active_ritual_tracker._participation_states[r_id]
         if r_id != ritual_id_4:
             ritualist.perform_round_1.assert_called_with(
                 ritual_id=r_id, initiator=ANY, participants=ANY, timestamp=ANY
@@ -662,7 +662,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
         ritualist.perform_round_1.call_count == 3
     )  # participation and action required
     assert ritualist.perform_round_2.call_count == 0  # nothing to do here
-    assert len(active_ritual_tracker.participation_states) == 4
+    assert len(active_ritual_tracker._participation_states) == 4
 
     #
     # Receive TranscriptPosted event for ritual_id 1
@@ -687,19 +687,19 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert ritualist.perform_round_2.call_count == 0  # nothing to do here
 
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[ritual_id_1],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[ritual_id_2],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[ritual_id_3],
         expected_participating=True,
     )
-    check_participation_state(active_ritual_tracker.participation_states[ritual_id_4])
+    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
 
     #
     # Receive StartAggregationRound for ritual_id 2
@@ -723,20 +723,20 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     ritualist.perform_round_2.assert_called_with(ritual_id=ritual_id_2, timestamp=ANY)
 
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[ritual_id_1],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[ritual_id_2],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[ritual_id_3],
         expected_participating=True,
     )
-    check_participation_state(active_ritual_tracker.participation_states[ritual_id_4])
+    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
 
     #
     # Receive AggregationPosted for ritual_id 3
@@ -763,22 +763,22 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert ritualist.perform_round_2.call_count == 1
 
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[ritual_id_1],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[ritual_id_2],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[ritual_id_3],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
     )
-    check_participation_state(active_ritual_tracker.participation_states[ritual_id_4])
+    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
 
     #
     # Receive AggregationPosted for ritual id 4
@@ -803,22 +803,22 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert ritualist.perform_round_2.call_count == 1  # same as before
 
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[ritual_id_1],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[ritual_id_2],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[ritual_id_3],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
     )
-    check_participation_state(active_ritual_tracker.participation_states[ritual_id_4])
+    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
 
     #
     # EndRitual received for ritual id 2
@@ -843,21 +843,21 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert ritualist.perform_round_2.call_count == 1  # same as before
 
     # ritual #2 removed from states
-    assert len(active_ritual_tracker.participation_states) == 3
-    assert not active_ritual_tracker.participation_states.get(ritual_id_2)
+    assert len(active_ritual_tracker._participation_states) == 3
+    assert not active_ritual_tracker._participation_states.get(ritual_id_2)
 
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[ritual_id_1],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[ritual_id_3],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
     )
-    check_participation_state(active_ritual_tracker.participation_states[ritual_id_4])
+    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
 
     #
     # EndRitual received for ritual id 4
@@ -882,17 +882,17 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert ritualist.perform_round_2.call_count == 1  # same as before
 
     # ritual #4 removed from states
-    assert len(active_ritual_tracker.participation_states) == 2
-    assert not active_ritual_tracker.participation_states.get(ritual_id_4)
+    assert len(active_ritual_tracker._participation_states) == 2
+    assert not active_ritual_tracker._participation_states.get(ritual_id_4)
 
     # only rituals #1 and #3 remain
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[ritual_id_1],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker.participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[ritual_id_3],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
@@ -912,8 +912,8 @@ def verify_non_participation_flow(
     check_participation_state(participation_state)
 
     # new participation state stored
-    assert len(active_ritual_tracker.participation_states) == 1
-    assert active_ritual_tracker.participation_states[ritual_id] == participation_state
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
 
     # check again that not participating
     participation_state = active_ritual_tracker._get_participation_state(
@@ -922,8 +922,8 @@ def verify_non_participation_flow(
     check_participation_state(participation_state)
 
     # no new information
-    assert len(active_ritual_tracker.participation_states) == 1
-    assert active_ritual_tracker.participation_states[ritual_id] == participation_state
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
 
 
 def verify_participation_flow(
@@ -946,8 +946,8 @@ def verify_participation_flow(
     )
 
     # new state stored
-    assert len(active_ritual_tracker.participation_states) == 1
-    assert active_ritual_tracker.participation_states[ritual_id] == participation_state
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
 
     # check again if relevant
     participation_state = active_ritual_tracker._get_participation_state(
@@ -961,12 +961,12 @@ def verify_participation_flow(
     )
 
     # no new information
-    assert len(active_ritual_tracker.participation_states) == 1
-    assert active_ritual_tracker.participation_states[ritual_id] == participation_state
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
 
     # pretend to lose previous information eg. restart of node etc.
-    active_ritual_tracker.participation_states.clear()
-    assert len(active_ritual_tracker.participation_states) == 0
+    active_ritual_tracker._participation_states.clear()
+    assert len(active_ritual_tracker._participation_states) == 0
 
     participation_state = active_ritual_tracker._get_participation_state(
         event_data, event_type
@@ -979,8 +979,8 @@ def verify_participation_flow(
     )
 
     # new state stored
-    assert len(active_ritual_tracker.participation_states) == 1
-    assert active_ritual_tracker.participation_states[ritual_id] == participation_state
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
 
 
 def check_event_args_match_latest_event_inputs(event: ContractEvent, args_dict: Dict):

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -890,9 +890,13 @@ def verify_participation_flow(
 def check_event_args_match_latest_event_inputs(event: ContractEvent, args_dict: Dict):
     """Ensures that we are testing with actual event arguments."""
     event_inputs = event.abi["inputs"]
-    assert len(event_inputs) == len(args_dict)
+    assert len(event_inputs) == len(
+        args_dict
+    ), "test events don't match latest Coordinator contract events"
     for event_input in event_inputs:
-        assert event_input["name"] in args_dict
+        assert (
+            event_input["name"] in args_dict
+        ), "test events don't match latest Coordinator contract events"
 
 
 def check_participation_state(

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -557,7 +557,7 @@ def test_get_participation_state_unexpected_event_without_ritual_id_arg(cohort):
         {"event": timeout_changed_event.event_name, "args": AttributeDict(args_dict)}
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         active_ritual_tracker._get_participation_state(event_data)
 
 
@@ -577,7 +577,7 @@ def test_get_participation_state_unexpected_event_with_ritual_id_arg(cohort):
         }
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         active_ritual_tracker._get_participation_state(event_data)
 
 

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -413,6 +413,47 @@ def test_is_relevant_event_end_ritual_participation_already_tracked(
     assert len(active_ritual_tracker.participation_states) == 0
 
 
+def test_is_relevant_event_unexpected_event_without_ritual_id_arg(cohort):
+    ursula = cohort[0]
+    agent = ursula.coordinator_agent
+    active_ritual_tracker = ActiveRitualTracker(ritualist=ursula)
+
+    # TimeoutChanged
+    timeout_changed_event = agent.contract.events.TimeoutChanged()
+    event_type = getattr(agent.contract.events, timeout_changed_event.event_name)
+
+    # create args data
+    args_dict = {"oldTimeout": 1, "newTimeout": 2}
+
+    # ensure that test matches latest event information
+    verify_event_args_match_latest_event_inputs(
+        event=timeout_changed_event, args_dict=args_dict
+    )
+
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    with pytest.raises(ValueError):
+        active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+
+def test_is_relevant_event_unexpected_event_with_ritual_id_arg(cohort):
+    ursula = cohort[0]
+    agent = ursula.coordinator_agent
+    active_ritual_tracker = ActiveRitualTracker(ritualist=ursula)
+
+    # TimeoutChanged
+    timeout_changed_event = agent.contract.events.TimeoutChanged()
+    event_type = getattr(agent.contract.events, timeout_changed_event.event_name)
+
+    # create args data - faked to include ritual id arg
+    args_dict = {"ritualId": 0, "oldTimeout": 1, "newTimeout": 2}
+
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    with pytest.raises(ValueError):
+        active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+
 def verify_not_participating(
     active_ritual_tracker,
     ritual_id,

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -1,0 +1,316 @@
+import os
+
+import pytest
+from web3.datastructures import AttributeDict
+
+from nucypher.blockchain.eth.trackers.dkg import ActiveRitualTracker
+
+
+@pytest.fixture(scope="module")
+def cohort(ursulas):
+    """Creates a cohort of Ursulas"""
+    nodes = list(sorted(ursulas[:4], key=lambda x: int(x.checksum_address, 16)))
+    assert len(nodes) == 4  # sanity check
+    return nodes
+
+
+def test_action_required(cohort):
+    ursula = cohort[0]
+    agent = ursula.coordinator_agent
+    active_ritual_tracker = ActiveRitualTracker(ritualist=ursula)
+
+    for event in agent.contract.events:
+        action_required = False
+        if (
+            event.event_name == "StartRitual"
+            or event.event_name == "StartAggregationRound"
+        ):
+            action_required = True
+
+        event_type = getattr(agent.contract.events, event.event_name)
+        assert (
+            active_ritual_tracker._action_required(event_type=event_type)
+            == action_required
+        )
+
+
+def test_is_relevant_event_start_ritual(cohort, get_random_checksum_address):
+    ritual_id = 12
+    args_dict = {"ritualId": ritual_id}
+    ursula = cohort[0]
+    agent = ursula.coordinator_agent
+    active_ritual_tracker = ActiveRitualTracker(ritualist=ursula)
+
+    # StartRitual
+    start_ritual_event = agent.contract.events.StartRitual()
+    event_type = getattr(agent.contract.events, start_ritual_event.event_name)
+
+    # create args data
+    args_dict["initiator"] = get_random_checksum_address()
+    args_dict["participants"] = [
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+    ]  # not included by default
+
+    # Ensure that test matches latest event information
+    verify_event_args_match_latest_event_inputs(
+        event=start_ritual_event, args_dict=args_dict
+    )
+
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    #
+    # not participating
+    #
+    verify_not_participating(active_ritual_tracker, ritual_id, event_data, event_type)
+
+    #
+    # clear prior information
+    #
+    active_ritual_tracker.participation_states.clear()
+
+    #
+    # actually participating now
+    #
+    args_dict["participants"] = [u.checksum_address for u in cohort]  # now included
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    verify_participating(
+        active_ritual_tracker,
+        ritual_id,
+        event_data,
+        event_type,
+        expected_posted_transcript=False,
+        expected_posted_aggregate=False,
+    )
+
+
+def test_is_relevant_event_transcript_posted(cohort, get_random_checksum_address):
+    ritual_id = 12
+    args_dict = {"ritualId": ritual_id}
+    ursula = cohort[0]
+    agent = ursula.coordinator_agent
+    active_ritual_tracker = ActiveRitualTracker(ritualist=ursula)
+
+    # TranscriptPosted
+    transcript_posted_event = agent.contract.events.TranscriptPosted()
+    event_type = getattr(agent.contract.events, transcript_posted_event.event_name)
+
+    # create args data
+    args_dict["node"] = get_random_checksum_address()  # node address not this one
+    args_dict["transcriptDigest"] = os.urandom(32)
+
+    # ensure that test matches latest event information
+    verify_event_args_match_latest_event_inputs(
+        event=transcript_posted_event, args_dict=args_dict
+    )
+
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    #
+    # not participating
+    #
+    verify_not_participating(active_ritual_tracker, ritual_id, event_data, event_type)
+
+    #
+    # clear prior information
+    #
+    active_ritual_tracker.participation_states.clear()
+
+    #
+    # actually participating now
+    #
+    args_dict["node"] = ursula.checksum_address  # set node address to this one
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    verify_participating(
+        active_ritual_tracker,
+        ritual_id,
+        event_data,
+        event_type,
+        expected_posted_transcript=True,
+        expected_posted_aggregate=False,
+    )
+
+
+def test_is_relevant_event_aggregation_posted(cohort, get_random_checksum_address):
+    ritual_id = 12
+    args_dict = {"ritualId": ritual_id}
+    ursula = cohort[0]
+    agent = ursula.coordinator_agent
+    active_ritual_tracker = ActiveRitualTracker(ritualist=ursula)
+
+    # AggregationPosted
+    aggregation_posted_event = agent.contract.events.AggregationPosted()
+    event_type = getattr(agent.contract.events, aggregation_posted_event.event_name)
+
+    # create args data
+    args_dict["node"] = get_random_checksum_address()  # node address not this one
+    args_dict["aggregatedTranscriptDigest"] = os.urandom(32)
+
+    # ensure that test matches latest event information
+    verify_event_args_match_latest_event_inputs(
+        event=aggregation_posted_event, args_dict=args_dict
+    )
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    #
+    # not participating
+    #
+    verify_not_participating(active_ritual_tracker, ritual_id, event_data, event_type)
+
+    #
+    # clear prior information
+    #
+    active_ritual_tracker.participation_states.clear()
+
+    #
+    # actually participating now
+    #
+    args_dict["node"] = ursula.checksum_address  # set node address to this one
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    verify_participating(
+        active_ritual_tracker,
+        ritual_id,
+        event_data,
+        event_type,
+        expected_posted_transcript=True,
+        expected_posted_aggregate=True,
+    )
+
+
+def test_is_relevant_event_start_aggregation_round_participation_already_tracked(
+    cohort, get_random_checksum_address
+):
+    # StartAggregation is a special case because we can't determine participation directly
+    #  from the event arguments
+    ritual_id = 12
+    args_dict = {"ritualId": ritual_id}
+    ursula = cohort[0]
+    agent = ursula.coordinator_agent
+    active_ritual_tracker = ActiveRitualTracker(ritualist=ursula)
+
+    start_aggregation_round_event = agent.contract.events.StartAggregationRound()
+    event_type = getattr(
+        agent.contract.events, start_aggregation_round_event.event_name
+    )
+
+    # ensure that test matches latest event information
+    verify_event_args_match_latest_event_inputs(
+        event=start_aggregation_round_event, args_dict=args_dict
+    )
+    event_data = AttributeDict({"args": AttributeDict(args_dict)})
+
+    #
+    # not participating
+    #
+
+    # mimic already tracked prior state: not participating
+    active_ritual_tracker.participation_states[
+        ritual_id
+    ] = active_ritual_tracker.ParticipationState(False, False, False)
+    verify_not_participating(active_ritual_tracker, ritual_id, event_data, event_type)
+
+    #
+    # actually participating now
+    #
+
+    # mimic already tracked prior state: participating
+    active_ritual_tracker.participation_states[
+        ritual_id
+    ] = active_ritual_tracker.ParticipationState(True, False, False)
+
+    assert active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+    # new state stored
+    assert len(active_ritual_tracker.participation_states) == 1
+
+    # check values
+    current_state = active_ritual_tracker.participation_states[ritual_id]
+    assert current_state.participating
+    assert not current_state.already_posted_aggregate
+
+    # check again if relevant
+    assert active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+    # no new information
+    assert len(active_ritual_tracker.participation_states) == 1
+
+
+def verify_not_participating(
+    active_ritual_tracker,
+    ritual_id,
+    event_data,
+    event_type,
+):
+    assert not active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+    # new participation state stored
+    assert len(active_ritual_tracker.participation_states) == 1
+
+    # check stored state
+    current_state = active_ritual_tracker.participation_states[ritual_id]
+    assert not current_state.participating
+    assert not current_state.already_posted_transcript
+    assert not current_state.already_posted_aggregate
+
+    # check again that not participating
+    assert not active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+    # no new information
+    assert len(active_ritual_tracker.participation_states) == 1
+
+    # check stored state
+    assert not current_state.participating
+    assert not current_state.already_posted_transcript
+    assert not current_state.already_posted_aggregate
+
+
+def verify_participating(
+    active_ritual_tracker,
+    ritual_id,
+    event_data,
+    event_type,
+    expected_posted_transcript,
+    expected_posted_aggregate,
+):
+    assert active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+    # new state stored
+    assert len(active_ritual_tracker.participation_states) == 1
+
+    # check values
+    current_state = active_ritual_tracker.participation_states[ritual_id]
+    assert current_state.participating
+    assert current_state.already_posted_transcript == expected_posted_transcript
+    assert current_state.already_posted_aggregate == expected_posted_aggregate
+
+    # check again if relevant
+    assert active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+    # no new information
+    assert len(active_ritual_tracker.participation_states) == 1
+
+    # pretend to lose previous information eg. restart of node etc.
+    active_ritual_tracker.participation_states.clear()
+    assert len(active_ritual_tracker.participation_states) == 0
+
+    assert active_ritual_tracker._is_relevant_event(event_data, event_type)
+
+    # new state stored
+    assert len(active_ritual_tracker.participation_states) == 1
+
+    # check values
+    current_state = active_ritual_tracker.participation_states[ritual_id]
+    assert current_state.participating
+    assert current_state.already_posted_transcript == expected_posted_transcript
+    assert current_state.already_posted_aggregate == expected_posted_aggregate
+
+
+def verify_event_args_match_latest_event_inputs(event, args_dict):
+    event_inputs = event.abi["inputs"]
+    assert len(event_inputs) == len(args_dict)
+    for event_input in event_inputs:
+        assert event_input["name"] in args_dict

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -642,7 +642,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
                         if r_id != ritual_id_4
                         else participants_when_not_participating,
                     }
-                )
+                ),
             }
         )
         d = active_ritual_tracker._handle_ritual_event(event_data, get_block_when)
@@ -712,7 +712,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
                 {
                     "ritualId": ritual_id_2,
                 }
-            )
+            ),
         }
     )
     d = active_ritual_tracker._handle_ritual_event(event_data, get_block_when)
@@ -833,7 +833,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
                     "initiator": get_random_checksum_address(),
                     "successful": True,
                 }
-            )
+            ),
         }
     )
     d = active_ritual_tracker._handle_ritual_event(event_data, get_block_when)

--- a/tests/integration/blockchain/test_ritual_tracker.py
+++ b/tests/integration/blockchain/test_ritual_tracker.py
@@ -249,9 +249,8 @@ def test_get_ritual_participant_info(ritualist, get_random_checksum_address):
     # random participants
     for i in range(0, 3):
         participant = CoordinatorAgent.Ritual.Participant(
-            provider=get_random_checksum_address
+            provider=get_random_checksum_address()
         )
-        participant.provider.return_value = get_random_checksum_address()
         participants.append(participant)
     mocked_agent.get_participants.return_value = participants
 
@@ -281,9 +280,8 @@ def test_get_participation_state_values_from_contract(
     # random participants
     for i in range(0, 5):
         participant = CoordinatorAgent.Ritual.Participant(
-            provider=get_random_checksum_address
+            provider=get_random_checksum_address()
         )
-        participant.provider.return_value = get_random_checksum_address()
         participants.append(participant)
 
     mocked_agent.get_participants.return_value = participants

--- a/tests/mock/coordinator.py
+++ b/tests/mock/coordinator.py
@@ -85,6 +85,7 @@ class MockCoordinatorAgent(MockContractAgent):
         ritual_id: int,
         transcript: Transcript,
         transacting_power: TransactingPower,
+        fire_and_forget: bool = False,
     ) -> TxReceipt:
         ritual = self.rituals[ritual_id]
         operator_address = transacting_power.account
@@ -114,6 +115,7 @@ class MockCoordinatorAgent(MockContractAgent):
         public_key: DkgPublicKey,
         participant_public_key: SessionStaticKey,
         transacting_power: TransactingPower,
+        fire_and_forget: bool = False,
     ) -> TxReceipt:
         ritual = self.rituals[ritual_id]
         operator_address = transacting_power.account

--- a/tests/unit/test_ritualist.py
+++ b/tests/unit/test_ritualist.py
@@ -78,7 +78,6 @@ def test_perform_round_1(ursula, random_address, cohort, agent):
 
     agent.get_participant_from_provider = lambda *args, **kwargs: participants[0]
 
-    ursula.ritual_tracker.refresh(fetch_rituals=[0])
     ursula.perform_round_1(
         ritual_id=0, initiator=random_address, participants=cohort, timestamp=0
     )


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Ideally, the handling of Ritual events during ritual initiation to be more robust:
- Properly ignore/filter away ritual events for rituals not relevant to the node
- Easily rectify/continue its participation in rituals in case it restarts while a ritual it is participating in is still going on
- Use Coordinator events to gleam node's participation in ritual, and what the node has/has not done already for a ritual.
- If unsure of state, use the Coordinator contract to update what its view of its state is.
- Don't block waiting for a tx to post transcript/aggregated transcript to be fully completed before being able to continue processing events - use `fire_and_forget`, store the tx hash, and keep it moving. 
- If the node already has a pending tx for posting a transcript/aggregated transcript do *not* submit another tx for the same action.

This PR attempts to achieve that. 

This PR does not address speeding up already submitted txs for post transcript/aggregation in the case of a gas spike that may last. There may be additional functionality we can do for replacement transactions (slow txs when posting transcripts/aggregations), adjusting gas etc. but if necessary that should be addressed in a separate PR. There may also be tweaks we can make to the event scanner. These need more mindshare before tackling. (cc @KPrasch , @cygnusv ).

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
During ETH Barcelona we initiated 15 rituals one after the other, and the nodes showed a significant decrease in performance for a variety of reasons:
- Incorrect filtering of events
- Lots of exception handling in twisted threads (cost of handling errors then executing again)
- Repeated events
- Blocking while waiting for txs to complete.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
