### PR TITLE
Fix staking metrics in Prometheus exporter

### DIFF
--- a/newsfragments/3199.bugfix.rst
+++ b/newsfragments/3199.bugfix.rst
@@ -1,0 +1,1 @@
+Fix staking metrics in Prometheus exporter

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -179,8 +179,8 @@ class StakingProviderMetricsCollector(BaseMetricsCollector):
     def _collect_internal(self) -> None:
         application_agent = ContractAgency.get_agent(
             PREApplicationAgent,
-            self.contract_registry,
-            self.eth_provider_uri,
+            registry=self.contract_registry,
+            eth_provider_uri=self.eth_provider_uri,
         )
         authorized = application_agent.get_authorized_stake(
             staking_provider=self.staking_provider_address

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -150,10 +150,12 @@ class StakingProviderMetricsCollector(BaseMetricsCollector):
         self,
         staking_provider_address: ChecksumAddress,
         contract_registry: BaseContractRegistry,
+        eth_provider_uri: str,
     ):
         super().__init__()
         self.staking_provider_address = staking_provider_address
         self.contract_registry = contract_registry
+        self.eth_provider_uri = eth_provider_uri
 
     def initialize(self, metrics_prefix: str, registry: CollectorRegistry) -> None:
         self.metrics = {
@@ -176,7 +178,9 @@ class StakingProviderMetricsCollector(BaseMetricsCollector):
 
     def _collect_internal(self) -> None:
         application_agent = ContractAgency.get_agent(
-            PREApplicationAgent, registry=self.contract_registry
+            PREApplicationAgent,
+            self.contract_registry,
+            self.eth_provider_uri,
         )
         authorized = application_agent.get_authorized_stake(
             staking_provider=self.staking_provider_address

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -166,6 +166,7 @@ def create_metrics_collectors(ursula: "lawful.Ursula") -> List[MetricsCollector]
         StakingProviderMetricsCollector(
             staking_provider_address=ursula.checksum_address,
             contract_registry=ursula.registry,
+            eth_provider_uri=ursula.eth_provider_uri,
         )
     )
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
When running Ursula with --prometheus flag, the execution crash after a while:

```
File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher-ursula/lib/python3.10/site-packages/twisted/internet/defer.py", line 206, in maybeDeferred
result = f(*args, **kwargs)
File "/Users/manumonti/nucypher/nucypher/utilities/prometheus/metrics.py", line 119, in collect_prometheus_metrics
collector.collect()
File "/Users/manumonti/nucypher/nucypher/utilities/prometheus/collector.py", line 62, in collect
self._collect_internal()
File "/Users/manumonti/nucypher/nucypher/utilities/prometheus/collector.py", line 178, in _collect_internal
application_agent = ContractAgency.get_agent(
builtins.TypeError: ContractAgency.get_agent() missing 1 required positional argument: 'provider_uri'
```

The reason is PR #3137 made `provider_uri` a required parameter for ContractAgency.get_agent function. This change was not reflected in Prometheus exporter.

**Issues fixed/closed:**

**Why it's needed:**

**Notes for reviewers:**
