### PR TITLE
Remove bandit conf file

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,3 +1,0 @@
-[bandit]
-exclude: tests, examples, demo, scripts, setup.py
-skips: B504,B610,B611,B703


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Bandit seems to have been removed in commit 1209a2dc1c. So .bandit config file is no longer necessary.
