### PR TITLE
Update DKG dev script to work on Lynx (`dkg-dev-13`)

### DIFF
--- a/nucypher/blockchain/eth/signers/__init__.py
+++ b/nucypher/blockchain/eth/signers/__init__.py
@@ -1,8 +1,7 @@
-
-
 from nucypher.blockchain.eth.signers.base import Signer
-from nucypher.blockchain.eth.signers.software import KeystoreSigner
+from nucypher.blockchain.eth.signers.software import InMemorySigner, KeystoreSigner
 
 Signer._SIGNERS = {
     KeystoreSigner.uri_scheme(): KeystoreSigner,
+    InMemorySigner.uri_scheme(): InMemorySigner,
 }

--- a/nucypher/blockchain/eth/signers/software.py
+++ b/nucypher/blockchain/eth/signers/software.py
@@ -3,7 +3,7 @@
 import json
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from cytoolz.dicttoolz import dissoc
@@ -11,7 +11,7 @@ from eth_account.account import Account
 from eth_account.messages import encode_defunct
 from eth_account.signers.local import LocalAccount
 from eth_utils.address import is_address, to_checksum_address
-from hexbytes.main import HexBytes
+from hexbytes.main import BytesLike, HexBytes
 
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.signers.base import Signer
@@ -269,9 +269,12 @@ class KeystoreSigner(Signer):
 class InMemorySigner(Signer):
     """Local signer implementation for in-memory-only keys"""
 
-    def __init__(self):
+    def __init__(self, private_key: Optional[BytesLike] = None):
         super().__init__()
-        account = Account.create()
+        if private_key:
+            account = Account.from_key(private_key)
+        else:
+            account = Account.create()
         self.__keys = {account.address: account.key.hex()}
         self.__signers = {account.address: account}
 

--- a/tests/unit/test_memory_signer.py
+++ b/tests/unit/test_memory_signer.py
@@ -1,0 +1,57 @@
+import pytest
+from cytoolz import assoc
+from eth_account._utils.legacy_transactions import Transaction
+from eth_utils import to_checksum_address
+from hexbytes import HexBytes
+
+from nucypher.blockchain.eth.constants import LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY
+from nucypher.blockchain.eth.signers import InMemorySigner, Signer
+from tests.unit.test_web3_signers import TRANSACTION_DICT
+
+
+@pytest.fixture(scope="function")
+def signer():
+    _signer = InMemorySigner()
+    return _signer
+
+
+@pytest.fixture(scope="function")
+def account(signer):
+    _account = signer.accounts[0]
+    return _account
+
+
+def test_memory_signer_from_signer_uri():
+    signer = Signer.from_signer_uri(uri="memory://")
+    assert isinstance(signer, InMemorySigner)
+
+
+def test_memory_signer_uri_scheme(signer):
+    assert signer.uri_scheme() == "memory"
+
+
+def test_memory_signer_accounts(signer):
+    assert len(signer.accounts) == 1
+    assert isinstance(signer.accounts[0], str)
+    assert len(signer.accounts[0]) == 42
+
+
+def test_memory_signer_lock_account(signer, account):
+    assert signer.is_device(account=account) is False
+    assert signer.lock_account(account=account) is True
+    assert signer.is_device(account=account) is False
+    assert signer.unlock_account(account=account, password="password") is True
+
+
+def test_memory_signer_message(signer, account):
+    message = b"An in-memory signer - because sometimes, having a short-term memory is actually a superpower!"
+    signature = signer.sign_message(account=account, message=message)
+    assert len(signature) == LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY
+
+
+def test_memory_signer_transaction(signer, account):
+    transaction_dict = assoc(TRANSACTION_DICT, "from", value=account)
+    signed_transaction = signer.sign_transaction(transaction_dict=transaction_dict)
+    assert isinstance(signed_transaction, HexBytes)
+    transaction = Transaction.from_bytes(signed_transaction)
+    assert to_checksum_address(transaction.to) == transaction_dict["to"]


### PR DESCRIPTION
**Type of PR:**
Other

**Required reviews:** 
2

**What this does:**
- Introduces `InMemorySigner` with tests
- Updates DKG script to account for enrico authorization.

**Why it's needed:**
- DKG scripting had fallen out of compatibility with the alpha 13 contract suite, this PR restores compatibility
- After redeploying Lynx with Alpha 13, new rituals and threshold decryption live testing is needed

**Notes for reviewers:**

- Related to #3242 .

- We've successfully initiated ritual id `#1`, authorized the default Enrico ('0x070a85eD1Ddb44ecD07e746235bE0B959ff5b30A') to use it, and can encrypt/decrypt data using the ritual.
- You can observe Coordinator txs here - https://mumbai.polygonscan.com/address/0x8e49989f9d3ad89c8ab0de21fba2e00c67ca872f
- You can run the script yourself to test encryption/decryption with ritual 1 by running:
```bash
$ python scripts/hooks/nucypher_dkg.py --eth-provider <GOERLI PROVIDER URI> --coordinator-provider <MUMBAI PROVIDER URI> --ritual-id 1
```
