### PR TITLE
Bump CI's Maximum Python Version to 3.11

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.10" ]
+        python-version: [ "3.8", "3.10", "3.11" ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -53,94 +53,94 @@ jobs:
 
       # Unit tests
       - name: Unit Tests (Coverage)
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         run: |
           coverage run --data-file=unit_data -m pytest tests/unit
           coverage xml -i --data-file=unit_data -o unit-coverage.xml
 
       - name: Unit Tests
-        if: matrix.python-version != '3.10'
+        if: matrix.python-version != '3.11'
         run: python -m pytest tests/unit
 
       # Integration tests
       - name: Integration Tests (Coverage)
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         run: |
           coverage run --data-file=integration_data -m pytest tests/integration
           coverage xml -i --data-file=integration_data -o integration-coverage.xml
 
       - name: Integration Tests
-        if: matrix.python-version != '3.10'
+        if: matrix.python-version != '3.11'
         run: python -m pytest tests/integration
 
       # Acceptance tests
       - name: Agents Tests (Coverage)
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_agent_data -m pytest agents
           coverage xml -i --data-file=acceptance_agent_data -o acceptance-agents-coverage.xml
 
       - name: Agents Tests
-        if: matrix.python-version != '3.10'
+        if: matrix.python-version != '3.11'
         working-directory: tests/acceptance
         run: python -m pytest agents
 
       - name: Actors Tests (Coverage)
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_actors_data -m pytest actors
           coverage xml -i --data-file=acceptance_actors_data -o acceptance-actors-coverage.xml
 
       - name: Actors Tests
-        if: matrix.python-version != '3.10'
+        if: matrix.python-version != '3.11'
         working-directory: tests/acceptance
         run: python -m pytest actors
 
 
       - name: Conditions Tests (Coverage)
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_conditions_data -m pytest conditions
           coverage xml -i --data-file=acceptance_conditions_data -o acceptance-conditions-coverage.xml
 
       - name: Conditions Tests
-        if: matrix.python-version != '3.10'
+        if: matrix.python-version != '3.11'
         working-directory: tests/acceptance
         run: python -m pytest conditions
 
 
       - name: Characters Tests (Coverage)
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_characters_data -m pytest characters
           coverage xml -i --data-file=acceptance_characters_data -o acceptance-characters-coverage.xml
 
       - name: Characters Tests
-        if: matrix.python-version != '3.10'
+        if: matrix.python-version != '3.11'
         working-directory: tests/acceptance
         run: python -m pytest characters
 
 
       - name: CLI Tests (Coverage)
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_cli_data -m pytest cli
           coverage xml -i --data-file=acceptance_cli_data -o acceptance-cli-coverage.xml
 
       - name: CLI Tests
-        if: matrix.python-version != '3.10'
+        if: matrix.python-version != '3.11'
         working-directory: tests/acceptance
         run: python -m pytest cli
 
 
       # Only upload coverage files after all tests have passed
       - name: Upload unit tests coverage to Codecov
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -150,7 +150,7 @@ jobs:
           verbose: true
 
       - name: Upload integration tests coverage to Codecov
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -160,7 +160,7 @@ jobs:
           verbose: true
 
       - name: Upload acceptance tests coverage to Codecov
-        if: matrix.python-version == '3.10'
+        if: matrix.python-version == '3.11'
         uses: codecov/codecov-action@v3.1.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/source/references/installation.rst
+++ b/docs/source/references/installation.rst
@@ -24,7 +24,7 @@ Docker Installation and Update
 Local Installation
 ------------------
 
-``nucypher`` supports Python 3.7 and 3.8. If you don’t already have it, install `Python <https://www.python.org/downloads/>`_.
+``nucypher`` supports Python 3.9, 3.10, and 3.11. If you don’t already have it, install `Python <https://www.python.org/downloads/>`_.
 
 In order to isolate global system dependencies from nucypher-specific dependencies, we *highly* recommend
 using ``python-virtualenv`` to install ``nucypher`` inside a dedicated virtual environment.

--- a/docs/source/references/installation.rst
+++ b/docs/source/references/installation.rst
@@ -24,7 +24,7 @@ Docker Installation and Update
 Local Installation
 ------------------
 
-``nucypher`` supports Python 3.9, 3.10, and 3.11. If you don’t already have it, install `Python <https://www.python.org/downloads/>`_.
+``nucypher`` supports Python 3.8, 3.9, 3.10, and 3.11. If you don’t already have it, install `Python <https://www.python.org/downloads/>`_.
 
 In order to isolate global system dependencies from nucypher-specific dependencies, we *highly* recommend
 using ``python-virtualenv`` to install ``nucypher`` inside a dedicated virtual environment.

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -12,7 +12,7 @@ sphinx:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ PYPI_CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -19,14 +19,12 @@ You should have received a copy of the GNU Affero General Public License
 along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-
 import os
-import subprocess
+import sys
 from pathlib import Path
 from typing import Dict
 from urllib.parse import urlparse
 
-import sys
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
@@ -45,9 +43,9 @@ PYPI_CLASSIFIERS = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Security",
 ]
 
@@ -87,6 +85,7 @@ class PostDevelopCommand(develop):
     Execute manually with python setup.py develop or automatically included with
     `pip install -e . -r dev-requirements.txt`.
     """
+
     def run(self):
         """development setup scripts (pre-requirements)"""
         develop.run(self)
@@ -143,7 +142,6 @@ EXTRAS = {
     "ursula": URSULA_REQUIRES,
     "docs": DOC_REQUIRES,
 }
-
 
 setup(
 


### PR DESCRIPTION
##### Requested Reviews 
1

##### What this does
- Indicates compatibility with python 3.11 in package metadata
- Bumps the upper limit bookend python version on CI to python 3.11
- Run Codecov alongside 3.11 test execution