### PR TITLE
Replace git dependency with `nucypher-core@0.11.0` package

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,7 +11,7 @@ python_version = "3"
 constant-sorrow = ">=0.1.0a9"
 bytestring-splitter = ">=2.4.0"
 hendrix = ">=4.0"
-nucypher-core = {git="https://github.com/nucypher/nucypher-core.git", ref="b3dbb5fc38a1a044dce5ea5d47cbda540a532227", subdirectory="nucypher-core-python"}
+nucypher-core = "==0.11.0"
 # Cryptography
 cryptography = ">=3.2"
 mnemonic = "*"

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ msgpack==1.0.5
 msgpack-python==0.5.6
 multidict==5.2.0 ; python_version >= '3.6'
 mypy-extensions==0.4.4 ; python_version >= '2.7'
-nucypher-core@git+https://github.com/nucypher/nucypher-core.git@b3dbb5fc38a1a044dce5ea5d47cbda540a532227#subdirectory=nucypher-core-python
+nucypher-core==0.11.0
 packaging==23.1 ; python_version >= '3.7'
 parsimonious==0.9.0
 pendulum==3.0.0a1 ; python_version >= '3.7' and python_version < '4.0'


### PR DESCRIPTION
**Type of PR:**
- Other

**Required reviews:** 
- 1

**What this does:**
- Follow-up to https://github.com/nucypher/nucypher/pull/3171
