### PR TITLE
UrsulaConfiguration logic was too eager to connect to provided endpoints

### DIFF
--- a/newsfragments/3282.bugfix.rst
+++ b/newsfragments/3282.bugfix.rst
@@ -1,0 +1,1 @@
+``UrsulaConfiguration`` object should not be too eager to connect to provided blockchain endpoints; if faulty then the configuration file can't be updated.


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
When creating an `UrsulaConfiguration` object, there is a call to connect to the provided endpoints as part of prior work. This is a problem if the endpoint is faulty because it means that the connection can't be established, which raises an exception and prevents the configuration object from being created, which means that the configuration file can't be updated to change the faulty endpoint. 

For example, running `nucypher ursula config` fails, and this is the mechanism to update existing configuration values eg. `nucypher ursula config --eth-endpoint <>` to update the `eth_endpoint` value in the configuration file. Therefore, the only recourse is to update the configuration file manually.

Instead, connections to endpoints should be primed only when `UrsulaConfiguration.produce(...)` is called, i.e. before the configuration object is used to create an actual Character object, in this case, Ursula. This way the Configuration object can be created and used to update the configuration file independently of the state of the endpoint connection.

This was observed in an issue with attempting to update the endpoints used by `tapir` nodes via `nucypher-ops`.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
