### PR TITLE
Fix Prometheus staking provider metrics test

### DIFF
--- a/tests/integration/utilities/test_prometheus_collectors.py
+++ b/tests/integration/utilities/test_prometheus_collectors.py
@@ -100,6 +100,7 @@ def test_staking_provider_metrics_collector(test_registry, staking_providers, mo
     collector = StakingProviderMetricsCollector(
         staking_provider_address=staking_provider_address,
         contract_registry=test_registry,
+        eth_provider_uri=MOCK_ETH_PROVIDER_URI,
     )
     collector_registry = CollectorRegistry()
     prefix = "test_staking_provider_metrics_collector"


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> Commit fb32b081 made eth_provider_uri argument mandatory when creating a StakingProviderMetricsCollector object. This change was not reflected in test_prometheus_collectors.py, causing the test to fail.