### PR TITLE
Format tests code to meet Ruff and Darker code style 

### DIFF
--- a/tests/integration/blockchain/test_block_confirmations.py
+++ b/tests/integration/blockchain/test_block_confirmations.py
@@ -5,39 +5,53 @@ from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.crypto.powers import TransactingPower
 
 
-@pytest.mark.skip("This test need to be refactored to use some other transaction than deployment")
+@pytest.mark.skip(
+    "This test need to be refactored to use some other transaction than deployment"
+)
 def test_block_confirmations(testerchain, test_registry, mocker):
     origin = testerchain.etherbase_account
-    transacting_power = TransactingPower(account=origin, signer=Web3Signer(testerchain.client))
+    transacting_power = TransactingPower(
+        account=origin, signer=Web3Signer(testerchain.client)
+    )
 
     # Mocks and test adjustments
     testerchain.TIMEOUT = 5  # Reduce timeout for tests, for the moment
-    mocker.patch.object(testerchain.client, '_calculate_confirmations_timeout', return_value=1)
+    mocker.patch.object(
+        testerchain.client, "_calculate_confirmations_timeout", return_value=1
+    )
     EthereumClient.BLOCK_CONFIRMATIONS_POLLING_TIME = 0.1
     EthereumClient.COOLING_TIME = 0
 
     # Let's try to deploy a simple contract (ReceiveApprovalMethodMock) with 1 confirmation.
     # Since the testerchain doesn't mine new blocks automatically, this fails.
     with pytest.raises(EthereumClient.TransactionTimeout):
-        _ = testerchain.deploy_contract(transacting_power=transacting_power,
-                                        registry=test_registry,
-                                        contract_name='ReceiveApprovalMethodMock',
-                                        confirmations=1)
+        _ = testerchain.deploy_contract(
+            transacting_power=transacting_power,
+            registry=test_registry,
+            contract_name="ReceiveApprovalMethodMock",
+            confirmations=1,
+        )
 
     # Trying again with no confirmation succeeds.
-    contract, _ = testerchain.deploy_contract(transacting_power=transacting_power,
-                                              registry=test_registry,
-                                              contract_name='ReceiveApprovalMethodMock')
+    contract, _ = testerchain.deploy_contract(
+        transacting_power=transacting_power,
+        registry=test_registry,
+        contract_name="ReceiveApprovalMethodMock",
+    )
 
     # Trying a simple function of the contract with 1 confirmations fails too, for the same reason
-    tx_function = contract.functions.receiveApproval(origin, 0, origin, b'')
+    tx_function = contract.functions.receiveApproval(origin, 0, origin, b"")
     with pytest.raises(EthereumClient.TransactionTimeout):
-        _ = testerchain.send_transaction(contract_function=tx_function,
-                                         transacting_power=transacting_power,
-                                         confirmations=1)
+        _ = testerchain.send_transaction(
+            contract_function=tx_function,
+            transacting_power=transacting_power,
+            confirmations=1,
+        )
 
     # Trying again with no confirmation succeeds.
-    receipt = testerchain.send_transaction(contract_function=tx_function,
-                                           transacting_power=transacting_power,
-                                           confirmations=0)
-    assert receipt['status'] == 1
+    receipt = testerchain.send_transaction(
+        contract_function=tx_function,
+        transacting_power=transacting_power,
+        confirmations=0,
+    )
+    assert receipt["status"] == 1

--- a/tests/integration/blockchain/test_dkg_ritual.py
+++ b/tests/integration/blockchain/test_dkg_ritual.py
@@ -60,7 +60,7 @@ def mock_coordinator_agent(testerchain, application_economics, mock_contract_age
     COORDINATOR.reset()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def cohort(ursulas, mock_coordinator_agent):
     """Creates a cohort of Ursulas"""
     for u in ursulas:
@@ -75,7 +75,6 @@ def cohort(ursulas, mock_coordinator_agent):
 
 
 def execute_round_1(ritual_id: int, authority: ChecksumAddress, cohort: List[Ursula]):
-
     # check that the ritual is being tracked locally upon initialization for each node
     for ursula in cohort:
         # this is a testing hack to make the event scanner work
@@ -114,11 +113,13 @@ def execute_round_2(ritual_id: int, cohort: List[Ursula]):
             )
         )
 
-        ursula.ritual_tracker._handle_ritual_event(event, get_block_when=lambda x: event)
+        ursula.ritual_tracker._handle_ritual_event(
+            event, get_block_when=lambda x: event
+        )
 
 
 @pytest.mark.usefixtures("mock_sign_message")
-@pytest.mark.parametrize('dkg_size, ritual_id, variant', PARAMS)
+@pytest.mark.parametrize("dkg_size, ritual_id, variant", PARAMS)
 @pytest_twisted.inlineCallbacks()
 def test_ursula_ritualist(
     testerchain,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**

This reformats the code of the following tests to meet Ruff and Darker code style guides.

This is a necessary step for PR #3238 . The mentioned PR consists of a renaming of these tests, so Ruff and Darker checks are executed in CI, resulting in failed tests since currently, these tests don't meet the mentioned code style guidelines.