### PR TITLE
Reset nucypher-contracts dependency to be main repos and not a fork

### DIFF
--- a/tests/acceptance/ape-config.yaml
+++ b/tests/acceptance/ape-config.yaml
@@ -5,8 +5,8 @@ plugins:
 
 dependencies:
   - name: nucypher-contracts
-    github: derekpierre/nucypher-contracts
-    ref: lynx-deployment
+    github: nucypher/nucypher-contracts
+    ref: main
   - name: openzeppelin
     github: OpenZeppelin/openzeppelin-contracts
     version: 4.9.1


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Ensures that ape configuration points to `nucypher-contracts:main`  for acceptance tests instead of a fork.

**Issues fixed/closed:**
> - Fixes #...

Related to https://github.com/nucypher/nucypher-contracts/pull/119.


**Why it's needed:**


**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
