### PR TITLE
Remove `eip712_structs` dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -27,7 +27,6 @@ aiohttp = "==3.8.2"
 flask = "*"
 requests = "*"
 # Third-Party Ethereum
-eip712-structs = "*"
 eth-tester = "*"   # providers.py still uses this
 py-evm = "*"
 web3 = ">=6.0.0"

--- a/tests/acceptance/conditions/conftest.py
+++ b/tests/acceptance/conditions/conftest.py
@@ -133,7 +133,9 @@ def subscription_manager_get_policy_zeroized_policy_struct_condition(
 @pytest.fixture
 def subscription_manager_is_active_policy_condition(testerchain, test_registry):
     subscription_manager = ContractAgency.get_agent(
-        SubscriptionManagerAgent, registry=test_registry
+        SubscriptionManagerAgent,
+        registry=test_registry,
+        provider_uri=TEST_ETH_PROVIDER_URI,
     )
     condition = ContractCondition(
         contract_address=subscription_manager.contract.address,

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -25,7 +25,11 @@ from nucypher.policy.conditions.exceptions import (
     RPCExecutionFailed,
 )
 from nucypher.policy.conditions.lingo import ConditionLingo, ReturnValueTest
-from tests.constants import TEST_POLYGON_PROVIDER_URI, TESTERCHAIN_CHAIN_ID
+from tests.constants import (
+    TEST_ETH_PROVIDER_URI,
+    TEST_POLYGON_PROVIDER_URI,
+    TESTERCHAIN_CHAIN_ID,
+)
 from tests.utils.policy import make_message_kits
 
 
@@ -97,7 +101,6 @@ def test_user_address_context_variable_verification(testerchain, valid_user_addr
         _recover_user_address(**invalid_signature_context)
 
 
-@pytest.mark.skip(reason="TODO")
 @mock.patch(
     "nucypher.policy.conditions.evm.get_context_value",
     side_effect=_dont_validate_user_address,
@@ -269,7 +272,6 @@ def test_erc721_evm_condition_balanceof_evaluation(
     assert not condition_result
 
 
-@pytest.mark.skip(reason="execution reverted: Invalid timestamps")
 def test_subscription_manager_is_active_policy_condition_evaluation(
     testerchain,
     enacted_policy,
@@ -295,7 +297,6 @@ def test_subscription_manager_is_active_policy_condition_evaluation(
     assert not condition_result
 
 
-@pytest.mark.skip(reason="execution reverted: Invalid timestamps")
 def test_subscription_manager_get_policy_policy_struct_condition_evaluation(
     testerchain,
     enacted_policy,
@@ -326,7 +327,6 @@ def test_subscription_manager_get_policy_policy_struct_condition_evaluation(
     assert condition_result is True  # zeroized policy was indeed returned
 
 
-@pytest.mark.skip(reason="invalid timestamps")
 def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evaluation(
     testerchain,
     test_registry,
@@ -344,7 +344,9 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
         ":hrac": bytes(enacted_policy.hrac),
     }  # user-defined context vars
     subscription_manager = ContractAgency.get_agent(
-        SubscriptionManagerAgent, registry=test_registry
+        SubscriptionManagerAgent,
+        registry=test_registry,
+        provider_uri=TEST_ETH_PROVIDER_URI,
     )
 
     # test "sponsor" key (owner is the same as sponsor for this policy)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Removes the reliance on `eip712_structs` library and pave the way for a relock of dependencies without `pysha3`.

The `tests/acceptance/conditions` tests, which test validation of userAddress context variable, pass for me locally.

I tried relocking which worked with some tweaks, but the latest version of eth-ape seems to have some changes that are causing acceptance test issues. Therefore such a change will be bigger than expected. cc @jMyles 

**Issues fixed/closed:**
> - Fixes #...

Related to https://github.com/nucypher/nucypher/issues/3184. 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
