### PR TITLE
Nodes should reject decryption requests for expired rituals

### DIFF
--- a/examples/testnet_compound_multichain_taco.py
+++ b/examples/testnet_compound_multichain_taco.py
@@ -40,6 +40,8 @@ coordinator_agent = CoordinatorAgent(
 )
 ritual_id = 3  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
+
+# known authorized encryptor for ritual 3
 signer = InMemorySigner(private_key=DEFAULT_TEST_ENRICO_PRIVATE_KEY)
 enrico = Enrico(
     encrypting_key=DkgPublicKey.from_bytes(bytes(ritual.public_key)), signer=signer

--- a/examples/testnet_compound_multichain_taco.py
+++ b/examples/testnet_compound_multichain_taco.py
@@ -38,7 +38,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 1  # got this from a side channel
+ritual_id = 3  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 signer = InMemorySigner(private_key=DEFAULT_TEST_ENRICO_PRIVATE_KEY)
 enrico = Enrico(

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -41,7 +41,7 @@ coordinator_agent = CoordinatorAgent(
 ritual_id = 3  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
-# known already authorized signer for ritual 1
+# known authorized encryptor for ritual 3
 signer = InMemorySigner(private_key=DEFAULT_TEST_ENRICO_PRIVATE_KEY)
 enrico = Enrico(
     encrypting_key=DkgPublicKey.from_bytes(bytes(ritual.public_key)), signer=signer

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -38,7 +38,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 1  # got this from a side channel
+ritual_id = 3  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
 # known already authorized signer for ritual 1

--- a/newsfragments/3279.feature.rst
+++ b/newsfragments/3279.feature.rst
@@ -1,0 +1,1 @@
+Nodes reject decryption requests for already expired rituals.

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -154,7 +154,10 @@ def test_ursula_ritualist(
         print("======== DKG DECRYPTION UNAUTHORIZED ENCRYPTION ========")
         # ritual_id, ciphertext, conditions are obtained from the side channel
         bob.start_learning_loop(now=True)
-        with pytest.raises(Ursula.NotEnoughUrsulas):
+        with pytest.raises(
+            Ursula.NotEnoughUrsulas,
+            match=f"Encrypted data not authorized for ritual {RITUAL_ID}",
+        ):
             _ = bob.threshold_decrypt(
                 threshold_message_kit=threshold_message_kit,
                 peering_timeout=0,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Expired rituals should not be allowed by nodes.

Technically this was implemented at the smart contract level for defining duration, but the nodes never enforced it. It's a bug from a testnet perspective, but a feature for 7.0.0 that wasn't completed previously, hence the newsfragment is a "feature" and not "bug".

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
Otherwise, what's the point of paying for longer periods of time 😅 .

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
