### PR TITLE
Fix missing argument in character config loading

### DIFF
--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -383,6 +383,7 @@ class CharacterConfiguration(BaseConfiguration):
         registry_filepath: Optional[Path] = None,
         policy_registry: Optional[BaseContractRegistry] = None,
         policy_registry_filepath: Optional[Path] = None,
+        condition_providers: Optional[dict] = None,
     ):
 
         self.log = Logger(self.__class__.__name__)
@@ -420,6 +421,7 @@ class CharacterConfiguration(BaseConfiguration):
         self.poa = poa
         self.is_light = light
         self.eth_provider_uri = eth_provider_uri or NO_BLOCKCHAIN_CONNECTION
+        self.condition_providers = condition_providers
         self.signer_uri = signer_uri or None
 
         # Learner


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**Why it's needed:**
PR #3207 introduces a new migration script of the config JSON from v5 to v6. This new version adds a new property "condition_providers" to the JSON.

The configuration loader doesn't expect this new field, so an "unexpected keyword argument'condition_provider'" is raised when trying to run ursula `nucypher ursula run`.

This commit adds this field to the loader.

Error:

```
Traceback (most recent call last):
  File "/Users/manumonti/.pyenv/versions/nucypher/bin/nucypher", line 8, in <module>
    sys.exit(nucypher_cli())
  File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/cli/options.py", line 151, in wrapper
    return func(**kwargs)
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/cli/options.py", line 151, in wrapper
    return func(**kwargs)
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/cli/options.py", line 151, in wrapper
    return func(**kwargs)
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/cli/commands/ursula.py", line 452, in run
    ursula_config, URSULA = character_options.create_character(
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/cli/commands/ursula.py", line 287, in create_character
    ursula_config = self.config_options.create_config(emitter, config_file)
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/cli/commands/ursula.py", line 144, in create_config
    return UrsulaConfiguration.from_configuration_file(
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/config/base.py", line 667, in from_configuration_file
    node_configuration = cls(filepath=filepath, **assembled_params)
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/config/characters.py", line 67, in __init__
    super().__init__(
TypeError: CharacterConfiguration.__init__() got an unexpected keyword argument 'condition_providers'
```