### PR TITLE
Fix Prometheus import error when running Porter

### DIFF
--- a/newsfragments/3202.bugfix.rst
+++ b/newsfragments/3202.bugfix.rst
@@ -1,0 +1,1 @@
+Fix Prometheus import error when running Porter

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -4,6 +4,7 @@ import time
 from pathlib import Path
 from queue import Queue
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
@@ -116,7 +117,9 @@ from nucypher.policy.policies import Policy
 from nucypher.utilities.emitters import StdoutEmitter
 from nucypher.utilities.logging import Logger
 from nucypher.utilities.networking import validate_operator_ip
-from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
+
+if TYPE_CHECKING:
+    from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
 
 
 class Alice(Character, actors.PolicyAuthor):
@@ -990,13 +993,13 @@ class Ursula(Teacher, Character, actors.Operator, actors.Ritualist):
     def run(
         self,
         emitter: StdoutEmitter = None,
-        discovery: bool = True,  # TODO: see below
+        discovery: bool = True,
         availability: bool = False,
         worker: bool = True,
         ritualist: bool = True,
         hendrix: bool = True,
         start_reactor: bool = True,
-        prometheus_config: PrometheusMetricsConfig = None,
+        prometheus_config: "PrometheusMetricsConfig" = None,
         preflight: bool = True,
         block_until_ready: bool = True,
         eager: bool = False,

--- a/tests/integration/utilities/test_prometheus_collectors.py
+++ b/tests/integration/utilities/test_prometheus_collectors.py
@@ -100,6 +100,7 @@ def test_staking_provider_metrics_collector(test_registry, staking_providers, mo
     collector = StakingProviderMetricsCollector(
         staking_provider_address=staking_provider_address,
         contract_registry=test_registry,
+        eth_provider_uri=MOCK_ETH_PROVIDER_URI,
     )
     collector_registry = CollectorRegistry()
     prefix = "test_staking_provider_metrics_collector"


### PR DESCRIPTION
**Please, don't merge until #3203  is merged**

**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Commit a4de8a88 introduced amazing changes and solved linting errors like F821. To achieve it, this change introduced the import of PrometheusMetricsConfig in lawful.py, which is dependent on prometheus-client package.

Ursula imports prometheus-client, so no problem with this. But Porter does not. So an import error is raised when Porter is run.

Also, a remaining TODO comment has been cleaned. This TODO is part of a larger comment and was introduced in commit 424e373a and solved afterwards.