### PR TITLE
Reduce blockchain calls to get chain id

### DIFF
--- a/newsfragments/3285.misc.rst
+++ b/newsfragments/3285.misc.rst
@@ -1,0 +1,1 @@
+Reduce the number of times the blockchain is queried for chain id.

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -139,6 +139,8 @@ class EthereumClient:
 
         self._add_default_middleware()
 
+        self.__chain_id = None
+
     def _add_default_middleware(self):
         # default retry functionality
         self.log.debug('Adding RPC retry middleware to client')
@@ -242,12 +244,17 @@ class EthereumClient:
 
     @property
     def chain_id(self) -> int:
-        try:
-            # from hex-str
-            return int(self.w3.eth.chain_id, 16)
-        except TypeError:
-            # from str
-            return int(self.w3.eth.chain_id)
+        if not self.__chain_id:
+            try:
+                # from hex-str
+                chain_id = int(self.w3.eth.chain_id, 16)
+            except TypeError:
+                # from str
+                chain_id = int(self.w3.eth.chain_id)
+
+            self.__chain_id = chain_id
+
+        return self.__chain_id
 
     @property
     def net_version(self) -> int:

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -245,12 +245,13 @@ class EthereumClient:
     @property
     def chain_id(self) -> int:
         if not self.__chain_id:
+            result = self.w3.eth.chain_id
             try:
                 # from hex-str
-                chain_id = int(self.w3.eth.chain_id, 16)
+                chain_id = int(result, 16)
             except TypeError:
                 # from str
-                chain_id = int(self.w3.eth.chain_id)
+                chain_id = int(result)
 
             self.__chain_id = chain_id
 

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from functools import cached_property
 from typing import Union
 
 from constant_sorrow.constants import UNKNOWN_DEVELOPMENT_CHAIN_ID
@@ -139,8 +140,6 @@ class EthereumClient:
 
         self._add_default_middleware()
 
-        self.__chain_id = None
-
     def _add_default_middleware(self):
         # default retry functionality
         self.log.debug('Adding RPC retry middleware to client')
@@ -242,20 +241,17 @@ class EthereumClient:
     def set_gas_strategy(self, gas_strategy):
         self.w3.eth.set_gas_price_strategy(gas_strategy)
 
-    @property
+    @cached_property
     def chain_id(self) -> int:
-        if not self.__chain_id:
-            result = self.w3.eth.chain_id
-            try:
-                # from hex-str
-                chain_id = int(result, 16)
-            except TypeError:
-                # from str
-                chain_id = int(result)
+        result = self.w3.eth.chain_id
+        try:
+            # from hex-str
+            chain_id = int(result, 16)
+        except TypeError:
+            # from str
+            chain_id = int(result)
 
-            self.__chain_id = chain_id
-
-        return self.__chain_id
+        return chain_id
 
     @property
     def net_version(self) -> int:

--- a/tests/unit/test_ethereum_client.py
+++ b/tests/unit/test_ethereum_client.py
@@ -1,0 +1,36 @@
+from unittest.mock import PropertyMock
+
+import pytest
+
+from nucypher.blockchain.eth.clients import EthereumClient
+
+CHAIN_ID = 23
+
+
+@pytest.mark.parametrize("chain_id_return_value", [hex(CHAIN_ID), CHAIN_ID])
+def test_cached_chain_id(mocker, chain_id_return_value):
+    web3_mock = mocker.MagicMock()
+    mock_client = EthereumClient(
+        w3=web3_mock, node_technology=None, version=None, platform=None, backend=None
+    )
+
+    chain_id_property_mock = PropertyMock(return_value=chain_id_return_value)
+    type(web3_mock.eth).chain_id = chain_id_property_mock
+
+    assert mock_client.chain_id == CHAIN_ID
+    chain_id_property_mock.assert_called_once()
+
+    assert mock_client.chain_id == CHAIN_ID
+    chain_id_property_mock.assert_called_once(), "not called again since cached"
+
+    # second instance of client, but uses the same w3 mock
+    mock_client_2 = EthereumClient(
+        w3=web3_mock, node_technology=None, version=None, platform=None, backend=None
+    )
+    assert mock_client_2.chain_id == CHAIN_ID
+    assert (
+        chain_id_property_mock.call_count == 2
+    ), "additional call since different client instance"
+
+    assert mock_client_2.chain_id == CHAIN_ID
+    assert chain_id_property_mock.call_count == 2, "not called again since cached"


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**

- 2 Blockchain calls were being made whenever chain id received was an integer instead of hex; this is unnecessary. Simply get the returned result of the blockchain call, then determine if it is hex or int.
- Cache chain id value once obtained for the lifetime of the `EthereumClient` since it will not change - no need to continuously make the call every time.

**Issues fixed/closed:**
> - Fixes #...
Related to #3281 , #3283 from a more general efficiency perspective.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
