### PR TITLE
[WIP] Update deployment parameters for TACoChildApplication

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -199,7 +199,9 @@ def taco_child_application(
     nucypher_dependency, taco_application_proxy, deployer_account
 ):
     _taco_child_application = deployer_account.deploy(
-        nucypher_dependency.TACoChildApplication, taco_application_proxy.address
+        nucypher_dependency.TACoChildApplication,
+        taco_application_proxy.address,
+        MIN_AUTHORIZATION,
     )
 
     return _taco_child_application


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- https://github.com/nucypher/nucypher-contracts/pull/145 modified `TACoChildApplication` to accept minimum authorization in its constructor. Update test fixture accordingly.

TBD:
- Currently, discussing the reason for `Potential overflow` that happens during constructor of `TACoApplication` when an ERC20 token with a token supply of `10B` is used.
```
Traceback (most recent call last):
  File "/Users/derek/Documents/Github/repos/forks/derek/nucypher/tests/acceptance/conftest.py", line 162, in taco_application
    _taco_application = deployer_account.deploy(
  File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.10/site-packages/ape/api/accounts.py", line 228, in deploy
    receipt = contract._cache_wrap(lambda: self.call(txn, **kwargs))
  File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.10/site-packages/ape/contracts/base.py", line 1346, in _cache_wrap
    return function()
  File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.10/site-packages/ape/api/accounts.py", line 228, in <lambda>
    receipt = contract._cache_wrap(lambda: self.call(txn, **kwargs))
  File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.10/site-packages/ape/api/accounts.py", line 156, in call
    else self.provider.send_transaction(signed_txn)
  File "/Users/derek/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.10/site-packages/ape_test/provider.py", line 188, in send_transaction
    raise vm_err from err
ape.exceptions.ContractLogicError: Potential overflow
```

raised from here - https://github.com/nucypher/nucypher-contracts/blob/main/contracts/contracts/TACoApplication.sol#L209

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
