### PR TITLE
Disable default collector metrics

### DIFF
--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -2,6 +2,7 @@
 import json
 from typing import List
 
+from prometheus_client import GC_COLLECTOR, PLATFORM_COLLECTOR, PROCESS_COLLECTOR
 from prometheus_client.core import Timestamp
 from prometheus_client.registry import REGISTRY, CollectorRegistry
 from prometheus_client.utils import floatToGoString
@@ -122,6 +123,11 @@ def start_prometheus_exporter(
     from prometheus_client.twisted import MetricsResource
     from twisted.web.resource import Resource
     from twisted.web.server import Site
+
+    # Disabling default collector metrics
+    REGISTRY.unregister(GC_COLLECTOR)
+    REGISTRY.unregister(PLATFORM_COLLECTOR)
+    REGISTRY.unregister(PROCESS_COLLECTOR)
 
     metrics_collectors = create_metrics_collectors(ursula)
     # initialize collectors


### PR DESCRIPTION
By default, prometheus exports 'process', 'gc' and 'platform' collector metrics. This information is not useful in our case and introduces some noise to the metrics, so they have been disabled.

**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
By default, prometheus exports 'process', 'gc' and 'platform' collector metrics. This information is not useful in our case and introduces some noise to the metrics, so they have been disabled.

Example of default metrics:

```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 10717.0
python_gc_objects_collected_total{generation="1"} 3776.0
python_gc_objects_collected_total{generation="2"} 75.0
# HELP python_gc_objects_uncollectable_total Uncollectable objects found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 549.0
python_gc_collections_total{generation="1"} 49.0
python_gc_collections_total{generation="2"} 4.0
```

**Issues fixed/closed:**
This is part of "Revisiting Prometheus work": https://github.com/nucypher/nucypher/issues/3240

**Note for reviewers:**

**This is the 2nd PR to review about Prometheus epic.**