### PR TITLE
Remove Ape chain ID workarounds for acceptance tests

### DIFF
--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -6,7 +6,7 @@ from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.blockchain.eth.trackers.dkg import EventScannerTask
 from nucypher.characters.lawful import Enrico, Ursula
 from nucypher.policy.conditions.lingo import ConditionLingo
-from tests.constants import APE_TEST_CHAIN_ID
+from tests.constants import TESTERCHAIN_CHAIN_ID
 
 # constants
 DKG_SIZE = 4
@@ -24,7 +24,7 @@ CONDITIONS = {
         "conditionType": "time",
         "returnValueTest": {"value": "0", "comparator": ">"},
         "method": "blocktime",
-        "chain": APE_TEST_CHAIN_ID,
+        "chain": TESTERCHAIN_CHAIN_ID,
     },
 }
 

--- a/tests/acceptance/ape-config.yaml
+++ b/tests/acceptance/ape-config.yaml
@@ -19,5 +19,7 @@ solidity:
 
 
 test:
+  provider:
+    chain_id: 131277322940537  # ensure ape doesn't change chain id to 1337
   mnemonic: test test test test test test test test test test test junk
   number_of_accounts: 30

--- a/tests/acceptance/conditions/conftest.py
+++ b/tests/acceptance/conditions/conftest.py
@@ -13,7 +13,7 @@ from nucypher.policy.conditions.lingo import (
     OrCompoundCondition,
     ReturnValueTest,
 )
-from tests.constants import APE_TEST_CHAIN_ID, TEST_ETH_PROVIDER_URI
+from tests.constants import TEST_ETH_PROVIDER_URI, TESTERCHAIN_CHAIN_ID
 
 
 @pytest.fixture()
@@ -58,7 +58,7 @@ def erc20_evm_condition_balanceof(testerchain, test_registry):
         contract_address=token.contract.address,
         method="balanceOf",
         standard_contract_type="ERC20",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest("==", 0),
         parameters=[USER_ADDRESS_CONTEXT],
     )
@@ -83,7 +83,7 @@ def erc721_evm_condition_owner(erc721_contract):
         contract_address=erc721_contract.address,
         method="ownerOf",
         standard_contract_type="ERC721",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest("==", ":userAddress"),
         parameters=[
             ":tokenId",
@@ -98,7 +98,7 @@ def erc721_evm_condition_balanceof(erc721_contract):
         contract_address=erc721_contract.address,
         method="balanceOf",
         standard_contract_type="ERC721",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(">", 0),
         parameters=[
             ":userAddress",
@@ -123,7 +123,7 @@ def subscription_manager_get_policy_zeroized_policy_struct_condition(
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest("==", ":expectedPolicyStruct"),
         parameters=[":hrac"],
     )
@@ -143,7 +143,7 @@ def subscription_manager_is_active_policy_condition(testerchain, test_registry):
             "isPolicyActive"
         ).abi,
         method="isPolicyActive",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest("==", True),
         parameters=[":hrac"],
     )
@@ -163,7 +163,7 @@ def custom_context_variable_erc20_condition(
         contract_address=token.contract.address,
         method="balanceOf",
         standard_contract_type="ERC20",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest("==", 0),
         parameters=[":addressToUse"],
     )

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -26,9 +26,9 @@ from nucypher.policy.conditions.exceptions import (
 )
 from nucypher.policy.conditions.lingo import ConditionLingo, ReturnValueTest
 from tests.constants import (
-    APE_TEST_CHAIN_ID,
     TEST_ETH_PROVIDER_URI,
     TEST_POLYGON_PROVIDER_URI,
+    TESTERCHAIN_CHAIN_ID,
 )
 from tests.utils.policy import make_message_kits
 
@@ -148,7 +148,7 @@ def test_rpc_condition_evaluation_with_context_var_in_return_value_test(
     # we have balance stored, use for rpc condition with context variable
     rpc_condition = RPCCondition(
         method="eth_getBalance",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(
             "==", ":balanceContextVar"
         ),  # user-defined context var
@@ -356,7 +356,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(comparator="==", value=sponsor, index=0),
         parameters=[":hrac"],
     )
@@ -370,7 +370,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(comparator="!=", value=sponsor, index=0),
         parameters=[":hrac"],
     )
@@ -384,7 +384,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(comparator="==", value=start, index=1),
         parameters=[":hrac"],
     )
@@ -398,7 +398,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(comparator="!=", value=start, index=1),
         parameters=[":hrac"],
     )
@@ -412,7 +412,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(comparator="==", value=end, index=2),
         parameters=[":hrac"],
     )
@@ -426,7 +426,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(comparator="==", value=size, index=3),
         parameters=[":hrac"],
     )
@@ -440,7 +440,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(comparator="==", value=NULL_ADDRESS, index=4),
         parameters=[":hrac"],
     )
@@ -474,7 +474,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_index_and_value
             "getPolicy"
         ).abi,
         method="getPolicy",
-        chain=APE_TEST_CHAIN_ID,
+        chain=TESTERCHAIN_CHAIN_ID,
         return_value_test=ReturnValueTest(
             comparator="!=",
             value=":sponsor",  # use sponsor sponsor context var
@@ -530,11 +530,11 @@ def test_single_retrieve_with_onchain_conditions(enacted_policy, bob, ursulas):
                     "conditionType": "time",
                     "returnValueTest": {"value": "0", "comparator": ">"},
                     "method": "blocktime",
-                    "chain": APE_TEST_CHAIN_ID,
+                    "chain": TESTERCHAIN_CHAIN_ID,
                 },
                 {
                     "conditionType": "rpc",
-                    "chain": APE_TEST_CHAIN_ID,
+                    "chain": TESTERCHAIN_CHAIN_ID,
                     "method": "eth_getBalance",
                     "parameters": [bob.checksum_address, "latest"],
                     "returnValueTest": {"comparator": ">=", "value": "10000000000000"},

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -13,16 +13,13 @@ from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.networks import NetworksInventory
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.crypto.powers import TransactingPower
-from nucypher.policy.conditions.context import USER_ADDRESS_CONTEXT
 from nucypher.policy.conditions.evm import RPCCondition
-from nucypher.policy.conditions.lingo import ConditionLingo, ReturnValueTest
-from nucypher.policy.conditions.time import TimeCondition
 from nucypher.utilities.logging import Logger
 from tests.constants import (
-    APE_TEST_CHAIN_ID,
     BONUS_TOKENS_FOR_TESTS,
     INSECURE_DEVELOPMENT_PASSWORD,
     TEST_ETH_PROVIDER_URI,
+    TESTERCHAIN_CHAIN_ID,
 )
 from tests.utils.ape import registry_from_ape_deployments
 from tests.utils.blockchain import TesterBlockchain
@@ -412,73 +409,20 @@ def multichain_ursulas(ursulas, multichain_ids, mock_rpc_condition):
     return ursulas
 
 
-@pytest.fixture
-def time_condition():
-    condition = TimeCondition(
-        chain=APE_TEST_CHAIN_ID, return_value_test=ReturnValueTest(">", 0)
-    )
-    return condition
-
-
-@pytest.fixture
-def compound_blocktime_lingo():
-    return {
-        "version": ConditionLingo.VERSION,
-        "condition": {
-            "conditionType": "compound",
-            "operator": "and",
-            "operands": [
-                {
-                    "conditionType": "time",
-                    "returnValueTest": {"value": "0", "comparator": ">"},
-                    "method": "blocktime",
-                    "chain": APE_TEST_CHAIN_ID,
-                },
-                {
-                    "conditionType": "time",
-                    "returnValueTest": {
-                        "value": "99999999999999999",
-                        "comparator": "<",
-                    },
-                    "method": "blocktime",
-                    "chain": APE_TEST_CHAIN_ID,
-                },
-                {
-                    "conditionType": "time",
-                    "returnValueTest": {"value": "0", "comparator": ">"},
-                    "method": "blocktime",
-                    "chain": APE_TEST_CHAIN_ID,
-                },
-            ],
-        },
-    }
-
-
-@pytest.fixture
-def rpc_condition():
-    condition = RPCCondition(
-        method="eth_getBalance",
-        chain=APE_TEST_CHAIN_ID,
-        return_value_test=ReturnValueTest("==", Web3.to_wei(1_000_000, "ether")),
-        parameters=[USER_ADDRESS_CONTEXT],
-    )
-    return condition
-
-
 @pytest.fixture(scope="session", autouse=True)
 def mock_condition_blockchains(session_mocker):
     """adds testerchain's chain ID to permitted conditional chains"""
     session_mocker.patch.dict(
         "nucypher.policy.conditions.evm._CONDITION_CHAINS",
-        {APE_TEST_CHAIN_ID: "eth-tester/pyevm"},
+        {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
     )
 
     session_mocker.patch.object(
-        NetworksInventory, "get_polygon_chain_id", return_value=APE_TEST_CHAIN_ID
+        NetworksInventory, "get_polygon_chain_id", return_value=TESTERCHAIN_CHAIN_ID
     )
 
     session_mocker.patch.object(
-        NetworksInventory, "get_ethereum_chain_id", return_value=APE_TEST_CHAIN_ID
+        NetworksInventory, "get_ethereum_chain_id", return_value=TESTERCHAIN_CHAIN_ID
     )
 
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from pathlib import Path
 from random import SystemRandom
 
-from ape.utils import DEFAULT_TEST_CHAIN_ID
 from web3 import Web3
 
 from nucypher.blockchain.eth.token import NU
@@ -25,12 +24,6 @@ TACO_CHILD_APPLICATION = "TACoChildApplication"
 CONDITION_NFT = "ConditionNFT"
 GLOBAL_ALLOW_LIST = "GlobalAllowList"
 
-
-#
-# Ape
-#
-
-APE_TEST_CHAIN_ID = DEFAULT_TEST_CHAIN_ID  # ape uses this chain id
 
 #
 # Ursula


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
As part of #3222 , the version of ape used was updated. Newer versions of ape specifically modify the chain id to no longer be the eth-tester chain id (131277322940537) but instead set it to the geth dev chain id (1337) even though eth-tester is still used. This means that the provider and the testerchain return two different chain ids, which cause our acceptance tests to fail. 

As a fix/workaround, we updated our acceptance tests to use the APE default chain id via commit https://github.com/nucypher/nucypher/commit/f9b3babd69d9d1a93290ef53a4438e424a75d297.

However, after [chatting with APE folks](https://discord.com/channels/922917176040640612/938897808147247186/1151549751318298654), there is a better workaround that can be done via the APE configruation file. 

Therefore, the old workaround is no longer needed and this PR removes it.

**Issues fixed/closed:**

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?