### PR TITLE
Use a time-to-live cache for participation states to remove stale ritual participation state information

### DIFF
--- a/newsfragments/3191.misc.rst
+++ b/newsfragments/3191.misc.rst
@@ -1,0 +1,1 @@
+Use a time-to-live cache for trakcing ritual participation state which gets periodically purged when ritual state is deemed stale.

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -73,6 +73,9 @@ class ActiveRitualTracker:
     # how often to check/purge for expired cached values - 8hrs?
     _PARTICIPATION_STATES_PURGE_INTERVAL = 60 * 60 * 8
 
+    # what's the buffer for potentially receiving repeated events - 10mins?
+    _RITUAL_TIMEOUT_ADDITIONAL_TTL_BUFFER = 60 * 10
+
     class ParticipationState:
         def __init__(
             self,
@@ -129,10 +132,10 @@ class ActiveRitualTracker:
 
         self.task = EventScannerTask(scanner=self.scan)
 
-        ritual_timeout = self.coordinator_agent.get_timeout()
-        # what's the buffer for potentially receiving repeated events - one hour?
-        cache_ttl = ritual_timeout + (60 * 60)
-
+        cache_ttl = (
+            self.coordinator_agent.get_timeout()
+            + self._RITUAL_TIMEOUT_ADDITIONAL_TTL_BUFFER
+        )
         self._participation_states = TTLCache(
             ttl=cache_ttl
         )  # { ritual_id -> ParticipationState }

--- a/nucypher/utilities/cache.py
+++ b/nucypher/utilities/cache.py
@@ -1,0 +1,143 @@
+from threading import RLock
+from typing import Dict, Optional
+
+import maya
+
+
+class TTLCache:
+    """
+    Thread-safe cache that stores keyed data with auto-expiring values via a time-to-live.
+
+    Expired items are not proactively removed from the cache unless functionality
+    necessitates it. Either specific items get proactively removed for example trying
+    to access a keyed-value that is already expired, OR a wholistic purge occurs because
+    consistent global state is needed, for example, the length of the cache queried or
+    a list of key-value pairs requested.
+
+    Expired entries can be forcibly purged at any time using the purge_expired() function.
+    """
+
+    class TTLEntry:
+        def __init__(self, value: object, ttl: int):
+            self._value = value
+            self._expiration = maya.now().add(seconds=ttl)
+
+        @property
+        def value(self) -> Optional[object]:
+            """
+            Return the value if not expired, None otherwise
+            """
+            if self.is_expired():
+                return None
+
+            return self._value
+
+        def is_expired(self) -> bool:
+            """
+            Return true if the entry has exceeded its time-to-live.
+            """
+            return self._expiration < maya.now()
+
+    def __init__(self, ttl: int, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if ttl <= 0:
+            raise ValueError(f"Invalid time-to-live {ttl}")
+        self.ttl = ttl
+        self.__cache: Dict[object, TTLCache.TTLEntry] = {}
+        self.__cache_lock = RLock()
+
+    def __setitem__(self, key, value):
+        """
+        Add the provided key entry to be the provided value.
+        """
+        if key is None or value is None:
+            raise ValueError(f"Invalid key-value pair ({key}, {value})")
+
+        with self.__cache_lock:
+            self.__cache[key] = self.TTLEntry(value=value, ttl=self.ttl)
+
+    def __getitem__(self, key):
+        """
+        Return the associated keyed item, else None if expired or not present.
+        """
+        with self.__cache_lock:
+            ttl_entry = self.__cache.get(key)
+            if not ttl_entry:
+                # no value stored
+                return None
+
+            value = ttl_entry.value
+            if not value:
+                # entry is expired
+                del self.__cache[key]
+                return None
+
+            return value
+
+    def items(self):
+        """
+        Returns a copy of the cache's list of non-expired (key, value) pairs.
+        """
+        key_value_pairs = []
+        with self.__cache_lock:
+            for key in list(self.__cache):
+                ttl_entry = self.__cache[key]
+                value = ttl_entry.value
+                if value:
+                    key_value_pairs.append((key, ttl_entry.value))
+                else:
+                    # expired entry, opportunity to remove it
+                    del self.__cache[key]
+
+        return key_value_pairs
+
+    def pop(self, key, default=None):
+        """
+        Get item from the cache and remove it.
+        Return default if expired or does not exist.
+        """
+        with self.__cache_lock:
+            ttl_entry = self.__cache.get(key)
+            if not ttl_entry:
+                return default
+
+            del self.__cache[key]
+            value = ttl_entry.value
+            if not value:
+                # entry expired
+                return default
+
+            return value
+
+    def remove(self, key):
+        """
+        Remove keyed item from the cache.
+        """
+        with self.__cache_lock:
+            if key in self.__cache:
+                del self.__cache[key]
+
+    def purge_expired(self):
+        """
+        Remove all expired items from the cache.
+        """
+        with self.__cache_lock:
+            for key in list(self.__cache):
+                entry = self.__cache[key]
+                if entry.is_expired():
+                    del self.__cache[key]
+
+    def __len__(self):
+        """
+        Returns the current (non-expired entries) size of the cache.
+        """
+        with self.__cache_lock:
+            self.purge_expired()
+            return len(self.__cache)
+
+    def clear(self):
+        """
+        Remove all items from the cache.
+        """
+        with self.__cache_lock:
+            self.__cache.clear()

--- a/tests/integration/blockchain/test_ritual_tracker.py
+++ b/tests/integration/blockchain/test_ritual_tracker.py
@@ -21,6 +21,7 @@ def ritualist(ursulas, mock_coordinator_agent) -> Ritualist:
     ursula = ursulas[0]
     mocked_agent = Mock(spec=CoordinatorAgent)
     mocked_agent.contract = mock_coordinator_agent.contract
+    mocked_agent.get_timeout.return_value = 60  # 60s
     mocked_blockchain = Mock()
     mocked_agent.blockchain = mocked_blockchain
     mocked_w3 = Mock()

--- a/tests/unit/test_ttl_cache.py
+++ b/tests/unit/test_ttl_cache.py
@@ -1,0 +1,292 @@
+import random
+from concurrent.futures import ThreadPoolExecutor, wait
+from unittest.mock import patch
+
+import maya
+import pytest
+
+from nucypher.utilities.cache import TTLCache
+
+
+def test_cache_invalid_ttl():
+    with pytest.raises(ValueError):
+        TTLCache(ttl=0)
+
+    with pytest.raises(ValueError):
+        TTLCache(ttl=-1)
+
+
+def test_cache_invalid_key_value_pair():
+    ttl_cache = TTLCache(ttl=60)
+    with pytest.raises(ValueError):
+        ttl_cache[None] = "a"
+
+    with pytest.raises(ValueError):
+        ttl_cache["a"] = None
+
+
+def test_cache_get_remove_non_existent_entry():
+    ttl_cache = TTLCache(ttl=60)
+
+    # try to get non-existent entry
+    assert ttl_cache[1] is None
+
+    # try to remove non-existent entry
+    ttl_cache.remove(1)
+
+
+def test_cache_pop():
+    ttl = 60
+    ttl_cache = TTLCache(ttl=ttl)
+
+    now = maya.now()
+    ttl_cache[1] = "a"
+    ttl_cache[2] = "b"
+    ttl_cache[3] = "c"
+    ttl_cache[4] = "c"
+
+    assert len(ttl_cache) == 4
+
+    assert ttl_cache.pop(3) == "c"
+    assert len(ttl_cache) == 3
+
+    # pop non-existent entry with default none
+    assert ttl_cache.pop(42) is None
+    assert len(ttl_cache) == 3
+
+    # pop non-existent entry with default specified
+    assert ttl_cache.pop(42, "-1") == "-1"
+    assert len(ttl_cache) == 3
+
+    assert ttl_cache.pop(1) == "a"
+    assert len(ttl_cache) == 2
+
+    assert ttl_cache.pop(2) == "b"
+    assert len(ttl_cache) == 1
+
+    # ensure last entry still present
+    assert ttl_cache[4] == "c"
+
+    # pop expired entry
+    def maya_now():
+        # pretend time has passed
+        return now.add(seconds=ttl + 1)
+
+    with patch("maya.now", maya_now):
+        assert ttl_cache.pop(4) is None, "entry should be expired"
+
+
+def test_cache_items():
+    ttl = 60  # 60s
+    ttl_cache = TTLCache(ttl=ttl)
+
+    now = maya.now()
+
+    ttl_cache[1] = "a"
+    ttl_cache[2] = "b"
+    assert len(ttl_cache) == 2
+
+    def maya_now_1():
+        # pretend time has passed
+        return now.add(seconds=ttl / 2)
+
+    with patch("maya.now", maya_now_1):
+        # items added later and will not be expired
+        ttl_cache[3] = "c"
+        ttl_cache[4] = "d"
+        ttl_cache[5] = "e"
+
+    assert len(ttl_cache) == 5
+
+    cache_key_value_pairs = dict(ttl_cache.items())
+    assert len(cache_key_value_pairs) == len(ttl_cache)
+    assert cache_key_value_pairs[1] == "a"
+    assert cache_key_value_pairs[2] == "b"
+    assert cache_key_value_pairs[3] == "c"
+    assert cache_key_value_pairs[4] == "d"
+    assert cache_key_value_pairs[5] == "e"
+
+    def maya_now_2():
+        # pretend time has passed
+        return now.add(seconds=ttl + 1)
+
+    with patch("maya.now", maya_now_2):
+        latest_cache_key_value_pairs = dict(ttl_cache.items())
+        # 2 expired entries not returned
+        assert len(latest_cache_key_value_pairs) == 3
+        assert cache_key_value_pairs[3] == "c"
+        assert cache_key_value_pairs[4] == "d"
+        assert cache_key_value_pairs[5] == "e"
+
+
+def test_cache_simple_no_expiry():
+    ttl = 60  # 60s
+    ttl_cache = TTLCache(ttl=ttl)
+
+    key_value_pairs = {1: "a", 2: "b", 3: "c", 4: "d"}
+
+    for key, value in key_value_pairs.items():
+        ttl_cache[key] = value
+        assert ttl_cache[key] == value
+
+    assert len(ttl_cache) == len(key_value_pairs)
+
+    cached_key_value_pairs = dict(ttl_cache.items())
+    assert cached_key_value_pairs == key_value_pairs
+
+    key_to_remove = list(key_value_pairs.keys())[0]
+    ttl_cache.remove(key_to_remove)
+    assert len(ttl_cache) == len(key_value_pairs) - 1
+    assert ttl_cache[key_to_remove] is None
+
+    # no expired entries - no change in length after purge
+    ttl_cache.purge_expired()
+    assert len(ttl_cache) == len(key_value_pairs) - 1
+
+    ttl_cache.clear()
+    assert len(ttl_cache) == 0
+    assert ttl_cache[list(key_value_pairs.keys())[2]] is None
+
+
+def test_cache_expiry_all_entries():
+    ttl = 60  # 60s
+    ttl_cache = TTLCache(ttl=ttl)
+
+    now = maya.now()
+
+    ttl_cache[1] = "a"
+    ttl_cache[2] = "b"
+
+    def maya_now():
+        # pretend time has passed
+        return now.add(seconds=ttl + 1)
+
+    with patch("maya.now", maya_now):
+        assert ttl_cache[1] is None, "entry should be expired"
+        assert ttl_cache[2] is None, "entry should be expired"
+
+    assert len(ttl_cache) == 0
+
+
+def test_cache_expiry_some_entries():
+    ttl = 60  # 60s
+    ttl_cache = TTLCache(ttl=ttl)
+
+    now = maya.now()
+
+    ttl_cache[1] = "a"
+    assert len(ttl_cache) == 1
+    assert ttl_cache[1] == "a"
+
+    def maya_now_1():
+        # pretend time has passed
+        return now.add(seconds=ttl / 3)  # 20s
+
+    with patch("maya.now", maya_now_1):
+        ttl_cache[2] = "b"
+        assert len(ttl_cache) == 2
+        assert ttl_cache[1] == "a"
+        assert ttl_cache[2] == "b"
+
+    def maya_now_2():
+        return now.add(seconds=(ttl / 3) * 2)  # 40s
+
+    with patch("maya.now", maya_now_2):
+        ttl_cache[3] = "c"
+        assert len(ttl_cache) == 3
+        assert ttl_cache[1] == "a"
+        assert ttl_cache[2] == "b"
+        assert ttl_cache[3] == "c"
+
+    def maya_now_expired_1():
+        return now.add(seconds=ttl + 1)
+
+    with patch("maya.now", maya_now_expired_1):
+        assert ttl_cache[1] is None  # expired entry
+        assert ttl_cache[2] == "b"
+        assert ttl_cache[3] == "c"
+        assert len(ttl_cache) == 2
+
+    def maya_now_expired_2():
+        return now.add(seconds=(ttl / 3) + ttl + 1)
+
+    with patch("maya.now", maya_now_expired_2):
+        assert ttl_cache[1] is None
+        assert ttl_cache[2] is None
+        assert ttl_cache[3] == "c"
+        assert len(ttl_cache) == 1
+
+    def maya_now_expired_3():
+        return now.add(seconds=(ttl / 3 * 2) + ttl + 1)
+
+    with patch("maya.now", maya_now_expired_3):
+        assert ttl_cache[1] is None
+        assert ttl_cache[2] is None
+        assert ttl_cache[3] is None
+        assert len(ttl_cache) == 0
+
+
+def test_cache_purge_expired_entries():
+    ttl = 60  # 60s
+    ttl_cache = TTLCache(ttl=ttl)
+
+    now = maya.now()
+
+    ttl_cache[1] = "a"
+    ttl_cache[2] = "b"
+    ttl_cache[3] = "c"
+
+    assert len(ttl_cache) == 3
+    assert ttl_cache[1] == "a"
+    assert ttl_cache[2] == "b"
+    assert ttl_cache[3] == "c"
+
+    def maya_now():
+        # pretend time has passed
+        return now.add(seconds=ttl + 1)
+
+    with patch("maya.now", maya_now):
+        ttl_cache.purge_expired()
+        assert len(ttl_cache) == 0
+
+
+def test_cache_simple_concurrency():
+    ttl = 60  # 60s
+    ttl_cache = TTLCache(ttl=ttl)
+
+    def store_random_entries(ttl_cache: TTLCache):
+        num_times = 30
+        for i in range(num_times):
+            # run 30 times with some repeats
+            key = random.randint(1, 25)
+            value = random.randint(1, 100)
+            ttl_cache[key] = value
+
+            if i > int(num_times * 2 / 3):
+                # pick a random key to possibly remove
+                random_key_to_remove = random.randint(1, 25)
+                ttl_cache.remove(random_key_to_remove)
+
+        # do some purging - does nothing since no entries expire but
+        # ensures that locks are acquired/released
+        ttl_cache.purge_expired()
+
+    num_total_executions = 30
+    assert len(ttl_cache) == 0
+
+    # use thread pool
+    n_threads = 10
+    with ThreadPoolExecutor(n_threads) as executor:
+        # download each url and save as a local file
+        futures = []
+        for _ in range(num_total_executions):
+            f = executor.submit(store_random_entries, ttl_cache)
+            futures.append(f)
+
+        wait(futures, timeout=5)  # only wait max 5s
+
+    # probability that at the end of concurrent execution there is no entry
+    # is very low (not 0) - but I can live with that.
+    assert (
+        len(ttl_cache) > 0
+    ), "this can fail with a very low probability - most likely rerun test"


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Builds on #3183  (based over it).

One concern during a walkthrough with @KPrasch was that the `ParticipationState` dictionary is linearly increasing as rituals are initiated, and never cleared. This can be a very slow memory leak.

This PR uses a time-to-live cache utility for storing participation states and is periodically purged once entries are expired. ParticipationStates are cached for a little longer than the ritual timeout (an additional buffer (1hr in this PR)) just to be sure that we don't potentially get a repeated event right after purging. Remember that the EventScanner goes back some blocks when scanning in case there is a blockchain reorg, so we can get repeated events.

The overall goal here is to ensure that the participation states tracking mechanism used the `ActiveRitualTracker` periodically clears stale ritual state information.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Take note of the timeout numbers, tough to guess them, but if you have some intuition of a better value, please speak up.
