### PR TITLE
Condition type alignment and enforcement

### DIFF
--- a/newsfragments/3303.bugfix.rst
+++ b/newsfragments/3303.bugfix.rst
@@ -1,0 +1,2 @@
+Fix issues when bytes are provided as hex for return value comparators.
+Make condition value types more strict by using ABI to validate.

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -265,7 +265,7 @@ class RPCCondition(AccessControlCondition):
         rpc_result = rpc_function(*parameters)  # RPC read
         return rpc_result
 
-    def _align_comparator_with_abi(
+    def _align_comparator_value_with_abi(
         self, return_value_test: ReturnValueTest
     ) -> ReturnValueTest:
         return return_value_test
@@ -283,7 +283,7 @@ class RPCCondition(AccessControlCondition):
             parameters, return_value_test = _resolve_any_context_variables(
                 self.parameters, self.return_value_test, **context
             )
-            return_value_test = self._align_comparator_with_abi(return_value_test)
+            return_value_test = self._align_comparator_value_with_abi(return_value_test)
             try:
                 result = self._execute_call(parameters=parameters)
                 break
@@ -424,8 +424,9 @@ class ContractCondition(RPCCondition):
         if not w3.is_encodable(expected_type, comparator_value):
             raise InvalidCondition(failure_message)
 
+    @staticmethod
     def _align_comparator_value(
-        self, comparator_value: Any, expected_type: str, failure_message: str
+        comparator_value: Any, expected_type: str, failure_message: str
     ):
         if expected_type.startswith("bytes"):
             try:
@@ -473,7 +474,7 @@ class ContractCondition(RPCCondition):
         contract_result = bound_contract_function.call()  # onchain read
         return contract_result
 
-    def _align_comparator_with_abi(
+    def _align_comparator_value_with_abi(
         self, return_value_test: ReturnValueTest
     ) -> ReturnValueTest:
         output_abi_types = self._get_abi_types(self.contract_function.contract_abi[0])
@@ -481,9 +482,7 @@ class ContractCondition(RPCCondition):
         comparator_value = return_value_test.value
         comparator_index = return_value_test.index
         if isinstance(comparator_value, tuple):
-            # must be list;
-            # TODO revisit this - when processing returned tuples from contract calls
-            #  we convert to list, hence this conversion is needed
+            # must be list
             comparator_value = list(comparator_value)
 
         if len(output_abi_types) == 1:

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -409,13 +409,11 @@ class ContractCondition(RPCCondition):
                     output_abi_type, component_value, failure_message
                 )
         else:
-            raise InvalidCondition(
-                "No outputs for ABI function."
-            )  # should never happen
+            raise InvalidCondition("No output types available for ABI function.")
 
     def _validate_value_type(self, expected_type, comparator_value, failure_message):
         if is_context_variable(comparator_value):
-            # can't know type for context variable
+            # context variable types cannot be known until execution time.
             return
 
         comparator_value = self._align_comparator_value(
@@ -520,14 +518,15 @@ class ContractCondition(RPCCondition):
                 comparator_value = self._align_comparator_value(
                     comparator_value,
                     output_abi_type,
-                    failure_message="Unencodable type",
+                    failure_message=f"Unencodable type ({comparator_value} as {output_abi_type})",
                 )
                 values.append(component_value)
             return ReturnValueTest(
                 comparator=comparator, value=values, index=comparator_index
             )
         else:
-            raise RuntimeError("No outputs for ABI function.")  # should never happen
+            # should never happen (validated on object initialization)
+            raise RuntimeError("No output types available for ABI function.")
 
     @classmethod
     def _get_abi_types(cls, abi: ABIFunction) -> List[str]:

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -378,9 +378,6 @@ class ContractCondition(RPCCondition):
         )
 
         if len(output_abi_types) == 1:
-            if is_context_variable(comparator_value):
-                return
-
             expected_type = output_abi_types[0]
             self._validate_value_type(expected_type, comparator_value, failure_message)
         elif len(output_abi_types) > 1:
@@ -401,15 +398,15 @@ class ContractCondition(RPCCondition):
             for output_abi_type, component_value in zip(
                 output_abi_types, comparator_value
             ):
-                if is_context_variable(component_value):
-                    # can't know type for context variable; skip
-                    continue
-
                 self._validate_value_type(
                     output_abi_type, component_value, failure_message
                 )
 
     def _validate_value_type(self, expected_type, comparator_value, failure_message):
+        if is_context_variable(comparator_value):
+            # can't know type for context variable
+            return
+
         comparator_value = self._normalize_comparator_value(
             comparator_value, expected_type, failure_message
         )

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -4,20 +4,16 @@ from typing import (
     Iterator,
     List,
     Optional,
-    Sequence,
     Set,
     Tuple,
     Type,
     Union,
-    cast,
 )
 
 from eth_typing import ChecksumAddress
 from eth_utils import to_checksum_address
-from hexbytes import HexBytes
 from marshmallow import ValidationError, fields, post_load, validate, validates_schema
 from web3 import HTTPProvider, Web3
-from web3.auto import w3
 from web3.contract.contract import ContractFunction
 from web3.middleware import geth_poa_middleware
 from web3.providers import BaseProvider
@@ -34,6 +30,12 @@ from nucypher.policy.conditions.exceptions import (
 )
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 from nucypher.policy.conditions.utils import CamelCaseSchema, camel_case_to_snake
+from nucypher.policy.conditions.validation import (
+    _align_comparator_value_with_abi,
+    _get_abi_types,
+    _validate_multiple_output_types,
+    _validate_single_output_type,
+)
 
 # TODO: Move this to a more appropriate location,
 #  but be sure to change the mocks in tests too.
@@ -369,41 +371,8 @@ class ContractCondition(RPCCondition):
     def _validate_method(self, method):
         return method
 
-    def _validate_single_output_type(
-        self,
-        expected_type: str,
-        comparator_value: Any,
-        comparator_index: Optional[int],
-        failure_message: str,
-    ) -> None:
-        if comparator_index is not None and self._is_tuple_type(expected_type):
-            type_entries = self._get_tuple_type_entries(expected_type)
-            expected_type = type_entries[comparator_index]
-        self._validate_value_type(expected_type, comparator_value, failure_message)
-
-    def _validate_multiple_output_types(
-        self,
-        output_abi_types: List[str],
-        comparator_value: Any,
-        comparator_index: Optional[int],
-        failure_message: str,
-    ) -> None:
-        if comparator_index is not None:
-            expected_type = output_abi_types[comparator_index]
-            self._validate_value_type(expected_type, comparator_value, failure_message)
-            return
-
-        if not isinstance(comparator_value, Sequence):
-            raise InvalidCondition(failure_message)
-
-        if len(output_abi_types) != len(comparator_value):
-            raise InvalidCondition(failure_message)
-
-        for output_abi_type, component_value in zip(output_abi_types, comparator_value):
-            self._validate_value_type(output_abi_type, component_value, failure_message)
-
     def _validate_expected_return_type(self) -> None:
-        output_abi_types = self._get_abi_types(self.contract_function.contract_abi[0])
+        output_abi_types = _get_abi_types(self.contract_function.contract_abi[0])
         comparator_value = self.return_value_test.value
         comparator_index = self.return_value_test.index
         index_string = (
@@ -415,39 +384,15 @@ class ContractCondition(RPCCondition):
         )
 
         if len(output_abi_types) == 1:
-            self._validate_single_output_type(
+            _validate_single_output_type(
                 output_abi_types[0], comparator_value, comparator_index, failure_message
             )
         elif len(output_abi_types) > 1:
-            self._validate_multiple_output_types(
+            _validate_multiple_output_types(
                 output_abi_types, comparator_value, comparator_index, failure_message
             )
         else:
             raise InvalidCondition("No output types available for ABI function.")
-
-    def _validate_value_type(
-        self, expected_type: str, comparator_value: Any, failure_message: str
-    ) -> None:
-        if is_context_variable(comparator_value):
-            # context variable types cannot be known until execution time.
-            return
-
-        comparator_value = self._align_comparator_value(
-            comparator_value, expected_type, failure_message
-        )
-        if not w3.is_encodable(expected_type, comparator_value):
-            raise InvalidCondition(failure_message)
-
-    @staticmethod
-    def _align_comparator_value(
-        comparator_value: Any, expected_type: str, failure_message: str
-    ) -> Any:
-        if expected_type.startswith("bytes"):
-            try:
-                comparator_value = bytes(HexBytes(comparator_value))
-            except Exception:
-                raise InvalidCondition(failure_message)
-        return comparator_value
 
     def __repr__(self) -> str:
         r = (
@@ -491,90 +436,7 @@ class ContractCondition(RPCCondition):
     def _align_comparator_value_with_abi(
         self, return_value_test: ReturnValueTest
     ) -> ReturnValueTest:
-        output_abi_types = self._get_abi_types(self.contract_function.contract_abi[0])
-        comparator = return_value_test.comparator
-        comparator_value = return_value_test.value
-        comparator_index = return_value_test.index
-        if isinstance(comparator_value, tuple):
-            # must be list
-            comparator_value = list(comparator_value)
-
-        if len(output_abi_types) == 1:
-            expected_type = output_abi_types[0]
-            if comparator_index is not None and self._is_tuple_type(expected_type):
-                type_entries = self._get_tuple_type_entries(expected_type)
-                expected_type = type_entries[comparator_index]
-            comparator_value = self._align_comparator_value(
-                comparator_value, expected_type, failure_message="Unencodable type"
-            )
-            return ReturnValueTest(
-                comparator=comparator,
-                value=comparator_value,
-                index=comparator_index,
-            )
-        elif len(output_abi_types) > 1:
-            if comparator_index is not None:
-                # only index entry we care about
-                expected_type = output_abi_types[comparator_index]
-                comparator_value = self._align_comparator_value(
-                    comparator_value,
-                    expected_type,
-                    failure_message="Unencodable type",
-                )
-                return ReturnValueTest(
-                    comparator=comparator,
-                    value=comparator_value,
-                    index=comparator_index,
-                )
-
-            values = list()
-            for output_abi_type, component_value in zip(
-                output_abi_types, comparator_value
-            ):
-                comparator_value = self._align_comparator_value(
-                    comparator_value,
-                    output_abi_type,
-                    failure_message=f"Unencodable type ({comparator_value} as {output_abi_type})",
-                )
-                values.append(component_value)
-            return ReturnValueTest(
-                comparator=comparator, value=values, index=comparator_index
-            )
-        else:
-            # should never happen (validated on object initialization)
-            raise RuntimeError("No output types available for ABI function.")
-
-    @classmethod
-    def _get_abi_types(cls, abi: ABIFunction) -> List[str]:
-        if abi["type"] == "fallback":
-            return []
-        else:
-            return [
-                cls._collapse_if_tuple(cast(Dict[str, Any], arg))
-                for arg in abi["outputs"]
-            ]
-
-    @classmethod
-    def _collapse_if_tuple(cls, abi: Dict[str, Any]) -> str:
-        abi_type = abi["type"]
-        if not abi_type.startswith("tuple"):
-            return abi_type
-
-        delimited = ",".join(cls._collapse_if_tuple(c) for c in abi["components"])
-        collapsed = f"({delimited})"
-        return collapsed
-
-    @classmethod
-    def _is_tuple_type(cls, abi_type: str):
-        return abi_type.startswith("(") and abi_type.endswith(")")
-
-    @classmethod
-    def _get_tuple_type_entries(cls, tuple_type: str) -> List[str]:
-        if not cls._is_tuple_type(tuple_type):
-            raise ValueError(
-                f"Invalid type provided '{tuple_type}; not a tuple type definition"
-            )
-
-        result = tuple_type.replace("(", "").replace(")", "")
-        result = result.split(",")
-        return result
+        return _align_comparator_value_with_abi(
+            abi=self.contract_function.contract_abi[0],
+            return_value_test=return_value_test,
+        )

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -465,6 +465,12 @@ class ContractCondition(RPCCondition):
     def _normalize(self, return_value_test: ReturnValueTest) -> ReturnValueTest:
         output_abi_types = self._get_abi_types(self.contract_function.contract_abi[0])
         comparator_value = return_value_test.value
+        if isinstance(comparator_value, tuple):
+            # must be list;
+            # TODO revisit this - when processing returned tuples we convert to list,
+            #  hence this conversion is needed
+            comparator_value = list(comparator_value)
+
         if len(output_abi_types) == 1:
             expected_type = output_abi_types[0]
             comparator_value = self._normalize_comparator_value(

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -6,8 +6,6 @@ from typing import (
     Optional,
     Set,
     Tuple,
-    Type,
-    Union,
 )
 
 from eth_typing import ChecksumAddress
@@ -33,6 +31,7 @@ from nucypher.policy.conditions.utils import CamelCaseSchema, camel_case_to_snak
 from nucypher.policy.conditions.validation import (
     _align_comparator_value_with_abi,
     _get_abi_types,
+    _validate_contract_type_or_function_abi,
     _validate_multiple_output_types,
     _validate_single_output_type,
 )
@@ -306,18 +305,6 @@ class RPCCondition(AccessControlCondition):
 class ContractCondition(RPCCondition):
     CONDITION_TYPE = ConditionType.CONTRACT.value
 
-    @classmethod
-    def _validate_contract_type_or_function_abi(
-        cls,
-        standard_contract_type: str,
-        function_abi: Dict,
-        exception_class: Union[Type[ValidationError], Type[InvalidCondition]],
-    ):
-        if not (bool(standard_contract_type) ^ bool(function_abi)):
-            raise exception_class(
-                f"Provide 'standardContractType' or 'functionAbi'; got ({standard_contract_type}, {function_abi})."
-            )
-
     class Schema(RPCCondition.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.CONTRACT.value), required=True
@@ -334,7 +321,7 @@ class ContractCondition(RPCCondition):
         def check_standard_contract_type_or_function_abi(self, data, **kwargs):
             standard_contract_type = data.get("standard_contract_type")
             function_abi = data.get("function_abi")
-            ContractCondition._validate_contract_type_or_function_abi(
+            _validate_contract_type_or_function_abi(
                 standard_contract_type, function_abi, ValidationError
             )
 
@@ -351,7 +338,7 @@ class ContractCondition(RPCCondition):
         self.method = method
         self.w3 = Web3()  # used to instantiate contract function without a provider
 
-        ContractCondition._validate_contract_type_or_function_abi(
+        _validate_contract_type_or_function_abi(
             standard_contract_type, function_abi, InvalidCondition
         )
 

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -356,6 +356,7 @@ class ContractCondition(RPCCondition):
         super().__init__(condition_type=condition_type, method=method, *args, **kwargs)
 
     def _validate_method(self, method):
+        # overrides validate method used by rpc superclass
         return method
 
     def _validate_expected_return_type(self) -> None:

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -185,7 +185,7 @@ class RPCCondition(AccessControlCondition):
         self._validate_expected_return_type()
 
     def _validate_method(self, method):
-        if method not in self.ALLOWED_METHODS.keys():
+        if method not in self.ALLOWED_METHODS:
             raise InvalidCondition(
                 f"'{method}' is not a permitted RPC endpoint for condition evaluation."
             )

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -264,9 +264,9 @@ class ReturnValueTest:
         processed_data = data
         if isinstance(data, (list, tuple)):
             if self.index is None:
-                # convert any bytes in sequence to hex
-                data = [self.__handle_potential_bytes(item) for item in data]
-                return data
+                # convert any bytes in list to hex
+                processed_data = [self.__handle_potential_bytes(item) for item in data]
+                return processed_data
 
             if isinstance(self.index, int):
                 try:

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -1,6 +1,5 @@
 import ast
 import base64
-import json
 import operator as pyoperator
 from enum import Enum
 from hashlib import md5
@@ -234,14 +233,6 @@ class ReturnValueTest:
         if index is not None and not isinstance(index, int):
             raise self.InvalidExpression(
                 f'"{index}" is not a permitted index. Must be a an integer.'
-            )
-
-        try:
-            # ensure that value is JSON serializable
-            json.dumps(value)
-        except TypeError:
-            raise self.InvalidExpression(
-                f"{value} object of type '{type(value)}' is not JSON serializable."
             )
 
         if not is_context_variable(value):

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -1,5 +1,6 @@
 import ast
 import base64
+import json
 import operator as pyoperator
 from enum import Enum
 from hashlib import md5
@@ -236,6 +237,19 @@ class ReturnValueTest:
             )
 
         if not is_context_variable(value):
+            # adjust stored value to be JSON serializable
+            if isinstance(value, (tuple, set)):
+                value = list(value)
+            if isinstance(value, bytes):
+                value = HexBytes(value).hex()
+
+            try:
+                json.dumps(value)
+            except Exception:
+                raise self.InvalidExpression(
+                    f"No JSON serializable equivalent found for type {type(value)}"
+                )
+
             # verify that value is valid, but don't set it here so as not to change the value;
             # it will be sanitized at eval time. Need to maintain serialization/deserialization
             # consistency

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -245,7 +245,7 @@ class ReturnValueTest:
 
             try:
                 json.dumps(value)
-            except Exception:
+            except TypeError:
                 raise self.InvalidExpression(
                     f"No JSON serializable equivalent found for type {type(value)}"
                 )

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -44,6 +44,8 @@ class TimeCondition(RPCCondition):
             raise InvalidCondition(
                 f"{self.__class__.__name__} must be instantiated with the {self.METHOD} method."
             )
+
+        # call to super must be at the end for proper validation
         super().__init__(
             chain=chain,
             method=method,
@@ -52,8 +54,15 @@ class TimeCondition(RPCCondition):
             condition_type=condition_type,
         )
 
-    def validate_method(self, method):
+    def _validate_method(self, method):
         return method
+
+    def _validate_expected_return_type(self):
+        comparator_value = self.return_value_test.value
+        if not isinstance(comparator_value, int):
+            raise InvalidCondition(
+                f"Invalid return value comparison type '{type(comparator_value)}'; must be an integer"
+            )
 
     @property
     def timestamp(self):

--- a/nucypher/policy/conditions/validation.py
+++ b/nucypher/policy/conditions/validation.py
@@ -4,10 +4,13 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Type,
+    Union,
     cast,
 )
 
 from hexbytes import HexBytes
+from marshmallow import ValidationError
 from web3.auto import w3
 from web3.types import ABIFunction
 
@@ -160,3 +163,14 @@ def _align_comparator_value_with_abi(
         )
     else:
         raise RuntimeError("No outputs for ABI function.")  # should never happen
+
+
+def _validate_contract_type_or_function_abi(
+    standard_contract_type: str,
+    function_abi: Dict,
+    exception_class: Union[Type[ValidationError], Type[InvalidCondition]],
+) -> None:
+    if not (bool(standard_contract_type) ^ bool(function_abi)):
+        raise exception_class(
+            f"Provide 'standardContractType' or 'functionAbi'; got ({standard_contract_type}, {function_abi})."
+        )

--- a/nucypher/policy/conditions/validation.py
+++ b/nucypher/policy/conditions/validation.py
@@ -1,0 +1,162 @@
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    cast,
+)
+
+from hexbytes import HexBytes
+from web3.auto import w3
+from web3.types import ABIFunction
+
+from nucypher.policy.conditions.context import is_context_variable
+from nucypher.policy.conditions.exceptions import (
+    InvalidCondition,
+)
+from nucypher.policy.conditions.lingo import ReturnValueTest
+
+
+def _align_comparator_value(
+    comparator_value: Any, expected_type: str, failure_message: str
+) -> Any:
+    if expected_type.startswith("bytes"):
+        try:
+            comparator_value = bytes(HexBytes(comparator_value))
+        except Exception:
+            raise InvalidCondition(failure_message)
+    return comparator_value
+
+
+def _validate_single_output_type(
+    expected_type: str,
+    comparator_value: Any,
+    comparator_index: Optional[int],
+    failure_message: str,
+) -> None:
+    if comparator_index is not None and _is_tuple_type(expected_type):
+        type_entries = _get_tuple_type_entries(expected_type)
+        expected_type = type_entries[comparator_index]
+    _validate_value_type(expected_type, comparator_value, failure_message)
+
+
+def _get_abi_types(abi: ABIFunction) -> List[str]:
+    if abi["type"] == "fallback":
+        return []
+    else:
+        return [_collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["outputs"]]
+
+
+def _validate_value_type(
+    expected_type: str, comparator_value: Any, failure_message: str
+) -> None:
+    if is_context_variable(comparator_value):
+        # can't know type for context variable
+        return
+
+    comparator_value = _align_comparator_value(
+        comparator_value, expected_type, failure_message
+    )
+    if not w3.is_encodable(expected_type, comparator_value):
+        raise InvalidCondition(failure_message)
+
+
+def _collapse_if_tuple(abi: Dict[str, Any]) -> str:
+    abi_type = abi["type"]
+    if not abi_type.startswith("tuple"):
+        return abi_type
+
+    delimited = ",".join(_collapse_if_tuple(c) for c in abi["components"])
+    collapsed = f"({delimited})"
+    return collapsed
+
+
+def _is_tuple_type(abi_type: str):
+    return abi_type.startswith("(") and abi_type.endswith(")")
+
+
+def _get_tuple_type_entries(tuple_type: str) -> List[str]:
+    if not _is_tuple_type(tuple_type):
+        raise ValueError(
+            f"Invalid type provided '{tuple_type}; not a tuple type definition"
+        )
+
+    result = tuple_type.replace("(", "").replace(")", "")
+    result = result.split(",")
+    return result
+
+
+def _validate_multiple_output_types(
+    output_abi_types: List[str],
+    comparator_value: Any,
+    comparator_index: Optional[int],
+    failure_message: str,
+) -> None:
+    if comparator_index is not None:
+        expected_type = output_abi_types[comparator_index]
+        _validate_value_type(expected_type, comparator_value, failure_message)
+        return
+
+    if not isinstance(comparator_value, Sequence):
+        raise InvalidCondition(failure_message)
+
+    if len(output_abi_types) != len(comparator_value):
+        raise InvalidCondition(failure_message)
+
+    for output_abi_type, component_value in zip(output_abi_types, comparator_value):
+        _validate_value_type(output_abi_type, component_value, failure_message)
+
+
+def _align_comparator_value_with_abi(
+    abi, return_value_test: ReturnValueTest
+) -> ReturnValueTest:
+    output_abi_types = _get_abi_types(abi)
+    comparator = return_value_test.comparator
+    comparator_value = return_value_test.value
+    comparator_index = return_value_test.index
+    if isinstance(comparator_value, tuple):
+        # must be list
+        comparator_value = list(comparator_value)
+
+    if len(output_abi_types) == 1:
+        expected_type = output_abi_types[0]
+        if comparator_index is not None and _is_tuple_type(expected_type):
+            type_entries = _get_tuple_type_entries(expected_type)
+            expected_type = type_entries[comparator_index]
+        comparator_value = _align_comparator_value(
+            comparator_value, expected_type, failure_message="Unencodable type"
+        )
+        return ReturnValueTest(
+            comparator=comparator,
+            value=comparator_value,
+            index=comparator_index,
+        )
+    elif len(output_abi_types) > 1:
+        if comparator_index is not None:
+            # only index entry we care about
+            expected_type = output_abi_types[comparator_index]
+            comparator_value = _align_comparator_value(
+                comparator_value,
+                expected_type,
+                failure_message="Unencodable type",
+            )
+            return ReturnValueTest(
+                comparator=comparator,
+                value=comparator_value,
+                index=comparator_index,
+            )
+
+        values = list()
+        for output_abi_type, component_value in zip(output_abi_types, comparator_value):
+            comparator_value = _align_comparator_value(
+                comparator_value,
+                output_abi_type,
+                failure_message="Unencodable type",
+            )
+            values.append(component_value)
+        return ReturnValueTest(
+            comparator=comparator, value=values, index=comparator_index
+        )
+    else:
+        raise RuntimeError("No outputs for ABI function.")  # should never happen

--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -304,7 +304,7 @@ def nucypher_dkg(
         "version": ConditionLingo.VERSION,
         "condition": {
             "conditionType": ConditionType.TIME.value,
-            "returnValueTest": {"value": "0", "comparator": ">"},
+            "returnValueTest": {"value": 0, "comparator": ">"},
             "method": "blocktime",
             "chain": application_agent.blockchain.client.chain_id,
         },

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -22,7 +22,7 @@ CONDITIONS = {
     "version": ConditionLingo.VERSION,
     "condition": {
         "conditionType": ConditionType.TIME.value,
-        "returnValueTest": {"value": "0", "comparator": ">"},
+        "returnValueTest": {"value": 0, "comparator": ">"},
         "method": "blocktime",
         "chain": TESTERCHAIN_CHAIN_ID,
     },

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -4,6 +4,7 @@ import os
 from unittest import mock
 
 import pytest
+from hexbytes import HexBytes
 from web3 import Web3
 
 from nucypher.blockchain.eth.agents import ContractAgency, SubscriptionManagerAgent
@@ -283,7 +284,9 @@ def test_subscription_manager_is_active_policy_condition_evaluation(
     subscription_manager_is_active_policy_condition,
     condition_providers
 ):
-    context = {":hrac": bytes(enacted_policy.hrac)}  # user-defined context var
+    context = {
+        ":hrac": HexBytes(bytes(enacted_policy.hrac)).hex()
+    }  # user-defined context var
     (
         condition_result,
         call_result,
@@ -294,7 +297,7 @@ def test_subscription_manager_is_active_policy_condition_evaluation(
     assert condition_result is True
 
     # non-active policy hrac
-    context[":hrac"] = os.urandom(16)
+    context[":hrac"] = HexBytes(os.urandom(16)).hex()
     condition_result, call_result = subscription_manager_is_active_policy_condition.verify(
         providers=condition_providers, **context
     )
@@ -331,7 +334,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_evaluation_stru
     )
 
     context = {
-        ":hrac": bytes(enacted_policy.hrac),
+        ":hrac": HexBytes(bytes(enacted_policy.hrac)).hex(),
     }  # user-defined context vars
     condition_result, call_result = condition.verify(
         providers=condition_providers, **context
@@ -339,7 +342,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_evaluation_stru
     assert not condition_result  # not zeroized policy
 
     # unknown policy hrac
-    context[":hrac"] = os.urandom(16)
+    context[":hrac"] = HexBytes(os.urandom(16)).hex()
     condition_result, call_result = condition.verify(
         providers=condition_providers, **context
     )
@@ -357,7 +360,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_evaluation_cont
         NULL_ADDRESS, 0, 0, 0, NULL_ADDRESS,
     )
     context = {
-        ":hrac": bytes(enacted_policy.hrac),
+        ":hrac": HexBytes(bytes(enacted_policy.hrac)).hex(),
         ":expectedPolicyStruct": zeroized_policy_struct,
     }  # user-defined context vars
     condition_result, call_result = subscription_manager_get_policy_zeroized_policy_struct_condition.verify(
@@ -367,7 +370,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_evaluation_cont
     assert not condition_result  # not zeroized policy
 
     # unknown policy hrac
-    context[":hrac"] = os.urandom(16)
+    context[":hrac"] = HexBytes(os.urandom(16)).hex()
     condition_result, call_result = subscription_manager_get_policy_zeroized_policy_struct_condition.verify(
         providers=condition_providers, **context
     )
@@ -389,7 +392,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_key_tuple_evalu
     sponsor = idle_policy.publisher.checksum_address
 
     context = {
-        ":hrac": bytes(enacted_policy.hrac),
+        ":hrac": HexBytes(bytes(enacted_policy.hrac)).hex(),
     }  # user-defined context vars
     subscription_manager = ContractAgency.get_agent(
         SubscriptionManagerAgent,
@@ -506,7 +509,7 @@ def test_subscription_manager_get_policy_policy_struct_condition_index_and_value
     # enacted policy created from idle policy
     sponsor = idle_policy.publisher.checksum_address
     context = {
-        ":hrac": bytes(enacted_policy.hrac),
+        ":hrac": HexBytes(bytes(enacted_policy.hrac)).hex(),
         ":sponsor": sponsor,
     }  # user-defined context vars
     subscription_manager = ContractAgency.get_agent(

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -586,7 +586,7 @@ def test_single_retrieve_with_onchain_conditions(enacted_policy, bob, ursulas):
             "operands": [
                 {
                     "conditionType": ConditionType.TIME.value,
-                    "returnValueTest": {"value": "0", "comparator": ">"},
+                    "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },
@@ -595,7 +595,7 @@ def test_single_retrieve_with_onchain_conditions(enacted_policy, bob, ursulas):
                     "chain": TESTERCHAIN_CHAIN_ID,
                     "method": "eth_getBalance",
                     "parameters": [bob.checksum_address, "latest"],
-                    "returnValueTest": {"comparator": ">=", "value": "10000000000000"},
+                    "returnValueTest": {"comparator": ">=", "value": 10000000000000},
                 },
             ],
         },

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -308,7 +308,6 @@ def test_subscription_manager_get_policy_policy_struct_condition_evaluation(
     subscription_manager_get_policy_zeroized_policy_struct_condition,
     condition_providers
 ):
-
     # zeroized policy struct
     zeroized_policy_struct = (
         NULL_ADDRESS, 0, 0, 0, NULL_ADDRESS,

--- a/tests/acceptance/conditions/test_multichain_evaluation.py
+++ b/tests/acceptance/conditions/test_multichain_evaluation.py
@@ -17,7 +17,7 @@ def make_multichain_evm_conditions(bob, chain_ids):
         operand = [
             {
                 "conditionType": ConditionType.TIME.value,
-                "returnValueTest": {"value": "0", "comparator": ">"},
+                "returnValueTest": {"value": 0, "comparator": ">"},
                 "method": "blocktime",
                 "chain": chain_id,
             },
@@ -26,7 +26,7 @@ def make_multichain_evm_conditions(bob, chain_ids):
                 "chain": chain_id,
                 "method": "eth_getBalance",
                 "parameters": [bob.checksum_address, "latest"],
-                "returnValueTest": {"comparator": ">=", "value": "10000000000000"},
+                "returnValueTest": {"comparator": ">=", "value": 10000000000000},
             },
         ]
         operands.extend(operand)

--- a/tests/data/test_conditions.json
+++ b/tests/data/test_conditions.json
@@ -29,41 +29,9 @@
       "name": "isSubscribedToToken",
       "outputs": [
         {
-          "components": [
-            {
-              "internalType": "bool",
-              "name": "valid",
-              "type": "bool"
-            },
-            {
-              "internalType": "bytes32",
-              "name": "subscriptionType",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "uint256",
-              "name": "price",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "createdAt",
-              "type": "uint256"
-            },
-            {
-              "internalType": "uint256",
-              "name": "expireAt",
-              "type": "uint256"
-            },
-            {
-              "internalType": "bytes",
-              "name": "data",
-              "type": "bytes"
-            }
-          ],
-          "internalType": "struct Project.SubscriberData",
-          "name": "",
-          "type": "tuple"
+          "internalType": "bool",
+          "name": "valid",
+          "type": "bool"
         }
       ],
       "stateMutability": "view",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -601,14 +601,14 @@ def compound_blocktime_lingo():
             "operands": [
                 {
                     "conditionType": ConditionType.TIME.value,
-                    "returnValueTest": {"value": "0", "comparator": ">"},
+                    "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },
                 {
                     "conditionType": ConditionType.TIME.value,
                     "returnValueTest": {
-                        "value": "99999999999999999",
+                        "value": 99999999999999999,
                         "comparator": "<",
                     },
                     "method": "blocktime",
@@ -616,7 +616,7 @@ def compound_blocktime_lingo():
                 },
                 {
                     "conditionType": ConditionType.TIME.value,
-                    "returnValueTest": {"value": "0", "comparator": ">"},
+                    "returnValueTest": {"value": 0, "comparator": ">"},
                     "method": "blocktime",
                     "chain": TESTERCHAIN_CHAIN_ID,
                 },

--- a/tests/integration/blockchain/test_integration_dkg_ritual.py
+++ b/tests/integration/blockchain/test_integration_dkg_ritual.py
@@ -23,7 +23,7 @@ CONDITIONS = {
     "version": ConditionLingo.VERSION,
     "condition": {
         "conditionType": ConditionType.TIME.value,
-        "returnValueTest": {"value": "0", "comparator": ">"},
+        "returnValueTest": {"value": 0, "comparator": ">"},
         "method": "blocktime",
         "chain": TESTERCHAIN_CHAIN_ID,
     },

--- a/tests/integration/config/test_keystore_integration.py
+++ b/tests/integration/config/test_keystore_integration.py
@@ -183,7 +183,7 @@ def test_ritualist(temp_dir_path, testerchain, dkg_public_key):
         "version": ConditionLingo.VERSION,
         "condition": {
             "conditionType": ConditionType.TIME.value,
-            "returnValueTest": {"value": "0", "comparator": ">"},
+            "returnValueTest": {"value": 0, "comparator": ">"},
             "method": "blocktime",
             "chain": TESTERCHAIN_CHAIN_ID,
         },

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -77,7 +77,7 @@ def lingo_with_compound_conditions(get_random_checksum_address):
                             "parameters": [get_random_checksum_address(), "latest"],
                             "returnValueTest": {
                                 "comparator": ">=",
-                                "value": "10000000000000",
+                                "value": 10000000000000,
                             },
                         },
                     ],

--- a/tests/unit/conditions/test_contract_conditions.py
+++ b/tests/unit/conditions/test_contract_conditions.py
@@ -1,0 +1,188 @@
+import copy
+import json
+from typing import Any, Dict, Sequence
+
+import pytest
+
+from nucypher.policy.conditions.evm import ContractCondition
+from nucypher.policy.conditions.exceptions import InvalidCondition
+
+CONTRACT_CONDITION = {
+    "conditionType": "contract",
+    "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
+    "method": "isSubscribedToToken",
+    "parameters": [":userAddress", "subscriptionCode", 4],
+    "functionAbi": {
+        "inputs": [
+            {"internalType": "address", "name": "subscriber", "type": "address"},
+            {"internalType": "bytes32", "name": "subscriptionCode", "type": "bytes32"},
+            {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
+        ],
+        "name": "isSubscribedToToken",
+        "outputs": [{"internalType": "bool", "name": "valid", "type": "bool"}],
+        "stateMutability": "view",
+        "type": "function",
+        "constant": True,
+    },
+    "chain": 137,
+    "returnValueTest": {"comparator": "==", "value": True},
+}
+
+
+@pytest.fixture(scope="function")
+def contract_condition_dict():
+    return copy.deepcopy(CONTRACT_CONDITION)
+
+
+def _replace_abi_outputs(condition_json: Dict, output_type: str, output_value: Any):
+    # modify outputs type
+    condition_json["functionAbi"]["outputs"][0]["internalType"] = output_type
+    condition_json["functionAbi"]["outputs"][0]["type"] = output_type
+
+    # modify return value test
+    condition_json["returnValueTest"]["value"] = output_value
+
+
+def test_abi_bool_output(contract_condition_dict):
+    # default - no changes to json
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, bool)
+
+    # invalid type fails
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = 23
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+
+def test_abi_uint_output(contract_condition_dict):
+    _replace_abi_outputs(contract_condition_dict, "uint256", 123456789)
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, int)
+
+    # invalid type fails
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = True
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+
+def test_abi_int_output(contract_condition_dict):
+    _replace_abi_outputs(contract_condition_dict, "int256", -123456789)
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, int)
+
+    # invalid type fails
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = [1, 2, 3]
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+
+def test_abi_address_output(contract_condition_dict, get_random_checksum_address):
+    _replace_abi_outputs(
+        contract_condition_dict, "address", get_random_checksum_address()
+    )
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, str)
+
+    # invalid type fails
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = 1.25
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+
+def test_abi_tuple_output(contract_condition_dict):
+    contract_condition_dict["functionAbi"]["outputs"] = [
+        {"internalType": "uint96", "name": "tStake", "type": "uint96"},
+        {"internalType": "uint96", "name": "keepInTStake", "type": "uint96"},
+        {"internalType": "uint96", "name": "nuInTStake", "type": "uint96"},
+    ]
+    contract_condition_dict["returnValueTest"]["value"] = [1, 2, 3]
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, Sequence)
+
+    # 1. invalid type
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = 1
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # 2. invalid number of values
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = [1, 2]
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # 3a. Unmatched type
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = [True, 2, 3]
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # 3b. Unmatched type
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = [1, False, 3]
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # 3c. Unmatched type
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["value"] = [1, 2, 3.14159]
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+
+def test_abi_tuple_output_with_index(
+    contract_condition_dict, get_random_checksum_address
+):
+    contract_condition_dict["functionAbi"]["outputs"] = [
+        {"internalType": "uint96", "name": "tStake", "type": "uint96"},
+        {"internalType": "uint96", "name": "hasKeep", "type": "bool"},
+        {"internalType": "uint96", "name": "nuAddress", "type": "address"},
+    ]
+
+    # without index
+    contract_condition_dict["returnValueTest"]["value"] = [
+        1,
+        True,
+        get_random_checksum_address(),
+    ]
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, Sequence)
+
+    # index 0
+    contract_condition_dict["returnValueTest"]["index"] = 0
+    contract_condition_dict["returnValueTest"]["value"] = 1
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, int)
+
+    # index 1
+    contract_condition_dict["returnValueTest"]["index"] = 1
+    contract_condition_dict["returnValueTest"]["value"] = True
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, bool)
+
+    # index 2
+    contract_condition_dict["returnValueTest"]["index"] = 2
+    contract_condition_dict["returnValueTest"]["value"] = get_random_checksum_address()
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
+    assert isinstance(contract_condition.return_value_test.value, str)
+
+    # invalid type at index
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        contract_condition_dict["returnValueTest"]["index"] = 0
+        contract_condition_dict["returnValueTest"][
+            "value"
+        ] = get_random_checksum_address()
+        ContractCondition.from_json(json.dumps(contract_condition_dict))

--- a/tests/unit/conditions/test_contract_conditions.py
+++ b/tests/unit/conditions/test_contract_conditions.py
@@ -1,17 +1,22 @@
 import copy
 import json
-from typing import Any, Dict, Sequence
+from typing import Any, Dict, List, Optional, Sequence
+from unittest.mock import Mock
 
 import pytest
+from marshmallow import post_load
+from web3.providers import BaseProvider
 
 from nucypher.policy.conditions.evm import ContractCondition
 from nucypher.policy.conditions.exceptions import InvalidCondition
+
+CHAIN_ID = 137
 
 CONTRACT_CONDITION = {
     "conditionType": "contract",
     "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
     "method": "isSubscribedToToken",
-    "parameters": [":userAddress", "subscriptionCode", 4],
+    "parameters": ["0x5082F249cDb2f2c1eE035E4f423c46EA2daB3ab1", "subscriptionCode", 4],
     "functionAbi": {
         "inputs": [
             {"internalType": "address", "name": "subscriber", "type": "address"},
@@ -24,9 +29,29 @@ CONTRACT_CONDITION = {
         "type": "function",
         "constant": True,
     },
-    "chain": 137,
+    "chain": CHAIN_ID,
     "returnValueTest": {"comparator": "==", "value": True},
 }
+
+
+class FakeExecutionContractCondition(ContractCondition):
+    class Schema(ContractCondition.Schema):
+        @post_load
+        def make(self, data, **kwargs):
+            return FakeExecutionContractCondition(**data)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.execution_return_value = None
+
+    def set_execution_return_value(self, value: Any):
+        self.execution_return_value = value
+
+    def _execute_call(self, parameters: List[Any]) -> Any:
+        return self.execution_return_value
+
+    def _configure_provider(self, provider: BaseProvider):
+        return
 
 
 @pytest.fixture(scope="function")
@@ -43,6 +68,32 @@ def _replace_abi_outputs(condition_json: Dict, output_type: str, output_value: A
     condition_json["returnValueTest"]["value"] = output_value
 
 
+def _check_execution_logic(
+    condition_dict: Dict,
+    execution_result: Any,
+    comparator_value: Any,
+    comparator: str,
+    expected_outcome: bool,
+    comparator_index: Optional[int] = None,
+):
+    # test execution logic for bool
+    condition_dict["returnValueTest"]["value"] = comparator_value
+    condition_dict["returnValueTest"]["comparator"] = comparator
+    if comparator_index is not None:
+        condition_dict["returnValueTest"]["index"] = comparator_index
+
+    fake_execution_contract_condition = FakeExecutionContractCondition.from_json(
+        json.dumps(condition_dict)
+    )
+    fake_execution_contract_condition.set_execution_return_value(execution_result)
+    fake_providers = {CHAIN_ID: {Mock(BaseProvider)}}
+    condition_result, call_result = fake_execution_contract_condition.verify(
+        fake_providers
+    )
+    assert call_result == execution_result
+    assert condition_result == expected_outcome
+
+
 def test_abi_bool_output(contract_condition_dict):
     # default - no changes to json
     contract_condition = ContractCondition.from_json(
@@ -54,6 +105,31 @@ def test_abi_bool_output(contract_condition_dict):
     with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
         contract_condition_dict["returnValueTest"]["value"] = 23
         ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # test execution logic
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=False,
+        comparator_value=False,
+        comparator="==",
+        expected_outcome=True,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=False,
+        comparator_value=False,
+        comparator="!=",
+        expected_outcome=False,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=True,
+        comparator_value=False,
+        comparator="==",
+        expected_outcome=False,
+    )
 
 
 def test_abi_uint_output(contract_condition_dict):
@@ -68,6 +144,31 @@ def test_abi_uint_output(contract_condition_dict):
         contract_condition_dict["returnValueTest"]["value"] = True
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
+    # test execution logic
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=123456789,
+        comparator_value=123456789,
+        comparator="==",
+        expected_outcome=True,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=1,
+        comparator_value=123456789,
+        comparator="!=",
+        expected_outcome=True,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=1,
+        comparator_value=2,
+        comparator="==",
+        expected_outcome=False,
+    )
+
 
 def test_abi_int_output(contract_condition_dict):
     _replace_abi_outputs(contract_condition_dict, "int256", -123456789)
@@ -80,6 +181,31 @@ def test_abi_int_output(contract_condition_dict):
     with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
         contract_condition_dict["returnValueTest"]["value"] = [1, 2, 3]
         ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # test execution logic
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=-123456789,
+        comparator_value=-123456789,
+        comparator="==",
+        expected_outcome=True,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=-1,
+        comparator_value=1,
+        comparator="!=",
+        expected_outcome=True,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=-1,
+        comparator_value=-1,
+        comparator="!=",
+        expected_outcome=False,
+    )
 
 
 def test_abi_address_output(contract_condition_dict, get_random_checksum_address):
@@ -95,6 +221,32 @@ def test_abi_address_output(contract_condition_dict, get_random_checksum_address
     with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
         contract_condition_dict["returnValueTest"]["value"] = 1.25
         ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # test execution logic
+    checksum_address = get_random_checksum_address()
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=checksum_address,
+        comparator_value=checksum_address,
+        comparator="==",
+        expected_outcome=True,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=checksum_address,
+        comparator_value=checksum_address,
+        comparator="!=",
+        expected_outcome=False,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=checksum_address,
+        comparator_value=get_random_checksum_address(),
+        comparator="==",
+        expected_outcome=False,
+    )
 
 
 def test_abi_tuple_output(contract_condition_dict):
@@ -134,9 +286,34 @@ def test_abi_tuple_output(contract_condition_dict):
         contract_condition_dict["returnValueTest"]["value"] = [1, 2, 3.14159]
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
+    # test execution logic (tuples are serialized as lists for comparator_value)
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=(1, 2, 3),
+        comparator_value=[1, 2, 3],
+        comparator="==",
+        expected_outcome=True,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=(2, 3, 4),
+        comparator_value=[2, 3, 4],
+        comparator="!=",
+        expected_outcome=False,
+    )
+
+    _check_execution_logic(
+        condition_dict=contract_condition_dict,
+        execution_result=(3, 4, 5),
+        comparator_value=[3, 4, 6],
+        comparator="==",
+        expected_outcome=False,
+    )
+
 
 def test_abi_tuple_output_with_index(
-    contract_condition_dict, get_random_checksum_address
+    mocker, contract_condition_dict, get_random_checksum_address
 ):
     contract_condition_dict["functionAbi"]["outputs"] = [
         {"internalType": "uint96", "name": "tStake", "type": "uint96"},
@@ -186,3 +363,280 @@ def test_abi_tuple_output_with_index(
             "value"
         ] = get_random_checksum_address()
         ContractCondition.from_json(json.dumps(contract_condition_dict))
+
+    # test execution logic with index for tuples
+    result = [1, True, get_random_checksum_address()]
+    for i in range(len(result)):
+        _check_execution_logic(
+            condition_dict=contract_condition_dict,
+            execution_result=tuple(result),
+            comparator_value=result[i],
+            comparator="==",
+            expected_outcome=True,
+            comparator_index=i,
+        )
+
+        _check_execution_logic(
+            condition_dict=contract_condition_dict,
+            execution_result=tuple(result),
+            comparator_value=result[i],
+            comparator="!=",
+            expected_outcome=False,
+            comparator_index=i,
+        )
+
+
+def test_abi_multiple_output_values(get_random_checksum_address):
+    condition_dict = {
+        "conditionType": "contract",
+        "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
+        "method": "isSubscribedToToken",
+        "parameters": [
+            "0x5082F249cDb2f2c1eE035E4f423c46EA2daB3ab1",
+            "subscriptionCode",
+            4,
+        ],
+        "functionAbi": {
+            "inputs": [
+                {"internalType": "address", "name": "subscriber", "type": "address"},
+                {
+                    "internalType": "bytes32",
+                    "name": "subscriptionCode",
+                    "type": "bytes32",
+                },
+                {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
+            ],
+            "name": "isSubscribedToToken",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "tuple",
+                    "components": [
+                        {
+                            "name": "sponsor",
+                            "type": "address",
+                            "internalType": "address payable",
+                        },
+                        {
+                            "name": "startTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                        },
+                        {
+                            "name": "endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                        },
+                        {"name": "size", "type": "uint16", "internalType": "uint16"},
+                        {"name": "owner", "type": "address", "internalType": "address"},
+                    ],
+                    "internalType": "struct SubscriptionManager.Policy",
+                },
+                {
+                    "name": "valid",
+                    "type": "bool",
+                    "internalType": "bool",
+                },
+                {
+                    "name": "randoValue",
+                    "type": "uint256",
+                    "internalType": "uint256",
+                },
+            ],
+            "stateMutability": "view",
+            "type": "function",
+            "constant": True,
+        },
+        "chain": 137,
+        "returnValueTest": {
+            "comparator": "==",
+            "value": True,
+            "index": 1,
+        },
+    }
+
+    # process index 0 (tuple)
+    condition_dict["returnValueTest"]["index"] = 0
+    condition_dict["returnValueTest"]["value"] = [
+        get_random_checksum_address(),
+        1,
+        2,
+        3,
+        get_random_checksum_address(),
+    ]
+    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    assert isinstance(contract_condition.return_value_test.value, Sequence)
+
+    # process index 1 (bool)
+    condition_dict["returnValueTest"]["index"] = 1
+    condition_dict["returnValueTest"]["value"] = False
+    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    assert isinstance(contract_condition.return_value_test.value, bool)
+
+    # process index 2 (int)
+    condition_dict["returnValueTest"]["index"] = 2
+    condition_dict["returnValueTest"]["value"] = 123456789
+    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    assert isinstance(contract_condition.return_value_test.value, int)
+
+    # test execution logic - multiple outputs including tuples
+    result = [
+        [get_random_checksum_address(), 1, 2, 3, get_random_checksum_address()],
+        True,
+        4,
+    ]
+    for i in range(len(result)):
+        _check_execution_logic(
+            condition_dict=condition_dict,
+            execution_result=tuple(result),
+            comparator_value=result[i],
+            comparator="==",
+            expected_outcome=True,
+            comparator_index=i,
+        )
+
+        _check_execution_logic(
+            condition_dict=condition_dict,
+            execution_result=tuple(result),
+            comparator_value=result[i],
+            comparator="!=",
+            expected_outcome=False,
+            comparator_index=i,
+        )
+
+
+def test_abi_nested_tuples_output_values(get_random_checksum_address):
+    condition_dict = {
+        "conditionType": "contract",
+        "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
+        "method": "isSubscribedToToken",
+        "parameters": [
+            "0x5082F249cDb2f2c1eE035E4f423c46EA2daB3ab1",
+            "subscriptionCode",
+            4,
+        ],
+        "functionAbi": {
+            "inputs": [
+                {"internalType": "address", "name": "subscriber", "type": "address"},
+                {
+                    "internalType": "bytes32",
+                    "name": "subscriptionCode",
+                    "type": "bytes32",
+                },
+                {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
+            ],
+            "name": "isSubscribedToToken",
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "tuple",
+                    "components": [
+                        {
+                            "name": "sponsor",
+                            "type": "address",
+                            "internalType": "address payable",
+                        },
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "startTimestamp",
+                                    "type": "uint32",
+                                    "internalType": "uint32",
+                                },
+                                {
+                                    "name": "endTimestamp",
+                                    "type": "uint32",
+                                    "internalType": "uint32",
+                                },
+                            ],
+                            "internalType": "struct SubscriptionManager.Timeframe",
+                        },
+                        {"name": "owner", "type": "address", "internalType": "address"},
+                    ],
+                    "internalType": "struct SubscriptionManager.Policy",
+                },
+                {
+                    "name": "valid",
+                    "type": "bool",
+                    "internalType": "bool",
+                },
+            ],
+            "stateMutability": "view",
+            "type": "function",
+            "constant": True,
+        },
+        "chain": 137,
+        "returnValueTest": {
+            "comparator": "==",
+            "value": True,
+            "index": 1,
+        },
+    }
+
+    # process index 0 (nested tuples)
+    condition_dict["returnValueTest"]["index"] = 0
+    condition_dict["returnValueTest"]["value"] = [
+        get_random_checksum_address(),
+        [1, 2],
+        get_random_checksum_address(),
+    ]
+    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    assert isinstance(contract_condition.return_value_test.value, Sequence)
+
+    # invalid if entire tuple not populated
+    condition_dict["returnValueTest"]["value"] = [
+        get_random_checksum_address(),
+        [1],
+        get_random_checksum_address(),  # missing tuple value
+    ]
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        ContractCondition.from_json(json.dumps(condition_dict))
+
+    condition_dict["returnValueTest"]["value"] = [
+        get_random_checksum_address(),
+        1,
+        2,
+        get_random_checksum_address(),  # incorrect tuple value for Timeframe
+    ]
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        ContractCondition.from_json(json.dumps(condition_dict))
+
+    condition_dict["returnValueTest"]["value"] = [
+        get_random_checksum_address(),
+        [1, 2, 3],
+        get_random_checksum_address(),  # too many values
+    ]
+    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+        ContractCondition.from_json(json.dumps(condition_dict))
+
+    # process index 1 (bool)
+    condition_dict["returnValueTest"]["index"] = 1
+    condition_dict["returnValueTest"]["value"] = False
+    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    assert isinstance(contract_condition.return_value_test.value, bool)
+
+    # test execution logic - nested tuples
+    result = [
+        [get_random_checksum_address(), [1, 2], get_random_checksum_address()],
+        True,
+    ]
+    for i in range(len(result)):
+        _check_execution_logic(
+            condition_dict=condition_dict,
+            execution_result=tuple(result),
+            comparator_value=result[i],
+            comparator="==",
+            expected_outcome=True,
+            comparator_index=i,
+        )
+
+        _check_execution_logic(
+            condition_dict=condition_dict,
+            execution_result=tuple(result),
+            comparator_value=result[i],
+            comparator="!=",
+            expected_outcome=False,
+            comparator_index=i,
+        )

--- a/tests/unit/conditions/test_contract_conditions.py
+++ b/tests/unit/conditions/test_contract_conditions.py
@@ -446,97 +446,94 @@ def test_abi_tuple_output_with_index(
         )
 
 
-def test_abi_multiple_output_values(get_random_checksum_address):
-    condition_dict = {
-        "conditionType": "contract",
-        "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
-        "method": "isSubscribedToToken",
-        "parameters": [
-            "0x5082F249cDb2f2c1eE035E4f423c46EA2daB3ab1",
-            "subscriptionCode",
-            4,
+def test_abi_multiple_output_values(
+    contract_condition_dict, get_random_checksum_address
+):
+    contract_condition_dict["functionAbi"] = {
+        "inputs": [
+            {"internalType": "address", "name": "subscriber", "type": "address"},
+            {
+                "internalType": "bytes32",
+                "name": "subscriptionCode",
+                "type": "bytes32",
+            },
+            {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
         ],
-        "functionAbi": {
-            "inputs": [
-                {"internalType": "address", "name": "subscriber", "type": "address"},
-                {
-                    "internalType": "bytes32",
-                    "name": "subscriptionCode",
-                    "type": "bytes32",
-                },
-                {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
-            ],
-            "name": "isSubscribedToToken",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "tuple",
-                    "components": [
-                        {
-                            "name": "sponsor",
-                            "type": "address",
-                            "internalType": "address payable",
-                        },
-                        {
-                            "name": "startTimestamp",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                        },
-                        {
-                            "name": "endTimestamp",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                        },
-                        {"name": "size", "type": "uint16", "internalType": "uint16"},
-                        {"name": "owner", "type": "address", "internalType": "address"},
-                    ],
-                    "internalType": "struct SubscriptionManager.Policy",
-                },
-                {
-                    "name": "valid",
-                    "type": "bool",
-                    "internalType": "bool",
-                },
-                {
-                    "name": "randoValue",
-                    "type": "uint256",
-                    "internalType": "uint256",
-                },
-            ],
-            "stateMutability": "view",
-            "type": "function",
-            "constant": True,
-        },
-        "chain": 137,
-        "returnValueTest": {
-            "comparator": "==",
-            "value": True,
-            "index": 1,
-        },
+        "name": "isSubscribedToToken",
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple",
+                "components": [
+                    {
+                        "name": "sponsor",
+                        "type": "address",
+                        "internalType": "address payable",
+                    },
+                    {
+                        "name": "startTimestamp",
+                        "type": "uint32",
+                        "internalType": "uint32",
+                    },
+                    {
+                        "name": "endTimestamp",
+                        "type": "uint32",
+                        "internalType": "uint32",
+                    },
+                    {"name": "size", "type": "uint16", "internalType": "uint16"},
+                    {"name": "owner", "type": "address", "internalType": "address"},
+                ],
+                "internalType": "struct SubscriptionManager.Policy",
+            },
+            {
+                "name": "valid",
+                "type": "bool",
+                "internalType": "bool",
+            },
+            {
+                "name": "randoValue",
+                "type": "uint256",
+                "internalType": "uint256",
+            },
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "constant": True,
+    }
+    contract_condition_dict["returnValueTest"] = {
+        "comparator": "==",
+        "value": True,
+        "index": 1,
     }
 
     # process index 0 (tuple)
-    condition_dict["returnValueTest"]["index"] = 0
-    condition_dict["returnValueTest"]["value"] = [
+    contract_condition_dict["returnValueTest"]["index"] = 0
+    contract_condition_dict["returnValueTest"]["value"] = [
         get_random_checksum_address(),
         1,
         2,
         3,
         get_random_checksum_address(),
     ]
-    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
     assert isinstance(contract_condition.return_value_test.value, Sequence)
 
     # process index 1 (bool)
-    condition_dict["returnValueTest"]["index"] = 1
-    condition_dict["returnValueTest"]["value"] = False
-    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    contract_condition_dict["returnValueTest"]["index"] = 1
+    contract_condition_dict["returnValueTest"]["value"] = False
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
     assert isinstance(contract_condition.return_value_test.value, bool)
 
     # process index 2 (int)
-    condition_dict["returnValueTest"]["index"] = 2
-    condition_dict["returnValueTest"]["value"] = 123456789
-    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    contract_condition_dict["returnValueTest"]["index"] = 2
+    contract_condition_dict["returnValueTest"]["value"] = 123456789
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
     assert isinstance(contract_condition.return_value_test.value, int)
 
     # test execution logic - multiple outputs including tuples
@@ -547,7 +544,7 @@ def test_abi_multiple_output_values(get_random_checksum_address):
     ]
     for i in range(len(result)):
         _check_execution_logic(
-            condition_dict=condition_dict,
+            condition_dict=contract_condition_dict,
             execution_result=tuple(result),
             comparator_value=result[i],
             comparator="==",
@@ -556,7 +553,7 @@ def test_abi_multiple_output_values(get_random_checksum_address):
         )
 
         _check_execution_logic(
-            condition_dict=condition_dict,
+            condition_dict=contract_condition_dict,
             execution_result=tuple(result),
             comparator_value=result[i],
             comparator="!=",
@@ -565,116 +562,111 @@ def test_abi_multiple_output_values(get_random_checksum_address):
         )
 
 
-def test_abi_nested_tuples_output_values(get_random_checksum_address):
-    condition_dict = {
-        "conditionType": "contract",
-        "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
-        "method": "isSubscribedToToken",
-        "parameters": [
-            "0x5082F249cDb2f2c1eE035E4f423c46EA2daB3ab1",
-            "subscriptionCode",
-            4,
+def test_abi_nested_tuples_output_values(
+    contract_condition_dict, get_random_checksum_address
+):
+    contract_condition_dict["functionAbi"] = {
+        "inputs": [
+            {"internalType": "address", "name": "subscriber", "type": "address"},
+            {
+                "internalType": "bytes32",
+                "name": "subscriptionCode",
+                "type": "bytes32",
+            },
+            {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
         ],
-        "functionAbi": {
-            "inputs": [
-                {"internalType": "address", "name": "subscriber", "type": "address"},
-                {
-                    "internalType": "bytes32",
-                    "name": "subscriptionCode",
-                    "type": "bytes32",
-                },
-                {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
-            ],
-            "name": "isSubscribedToToken",
-            "outputs": [
-                {
-                    "name": "",
-                    "type": "tuple",
-                    "components": [
-                        {
-                            "name": "sponsor",
-                            "type": "address",
-                            "internalType": "address payable",
-                        },
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "startTimestamp",
-                                    "type": "uint32",
-                                    "internalType": "uint32",
-                                },
-                                {
-                                    "name": "endTimestamp",
-                                    "type": "uint32",
-                                    "internalType": "uint32",
-                                },
-                            ],
-                            "internalType": "struct SubscriptionManager.Timeframe",
-                        },
-                        {"name": "owner", "type": "address", "internalType": "address"},
-                    ],
-                    "internalType": "struct SubscriptionManager.Policy",
-                },
-                {
-                    "name": "valid",
-                    "type": "bool",
-                    "internalType": "bool",
-                },
-            ],
-            "stateMutability": "view",
-            "type": "function",
-            "constant": True,
-        },
-        "chain": 137,
-        "returnValueTest": {
-            "comparator": "==",
-            "value": True,
-            "index": 1,
-        },
+        "name": "isSubscribedToToken",
+        "outputs": [
+            {
+                "name": "",
+                "type": "tuple",
+                "components": [
+                    {
+                        "name": "sponsor",
+                        "type": "address",
+                        "internalType": "address payable",
+                    },
+                    {
+                        "name": "",
+                        "type": "tuple",
+                        "components": [
+                            {
+                                "name": "startTimestamp",
+                                "type": "uint32",
+                                "internalType": "uint32",
+                            },
+                            {
+                                "name": "endTimestamp",
+                                "type": "uint32",
+                                "internalType": "uint32",
+                            },
+                        ],
+                        "internalType": "struct SubscriptionManager.Timeframe",
+                    },
+                    {"name": "owner", "type": "address", "internalType": "address"},
+                ],
+                "internalType": "struct SubscriptionManager.Policy",
+            },
+            {
+                "name": "valid",
+                "type": "bool",
+                "internalType": "bool",
+            },
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "constant": True,
+    }
+    contract_condition_dict["returnValueTest"] = {
+        "comparator": "==",
+        "value": True,
+        "index": 1,
     }
 
     # process index 0 (nested tuples)
-    condition_dict["returnValueTest"]["index"] = 0
-    condition_dict["returnValueTest"]["value"] = [
+    contract_condition_dict["returnValueTest"]["index"] = 0
+    contract_condition_dict["returnValueTest"]["value"] = [
         get_random_checksum_address(),
         [1, 2],
         get_random_checksum_address(),
     ]
-    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
     assert isinstance(contract_condition.return_value_test.value, Sequence)
 
     # invalid if entire tuple not populated
-    condition_dict["returnValueTest"]["value"] = [
+    contract_condition_dict["returnValueTest"]["value"] = [
         get_random_checksum_address(),
         [1],
         get_random_checksum_address(),  # missing tuple value
     ]
     with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
-        ContractCondition.from_json(json.dumps(condition_dict))
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
 
-    condition_dict["returnValueTest"]["value"] = [
+    contract_condition_dict["returnValueTest"]["value"] = [
         get_random_checksum_address(),
         1,
         2,
         get_random_checksum_address(),  # incorrect tuple value for Timeframe
     ]
     with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
-        ContractCondition.from_json(json.dumps(condition_dict))
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
 
-    condition_dict["returnValueTest"]["value"] = [
+    contract_condition_dict["returnValueTest"]["value"] = [
         get_random_checksum_address(),
         [1, 2, 3],
         get_random_checksum_address(),  # too many values
     ]
     with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
-        ContractCondition.from_json(json.dumps(condition_dict))
+        ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     # process index 1 (bool)
-    condition_dict["returnValueTest"]["index"] = 1
-    condition_dict["returnValueTest"]["value"] = False
-    contract_condition = ContractCondition.from_json(json.dumps(condition_dict))
+    contract_condition_dict["returnValueTest"]["index"] = 1
+    contract_condition_dict["returnValueTest"]["value"] = False
+    contract_condition = ContractCondition.from_json(
+        json.dumps(contract_condition_dict)
+    )
     assert isinstance(contract_condition.return_value_test.value, bool)
 
     # test execution logic - nested tuples
@@ -684,7 +676,7 @@ def test_abi_nested_tuples_output_values(get_random_checksum_address):
     ]
     for i in range(len(result)):
         _check_execution_logic(
-            condition_dict=condition_dict,
+            condition_dict=contract_condition_dict,
             execution_result=tuple(result),
             comparator_value=result[i],
             comparator="==",
@@ -693,7 +685,7 @@ def test_abi_nested_tuples_output_values(get_random_checksum_address):
         )
 
         _check_execution_logic(
-            condition_dict=condition_dict,
+            condition_dict=contract_condition_dict,
             execution_result=tuple(result),
             comparator_value=result[i],
             comparator="!=",

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -61,20 +61,6 @@ def test_return_value_index_tuple():
 
 
 @pytest.mark.parametrize(
-    "not_json_serializable",
-    [
-        {1, 2, 3},  # sets
-        os.urandom(32),  # bytes
-    ],
-)
-def test_return_value_test_not_json_serializable_value(not_json_serializable):
-    with pytest.raises(
-        ReturnValueTest.InvalidExpression, match="not JSON serializable"
-    ):
-        _ = ReturnValueTest(comparator="==", value=not_json_serializable)
-
-
-@pytest.mark.parametrize(
     "comparator",
     [
         "eq",
@@ -287,6 +273,7 @@ def test_return_value_test_tuples():
         ),  # hex string that is evaluated as int
         (125, None),  # int
         (1.223, None),  # float
+        # (Decimal('10.5'), None),  # decimal
         (True, None),  # bool
         (False, None),  # bool as string
         ({"name": "John", "age": 22}, None),  # dict
@@ -316,12 +303,15 @@ def test_return_value_sanitize(test_scenario):
         ":userAddress",  # context variable is an exception case for a string value
         "0xaDD9D957170dF6F33982001E4c22eCCdd5539118",  # string that is evaluated as int
         125,  # int
+        -123456789,  # negative int
         1.223,  # float
+        # Decimal('10.5'),  # decimal
         True,  # bool
         [1, 1.2314, False, "love"],  # list of different types
         ["a", "b", "c"],  # list
         [True, False],  # list of bools
         {"name": "John", "age": 22},  # dict
+        # namedtuple('MyStruct', ['field1', 'field2'])(1, 'a'),  # named tuple
     ],
 )
 def test_return_value_json_serialization(test_value):

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -216,7 +216,7 @@ def test_return_value_test_bytes():
     assert (test.comparator == reloaded.comparator) and (test.value == reloaded.value)
 
     # ensure correct bytes/hex comparison
-    assert reloaded.eval(value), "passing in bytes compared correctly to hex"
+    assert reloaded.eval(value), "bytes compared correctly to hex"
     assert not reloaded.eval(
         b"Here every creed and race find an equal place"
     )  # TT national anthem
@@ -240,7 +240,7 @@ def test_return_value_test_bytes_in_list_of_values():
     reloaded = schema.loads(schema.dumps(test))
     assert (test.comparator == reloaded.comparator) and (test.value == reloaded.value)
     # ensure correct bytes/hex comparison
-    assert reloaded.eval(value), "passing in bytes compared correctly to hex"
+    assert reloaded.eval(value), "bytes compared correctly to hex"
     assert not reloaded.eval([1, 2, 3])
 
 
@@ -305,13 +305,11 @@ def test_return_value_sanitize(test_scenario):
         125,  # int
         -123456789,  # negative int
         1.223,  # float
-        # Decimal('10.5'),  # decimal
         True,  # bool
         [1, 1.2314, False, "love"],  # list of different types
         ["a", "b", "c"],  # list
         [True, False],  # list of bools
         {"name": "John", "age": 22},  # dict
-        # namedtuple('MyStruct', ['field1', 'field2'])(1, 'a'),  # named tuple
     ],
 )
 def test_return_value_json_serialization(test_value):


### PR DESCRIPTION
**Type of PR:**
- Bugfix
- Rework

**Required reviews:** 
3

**What this does:**
- ReturnValueTest comparator values can't be bytes (since it must be JSON serializable) and therefore will be hex, but it needs to be compared to a contract call result which is in bytes. The bytes returned needs to be converted to hex to compare with the comparator value.
- Prevent `ReturnValueTest` from accepting values that aren't JSON serializable. Try to modify the type to be serializable i.e. tuple/set -> list, bytes -> hex, but otherwise raise exception
- Use ABI types to ensure that return value comparator type and output type of a contract call are congruent. This can be done on condition creation. However, there can be context variables whose value is unknown at creation time, and can only be verified at decryption time i.e. condition evaluation.

**Issues fixed/closed:**
 - Fixes #3300

