### PR TITLE
Don't expose Ferveo variant in python Bob public API

### DIFF
--- a/newsfragments/3193.misc.rst
+++ b/newsfragments/3193.misc.rst
@@ -1,0 +1,1 @@
+Don't allow users to specify the FerveoVariant to use for threshold decryption. The default, simple variant, will be used.

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1453,7 +1453,6 @@ class Enrico:
     """A data source that encrypts data for some policy's public key"""
 
     banner = ENRICO_BANNER
-    default_dkg_variant = FerveoVariant.SIMPLE
 
     def __init__(self, encrypting_key: Union[PublicKey, DkgPublicKey]):
         self.signing_power = SigningPower()
@@ -1479,29 +1478,6 @@ class Enrico:
         conditions_bytes = json.dumps(conditions).encode()
         ciphertext = encrypt(plaintext, conditions_bytes, self.policy_pubkey)
         return ciphertext
-
-    def encrypt_for_dkg_and_produce_decryption_request(
-        self,
-        plaintext: bytes,
-        conditions: Lingo,
-        ritual_id: int,
-        variant: int = None,
-        context: Optional[bytes] = None,
-    ) -> Tuple[Ciphertext, ThresholdDecryptionRequest]:
-        ciphertext = self.encrypt_for_dkg(plaintext=plaintext, conditions=conditions)
-
-        if variant is None:
-            variant = self.default_dkg_variant.value
-
-        tdr = ThresholdDecryptionRequest(
-            ritual_id=ritual_id,
-            ciphertext=ciphertext,
-            conditions=Conditions(json.dumps(conditions)),
-            context=context,
-            variant=variant,
-        )
-
-        return ciphertext, tdr
 
     @classmethod
     def from_alice(cls, alice: Alice, label: bytes):

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -622,7 +622,7 @@ class Bob(Character):
         return cohort
 
     @staticmethod
-    def make_decryption_request(
+    def __make_decryption_request(
         ritual_id: int,
         ciphertext: Ciphertext,
         lingo: Lingo,
@@ -736,7 +736,7 @@ class Bob(Character):
             else ritual.shares
         )  # TODO: #3095 get this from the ritual / put it on-chain?
 
-        decryption_request = self.make_decryption_request(
+        decryption_request = self.__make_decryption_request(
             ritual_id=ritual_id,
             ciphertext=ciphertext,
             lingo=conditions,
@@ -751,12 +751,12 @@ class Bob(Character):
             threshold=threshold,
         )
 
-        return self._decrypt(
+        return self.__decrypt(
             list(decryption_shares.values()), ciphertext, conditions, variant
         )
 
     @staticmethod
-    def _decrypt(
+    def __decrypt(
         shares: List[Union[DecryptionShareSimple, DecryptionSharePrecomputed]],
         ciphertext: Ciphertext,
         conditions: Lingo,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -438,7 +438,7 @@ class Alice(Character, actors.PolicyAuthor):
 
 class Bob(Character):
     banner = BOB_BANNER
-    default_dkg_variant = FerveoVariant.SIMPLE
+    _default_dkg_variant = FerveoVariant.SIMPLE
     _default_crypto_powerups = [SigningPower, DecryptingPower]
     _threshold_decryption_client_class = ThresholdDecryptionClient
 
@@ -712,7 +712,6 @@ class Bob(Character):
         conditions: Lingo,
         context: Optional[dict] = None,
         ursulas: Optional[List["Ursula"]] = None,
-        variant: str = "simple",
         peering_timeout: int = 60,
     ) -> bytes:
         ritual = self.get_ritual_from_id(ritual_id)
@@ -730,13 +729,7 @@ class Bob(Character):
                     )
                 self.remember_node(ursula)
 
-        try:
-            variant = FerveoVariant(getattr(FerveoVariant, variant.upper()).value)
-        except AttributeError:
-            raise ValueError(
-                f"Invalid variant: {variant}; Options are: {list(v.name.lower() for v in list(FerveoVariant))}"
-            )
-
+        variant = self._default_dkg_variant
         threshold = (
             (ritual.shares // 2) + 1
             if variant == FerveoVariant.SIMPLE

--- a/nucypher/crypto/ferveo/dkg.py
+++ b/nucypher/crypto/ferveo/dkg.py
@@ -78,6 +78,7 @@ def verify_aggregate(
 ):
     pvss_aggregated.verify(shares, transcripts)
 
+
 def derive_decryption_share(
     nodes: List[Validator],
     aggregated_transcript: AggregatedTranscript,
@@ -93,7 +94,7 @@ def derive_decryption_share(
     try:
         derive_share = _VARIANTS[variant]
     except KeyError:
-        raise Exception(f"invalid variant {variant}")
+        raise ValueError(f"Invalid variant {variant}")
     share = derive_share(
         # first arg here is intended to be "self" since the method is unbound
         aggregated_transcript,

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -134,7 +134,6 @@ def test_ursula_ritualist(testerchain, coordinator_agent, cohort, alice, bob):
             ritual_id=RITUAL_ID,
             ciphertext=ciphertext,
             conditions=CONDITIONS,
-            # params=cohort[0].dkg_storage.get_dkg_params(RITUAL_ID),
             peering_timeout=0
         )
         assert bytes(cleartext) == PLAINTEXT.encode()

--- a/tests/integration/blockchain/test_dkg_ritual.py
+++ b/tests/integration/blockchain/test_dkg_ritual.py
@@ -198,14 +198,6 @@ def test_ursula_ritualist(
             )
             assert bytes(cleartext) == PLAINTEXT.encode()
 
-            # again, but without `params`
-            cleartext = bob.threshold_decrypt(
-                ritual_id=ritual_id,
-                ciphertext=ciphertext,
-                conditions=CONDITIONS,
-                peering_timeout=0,
-            )
-            assert bytes(cleartext) == PLAINTEXT.encode()
         print("==================== DECRYPTION SUCCESSFUL ====================")
 
     def error_handler(e):

--- a/tests/integration/config/test_keystore_integration.py
+++ b/tests/integration/config/test_keystore_integration.py
@@ -15,6 +15,7 @@ from nucypher_core.umbral import SecretKey, Signer
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Alice, Bob, Enrico, Ursula
 from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.crypto.ferveo.dkg import FerveoVariant
 from nucypher.crypto.keystore import Keystore
 from nucypher.crypto.powers import (
     DecryptingPower,
@@ -191,7 +192,7 @@ def test_ritualist(temp_dir_path, testerchain, dkg_public_key):
     ciphertext = enrico.encrypt_for_dkg(plaintext=plaintext, conditions=CONDITIONS)
     decryption_request = ThresholdDecryptionRequest(
         ritual_id=ritual_id,
-        variant=0,
+        variant=FerveoVariant.SIMPLE.value,
         ciphertext=ciphertext,
         conditions=Conditions(json.dumps(CONDITIONS)),
     )


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Remove FerveoVariant parameter from public python API for threshold decryption.

**Issues fixed/closed:**
Fixes #3181 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
