### PR TITLE
Measure decryption time on simple testnet script. Update CI actions. 

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -11,7 +11,8 @@ jobs:
   darker-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4

--- a/.github/workflows/lynx.yml
+++ b/.github/workflows/lynx.yml
@@ -22,7 +22,9 @@ jobs:
         python-version: [ "3.10" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Install latest Rust stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/lynx.yml
+++ b/.github/workflows/lynx.yml
@@ -26,9 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install latest Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - id: setup_python
         name: Set up Python ${{ matrix.python-version }} Environment

--- a/.github/workflows/pr_release_note_entry.yml
+++ b/.github/workflows/pr_release_note_entry.yml
@@ -14,5 +14,8 @@ jobs:
     name: 'Checking release note entry for PR ${{ github.event.number }}'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - run: ls -l ${{ github.workspace }}/newsfragments/ | grep -E '${{ github.event.number }}\.(feature|bugfix|doc|removal|misc|dev)\.rst'
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Check for presence of newsfragment file
+        run: ls -l ${{ github.workspace }}/newsfragments/ | grep -E '${{ github.event.number }}\.(feature|bugfix|doc|removal|misc|dev)\.rst'

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -24,9 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install latest Rust stable
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@stable
 
       - id: setup_python
         name: Set up Python ${{ matrix.python-version }} Environment

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -20,7 +20,9 @@ jobs:
         python-version: [ "3.8", "3.11" ]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Install latest Rust stable
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from nucypher_core.ferveo import DkgPublicKey
 
@@ -85,10 +86,14 @@ bob = Bob(
 
 bob.start_learning_loop(now=True)
 
+start = time.time()
 cleartext = bob.threshold_decrypt(
     threshold_message_kit=threshold_message_kit,
 )
+end = time.time()
 
 cleartext = bytes(cleartext)
 print(f"\nCleartext: {cleartext.decode()}")
 assert message == cleartext
+
+print(f"\nDecryption time: {end - start} seconds")


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
* The testnet script is taking ~15 seconds to execute (see e.g. `Lynx testnet script` step in https://github.com/nucypher/nucypher/actions/runs/6508218447/job/17677145327). This is clearly not great, but tbf that's the execution time of the whole script, including Bob-side learning (which we won't have for normal uses via Porter). This PR simply adds a small console output with only Bob decryption.
   * Opened https://github.com/nucypher/nucypher/issues/3283
 * This PR also performs some janitorial work on our CI actions:
   * Bumps `actions/checkout` from v3 to v4 (this is the most likely reason for a bunch of CI warnings we currently have)
   * Switches to `dtolnay/rust-toolchain`, since `actions-rs/toolchain` is no longer maintained, and repo is archived (See https://github.com/actions-rs/toolchain/issues/216)

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
