### PR TITLE
Make Prometheus exporter always run with Ursula

### DIFF
--- a/newsfragments/3223.feature.rst
+++ b/newsfragments/3223.feature.rst
@@ -1,0 +1,1 @@
+Make Prometheus exporter always run for Ursula

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -64,6 +64,7 @@ from nucypher.config.migrations.common import (
     WrongConfigurationVersion,
 )
 from nucypher.crypto.keystore import Keystore
+from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
 
 
 class UrsulaConfigOptions:
@@ -388,26 +389,10 @@ def forget(general_config, config_options, config_file):
 @option_force
 @group_general_config
 @click.option(
-    "--prometheus",
-    help="Run the ursula prometheus exporter",
-    is_flag=True,
-    default=False,
-)
-@click.option(
     "--metrics-port",
-    help="Run a Prometheus metrics exporter on specified HTTP port",
+    help="Specify the HTTP port of the Prometheus metrics exporter",
+    default=9101,
     type=NETWORK_PORT,
-)
-@click.option(
-    "--metrics-listen-address",
-    help="Run a prometheus metrics exporter on specified IP address",
-    default="",
-)
-@click.option(
-    "--metrics-interval",
-    help="The frequency of metrics collection",
-    type=click.INT,
-    default=90,
 )
 @click.option(
     "--ip-checkup/--no-ip-checkup",
@@ -419,10 +404,7 @@ def run(
     character_options,
     config_file,
     dry_run,
-    prometheus,
     metrics_port,
-    metrics_listen_address,
-    metrics_interval,
     force,
     ip_checkup,
 ):
@@ -432,23 +414,9 @@ def run(
     dev_mode = character_options.config_options.dev
     lonely = character_options.config_options.lonely
 
-    if prometheus and not metrics_port:
-        # Require metrics port when using prometheus
-        raise click.BadOptionUsage(option_name='metrics-port',
-                                   message=click.style('--metrics-port is required when using --prometheus', fg="red"))
-
     _pre_launch_warnings(emitter, dev=dev_mode, force=None)
 
-    prometheus_config: "PrometheusMetricsConfig" = None
-    if prometheus and not dev_mode:
-        # Locally scoped to prevent import without prometheus explicitly installed
-        from nucypher.utilities.prometheus.metrics import PrometheusMetricsConfig
-
-        prometheus_config = PrometheusMetricsConfig(
-            port=metrics_port,
-            listen_address=metrics_listen_address,
-            collection_interval=metrics_interval,
-        )
+    prometheus_config = PrometheusMetricsConfig(port=metrics_port)
 
     ursula_config, URSULA = character_options.create_character(
         emitter=emitter, config_file=config_file, json_ipc=general_config.json_ipc

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -22,10 +22,11 @@ from nucypher.utilities.prometheus.collector import (
 class PrometheusMetricsConfig:
     """Prometheus configuration."""
     def __init__(self,
-                 port: int,
-                 listen_address: str = '',  # default to localhost ip
-                 collection_interval: int = 90,  # every 1.5 minutes
-                 start_now: bool = False):
+        port: int,
+        listen_address: str = "",  # default to localhost ip
+        collection_interval: int = 90,  # every 1.5 minutes
+        start_now: bool = False,
+    ):
 
         if not port:
             raise ValueError('port must be provided')

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -684,6 +684,11 @@ def control_time():
     return clock
 
 
+@pytest.fixture(scope="session", autouse=True)
+def mock_prometheus(session_mocker):
+    return session_mocker.patch("nucypher.characters.lawful.start_prometheus_exporter")
+
+
 @pytest.fixture(scope="module")
 def ursulas(testerchain, ursula_test_config, staking_providers):
     if MOCK_KNOWN_URSULAS_CACHE:

--- a/tests/integration/cli/test_ursula_cli_prometheus.py
+++ b/tests/integration/cli/test_ursula_cli_prometheus.py
@@ -1,0 +1,119 @@
+from nucypher.blockchain.eth.actors import Operator
+from nucypher.cli.main import nucypher_cli
+from nucypher.config.characters import UrsulaConfiguration
+from tests.constants import FAKE_PASSWORD_CONFIRMED, MOCK_IP_ADDRESS
+
+
+def mock_ursula_run(mocker, ursulas, monkeypatch, ursula_test_config, mock_prometheus):
+    # Mock IP determination
+    target = "nucypher.cli.actions.configure.determine_external_ip_address"
+    mocker.patch(target, return_value=MOCK_IP_ADDRESS)
+
+    ursula_test_config.rest_host = MOCK_IP_ADDRESS
+
+    # Mock worker qualification
+    staking_provider = ursulas[1]
+
+    def set_staking_provider_address(operator):
+        operator.checksum_address = staking_provider.checksum_address
+        return True
+
+    monkeypatch.setattr(Operator, "block_until_ready", set_staking_provider_address)
+
+    # Mock Ursula configuration
+    mocker.patch.object(
+        UrsulaConfiguration, "from_configuration_file", return_value=ursula_test_config
+    )
+
+    # Resetting start_prometheus_exporter mock just in case it was called in other test
+    mock_prometheus.reset_mock()
+
+
+def test_ursula_cli_prometheus(
+    click_runner,
+    mocker,
+    ursulas,
+    monkeypatch,
+    ursula_test_config,
+    tempfile_path,
+    mock_prometheus,
+):
+    mock_ursula_run(mocker, ursulas, monkeypatch, ursula_test_config, mock_prometheus)
+
+    run_args = (
+        "ursula",
+        "run",
+        "--dry-run",
+        "--debug",
+        "--config-file",
+        str(tempfile_path.absolute()),
+    )
+
+    result = click_runner.invoke(
+        nucypher_cli, run_args, input=FAKE_PASSWORD_CONFIRMED, catch_exceptions=False
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "✓ Prometheus Exporter" in result.output
+    ), "CLI didn't print Prometheus exporter check"
+
+    mock_prometheus.assert_called_once()
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].port == 9101
+    ), "Wrong port set in prometheus_config"
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].listen_address == ""
+    ), "Wrong listen address set in prometheus_config"
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].collection_interval == 90
+    ), "Wrong collection interval set in prometheus_config"
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].start_now is False
+    ), "Wrong value for start_now in prometheus_config"
+
+
+def test_ursula_cli_prometheus_metrics_port(
+    click_runner,
+    mocker,
+    ursulas,
+    monkeypatch,
+    ursula_test_config,
+    tempfile_path,
+    mock_prometheus,
+):
+    mock_ursula_run(mocker, ursulas, monkeypatch, ursula_test_config, mock_prometheus)
+
+    run_args = (
+        "ursula",
+        "run",
+        "--dry-run",
+        "--debug",
+        "--config-file",
+        str(tempfile_path.absolute()),
+        "--metrics-port",
+        "6666",
+    )
+
+    result = click_runner.invoke(
+        nucypher_cli, run_args, input=FAKE_PASSWORD_CONFIRMED, catch_exceptions=False
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (
+        "✓ Prometheus Exporter" in result.output
+    ), "CLI didn't print Prometheus exporter check"
+
+    mock_prometheus.assert_called_once()
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].port == 6666
+    ), "Wrong port set in prometheus_config"
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].listen_address == ""
+    ), "Wrong listen address set in prometheus_config"
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].collection_interval == 90
+    ), "Wrong collection interval set in prometheus_config"
+    assert (
+        mock_prometheus.call_args.kwargs["prometheus_config"].start_now is False
+    ), "Wrong value for start_now in prometheus_config"

--- a/tests/unit/test_prometheus.py
+++ b/tests/unit/test_prometheus.py
@@ -39,7 +39,6 @@ def test_prometheus_metrics_config():
     prometheus_config = PrometheusMetricsConfig(port=port)
 
     assert prometheus_config.port == 2020
-    assert prometheus_config.listen_address == ''
 
     # defaults
     assert prometheus_config.collection_interval == 90
@@ -55,7 +54,7 @@ def test_prometheus_metrics_config():
                                                 start_now=True)
     assert prometheus_config.listen_address == listen_address
     assert prometheus_config.collection_interval == collection_interval
-    assert prometheus_config.start_now
+    assert prometheus_config.start_now is True
 
 
 def test_base_metrics_collector():


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Prometheus metrics are going to be a necessary part of the Threshold network. Through them, the network can know if the PRE nodes are meeting the node's requirements. This can be useful, for instance, to calculate the staking rewards.

So, the export of these metrics must be mandatory and not an option that the user can enable or disable using command flags.