### PR TITLE
Update Registries (Root & Child) with new MockPolygon[Root/Child] naming

### DIFF
--- a/nucypher/blockchain/eth/contract_registry/lynx/contract_registry.json
+++ b/nucypher/blockchain/eth/contract_registry/lynx/contract_registry.json
@@ -2007,9 +2007,9 @@
         ]
     ],
     [
-        "LynxMockTACoChildApplication",
+        "MockPolygonRoot",
         "v0.0.0",
-        "0xb5841C2707De89e6F64c1a8b9F4c2fe4d399a51a",
+        "0x49e3973596522DD789d8D8dc9DA62e8580701e37",
         [
             {
                 "type": "constructor",
@@ -2024,7 +2024,45 @@
             },
             {
                 "type": "event",
+                "name": "AuthorizationUpdated",
+                "inputs": [
+                    {
+                        "name": "stakingProvider",
+                        "type": "address",
+                        "internalType": "address",
+                        "indexed": true
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint96",
+                        "internalType": "uint96",
+                        "indexed": false
+                    }
+                ],
+                "anonymous": false
+            },
+            {
+                "type": "event",
                 "name": "OperatorConfirmed",
+                "inputs": [
+                    {
+                        "name": "stakingProvider",
+                        "type": "address",
+                        "internalType": "address",
+                        "indexed": true
+                    },
+                    {
+                        "name": "operator",
+                        "type": "address",
+                        "internalType": "address",
+                        "indexed": true
+                    }
+                ],
+                "anonymous": false
+            },
+            {
+                "type": "event",
+                "name": "OperatorUpdated",
                 "inputs": [
                     {
                         "name": "stakingProvider",
@@ -2108,11 +2146,60 @@
             },
             {
                 "type": "function",
+                "name": "setRootApplication",
+                "stateMutability": "nonpayable",
+                "inputs": [
+                    {
+                        "name": "application",
+                        "type": "address",
+                        "internalType": "contract ITACoChildToRoot"
+                    }
+                ],
+                "outputs": []
+            },
+            {
+                "type": "function",
                 "name": "transferOwnership",
                 "stateMutability": "nonpayable",
                 "inputs": [
                     {
                         "name": "newOwner",
+                        "type": "address",
+                        "internalType": "address"
+                    }
+                ],
+                "outputs": []
+            },
+            {
+                "type": "function",
+                "name": "updateAuthorization",
+                "stateMutability": "nonpayable",
+                "inputs": [
+                    {
+                        "name": "stakingProvider",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "amount",
+                        "type": "uint96",
+                        "internalType": "uint96"
+                    }
+                ],
+                "outputs": []
+            },
+            {
+                "type": "function",
+                "name": "updateOperator",
+                "stateMutability": "nonpayable",
+                "inputs": [
+                    {
+                        "name": "stakingProvider",
+                        "type": "address",
+                        "internalType": "address"
+                    },
+                    {
+                        "name": "operator",
                         "type": "address",
                         "internalType": "address"
                     }

--- a/nucypher/blockchain/eth/contract_registry/mumbai/contract_registry.json
+++ b/nucypher/blockchain/eth/contract_registry/mumbai/contract_registry.json
@@ -1,6 +1,6 @@
 [
     [
-        "LynxMockTACoApplication",
+        "MockPolygonChild",
         "v0.0.0",
         "0x45e06A2EaC4D928C8773A64b9eFe9d757B17F04D",
         [


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
- `LynxMockTACoChildApplication` was renamed and implementation updated to be `MockPolygonRoot` in `nucypher-contracts`. The contract was then redeployed and reconfigured on Goerli, so the `lynx` contract registry was updated
- `LynxMockTACoApplication` was only renamed (no implementation changes) to `MockPolygonChild`. While not redeployed on Mumbai (because it can't be updated without needing to redeploy other Mumbai contracts) - the name did change, so we simply renamed the contract registry entry for proper tracking.

**Issues fixed/closed:**
> - Fixes #...

Related to https://github.com/nucypher/nucypher-contracts/pull/119

**Why it's needed:**
Proper tracking of deployed contracts.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
