### PR TITLE
Fix nucypher CLI: ursula config ip-address

### DIFF
--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -478,7 +478,7 @@ def config(general_config, config_options, config_file, force, action):
             eth_endpoint=config_options.eth_endpoint,
         )
         config_options.rest_host = rest_host
-    if action == "migrate":
+    elif action == "migrate":
         for jump, migration in MIGRATIONS.items():
             old, new = jump
             emitter.message(f"Checking migration {old} -> {new}")

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -75,7 +75,7 @@ SUCCESSFUL_FORGET_NODES = "Removed all stored known nodes metadata and certifica
 
 IGNORE_OLD_CONFIGURATION = """
 Ignoring configuration file '{config_file}' - version is too old,
-Run `nucypher ursula config migrate --config-file {config_file}` to update it.
+Run `nucypher ursula config migrate --config-file '{config_file}'` to update it.
 """
 
 DEFAULT_TO_LONE_CONFIG_FILE = "Defaulting to {config_class} configuration file: '{config_file}'"
@@ -158,7 +158,7 @@ REGISTRY_NOT_AVAILABLE = "Registry not available."
 
 DEPLOYER_BALANCE = "\n\nDeployer ETH balance: {eth_balance}"
 
-SELECT_DEPLOYER_ACCOUNT = "Select deployer account" 
+SELECT_DEPLOYER_ACCOUNT = "Select deployer account"
 
 DEPLOYER_ADDRESS_ZERO_ETH = "Deployer address has no ETH."
 

--- a/tests/integration/cli/test_ursula_config_cli.py
+++ b/tests/integration/cli/test_ursula_config_cli.py
@@ -236,7 +236,7 @@ def test_ursula_config_ip_address(click_runner, custom_filepath: Path):
     assert result.exit_code == 0, result.output
     assert (
         f'"rest_host": "{ip_address}"' in result.output
-    ), "IP address Not updated in command output"
+    ), "IP address not updated in command output"
 
 
 # Should be the last test since it deletes the configuration file

--- a/tests/integration/cli/test_ursula_config_cli.py
+++ b/tests/integration/cli/test_ursula_config_cli.py
@@ -228,10 +228,10 @@ def test_ursula_config_ip_address(click_runner, custom_filepath: Path):
             data = json.loads(raw_contents)
         except JSONDecodeError:
             raise pytest.fail(
-                msg="Invalid JSON configuration file {}".format(custom_config_filepath)
+                msg=f"Invalid JSON configuration file {custom_config_filepath}"
             )
 
-        assert data["rest_host"] == ip_address, "IP address not updated in "
+        assert data["rest_host"] == ip_address, "IP address not updated in command output"
 
     assert result.exit_code == 0, result.output
     assert (


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Running the command `ursula config ip-address` results in error:
`"ip-address" is not a valid command`.

```
% nucypher ursula config ip-address                                                                                     ✹
Defaulting to Ursula configuration file: '/Users/manumonti/Library/Application Support/nucypher/ursula.json'
Detected IPv4 address (xx.yy.zz.aa) - Is this the public-facing address of Ursula? [y/N]: y
"ip-address" is not a valid command.
Aborted!
```

This is because, after checking the line `if action == "migrate"`, there
is an `elif` keyword. So, when the action is not "migrate", the decision
branch runs the `elif action:` section.

Also, a new test has been added to detect errors like this.
