### PR TITLE
Automated Configuration Migrations

### DIFF
--- a/newsfragments/3207.feature.rst
+++ b/newsfragments/3207.feature.rst
@@ -1,0 +1,1 @@
+Introduces `nucypher ursula config migrate` for configuration file automation.

--- a/nucypher/blockchain/eth/networks.py
+++ b/nucypher/blockchain/eth/networks.py
@@ -2,6 +2,7 @@ class NetworksInventory:  # TODO: See #1564
 
     MAINNET = "mainnet"
     LYNX = "lynx"
+    IBEX = "ibex"  # this is required for configuration file migrations (backwards compatibility)
     ETH = "ethereum"
     TAPIR = "tapir"
     ORYX = "oryx"
@@ -15,6 +16,7 @@ class NetworksInventory:  # TODO: See #1564
 
     __to_chain_id_eth = {
         MAINNET: 1,  # Ethereum Mainnet
+        IBEX: 5,  # this is required for configuration file migrations (backwards compatibility)
         LYNX: 5,  # Goerli
         TAPIR: 5,
         ORYX: 5

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -75,7 +75,10 @@ CONFIRM_FORGET_NODES = "Permanently delete all known node data?"
 
 SUCCESSFUL_FORGET_NODES = "Removed all stored known nodes metadata and certificates"
 
-IGNORE_OLD_CONFIGURATION = "Ignoring configuration file '{config_file}' - version is too old"
+IGNORE_OLD_CONFIGURATION = """
+Ignoring configuration file '{config_file}' - version is too old,
+Run `nucypher ursula config migrate --config-file {config_file}` to update it.
+"""
 
 DEFAULT_TO_LONE_CONFIG_FILE = "Defaulting to {config_class} configuration file: '{config_file}'"
 

--- a/nucypher/config/migrations/__init__.py
+++ b/nucypher/config/migrations/__init__.py
@@ -1,0 +1,18 @@
+from collections import OrderedDict
+
+from .configuration_v1_to_v2 import configuration_v1_to_v2
+from .configuration_v3_to_v4 import configuration_v3_to_v4
+from .configuration_v4_to_v5 import configuration_v4_to_v5
+from .configuration_v4_to_v6 import configuration_v4_to_v6
+from .configuration_v5_to_v6 import configuration_v5_to_v6
+
+MIGRATIONS = OrderedDict(
+    {
+        (1, 2): configuration_v1_to_v2,
+        (2, 3): None,  # (no-op)
+        (3, 4): configuration_v3_to_v4,
+        (4, 5): configuration_v4_to_v5,
+        (4, 6): configuration_v4_to_v6,
+        (5, 6): configuration_v5_to_v6,
+    }
+)

--- a/nucypher/config/migrations/__init__.py
+++ b/nucypher/config/migrations/__init__.py
@@ -2,17 +2,13 @@ from collections import OrderedDict
 
 from .configuration_v1_to_v2 import configuration_v1_to_v2
 from .configuration_v3_to_v4 import configuration_v3_to_v4
-from .configuration_v4_to_v5 import configuration_v4_to_v5
 from .configuration_v4_to_v6 import configuration_v4_to_v6
-from .configuration_v5_to_v6 import configuration_v5_to_v6
 
 MIGRATIONS = OrderedDict(
     {
         (1, 2): configuration_v1_to_v2,
         (2, 3): None,  # (no-op)
         (3, 4): configuration_v3_to_v4,
-        (4, 5): configuration_v4_to_v5,
         (4, 6): configuration_v4_to_v6,
-        (5, 6): configuration_v5_to_v6,
     }
 )

--- a/nucypher/config/migrations/__init__.py
+++ b/nucypher/config/migrations/__init__.py
@@ -3,6 +3,7 @@ from collections import OrderedDict
 from .configuration_v1_to_v2 import configuration_v1_to_v2
 from .configuration_v3_to_v4 import configuration_v3_to_v4
 from .configuration_v4_to_v6 import configuration_v4_to_v6
+from .configuration_v5_to_v6 import configuration_v5_to_v6
 
 MIGRATIONS = OrderedDict(
     {
@@ -10,5 +11,6 @@ MIGRATIONS = OrderedDict(
         (2, 3): None,  # (no-op)
         (3, 4): configuration_v3_to_v4,
         (4, 6): configuration_v4_to_v6,
+        (5, 6): configuration_v5_to_v6,
     }
 )

--- a/nucypher/config/migrations/_template.py
+++ b/nucypher/config/migrations/_template.py
@@ -1,0 +1,16 @@
+from typing import Dict
+
+from nucypher.config.migrations.common import perform_migration
+
+
+def __migration(config: Dict) -> None:
+    pass  # apply migrations here
+
+
+def configuration_v1_to_v2(filepath) -> None:  # rename accordingly
+    perform_migration(
+        old_version=1,  # migrating from version
+        new_version=2,  # migrating to version
+        migration=__migration,
+        filepath=filepath,
+    )

--- a/nucypher/config/migrations/common.py
+++ b/nucypher/config/migrations/common.py
@@ -1,0 +1,59 @@
+import json
+import os
+from pathlib import Path
+from typing import Callable, Dict, Tuple
+
+BACKUP_SUFFIX = ".old"
+
+
+class WrongConfigurationVersion(Exception):
+    pass
+
+
+class InvalidMigration(Exception):
+    pass
+
+
+def __prepare_migration(old_version: int, filepath: Path) -> Tuple[Dict, Path]:
+    # Read + deserialize
+    with open(filepath, "r") as file:
+        contents = file.read()
+    config = json.loads(contents)
+
+    # verify the correct version is being migrated
+    existing_version = config["version"]
+    if existing_version != old_version:
+        raise WrongConfigurationVersion(
+            f"Existing configuration is not version {old_version}; Got version {existing_version}"
+        )
+
+    # Make a copy of the original file
+    backup_filepath = str(filepath) + BACKUP_SUFFIX
+    os.rename(filepath, backup_filepath)
+    print(f"Backed up existing configuration to {backup_filepath}")
+    return config, Path(backup_filepath)
+
+
+def __finalize_migration(config: Dict, new_version: int, filepath: Path):
+    config["version"] = new_version
+    with open(filepath, "w") as file:
+        file.write(json.dumps(config, indent=4))
+
+
+def perform_migration(
+    old_version: int, new_version: int, migration: Callable, filepath: str
+):
+    config, backup_filepath = __prepare_migration(
+        old_version=old_version, filepath=Path(filepath)
+    )
+    try:
+        migration(config)
+    except KeyError:
+        os.rename(str(backup_filepath), filepath)  # rollback the changes
+        raise InvalidMigration(f"Invalid v{old_version} configuration file.")
+    __finalize_migration(
+        config=config, new_version=new_version, filepath=Path(filepath)
+    )
+    print(
+        f"OK! Migrated configuration file {filepath} from v{old_version} -> v{new_version}."
+    )

--- a/nucypher/config/migrations/configuration_v1_to_v2.py
+++ b/nucypher/config/migrations/configuration_v1_to_v2.py
@@ -1,44 +1,18 @@
-import json
-import os
+from typing import Dict
 
-BACKUP_SUFFIX = ".old"
-OLD_VERSION = 1
-NEW_VERSION = 2
+from nucypher.config.migrations.common import perform_migration
 
 
-def configuration_v1_to_v2(filepath: str):
-    # Read + deserialize
-    with open(filepath, "r") as file:
-        contents = file.read()
-    config = json.loads(contents)
+def __migration(config: Dict) -> None:
+    domains = config["domains"]
+    domain = domains[0]
+    if len(domains) > 1:
+        print(f"Multiple domains configured, using the first one ({domain}).")
+    del config["domains"]
+    config["domain"] = domain
 
-    try:
-        # Check we have version 1 indeed
-        existing_version = config["version"]
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(
-                f"Existing configuration is not version 1; Got version {existing_version}"
-            )
 
-        # Make a copy of the original file
-        backup_filepath = str(filepath) + BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f"Backed up existing configuration to {backup_filepath}")
-
-        # Get current domain value
-        domains = config["domains"]
-        domain = domains[0]
-        if len(domains) > 1:
-            print(f"Multiple domains configured, using the first one ({domain}).")
-
-        # Apply updates
-        del config["domains"]  # deprecated
-        config["domain"] = domain
-        config["version"] = NEW_VERSION
-    except KeyError:
-        raise KeyError(f"Invalid {OLD_VERSION} configuration file.")
-
-    # Commit updates
-    with open(filepath, "w") as file:
-        file.write(json.dumps(config, indent=4))
-    print("OK! Migrated configuration file from v1 -> v2.")
+def configuration_v1_to_v2(filepath) -> None:
+    perform_migration(
+        old_version=1, new_version=2, migration=__migration, filepath=filepath
+    )

--- a/nucypher/config/migrations/configuration_v1_to_v2.py
+++ b/nucypher/config/migrations/configuration_v1_to_v2.py
@@ -1,0 +1,44 @@
+import json
+import os
+
+BACKUP_SUFFIX = ".old"
+OLD_VERSION = 1
+NEW_VERSION = 2
+
+
+def configuration_v1_to_v2(filepath: str):
+    # Read + deserialize
+    with open(filepath, "r") as file:
+        contents = file.read()
+    config = json.loads(contents)
+
+    try:
+        # Check we have version 1 indeed
+        existing_version = config["version"]
+        if existing_version != OLD_VERSION:
+            raise RuntimeError(
+                f"Existing configuration is not version 1; Got version {existing_version}"
+            )
+
+        # Make a copy of the original file
+        backup_filepath = str(filepath) + BACKUP_SUFFIX
+        os.rename(filepath, backup_filepath)
+        print(f"Backed up existing configuration to {backup_filepath}")
+
+        # Get current domain value
+        domains = config["domains"]
+        domain = domains[0]
+        if len(domains) > 1:
+            print(f"Multiple domains configured, using the first one ({domain}).")
+
+        # Apply updates
+        del config["domains"]  # deprecated
+        config["domain"] = domain
+        config["version"] = NEW_VERSION
+    except KeyError:
+        raise KeyError(f"Invalid {OLD_VERSION} configuration file.")
+
+    # Commit updates
+    with open(filepath, "w") as file:
+        file.write(json.dumps(config, indent=4))
+    print("OK! Migrated configuration file from v1 -> v2.")

--- a/nucypher/config/migrations/configuration_v3_to_v4.py
+++ b/nucypher/config/migrations/configuration_v3_to_v4.py
@@ -1,0 +1,40 @@
+import json
+import os
+
+BACKUP_SUFFIX = ".old"
+OLD_VERSION = 3
+NEW_VERSION = 4
+
+
+def configuration_v3_to_v4(filepath: str):
+    # Read + deserialize
+    with open(filepath, "r") as file:
+        contents = file.read()
+    config = json.loads(contents)
+
+    try:
+        # Check we have version 1 indeed
+        existing_version = config["version"]
+        if existing_version != OLD_VERSION:
+            raise RuntimeError(
+                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
+            )
+
+        # Make a copy of the original file
+        backup_filepath = str(filepath) + BACKUP_SUFFIX
+        os.rename(filepath, backup_filepath)
+        print(f"Backed up existing configuration to {backup_filepath}")
+
+        # Apply updates
+        worker_address = config["worker_address"]
+        del config["worker_address"]  # deprecated
+        config["operator_address"] = worker_address
+        config["version"] = NEW_VERSION
+
+    except KeyError:
+        raise RuntimeError(f"Invalid {OLD_VERSION} configuration file.")
+
+    # Commit updates
+    with open(filepath, "w") as file:
+        file.write(json.dumps(config, indent=4))
+    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")

--- a/nucypher/config/migrations/configuration_v3_to_v4.py
+++ b/nucypher/config/migrations/configuration_v3_to_v4.py
@@ -1,40 +1,15 @@
-import json
-import os
+from typing import Dict
 
-BACKUP_SUFFIX = ".old"
-OLD_VERSION = 3
-NEW_VERSION = 4
+from nucypher.config.migrations.common import perform_migration
 
 
-def configuration_v3_to_v4(filepath: str):
-    # Read + deserialize
-    with open(filepath, "r") as file:
-        contents = file.read()
-    config = json.loads(contents)
+def __migration(config: Dict) -> None:
+    worker_address = config["worker_address"]
+    del config["worker_address"]  # deprecated
+    config["operator_address"] = worker_address
 
-    try:
-        # Check we have version 1 indeed
-        existing_version = config["version"]
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(
-                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
-            )
 
-        # Make a copy of the original file
-        backup_filepath = str(filepath) + BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f"Backed up existing configuration to {backup_filepath}")
-
-        # Apply updates
-        worker_address = config["worker_address"]
-        del config["worker_address"]  # deprecated
-        config["operator_address"] = worker_address
-        config["version"] = NEW_VERSION
-
-    except KeyError:
-        raise RuntimeError(f"Invalid {OLD_VERSION} configuration file.")
-
-    # Commit updates
-    with open(filepath, "w") as file:
-        file.write(json.dumps(config, indent=4))
-    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")
+def configuration_v3_to_v4(filepath) -> None:
+    perform_migration(
+        old_version=3, new_version=4, migration=__migration, filepath=filepath
+    )

--- a/nucypher/config/migrations/configuration_v4_to_v5.py
+++ b/nucypher/config/migrations/configuration_v4_to_v5.py
@@ -1,38 +1,14 @@
-import json
-import os
+from typing import Dict
 
-BACKUP_SUFFIX = ".old"
-OLD_VERSION = 4
-NEW_VERSION = 5
+from nucypher.config.migrations.common import perform_migration
 
 
-def configuration_v4_to_v5(filepath: str):
-    # Read + deserialize
-    with open(filepath, "r") as file:
-        contents = file.read()
-    config = json.loads(contents)
+def __migration(config: Dict) -> None:
+    del config["federated_only"]  # deprecated
+    del config["checksum_address"]
 
-    try:
-        existing_version = config["version"]
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(
-                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
-            )
 
-        # Make a copy of the original file
-        backup_filepath = str(filepath) + BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f"Backed up existing configuration to {backup_filepath}")
-
-        # Apply updates
-        del config["federated_only"]  # deprecated
-        del config["checksum_address"]
-        config["version"] = NEW_VERSION
-
-    except KeyError:
-        raise RuntimeError(f"Invalid {OLD_VERSION} configuration file.")
-
-    # Commit updates
-    with open(filepath, "w") as file:
-        file.write(json.dumps(config, indent=4))
-    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")
+def configuration_v4_to_v5(filepath) -> None:
+    perform_migration(
+        old_version=4, new_version=5, migration=__migration, filepath=filepath
+    )

--- a/nucypher/config/migrations/configuration_v4_to_v5.py
+++ b/nucypher/config/migrations/configuration_v4_to_v5.py
@@ -1,0 +1,38 @@
+import json
+import os
+
+BACKUP_SUFFIX = ".old"
+OLD_VERSION = 4
+NEW_VERSION = 5
+
+
+def configuration_v4_to_v5(filepath: str):
+    # Read + deserialize
+    with open(filepath, "r") as file:
+        contents = file.read()
+    config = json.loads(contents)
+
+    try:
+        existing_version = config["version"]
+        if existing_version != OLD_VERSION:
+            raise RuntimeError(
+                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
+            )
+
+        # Make a copy of the original file
+        backup_filepath = str(filepath) + BACKUP_SUFFIX
+        os.rename(filepath, backup_filepath)
+        print(f"Backed up existing configuration to {backup_filepath}")
+
+        # Apply updates
+        del config["federated_only"]  # deprecated
+        del config["checksum_address"]
+        config["version"] = NEW_VERSION
+
+    except KeyError:
+        raise RuntimeError(f"Invalid {OLD_VERSION} configuration file.")
+
+    # Commit updates
+    with open(filepath, "w") as file:
+        file.write(json.dumps(config, indent=4))
+    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")

--- a/nucypher/config/migrations/configuration_v4_to_v6.py
+++ b/nucypher/config/migrations/configuration_v4_to_v6.py
@@ -1,52 +1,25 @@
-import json
-import os
+from typing import Dict
 
 from nucypher.blockchain.eth.networks import NetworksInventory
-
-BACKUP_SUFFIX = ".old"
-OLD_VERSION = 4
-NEW_VERSION = 6
+from nucypher.config.migrations.common import perform_migration
 
 
-def configuration_v4_to_v6(filepath: str):
-    # Read + deserialize
-    with open(filepath, "r") as file:
-        contents = file.read()
-    config = json.loads(contents)
+def __migration(config: Dict) -> None:
+    del config["federated_only"]  # deprecated
+    del config["checksum_address"]
 
-    try:
-        existing_version = config["version"]
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(
-                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
-            )
+    # Multichain support
+    eth_provider = config["eth_provider_uri"]
+    eth_chain_id = NetworksInventory.get_ethereum_chain_id(config["domain"])
+    polygon_provider = config["payment_provider"]
+    polygon_chain_id = NetworksInventory.get_polygon_chain_id(config["payment_network"])
+    config["condition_providers"] = {
+        eth_chain_id: [eth_provider],
+        polygon_chain_id: [polygon_provider],
+    }
 
-        # Make a copy of the original file
-        backup_filepath = str(filepath) + BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f"Backed up existing configuration to {backup_filepath}")
 
-        # Apply updates
-        del config["federated_only"]  # deprecated
-        del config["checksum_address"]
-        config["version"] = NEW_VERSION
-
-        # Multichain support
-        eth_provider = config["eth_provider_uri"]
-        eth_chain_id = NetworksInventory.get_ethereum_chain_id(config["domain"])
-        polygon_provider = config["payment_provider"]
-        polygon_chain_id = NetworksInventory.get_polygon_chain_id(
-            config["payment_network"]
-        )
-        config["condition_providers"] = {
-            eth_chain_id: [eth_provider],
-            polygon_chain_id: [polygon_provider],
-        }
-
-    except KeyError:
-        raise RuntimeError(f"Invalid {OLD_VERSION} configuration file.")
-
-    # Commit updates
-    with open(filepath, "w") as file:
-        file.write(json.dumps(config, indent=4))
-    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")
+def configuration_v4_to_v6(filepath) -> None:
+    perform_migration(
+        old_version=4, new_version=6, migration=__migration, filepath=filepath
+    )

--- a/nucypher/config/migrations/configuration_v4_to_v6.py
+++ b/nucypher/config/migrations/configuration_v4_to_v6.py
@@ -1,0 +1,52 @@
+import json
+import os
+
+from nucypher.blockchain.eth.networks import NetworksInventory
+
+BACKUP_SUFFIX = ".old"
+OLD_VERSION = 4
+NEW_VERSION = 6
+
+
+def configuration_v4_to_v6(filepath: str):
+    # Read + deserialize
+    with open(filepath, "r") as file:
+        contents = file.read()
+    config = json.loads(contents)
+
+    try:
+        existing_version = config["version"]
+        if existing_version != OLD_VERSION:
+            raise RuntimeError(
+                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
+            )
+
+        # Make a copy of the original file
+        backup_filepath = str(filepath) + BACKUP_SUFFIX
+        os.rename(filepath, backup_filepath)
+        print(f"Backed up existing configuration to {backup_filepath}")
+
+        # Apply updates
+        del config["federated_only"]  # deprecated
+        del config["checksum_address"]
+        config["version"] = NEW_VERSION
+
+        # Multichain support
+        eth_provider = config["eth_provider_uri"]
+        eth_chain_id = NetworksInventory.get_ethereum_chain_id(config["domain"])
+        polygon_provider = config["payment_provider"]
+        polygon_chain_id = NetworksInventory.get_polygon_chain_id(
+            config["payment_network"]
+        )
+        config["condition_providers"] = {
+            eth_chain_id: [eth_provider],
+            polygon_chain_id: [polygon_provider],
+        }
+
+    except KeyError:
+        raise RuntimeError(f"Invalid {OLD_VERSION} configuration file.")
+
+    # Commit updates
+    with open(filepath, "w") as file:
+        file.write(json.dumps(config, indent=4))
+    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")

--- a/nucypher/config/migrations/configuration_v5_to_v6.py
+++ b/nucypher/config/migrations/configuration_v5_to_v6.py
@@ -1,0 +1,50 @@
+import json
+import os
+
+from nucypher.blockchain.eth.networks import NetworksInventory
+
+BACKUP_SUFFIX = ".old"
+OLD_VERSION = 5
+NEW_VERSION = 6
+
+
+def configuration_v5_to_v6(filepath: str):
+    # Read + deserialize
+    with open(filepath, "r") as file:
+        contents = file.read()
+    config = json.loads(contents)
+
+    try:
+        existing_version = config["version"]
+        if existing_version != OLD_VERSION:
+            raise RuntimeError(
+                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
+            )
+
+        # Make a copy of the original file
+        backup_filepath = str(filepath) + BACKUP_SUFFIX
+        os.rename(filepath, backup_filepath)
+        print(f"Backed up existing configuration to {backup_filepath}")
+
+        # Apply updates
+        config["version"] = NEW_VERSION
+
+        # Multichain support
+        eth_provider = config["eth_provider_uri"]
+        eth_chain_id = NetworksInventory.get_ethereum_chain_id(config["domain"])
+        polygon_provider = config["payment_provider"]
+        polygon_chain_id = NetworksInventory.get_polygon_chain_id(
+            config["payment_network"]
+        )
+        config["condition_providers"] = {
+            eth_chain_id: [eth_provider],
+            polygon_chain_id: [polygon_provider],
+        }
+
+    except KeyError:
+        raise KeyError(f"Invalid {OLD_VERSION} configuration file.")
+
+    # Commit updates
+    with open(filepath, "w") as file:
+        file.write(json.dumps(config, indent=4))
+    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")

--- a/nucypher/config/migrations/configuration_v5_to_v6.py
+++ b/nucypher/config/migrations/configuration_v5_to_v6.py
@@ -1,50 +1,21 @@
-import json
-import os
+from typing import Dict
 
 from nucypher.blockchain.eth.networks import NetworksInventory
-
-BACKUP_SUFFIX = ".old"
-OLD_VERSION = 5
-NEW_VERSION = 6
+from nucypher.config.migrations.common import perform_migration
 
 
-def configuration_v5_to_v6(filepath: str):
-    # Read + deserialize
-    with open(filepath, "r") as file:
-        contents = file.read()
-    config = json.loads(contents)
+def __migration(config: Dict) -> None:
+    eth_provider = config["eth_provider_uri"]
+    eth_chain_id = NetworksInventory.get_ethereum_chain_id(config["domain"])
+    polygon_provider = config["payment_provider"]
+    polygon_chain_id = NetworksInventory.get_polygon_chain_id(config["payment_network"])
+    config["condition_providers"] = {
+        eth_chain_id: [eth_provider],
+        polygon_chain_id: [polygon_provider],
+    }
 
-    try:
-        existing_version = config["version"]
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(
-                f"Existing configuration is not version {OLD_VERSION}; Got version {existing_version}"
-            )
 
-        # Make a copy of the original file
-        backup_filepath = str(filepath) + BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f"Backed up existing configuration to {backup_filepath}")
-
-        # Apply updates
-        config["version"] = NEW_VERSION
-
-        # Multichain support
-        eth_provider = config["eth_provider_uri"]
-        eth_chain_id = NetworksInventory.get_ethereum_chain_id(config["domain"])
-        polygon_provider = config["payment_provider"]
-        polygon_chain_id = NetworksInventory.get_polygon_chain_id(
-            config["payment_network"]
-        )
-        config["condition_providers"] = {
-            eth_chain_id: [eth_provider],
-            polygon_chain_id: [polygon_provider],
-        }
-
-    except KeyError:
-        raise KeyError(f"Invalid {OLD_VERSION} configuration file.")
-
-    # Commit updates
-    with open(filepath, "w") as file:
-        file.write(json.dumps(config, indent=4))
-    print(f"OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.")
+def configuration_v5_to_v6(filepath) -> None:
+    perform_migration(
+        old_version=5, new_version=6, migration=__migration, filepath=filepath
+    )

--- a/scripts/migrations/configuration_v1_to_v2.py
+++ b/scripts/migrations/configuration_v1_to_v2.py
@@ -1,68 +1,8 @@
 #!/usr/bin/env python
 
-"""
- This file is part of nucypher.
-
- nucypher is free software: you can redistribute it and/or modify
- it under the terms of the GNU Affero General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- nucypher is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
-"""
-
-import json
-import os
 import sys
 
-BACKUP_SUFFIX = '.old'
-OLD_VERSION = 1
-NEW_VERSION = 2
-
-
-def configuration_v1_to_v2(filepath: str):
-    """Updates configuration file v1 to v2 by remapping 'domains' to 'domain'"""
-
-    # Read + deserialize
-    with open(filepath, 'r') as file:
-        contents = file.read()
-    config = json.loads(contents)
-
-    try:
-        # Check we have version 1 indeed
-        existing_version = config['version']
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(f'Existing configuration is not version 1; Got version {existing_version}')
-
-        # Make a copy of the original file
-        backup_filepath = filepath+BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f'Backed up existing configuration to {backup_filepath}')
-
-        # Get current domain value
-        domains = config['domains']
-        domain = domains[0]
-        if len(domains) > 1:
-            print(f'Multiple domains configured, using the first one ({domain}).')
-
-        # Apply updates
-        del config['domains']  # deprecated
-        config['domain'] = domain
-        config['version'] = NEW_VERSION
-    except KeyError:
-        raise RuntimeError(f'Invalid {OLD_VERSION} configuration file.')
-
-    # Commit updates
-    with open(filepath, 'w') as file:
-        file.write(json.dumps(config, indent=4))
-    print('OK! Migrated configuration file from v1 -> v2.')
-
+from nucypher.config.migrations import configuration_v1_to_v2
 
 if __name__ == "__main__":
     try:

--- a/scripts/migrations/configuration_v3_to_v4.py
+++ b/scripts/migrations/configuration_v3_to_v4.py
@@ -1,64 +1,8 @@
 #!/usr/bin/env python
 
-"""
- This file is part of nucypher.
-
- nucypher is free software: you can redistribute it and/or modify
- it under the terms of the GNU Affero General Public License as published by
- the Free Software Foundation, either version 3 of the License, or
- (at your option) any later version.
-
- nucypher is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
-"""
-
-import json
-import os
 import sys
 
-BACKUP_SUFFIX = '.old'
-OLD_VERSION = 3
-NEW_VERSION = 4
-
-
-def configuration_v3_to_v4(filepath: str):
-    """Updates configuration file v3 to v4 by remapping 'domains' to 'domain'"""
-
-    # Read + deserialize
-    with open(filepath, 'r') as file:
-        contents = file.read()
-    config = json.loads(contents)
-
-    try:
-        # Check we have version 1 indeed
-        existing_version = config['version']
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(f'Existing configuration is not version {OLD_VERSION}; Got version {existing_version}')
-
-        # Make a copy of the original file
-        backup_filepath = filepath+BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f'Backed up existing configuration to {backup_filepath}')
-
-        # Apply updates
-        worker_address = config['worker_address']
-        del config['worker_address']  # deprecated
-        config['operator_address'] = worker_address
-        config['version'] = NEW_VERSION
-
-    except KeyError:
-        raise RuntimeError(f'Invalid {OLD_VERSION} configuration file.')
-
-    # Commit updates
-    with open(filepath, 'w') as file:
-        file.write(json.dumps(config, indent=4))
-    print(f'OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.')
-
+from nucypher.config.migrations import configuration_v3_to_v4
 
 if __name__ == "__main__":
     try:

--- a/scripts/migrations/configuration_v4_to_v5.py
+++ b/scripts/migrations/configuration_v4_to_v5.py
@@ -1,45 +1,8 @@
 #!/usr/bin/env python
 
-import json
-import os
 import sys
 
-BACKUP_SUFFIX = '.old'
-OLD_VERSION = 4
-NEW_VERSION = 5
-
-
-def configuration_v4_to_v5(filepath: str):
-    """Updates configuration file v3 to v4 by remapping 'domains' to 'domain'"""
-
-    # Read + deserialize
-    with open(filepath, 'r') as file:
-        contents = file.read()
-    config = json.loads(contents)
-
-    try:
-        existing_version = config['version']
-        if existing_version != OLD_VERSION:
-            raise RuntimeError(f'Existing configuration is not version {OLD_VERSION}; Got version {existing_version}')
-
-        # Make a copy of the original file
-        backup_filepath = filepath+BACKUP_SUFFIX
-        os.rename(filepath, backup_filepath)
-        print(f'Backed up existing configuration to {backup_filepath}')
-
-        # Apply updates
-        del config['federated_only']  # deprecated
-        del config['checksum_address']
-        config['version'] = NEW_VERSION
-
-    except KeyError:
-        raise RuntimeError(f'Invalid {OLD_VERSION} configuration file.')
-
-    # Commit updates
-    with open(filepath, 'w') as file:
-        file.write(json.dumps(config, indent=4))
-    print(f'OK! Migrated configuration file from v{OLD_VERSION} -> v{NEW_VERSION}.')
-
+from nucypher.config.migrations import configuration_v4_to_v5
 
 if __name__ == "__main__":
     try:

--- a/scripts/migrations/configuration_v5_to_v6.py
+++ b/scripts/migrations/configuration_v5_to_v6.py
@@ -2,11 +2,11 @@
 
 import sys
 
-from nucypher.config.migrations import configuration_v4_to_v6
+from nucypher.config.migrations import configuration_v5_to_v6
 
 if __name__ == "__main__":
     try:
         _python, filepath = sys.argv
     except ValueError:
         raise ValueError("Invalid command: Provide a single configuration filepath.")
-    configuration_v4_to_v6(filepath=filepath)
+    configuration_v5_to_v6(filepath=filepath)


### PR DESCRIPTION
**Type of PR:**
Feature 

**Required reviews:** 
2

**What this does:**
- Introduces new CLI command (`nucypher ursula config migrate`) to migrate ursula configuration files
- Automatically updates configurations to the latest version
- Relocates core migrations functions from `/scripts` -> `nucypher.config.migrations`
- Encapsulates common migration functionality for better code reuse (`nucypher.config.migratons.common`)
- Improves failed migration handling by rolling back the original filename upon failure

**Why it's needed:**
- Nodes need an easy way to migrate to the latest version of nucypher
- Prerequisite change for nucypher-ops automation supporting multichain configuration updates 
- Follow-up for #3185 

**Notes for Reviewers**
- Most of the changes are code reorg and relocation needed to use migration functions from importable modules
- Co-Authored-By @theref 