### PR TITLE
Multichain connection broadcasting endpoint for Ursula

### DIFF
--- a/newsfragments/3205.feature.rst
+++ b/newsfragments/3205.feature.rst
@@ -1,0 +1,1 @@
+New HTTP(S) endpoint to return a list of all the blockchains a node is currently connected to for conditions evaluation.

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -135,6 +135,18 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
         # TODO: What's the right status code here?  202?  Different if we already knew about the node(s)?
         return all_known_nodes()
 
+    @rest_app.route("/condition_chains", methods=["GET"])
+    def condition_chains():
+        """
+        An endpoint that returns the condition evaluation blockchains
+        this node has connected to.
+        """
+        # TODO: When non-evm chains are supported, bump the version.
+        #  this can return a list of chain names or other verifiable identifiers.
+
+        payload = {"version": 1.0, "evm": list(this_node.condition_providers)}
+        return Response(json.dumps(payload), mimetype="application/json")
+
     @rest_app.route('/decrypt', methods=["POST"])
     def threshold_decrypt():
 

--- a/tests/integration/network/test_condition_blockchain_broadcast.py
+++ b/tests/integration/network/test_condition_blockchain_broadcast.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.fixture(scope="module")
+def multichain_ursula(multichain_ursulas):
+    ursula = multichain_ursulas[3]
+    return ursula
+
+
+@pytest.fixture(scope="module")
+def client(multichain_ursula):
+    multichain_ursula.rest_app.config.update({"TESTING": True})
+    yield multichain_ursula.rest_app.test_client()
+
+
+def test_condition_chains_endpoint_multichain(
+    multichain_ursula, client, multichain_ids
+):
+    response = client.get("/condition_chains")
+    assert response.status_code == 200
+    expected_payload = {"version": 1.0, "evm": multichain_ids}
+    assert response.get_json() == expected_payload


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
2

**What this does:**
- Defines a new JSON endpoint (GET @ `/condition_chains`) that returns a list of all chain IDs Ursula is connected to.
```python
{"version": 1.0, "evm": [1, 5, 80001]}
```
- Multichain fixture and utilities cleanup

**Why it's needed:**
- Assistance in evaluating network health and node operator compliance with multichain connection requirements

**Notes for reviewers:**
- The response is versioned so we can expand the number fields in a non-evm future feature
- Co-Authored by @theref 