### PR TITLE
Add .ruff_cache folder to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ __pycache__
 tests/acceptance/blockchain/.build/
 __local__.json
 /.cache
+.ruff_cache/
 *.so
 /MANIFEST
 /.tox


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Ruff linter generates a cache folder when it runs pre-commit checks. This folder is ignored since it has its own .gitignore file inside the folder. But for homogeneity purposes, this should be added to .gitignore file.

Also, adding to the general .gitignore file makes this folder have a different treatment by IDEs.
