### PR TITLE
Fix Prometheus collector when using get_agent func

### DIFF
--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -180,7 +180,7 @@ class StakingProviderMetricsCollector(BaseMetricsCollector):
         application_agent = ContractAgency.get_agent(
             PREApplicationAgent,
             registry=self.contract_registry,
-            eth_provider_uri=self.eth_provider_uri,
+            provider_uri=self.eth_provider_uri,
         )
         authorized = application_agent.get_authorized_stake(
             staking_provider=self.staking_provider_address


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
PR #3199 added provider_uri as an argument to ContractAgency.get_agent() function. This fixed an error, but the name of the argument was not correct.

This commit fixes the bug caused by the use of an incorrect argument name.

The error appears when activating Prometheus in Ursula `nucypher ursula run --prometheus --metrics-port 9090`

```
  File "/Users/manumonti/.pyenv/versions/3.10.11/envs/nucypher/lib/python3.10/site-packages/twisted/internet/defer.py", line 206, in maybeDeferred
    result = f(*args, **kwargs)
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/utilities/prometheus/metrics.py", line 119, in collect_prometheus_metrics
    collector.collect()
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/utilities/prometheus/collector.py", line 62, in collect
    self._collect_internal()
  File "/Users/manumonti/Projects/nucypher/nucypher/nucypher/utilities/prometheus/collector.py", line 180, in _collect_internal
    application_agent = ContractAgency.get_agent(
builtins.TypeError: ContractAgency.get_agent() got an unexpected keyword argument 'eth_provider_uri'
```

Closes #3211 