### PR TITLE
Decouples Decryption from Server Logic

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -649,7 +649,7 @@ class Operator(BaseActor):
         if not condition_lingo:
             # this should never happen for CBD - defeats the purpose
             raise self.UnauthorizedRequest(
-                "No conditions present for ciphertext - invalid for CBD functionality",
+                "No conditions present for ciphertext.",
             )
 
         # evaluate the conditions for this ciphertext
@@ -659,9 +659,7 @@ class Operator(BaseActor):
             providers=self.condition_providers,
         )
         if error:
-            raise self.UnauthorizedRequest(
-                f"Condition evaluation failed: {error}",
-            )
+            raise error
 
     def _verify_decryption_request_authorization(
         self, decryption_request: ThresholdDecryptionRequest

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -37,6 +37,8 @@ from nucypher_core import (
     Conditions,
     Context,
     EncryptedKeyFrag,
+    EncryptedThresholdDecryptionRequest,
+    EncryptedThresholdDecryptionResponse,
     EncryptedTreasureMap,
     MessageKit,
     NodeMetadata,
@@ -112,6 +114,7 @@ from nucypher.network.retrieval import PRERetrievalClient
 from nucypher.network.server import ProxyRESTServer, make_rest_app
 from nucypher.policy.conditions.lingo import ConditionLingo
 from nucypher.policy.conditions.types import Lingo
+from nucypher.policy.conditions.utils import evaluate_condition_lingo
 from nucypher.policy.kits import PolicyMessageKit
 from nucypher.policy.payment import ContractPayment, PaymentMethod
 from nucypher.policy.policies import Policy
@@ -1363,6 +1366,55 @@ class Ursula(Teacher, Character, Operator):
             address=self.checksum_address, public_key=self.public_keys(RitualisticPower)
         )
         return validator
+
+    def _authorize_lingo(self, decryption_request: ThresholdDecryptionRequest) -> None:
+        # requester-supplied condition eval context
+        context = None
+        if decryption_request.context:
+            # nucypher_core.Context -> str -> dict
+            context = json.loads(str(decryption_request.context)) or dict()
+
+        # obtain condition from request
+        condition_lingo = json.loads(
+            str(decryption_request.acp.conditions)
+        )  # nucypher_core.Conditions -> str -> Lingo
+        if not condition_lingo:
+            # this should never happen for CBD - defeats the purpose
+            raise self.UnauthorizedRequest(
+                "No conditions present for ciphertext - invalid for CBD functionality",
+            )
+
+        # evaluate the conditions for this ciphertext
+        error = evaluate_condition_lingo(
+            condition_lingo=condition_lingo,
+            context=context,
+            providers=self.condition_providers,
+        )
+        if error:
+            raise self.UnauthorizedRequest(
+                f"Condition evaluation failed: {error}",
+            )
+        return condition_lingo
+
+    def _authorize_decryption_request(
+        self, decryption_request: ThresholdDecryptionRequest
+    ) -> None:
+        super()._authorize_decryption_request(decryption_request)
+        self._authorize_lingo(decryption_request)
+
+    def handle_threshold_decryption_request(
+        self, encrypted_decryption_request: EncryptedThresholdDecryptionRequest
+    ) -> EncryptedThresholdDecryptionResponse:
+        decryption_request = self.decrypt_threshold_decryption_request(
+            encrypted_decryption_request
+        )
+        decryption_share = self._derive_decryption_share_for_request(decryption_request)
+        encrypted_response = self._encrypt_decryption_share(
+            decryption_share=decryption_share,
+            ritual_id=decryption_request.ritual_id,
+            public_key=encrypted_decryption_request.requester_public_key,
+        )
+        return encrypted_response
 
 
 class LocalUrsulaStatus(NamedTuple):

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -167,7 +167,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
         except EvalError as e:
             return Response(e.message, status=e.status_code)
         except this_node.DecryptionFailure as e:
-            return Response(str(e), status=HTTPStatus.BAD_REQUEST)
+            return Response(str(e), status=HTTPStatus.INTERNAL_SERVER_ERROR)
         except Exception as e:
             return Response(str(e), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -21,7 +21,7 @@ from nucypher.crypto.keypairs import DecryptingKeypair
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.network.nodes import NodeSprout
 from nucypher.network.protocols import InterfaceInfo
-from nucypher.policy.conditions.utils import evaluate_condition_lingo
+from nucypher.policy.conditions.utils import EvalError, evaluate_condition_lingo
 from nucypher.utilities.logging import Logger
 
 HERE = BASE_DIR = Path(__file__).parent
@@ -164,6 +164,8 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             return Response("Ritual not found", status=HTTPStatus.NOT_FOUND)
         except this_node.UnauthorizedRequest as e:
             return Response(str(e), status=HTTPStatus.UNAUTHORIZED)
+        except EvalError as e:
+            return Response(e.message, status=e.status_code)
         except this_node.DecryptionFailure as e:
             return Response(str(e), status=HTTPStatus.BAD_REQUEST)
         except Exception as e:

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -151,9 +151,11 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             encrypted_request = EncryptedThresholdDecryptionRequest.from_bytes(
                 request.data
             )
-            response = this_node.handle_threshold_decryption_request(encrypted_request)
+            encrypted_response = this_node.handle_threshold_decryption_request(
+                encrypted_request
+            )
             response = Response(
-                response=bytes(response),
+                response=bytes(encrypted_response),
                 status=HTTPStatus.OK,
                 mimetype="application/octet-stream",
             )
@@ -163,7 +165,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
         except this_node.UnauthorizedRequest as e:
             return Response(str(e), status=HTTPStatus.UNAUTHORIZED)
         except this_node.DecryptionFailure as e:
-            return Response(str(e), status=HTTPStatus.INTERNAL_SERVER_ERROR)
+            return Response(str(e), status=HTTPStatus.BAD_REQUEST)
         except Exception as e:
             return Response(str(e), status=HTTPStatus.INTERNAL_SERVER_ERROR)
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -227,12 +227,18 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             )
 
         # derive the decryption share
-        decryption_share = this_node.derive_decryption_share(
-            ritual_id=decryption_request.ritual_id,
-            ciphertext_header=decryption_request.ciphertext_header,
-            aad=decryption_request.acp.aad(),
-            variant=decryption_request.variant,
-        )
+        try:
+            decryption_share = this_node.derive_decryption_share(
+                ritual_id=decryption_request.ritual_id,
+                ciphertext_header=decryption_request.ciphertext_header,
+                aad=decryption_request.acp.aad(),
+                variant=decryption_request.variant,
+            )
+        except Exception as e:
+            log.warn(f"Failed to derive decryption share: {e}")
+            return Response(
+                f"Failed to derive decryption share: {e}", status=HTTPStatus.BAD_REQUEST
+            )
 
         # return the decryption share
         # TODO: #3098 nucypher-core#49 Use DecryptionShare type


### PR DESCRIPTION
**Type of PR:**
Bugfix

**Required reviews:** 
3

**What this does:**
- Fixes #3299 
- Catch errors while requesting tdec from nodes (during `derive_decryption_share`) and return them as an HTTP response.
- Ensures that an HTTP response is always produced even in the case of unexpected errors
- Improves the ability to create effective unit tests of core business logic


**Why it's needed:**
- Nodes are not explicitly handling decryption errors which makes them noisy and feedback less useful.
- It's too difficult to unit test logic that must be executed inside a running flask server

