### PR TITLE
Add `condition_type` to condition schemas

### DIFF
--- a/newsfragments/3201.feature.rst
+++ b/newsfragments/3201.feature.rst
@@ -1,0 +1,1 @@
+Add a mandatory condition_type field to condition schemas

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -108,17 +108,17 @@ def _validate_chain(chain: int) -> None:
 
 class RPCCondition(AccessControlCondition):
     ETH_PREFIX = "eth_"
-
     ALLOWED_METHODS = (
         # RPC
         "eth_getBalance",
     )  # TODO other allowed methods (tDEC #64)
-
     LOG = logging.Logger(__name__)
+    CONDITION_TYPE = "rpc"
 
     class Schema(CamelCaseSchema):
         SKIP_VALUES = (None,)
         name = fields.Str(required=False)
+        condition_type = fields.Str(required=True)
         chain = fields.Int(required=True)
         method = fields.Str(required=True)
         parameters = fields.List(fields.Field, attribute="parameters", required=False)
@@ -139,6 +139,7 @@ class RPCCondition(AccessControlCondition):
         chain: int,
         method: str,
         return_value_test: ReturnValueTest,
+        condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
         parameters: Optional[List[Any]] = None,
     ):
@@ -147,6 +148,7 @@ class RPCCondition(AccessControlCondition):
         _validate_chain(chain=chain)
 
         # internal
+        self.condition_type = condition_type
         self.name = name
         self.chain = chain
         self.provider: Optional[BaseProvider] = None  # set in _configure_provider
@@ -258,7 +260,10 @@ class RPCCondition(AccessControlCondition):
 
 
 class ContractCondition(RPCCondition):
+    CONDITION_TYPE = "contract"
+
     class Schema(RPCCondition.Schema):
+        condition_type = fields.Str(required=True)
         standard_contract_type = fields.Str(required=False)
         contract_address = fields.Str(required=True)
         function_abi = fields.Dict(required=False)
@@ -279,6 +284,7 @@ class ContractCondition(RPCCondition):
     def __init__(
         self,
         contract_address: ChecksumAddress,
+        condition_type: str = CONDITION_TYPE,
         standard_contract_type: Optional[str] = None,
         function_abi: Optional[ABIFunction] = None,
         *args,
@@ -298,6 +304,7 @@ class ContractCondition(RPCCondition):
 
         # spec
         self.contract_address = contract_address
+        self.condition_type = condition_type
         self.standard_contract_type = standard_contract_type
         self.function_abi = function_abi
         self.contract_function = self._get_unbound_contract_function()

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -10,9 +10,11 @@ from nucypher.policy.conditions.utils import CamelCaseSchema
 
 class TimeCondition(RPCCondition):
     METHOD = "blocktime"
+    CONDITION_TYPE = "time"
 
     class Schema(CamelCaseSchema):
         SKIP_VALUES = (None,)
+        condition_type = fields.Str(required=True)
         name = fields.Str(required=False)
         chain = fields.Int(required=True)
         method = fields.Str(dump_default="blocktime", required=True)
@@ -33,6 +35,7 @@ class TimeCondition(RPCCondition):
         return_value_test: ReturnValueTest,
         chain: int,
         method: str = METHOD,
+        condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
     ):
         if method != self.METHOD:
@@ -40,7 +43,11 @@ class TimeCondition(RPCCondition):
                 f"{self.__class__.__name__} must be instantiated with the {self.METHOD} method."
             )
         super().__init__(
-            chain=chain, method=method, return_value_test=return_value_test, name=name
+            chain=chain,
+            method=method,
+            return_value_test=return_value_test,
+            name=name,
+            condition_type=condition_type,
         )
 
     def validate_method(self, method):

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -1,20 +1,22 @@
 from typing import Any, List, Optional
 
-from marshmallow import fields, post_load
+from marshmallow import fields, post_load, validate
 
 from nucypher.policy.conditions.evm import RPCCondition
 from nucypher.policy.conditions.exceptions import InvalidCondition
-from nucypher.policy.conditions.lingo import ReturnValueTest
+from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 from nucypher.policy.conditions.utils import CamelCaseSchema
 
 
 class TimeCondition(RPCCondition):
     METHOD = "blocktime"
-    CONDITION_TYPE = "time"
+    CONDITION_TYPE = ConditionType.TIME.value
 
     class Schema(CamelCaseSchema):
         SKIP_VALUES = (None,)
-        condition_type = fields.Str(required=True)
+        condition_type = fields.Str(
+            validate=validate.Equal(ConditionType.TIME.value), required=True
+        )
         name = fields.Str(required=False)
         chain = fields.Int(required=True)
         method = fields.Str(dump_default="blocktime", required=True)
@@ -35,7 +37,7 @@ class TimeCondition(RPCCondition):
         return_value_test: ReturnValueTest,
         chain: int,
         method: str = METHOD,
-        condition_type: str = CONDITION_TYPE,
+        condition_type: str = ConditionType.TIME.value,
         name: Optional[str] = None,
     ):
         if method != self.METHOD:

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -39,6 +39,7 @@ class _AccessControlCondition(TypedDict):
 
 
 class RPCConditionDict(_AccessControlCondition):
+    conditionType: str
     chain: int
     method: str
     parameters: NotRequired[List[Any]]
@@ -63,6 +64,7 @@ class ContractConditionDict(RPCConditionDict):
 #
 #
 class CompoundConditionDict(TypedDict):
+    conditionType: str
     operator: Literal["and", "or"]
     operands: List["Lingo"]
 

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -21,6 +21,7 @@ PLAINTEXT = "peace at dawn"
 CONDITIONS = {
     "version": ConditionLingo.VERSION,
     "condition": {
+        "conditionType": "time",
         "returnValueTest": {"value": "0", "comparator": ">"},
         "method": "blocktime",
         "chain": TESTERCHAIN_CHAIN_ID,

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -521,14 +521,17 @@ def test_single_retrieve_with_onchain_conditions(enacted_policy, bob, ursulas):
     conditions = {
         "version": ConditionLingo.VERSION,
         "condition": {
+            "conditionType": "compound",
             "operator": "and",
             "operands": [
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": "0", "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },
                 {
+                    "conditionType": "rpc",
                     "chain": TESTERCHAIN_CHAIN_ID,
                     "method": "eth_getBalance",
                     "parameters": [bob.checksum_address, "latest"],

--- a/tests/data/test_conditions.json
+++ b/tests/data/test_conditions.json
@@ -1,8 +1,13 @@
 {
-  "customABIMultipleParameters" : {
+  "customABIMultipleParameters": {
+    "conditionType": "contract",
     "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
     "method": "isSubscribedToToken",
-    "parameters": [":userAddress", "subscriptionCode", 4],
+    "parameters": [
+      ":userAddress",
+      "subscriptionCode",
+      4
+    ],
     "functionAbi": {
       "inputs": [
         {
@@ -72,6 +77,7 @@
     }
   },
   "TStaking": {
+    "conditionType": "contract",
     "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
     "chain": 1,
     "method": "stakes",
@@ -114,6 +120,7 @@
     }
   },
   "SubscriptionManagerPayment": {
+    "conditionType": "contract",
     "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "chain": 137,
     "method": "isValidPolicy",
@@ -126,6 +133,7 @@
     }
   },
   "ERC1155_balance": {
+    "conditionType": "contract",
     "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC1155",
     "chain": 1,
@@ -140,20 +148,32 @@
     }
   },
   "ERC1155_balance_batch": {
+    "conditionType": "contract",
     "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC1155",
     "chain": 1,
     "method": "balanceOfBatch",
     "parameters": [
-      [":userAddress",":userAddress",":userAddress",":userAddress"],
-      [1,2,10003,10004]
+      [
+        ":userAddress",
+        ":userAddress",
+        ":userAddress",
+        ":userAddress"
+      ],
+      [
+        1,
+        2,
+        10003,
+        10004
+      ]
     ],
     "returnValueTest": {
       "comparator": ">",
       "value": 0
     }
   },
-  "ERC721_ownership":   {
+  "ERC721_ownership": {
+    "conditionType": "contract",
     "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC721",
     "chain": 1,
@@ -166,7 +186,8 @@
       "value": ":userAddress"
     }
   },
-  "ERC721_balance":   {
+  "ERC721_balance": {
+    "conditionType": "contract",
     "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC721",
     "chain": 1,
@@ -179,7 +200,8 @@
       "value": 0
     }
   },
-  "ERC20_balance":   {
+  "ERC20_balance": {
+    "conditionType": "contract",
     "contractAddress": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
     "standardContractType": "ERC20",
     "chain": 1,
@@ -192,7 +214,8 @@
       "value": 0
     }
   },
-  "ETH_balance":   {
+  "ETH_balance": {
+    "conditionType": "contract",
     "contractAddress": "",
     "standardContractType": "",
     "chain": 1,
@@ -206,7 +229,8 @@
       "value": 10000000000000
     }
   },
-  "specific_wallet_address":   {
+  "specific_wallet_address": {
+    "conditionType": "contract",
     "contractAddress": "",
     "standardContractType": "",
     "chain": 1,
@@ -219,12 +243,15 @@
       "value": "0xaDD9D957170dF6F33982001E4c22eCCdd5539118"
     }
   },
-  "timestamp":   {
+  "timestamp": {
+    "conditionType": "contract",
     "contractAddress": "",
     "standardContractType": "timestamp",
     "chain": 1,
     "method": "eth_getBlockByNumber",
-    "parameters": ["latest"],
+    "parameters": [
+      "latest"
+    ],
     "returnValueTest": {
       "comparator": ">=",
       "value": 1234567890

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -612,14 +612,17 @@ def compound_blocktime_lingo():
     return {
         "version": ConditionLingo.VERSION,
         "condition": {
+            "conditionType": "compound",
             "operator": "and",
             "operands": [
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": "0", "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },
                 {
+                    "conditionType": "time",
                     "returnValueTest": {
                         "value": "99999999999999999",
                         "comparator": "<",
@@ -628,6 +631,7 @@ def compound_blocktime_lingo():
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": "0", "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,

--- a/tests/integration/blockchain/test_dkg_ritual.py
+++ b/tests/integration/blockchain/test_dkg_ritual.py
@@ -22,6 +22,7 @@ PLAINTEXT = "peace at dawn"
 CONDITIONS = {
     "version": ConditionLingo.VERSION,
     "condition": {
+        "conditionType": "time",
         "returnValueTest": {"value": "0", "comparator": ">"},
         "method": "blocktime",
         "chain": TESTERCHAIN_CHAIN_ID,

--- a/tests/integration/characters/test_conditional_reencryption.py
+++ b/tests/integration/characters/test_conditional_reencryption.py
@@ -28,14 +28,17 @@ def test_single_retrieve_with_truthy_conditions(enacted_policy, bob, ursulas, mo
     conditions = {
         "version": ConditionLingo.VERSION,
         "condition": {
+            "conditionType": "compound",
             "operator": "and",
             "operands": [
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": 99999999999999999, "comparator": "<"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
@@ -69,6 +72,7 @@ def test_single_retrieve_with_falsy_conditions(enacted_policy, bob, ursulas, moc
             {
                 "version": ConditionLingo.VERSION,
                 "condition": {
+                    "conditionType": "time",
                     "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
@@ -130,6 +134,7 @@ def test_middleware_handling_of_failed_condition_responses(
             {
                 "version": ConditionLingo.VERSION,
                 "condition": {
+                    "conditionType": "time",
                     "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,

--- a/tests/integration/characters/test_dkg_and_testnet_bypass.py
+++ b/tests/integration/characters/test_dkg_and_testnet_bypass.py
@@ -29,6 +29,7 @@ def _attempt_decryption(BobClass, plaintext):
     definitely_false_condition = {
         "version": ConditionLingo.VERSION,
         "condition": {
+            "conditionType": "time",
             "chain": TESTERCHAIN_CHAIN_ID,
             "method": "blocktime",
             "returnValueTest": {"comparator": "<", "value": 0},

--- a/tests/integration/config/test_keystore_integration.py
+++ b/tests/integration/config/test_keystore_integration.py
@@ -182,6 +182,7 @@ def test_ritualist(temp_dir_path, testerchain, dkg_public_key):
     CONDITIONS = {
         "version": ConditionLingo.VERSION,
         "condition": {
+            "conditionType": "time",
             "returnValueTest": {"value": "0", "comparator": ">"},
             "method": "blocktime",
             "chain": TESTERCHAIN_CHAIN_ID,

--- a/tests/integration/utilities/test_prometheus_collectors.py
+++ b/tests/integration/utilities/test_prometheus_collectors.py
@@ -100,6 +100,7 @@ def test_staking_provider_metrics_collector(test_registry, staking_providers, mo
     collector = StakingProviderMetricsCollector(
         staking_provider_address=staking_provider_address,
         contract_registry=test_registry,
+        eth_provider_uri=MOCK_ETH_PROVIDER_URI,
     )
     collector_registry = CollectorRegistry()
     prefix = "test_staking_provider_metrics_collector"

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -16,14 +16,17 @@ def lingo():
     return {
         "version": ConditionLingo.VERSION,
         "condition": {
+            "conditionType": "compound",
             "operator": "and",
             "operands": [
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": 99999999999999999, "comparator": "<"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
@@ -55,9 +58,11 @@ def test_invalid_condition():
     invalid_operator_position_lingo = {
         "version": ConditionLingo.VERSION,
         "condition": {
+            "conditionType": "compound",
             "operator": "and",
             "operands": [
                 {
+                    "conditionType": "time",
                     "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
@@ -87,6 +92,7 @@ def test_invalid_condition_version(case):
     lingo_dict = {
         "version": newer_version_string,
         "condition": {
+            "conditionType": "time",
             "returnValueTest": {"value": 0, "comparator": ">"},
             "method": "blocktime",
             "chain": TESTERCHAIN_CHAIN_ID,


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- Adds a mandatory `condition_type` field to condition schemas
- Handles downstream changes from https://github.com/nucypher/nucypher-ts/pull/267

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
- Provides a concrete condition type to avoid relying on duck-typing across different libraries/languages.

**Notes for reviewers:**
- The tests didn't catch any issues, but are there any other relevant places where this change could have gone unnoticed?