### PR TITLE
Update bumpversion to allow commit hashes as a suffix

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,19 +2,19 @@
 current_version = 7.0.0-rc.2
 commit = True
 tag = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>rc|dev)\.(?P<devnum>[A-Za-z0-9]{40}|\d{1,3}))?
 serialize = 
 	{major}.{minor}.{patch}-{stage}.{devnum}
-	{major}.{minor}.{patch}-{stage}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:stage]
 first_value = dev
 values = 
-	rc
 	dev
+	rc
 
 [bumpversion:part:devnum]
+first_value = 0
 
 [bumpversion:file:nucypher/__about__.py]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
       if: ${{ github.ref_name == 'development' }}
       run: |
         pip install bumpversion
-        export VERSION=$(bumpversion major --dry-run --list --allow-dirty | grep current_version= | sed 's/current_version=//g')
+        export VERSION=$(bumpversion devnum --dry-run --allow-dirty --list | grep current_version | sed 's/^current_version=\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/')
         echo "Set development version: $VERSION-dev.${{github.sha}}"
         bumpversion devnum --new-version $VERSION-dev.${{github.sha}} --no-tag --no-commit
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Properly allow gh action to specify a commit hash for bumpversion.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
