### PR TITLE
Fully Integrate `TACoDomain`

### DIFF
--- a/examples/local_simple_taco.py
+++ b/examples/local_simple_taco.py
@@ -1,5 +1,4 @@
 from nucypher.blockchain.eth import domains
-from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.characters.chaotic import NiceGuyEddie as _Enrico
 from nucypher.characters.chaotic import ThisBobAlwaysDecrypts

--- a/examples/local_simple_taco.py
+++ b/examples/local_simple_taco.py
@@ -1,3 +1,4 @@
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.characters.chaotic import NiceGuyEddie as _Enrico
@@ -9,7 +10,7 @@ THIS_IS_NOT_A_TRINKET = 55  # sometimes called "public key"
 
 signer = InMemorySigner()
 enrico = _Enrico(encrypting_key=THIS_IS_NOT_A_TRINKET, signer=signer)
-bob = ThisBobAlwaysDecrypts(domain=TACoDomain.LYNX.name, eth_endpoint="Nowhere")
+bob = ThisBobAlwaysDecrypts(domain=domains.LYNX, eth_endpoint="Nowhere")
 
 ANYTHING_CAN_BE_PASSED_AS_RITUAL_ID = 55
 

--- a/examples/local_simple_taco.py
+++ b/examples/local_simple_taco.py
@@ -1,5 +1,5 @@
 from nucypher.blockchain.eth import domains
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.characters.chaotic import NiceGuyEddie as _Enrico
 from nucypher.characters.chaotic import ThisBobAlwaysDecrypts

--- a/examples/pre/finnegans_wake_demo/finnegans-wake-demo-l2.py
+++ b/examples/pre/finnegans_wake_demo/finnegans-wake-demo-l2.py
@@ -1,11 +1,10 @@
 import datetime
+import maya
 import os
 from getpass import getpass
 from pathlib import Path
 
-import maya
-
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.signers.base import Signer
 from nucypher.characters.lawful import Alice, Bob
 from nucypher.characters.lawful import Enrico as Enrico
@@ -45,7 +44,7 @@ print("\n************** Setup **************\n")
 # Domain #
 ##########
 
-TACO_DOMAIN = TACoDomain.LYNX.name
+TACO_DOMAIN = domains.LYNX
 
 #####################
 # Bob the BUIDLer  ##

--- a/examples/pre/heartbeat_demo/alicia.py
+++ b/examples/pre/heartbeat_demo/alicia.py
@@ -17,14 +17,13 @@
 import base64
 import datetime
 import json
+import maya
 import os
 import shutil
 from getpass import getpass
 from pathlib import Path
 
-import maya
-
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.signers import Signer
 from nucypher.characters.lawful import Alice, Bob
 from nucypher.policy.payment import SubscriptionManagerPayment
@@ -58,7 +57,7 @@ try:
 except KeyError:
     raise RuntimeError("Missing environment variables to run demo.")
 
-TACO_DOMAIN = TACoDomain.LYNX.name
+TACO_DOMAIN = domains.LYNX
 
 
 #######################################

--- a/examples/pre/heartbeat_demo/doctor.py
+++ b/examples/pre/heartbeat_demo/doctor.py
@@ -1,15 +1,13 @@
 import base64
 import json
-import os
-import shutil
-from timeit import default_timer as timer
-
 import maya
 import msgpack
+import os
+import shutil
 from nucypher_core import EncryptedTreasureMap, MessageKit
 from nucypher_core.umbral import PublicKey
+from timeit import default_timer as timer
 
-from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth import domains
 from nucypher.characters.lawful import Bob
 from nucypher.crypto.keypairs import DecryptingKeypair, SigningKeypair

--- a/examples/pre/heartbeat_demo/doctor.py
+++ b/examples/pre/heartbeat_demo/doctor.py
@@ -10,7 +10,7 @@ from nucypher_core import EncryptedTreasureMap, MessageKit
 from nucypher_core.umbral import PublicKey
 
 from nucypher.blockchain.eth import domains
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.characters.lawful import Bob
 from nucypher.crypto.keypairs import DecryptingKeypair, SigningKeypair
 from nucypher.crypto.powers import DecryptingPower, SigningPower

--- a/examples/pre/heartbeat_demo/doctor.py
+++ b/examples/pre/heartbeat_demo/doctor.py
@@ -9,6 +9,7 @@ import msgpack
 from nucypher_core import EncryptedTreasureMap, MessageKit
 from nucypher_core.umbral import PublicKey
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.characters.lawful import Bob
 from nucypher.crypto.keypairs import DecryptingKeypair, SigningKeypair
@@ -28,7 +29,7 @@ except KeyError:
     raise RuntimeError("Missing environment variables to run demo.")
 
 
-TACO_DOMAIN = TACoDomain.LYNX.name
+TACO_DOMAIN = domains.LYNX
 
 # To create a Bob, we need the doctor's private keys previously generated.
 from doctor_keys import get_doctor_privkeys  # noqa: E402

--- a/examples/testnet_compound_multichain_taco.py
+++ b/examples/testnet_compound_multichain_taco.py
@@ -1,9 +1,8 @@
 import os
-
 from nucypher_core.ferveo import DkgPublicKey
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import CoordinatorAgent
-from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.characters.lawful import Bob, Enrico
@@ -20,7 +19,7 @@ GlobalLoggerSettings.set_log_level(log_level_name=LOG_LEVEL)
 GlobalLoggerSettings.start_console_logging()
 
 eth_endpoint = os.environ["DEMO_L1_PROVIDER_URI"]
-domain = TACoDomain.LYNX.name
+domain = domains.LYNX
 
 polygon_endpoint = os.environ["DEMO_L2_PROVIDER_URI"]
 

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -1,9 +1,8 @@
 import os
-
 from nucypher_core.ferveo import DkgPublicKey
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import CoordinatorAgent
-from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.characters.lawful import Bob, Enrico
@@ -21,7 +20,7 @@ GlobalLoggerSettings.set_log_level(log_level_name=LOG_LEVEL)
 GlobalLoggerSettings.start_console_logging()
 
 eth_endpoint = os.environ["DEMO_L1_PROVIDER_URI"]
-domain = TACoDomain.LYNX.name
+domain = domains.LYNX
 
 polygon_endpoint = os.environ["DEMO_L2_PROVIDER_URI"]
 

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -11,7 +11,8 @@ from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 from nucypher import characters
 from nucypher.utilities.logging import Logger
 from .nicknames import Nickname
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
+from ..blockchain.eth.domains import TACoDomain
 
 
 class ArchivedFleetState(NamedTuple):

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -1,16 +1,17 @@
-from collections import deque
-
-import maya
 import random
 import weakref
+from collections import deque
 from collections.abc import KeysView
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
+
+import maya
 from eth_typing import ChecksumAddress
 from nucypher_core import FleetStateChecksum, NodeMetadata
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 
 from nucypher import characters
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.utilities.logging import Logger
+
 from .nicknames import Nickname
 
 

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -9,10 +9,9 @@ from nucypher_core import FleetStateChecksum, NodeMetadata
 from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 
 from nucypher import characters
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.utilities.logging import Logger
 from .nicknames import Nickname
-from nucypher.blockchain.eth import domains
-from ..blockchain.eth.domains import TACoDomain
 
 
 class ArchivedFleetState(NamedTuple):

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -1,20 +1,17 @@
-
-
-
-import random
-import weakref
 from collections import deque
-from collections.abc import KeysView
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 
 import maya
+import random
+import weakref
+from collections.abc import KeysView
 from eth_typing import ChecksumAddress
 from nucypher_core import FleetStateChecksum, NodeMetadata
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Union
 
 from nucypher import characters
 from nucypher.utilities.logging import Logger
-
 from .nicknames import Nickname
+from nucypher.blockchain.eth.domains import TACoDomain
 
 
 class ArchivedFleetState(NamedTuple):
@@ -214,7 +211,7 @@ class FleetSensor:
     log = Logger("Learning")
 
     def __init__(
-        self, domain: str, this_node: Optional["characters.lawful.Ursula"] = None
+        self, domain: TACoDomain, this_node: Optional["characters.lawful.Ursula"] = None
     ):
         self._domain = domain
 
@@ -231,7 +228,7 @@ class FleetSensor:
 
     def record_node(self, node: "characters.lawful.Ursula"):
 
-        if node.domain == self._domain:
+        if str(node.domain) == str(self._domain):
             # Replace the existing object with a newer object, even if they're equal
             # (this object can be mutated externally).
             # This behavior is supposed to be consistent with that of the node storage

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1,8 +1,9 @@
+import time
 from collections import defaultdict
+from decimal import Decimal
+from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 import maya
-import time
-from decimal import Decimal
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from nucypher_core import (
@@ -22,12 +23,10 @@ from nucypher_core.ferveo import (
     Transcript,
     Validator,
 )
-from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union
 from web3 import HTTPProvider, Web3
 from web3.types import TxReceipt
 
 from nucypher.acumen.nicknames import Nickname
-from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     CoordinatorAgent,
@@ -39,9 +38,7 @@ from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
-from nucypher.blockchain.eth.registry import (
-    ContractRegistry,
-)
+from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import Signer
 from nucypher.blockchain.eth.trackers import dkg
 from nucypher.blockchain.eth.trackers.bonding import OperatorBondedTracker

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -248,22 +248,14 @@ class Operator(BaseActor):
     ) -> DefaultDict[int, Set[HTTPProvider]]:
         """Multi-provider support"""
 
-        # If condition_blockchain_endpoints is None the node operator
-        # did not configure any additional condition providers.
         condition_blockchain_endpoints = condition_blockchain_endpoints or dict()
-
-        # These are the chains that the Operator will connect to for conditions evaluation (read-only).
         condition_providers = defaultdict(set)
 
-        # Now, add any additional providers that were passed in.
         for (
             chain_id,
             condition_blockchain_endpoints,
         ) in condition_blockchain_endpoints.items():
             if not self._is_permitted_condition_chain(chain_id):
-                # this is a safety check to prevent the Operator from connecting to
-                # chains that are not supported by ursulas on the network;
-                # Prevents the Ursula/Operator from starting up if this happens.
                 raise NotImplementedError(
                     f"Chain ID {chain_id} is not supported for condition evaluation by this Operator."
                 )
@@ -272,10 +264,8 @@ class Operator(BaseActor):
             for uri in condition_blockchain_endpoints:
                 provider = self._make_condition_provider(uri)
                 providers.add(provider)
-
             condition_providers[int(chain_id)] = providers
 
-        # Log the chains that the Operator is connected to.
         humanized_chain_ids = ", ".join(
             _CONDITION_CHAINS[chain_id] for chain_id in condition_providers
         )

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -37,6 +37,7 @@ from nucypher.blockchain.eth.agents import (
 from nucypher.blockchain.eth.clients import PUBLIC_CHAINS
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.decorators import validate_checksum_address
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import (
     ContractRegistry,
@@ -69,7 +70,7 @@ class BaseActor:
     @validate_checksum_address
     def __init__(
         self,
-        domain: str,
+        domain: TACoDomain,
         registry: ContractRegistry,
         transacting_power: Optional[TransactingPower] = None,
         checksum_address: Optional[ChecksumAddress] = None,
@@ -92,7 +93,7 @@ class BaseActor:
 
         self.transacting_power = transacting_power
         self.registry = registry
-        self.domain = domains.get_domain(str(domain))
+        self.domain = domain
         self._saved_receipts = list()  # track receipts of transmitted transactions
 
     def __repr__(self):

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1,9 +1,8 @@
-import time
 from collections import defaultdict
-from decimal import Decimal
-from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union
 
 import maya
+import time
+from decimal import Decimal
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
 from nucypher_core import (
@@ -23,10 +22,12 @@ from nucypher_core.ferveo import (
     Transcript,
     Validator,
 )
+from typing import DefaultDict, Dict, List, Optional, Set, Tuple, Union
 from web3 import HTTPProvider, Web3
 from web3.types import TxReceipt
 
 from nucypher.acumen.nicknames import Nickname
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     CoordinatorAgent,
@@ -36,7 +37,6 @@ from nucypher.blockchain.eth.agents import (
 from nucypher.blockchain.eth.clients import PUBLIC_CHAINS
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.decorators import validate_checksum_address
-from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import (
     ContractRegistry,
@@ -92,8 +92,7 @@ class BaseActor:
 
         self.transacting_power = transacting_power
         self.registry = registry
-        self.network = domain
-        self.taco_domain_info = TACoDomain.get_domain_info(self.network)
+        self.domain = domains.get_domain(str(domain))
         self._saved_receipts = list()  # track receipts of transmitted transactions
 
     def __repr__(self):
@@ -189,7 +188,7 @@ class Operator(BaseActor):
             registry=self.registry,
         )
 
-        registry = ContractRegistry.from_latest_publication(domain=self.network)
+        registry = ContractRegistry.from_latest_publication(domain=self.domain)
         self.child_application_agent = ContractAgency.get_agent(
             TACoChildApplicationAgent,
             registry=registry,

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -1,6 +1,7 @@
-from cytoolz.functoolz import memoize
 from enum import Enum
-from typing import NamedTuple, Dict, Any
+from typing import Any, Dict, NamedTuple
+
+from cytoolz.functoolz import memoize
 
 
 class UnrecognizedTacoDomain(Exception):
@@ -24,7 +25,6 @@ class PolygonChain(ChainInfo, Enum):
 
 
 class TACoDomain:
-
     def __init__(self, name: str, eth_chain: EthChain, polygon_chain: PolygonChain):
         self.name = name
         self.eth_chain = eth_chain
@@ -77,8 +77,9 @@ TAPIR = TACoDomain(
 
 DEFAULT_DOMAIN: TACoDomain = MAINNET
 
-SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {str(domain): domain for domain in (MAINNET, LYNX, TAPIR)}
-
+SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {
+    str(domain): domain for domain in (MAINNET, LYNX, TAPIR)
+}
 
 
 @memoize

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -18,38 +18,82 @@ class PolygonChain(ChainInfo, Enum):
     MUMBAI = (80001, "mumbai")
 
 
-class DomainInfo(NamedTuple):
-    name: str
-    eth_chain: EthChain
-    polygon_chain: PolygonChain
+class TACoDomain:
+
+    def __init__(self,
+        name: str,
+        eth_chain: EthChain,
+        polygon_chain: PolygonChain,
+    ):
+        self.name = name
+        self.eth_chain = eth_chain
+        self.polygon_chain = polygon_chain
+
+    def __repr__(self):
+        return f"<TACoDomain {self.name}>"
+
+    def __str__(self):
+        return self.name
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __bytes__(self):
+        return self.name.encode()
+
+    def __eq__(self, other):
+        try:
+            return self.name == other.name
+        except AttributeError:
+            raise TypeError(f"Cannot compare TACoDomain to {type(other)}")
+
+    def __bool__(self):
+        return True
+
+    def __iter__(self):
+        return str(self)
 
     @property
     def is_testnet(self) -> bool:
         return self.eth_chain != EthChain.MAINNET
 
 
-class TACoDomain:
-    class Unrecognized(RuntimeError):
-        """Raised when a provided domain name is not recognized."""
 
-    MAINNET = DomainInfo("mainnet", EthChain.MAINNET, PolygonChain.MAINNET)
-    LYNX = DomainInfo("lynx", EthChain.GOERLI, PolygonChain.MUMBAI)
-    TAPIR = DomainInfo("tapir", EthChain.SEPOLIA, PolygonChain.MUMBAI)
+MAINNET = TACoDomain(
+    name="mainnet",
+    eth_chain=EthChain.MAINNET,
+    polygon_chain=PolygonChain.MAINNET,
+)
 
-    DEFAULT_DOMAIN_NAME: str = MAINNET.name
+LYNX = TACoDomain(
+    name="lynx",
+    eth_chain=EthChain.GOERLI,
+    polygon_chain=PolygonChain.MUMBAI,
+)
 
-    SUPPORTED_DOMAINS = [
-        MAINNET,
-        LYNX,
-        TAPIR,
-    ]
+TAPIR = TACoDomain(
+    name="tapir",
+    eth_chain=EthChain.SEPOLIA,
+    polygon_chain=PolygonChain.MUMBAI,
+)
 
-    SUPPORTED_DOMAIN_NAMES = [domain.name for domain in SUPPORTED_DOMAINS]
+DEFAULT_DOMAIN_NAME: str = MAINNET.name
 
-    @classmethod
-    def get_domain_info(cls, domain: str) -> DomainInfo:
-        for taco_domain in cls.SUPPORTED_DOMAINS:
-            if taco_domain.name == domain:
-                return taco_domain
+SUPPORTED_DOMAINS = [
+    MAINNET,
+    LYNX,
+    TAPIR,
+]
 
-        raise cls.Unrecognized(f"{domain} is not a recognized domain.")
+SUPPORTED_DOMAIN_NAMES = [str(domain) for domain in SUPPORTED_DOMAINS]
+
+class Unrecognized(Exception):
+    pass
+
+def get_domain(domain: str) -> TACoDomain:
+    if not isinstance(domain, str):
+        raise TypeError(f"domain must be a string, not {type(domain)}")
+    for taco_domain in SUPPORTED_DOMAINS:
+        if taco_domain.name == domain:
+            return taco_domain
+    raise Unrecognized(f"{domain} is not a recognized domain.")

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -1,5 +1,9 @@
 from enum import Enum
-from typing import NamedTuple
+from typing import NamedTuple, Dict
+
+
+class UnrecognizedTacoDomain(Exception):
+    """Raised when a domain is not recognized."""
 
 
 class ChainInfo(NamedTuple):
@@ -21,10 +25,10 @@ class PolygonChain(ChainInfo, Enum):
 class TACoDomain:
 
     def __init__(self,
-        name: str,
-        eth_chain: EthChain,
-        polygon_chain: PolygonChain,
-    ):
+                 name: str,
+                 eth_chain: EthChain,
+                 polygon_chain: PolygonChain,
+                 ):
         self.name = name
         self.eth_chain = eth_chain
         self.polygon_chain = polygon_chain
@@ -58,7 +62,6 @@ class TACoDomain:
         return self.eth_chain != EthChain.MAINNET
 
 
-
 MAINNET = TACoDomain(
     name="mainnet",
     eth_chain=EthChain.MAINNET,
@@ -77,23 +80,18 @@ TAPIR = TACoDomain(
     polygon_chain=PolygonChain.MUMBAI,
 )
 
-DEFAULT_DOMAIN_NAME: str = MAINNET.name
+__DOMAINS = (MAINNET, LYNX, TAPIR)
 
-SUPPORTED_DOMAINS = [
-    MAINNET,
-    LYNX,
-    TAPIR,
-]
+DEFAULT_DOMAIN: TACoDomain = MAINNET
 
-SUPPORTED_DOMAIN_NAMES = [str(domain) for domain in SUPPORTED_DOMAINS]
+SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {domain.name: domain for domain in __DOMAINS}
 
-class Unrecognized(Exception):
-    pass
 
-def get_domain(domain: str) -> TACoDomain:
-    if not isinstance(domain, str):
-        raise TypeError(f"domain must be a string, not {type(domain)}")
-    for taco_domain in SUPPORTED_DOMAINS:
-        if taco_domain.name == domain:
-            return taco_domain
-    raise Unrecognized(f"{domain} is not a recognized domain.")
+
+def get_domain(d: str) -> TACoDomain:
+    if not isinstance(d, str):
+        raise TypeError(f"domain must be a string, not {type(d)}")
+    for name, domain in SUPPORTED_DOMAINS.items():
+        if name == d == domain.name:
+            return domain
+    raise UnrecognizedTacoDomain(f"{d} is not a recognized domain.")

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -1,6 +1,6 @@
 from cytoolz.functoolz import memoize
 from enum import Enum
-from typing import NamedTuple, Dict
+from typing import NamedTuple, Dict, Any
 
 
 class UnrecognizedTacoDomain(Exception):
@@ -30,25 +30,25 @@ class TACoDomain:
         self.eth_chain = eth_chain
         self.polygon_chain = polygon_chain
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"<TACoDomain {self.name}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.name)
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self.name.encode()
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         try:
             return self.name == other.name
         except AttributeError:
             raise TypeError(f"Cannot compare TACoDomain to {type(other)}")
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return True
 
     @property
@@ -82,7 +82,7 @@ SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {domain.name: domain for domain in (M
 
 
 @memoize
-def get_domain(d: str) -> TACoDomain:
+def get_domain(d: Any) -> TACoDomain:
     if not isinstance(d, str):
         raise TypeError(f"domain must be a string, not {type(d)}")
     for name, domain in SUPPORTED_DOMAINS.items():

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -37,7 +37,7 @@ class TACoDomain:
         return self.name
 
     def __hash__(self) -> int:
-        return hash(self.name)
+        return hash((self.name, self.eth_chain, self.polygon_chain))
 
     def __bytes__(self) -> bytes:
         return self.name.encode()

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -43,10 +43,13 @@ class TACoDomain:
         return self.name.encode()
 
     def __eq__(self, other: Any) -> bool:
-        try:
-            return self.name == other.name
-        except AttributeError:
-            raise TypeError(f"Cannot compare TACoDomain to {type(other)}")
+        if not isinstance(other, TACoDomain):
+            return False
+        return (
+            self.name == other.name
+            and self.eth_chain == other.eth_chain
+            and self.polygon_chain == other.polygon_chain
+        )
 
     def __bool__(self) -> bool:
         return True

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -1,3 +1,4 @@
+from cytoolz.functoolz import memoize
 from enum import Enum
 from typing import NamedTuple, Dict
 
@@ -24,11 +25,7 @@ class PolygonChain(ChainInfo, Enum):
 
 class TACoDomain:
 
-    def __init__(self,
-                 name: str,
-                 eth_chain: EthChain,
-                 polygon_chain: PolygonChain,
-                 ):
+    def __init__(self, name: str, eth_chain: EthChain, polygon_chain: PolygonChain):
         self.name = name
         self.eth_chain = eth_chain
         self.polygon_chain = polygon_chain
@@ -54,9 +51,6 @@ class TACoDomain:
     def __bool__(self):
         return True
 
-    def __iter__(self):
-        return str(self)
-
     @property
     def is_testnet(self) -> bool:
         return self.eth_chain != EthChain.MAINNET
@@ -80,14 +74,14 @@ TAPIR = TACoDomain(
     polygon_chain=PolygonChain.MUMBAI,
 )
 
-__DOMAINS = (MAINNET, LYNX, TAPIR)
 
 DEFAULT_DOMAIN: TACoDomain = MAINNET
 
-SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {domain.name: domain for domain in __DOMAINS}
+SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {domain.name: domain for domain in (MAINNET, LYNX, TAPIR)}
 
 
 
+@memoize
 def get_domain(d: str) -> TACoDomain:
     if not isinstance(d, str):
         raise TypeError(f"domain must be a string, not {type(d)}")

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -77,7 +77,7 @@ TAPIR = TACoDomain(
 
 DEFAULT_DOMAIN: TACoDomain = MAINNET
 
-SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {domain.name: domain for domain in (MAINNET, LYNX, TAPIR)}
+SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {str(domain): domain for domain in (MAINNET, LYNX, TAPIR)}
 
 
 
@@ -86,6 +86,6 @@ def get_domain(d: Any) -> TACoDomain:
     if not isinstance(d, str):
         raise TypeError(f"domain must be a string, not {type(d)}")
     for name, domain in SUPPORTED_DOMAINS.items():
-        if name == d == domain.name:
+        if name == d == str(domain):
             return domain
     raise UnrecognizedTacoDomain(f"{d} is not a recognized domain.")

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -34,8 +34,7 @@ class RegistrySource(ABC):
     class Unavailable(RegistrySourceError):
         """Raised when there are no available registry sources"""
 
-    def __init__(self, domain: Union[str, TACoDomain], *args, **kwargs):
-        domain = domains.get_domain(str(domain))
+    def __init__(self, domain: TACoDomain, *args, **kwargs):
         if str(domain) not in domains.SUPPORTED_DOMAINS:
             raise ValueError(
                 f"{self.__class__.__name__} not available for domain '{domain}'. "
@@ -303,11 +302,10 @@ class ContractRegistry:
     @classmethod
     def from_latest_publication(
         cls,
-        domain: Union[str, TACoDomain],
+        domain: TACoDomain,
         source_manager: Optional[RegistrySourceManager] = None,
     ) -> "ContractRegistry":
         """Get the latest contract registry available from a registry source chain."""
-        domain = domains.get_domain(str(domain))
         source_manager = source_manager or RegistrySourceManager(domain=domain)
         source = source_manager.fetch_latest_publication()
         registry = cls(source=source)

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -1,12 +1,12 @@
-from json import JSONDecodeError
-
 import hashlib
 import json
-import requests
 from abc import ABC, abstractmethod
+from json import JSONDecodeError
 from pathlib import Path
-from requests import Response
 from typing import Dict, List, NamedTuple, Optional, Tuple, Type, Union
+
+import requests
+from requests import Response
 from web3.types import ABI
 
 from nucypher.blockchain.eth import domains

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -36,10 +36,10 @@ class RegistrySource(ABC):
 
     def __init__(self, domain: Union[str, TACoDomain], *args, **kwargs):
         domain = domains.get_domain(str(domain))
-        if domain not in domains.SUPPORTED_DOMAINS:
+        if str(domain) not in domains.SUPPORTED_DOMAINS:
             raise ValueError(
                 f"{self.__class__.__name__} not available for domain '{domain}'. "
-                f"Valid options are: {', '.join(list(domains.SUPPORTED_DOMAIN_NAMES))}"
+                f"Valid options are: {', '.join(list(domains.SUPPORTED_DOMAINS))}"
             )
         self.domain = domain
         self.data = self.get()

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -1,8 +1,9 @@
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional, Union
+
 from constant_sorrow.constants import NO_NICKNAME, NO_SIGNING_POWER, STRANGER
 from eth_utils import to_canonical_address
 from nucypher_core.umbral import PublicKey
-from pathlib import Path
-from typing import ClassVar, Dict, List, Optional, Union
 
 from nucypher.acumen.nicknames import Nickname
 from nucypher.blockchain.eth import domains
@@ -78,7 +79,6 @@ class Character(Learner):
             represented by zero Characters or by more than one Character.
 
         """
-
         self.domain = domains.get_domain(str(domain))
 
         #
@@ -128,11 +128,15 @@ class Character(Learner):
             )
 
             # Learner
-            Learner.__init__(self,
-                             network_middleware=self.network_middleware,
-                             node_class=known_node_class,
-                             include_self_in_the_state=include_self_in_the_state,
-                             *args, **kwargs)
+            Learner.__init__(
+                self,
+                domain=self.domain,
+                network_middleware=self.network_middleware,
+                node_class=known_node_class,
+                include_self_in_the_state=include_self_in_the_state,
+                *args,
+                **kwargs,
+            )
 
             self.checksum_address = checksum_address
 

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -12,7 +12,7 @@ from nucypher.blockchain.eth.registry import (
     ContractRegistry,
 )
 from nucypher.blockchain.eth.signers.base import Signer
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.keystore import Keystore
 from nucypher.crypto.powers import (
     CryptoPower,
@@ -249,7 +249,7 @@ class Character(Learner):
 
         return cls(
             is_me=False,
-            domain=TEMPORARY_DOMAIN,
+            domain=TEMPORARY_DOMAIN_NAME,
             crypto_power=crypto_power,
             *args,
             **kwargs,

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -79,6 +79,8 @@ class Character(Learner):
 
         """
 
+        self.domain = domains.get_domain(str(domain))
+
         #
         # Keys & Powers
         #
@@ -118,9 +120,7 @@ class Character(Learner):
             self.eth_endpoint = eth_endpoint
             self.polygon_endpoint = polygon_endpoint
 
-            self.registry = registry or ContractRegistry.from_latest_publication(
-                domain=domains.get_domain(str(domain)),
-            )
+            self.registry = registry or ContractRegistry.from_latest_publication(domain)
 
             # REST
             self.network_middleware = network_middleware or RestMiddleware(
@@ -129,7 +129,6 @@ class Character(Learner):
 
             # Learner
             Learner.__init__(self,
-                             domain=domain,
                              network_middleware=self.network_middleware,
                              node_class=known_node_class,
                              include_self_in_the_state=include_self_in_the_state,

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -1,11 +1,13 @@
 from pathlib import Path
-from typing import ClassVar, Dict, List, Optional
+from typing import ClassVar, Dict, List, Optional, Union
 
 from constant_sorrow.constants import NO_NICKNAME, NO_SIGNING_POWER, STRANGER
 from eth_utils import to_canonical_address
 from nucypher_core.umbral import PublicKey
 
 from nucypher.acumen.nicknames import Nickname
+from nucypher.blockchain.eth import domains
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import (
     ContractRegistry,
 )
@@ -33,7 +35,7 @@ class Character(Learner):
 
     def __init__(
         self,
-        domain: str,
+        domain: Union[str, TACoDomain],
         eth_endpoint: str = None,
         polygon_endpoint: str = None,
         known_node_class: object = None,
@@ -118,7 +120,7 @@ class Character(Learner):
             self.polygon_endpoint = polygon_endpoint
 
             self.registry = registry or ContractRegistry.from_latest_publication(
-                domain=domain
+                domain=domains.get_domain(str(domain)),
             )
 
             # REST

--- a/nucypher/characters/base.py
+++ b/nucypher/characters/base.py
@@ -1,9 +1,8 @@
-from pathlib import Path
-from typing import ClassVar, Dict, List, Optional, Union
-
 from constant_sorrow.constants import NO_NICKNAME, NO_SIGNING_POWER, STRANGER
 from eth_utils import to_canonical_address
 from nucypher_core.umbral import PublicKey
+from pathlib import Path
+from typing import ClassVar, Dict, List, Optional, Union
 
 from nucypher.acumen.nicknames import Nickname
 from nucypher.blockchain.eth import domains

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1,7 +1,23 @@
 import contextlib
 import json
-import maya
 import time
+from pathlib import Path
+from queue import Queue
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
+
+import maya
 from constant_sorrow import constants
 from constant_sorrow.constants import (
     INVALIDATED,
@@ -48,28 +64,13 @@ from nucypher_core.umbral import (
     VerifiedKeyFrag,
     reencrypt,
 )
-from pathlib import Path
-from queue import Queue
 from twisted.internet import reactor
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    List,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
 from web3.types import TxReceipt
 
 import nucypher
 from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import ArchivedFleetState, RemoteUrsulaStatus
-from nucypher.blockchain.eth import actors, domains
+from nucypher.blockchain.eth import actors
 from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
@@ -1006,9 +1007,7 @@ class Ursula(Teacher, Character, Operator):
         if discovery and not self.lonely:
             self.start_learning_loop(now=eager)
             if emitter:
-                emitter.message(
-                    f"✓ Node Discovery ({self.domain})", color="green"
-                )
+                emitter.message(f"✓ Node Discovery ({self.domain})", color="green")
 
         if ritual_tracking:
             self.ritual_tracker.start()

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -827,7 +827,6 @@ class Ursula(Teacher, Character, Operator):
         known_nodes: Iterable[Teacher] = None,
         **character_kwargs,
     ):
-        domain = domains.get_domain(str(domain))
         Character.__init__(
             self,
             is_me=is_me,
@@ -905,7 +904,6 @@ class Ursula(Teacher, Character, Operator):
         # Teacher (All Modes)
         Teacher.__init__(
             self,
-            domain=domain,
             certificate=certificate,
             certificate_filepath=certificate_filepath,
         )

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1010,7 +1010,7 @@ class Ursula(Teacher, Character, Operator):
             self.start_learning_loop(now=eager)
             if emitter:
                 emitter.message(
-                    f"✓ Node Discovery ({self.domain.capitalize()})", color="green"
+                    f"✓ Node Discovery ({self.domain})", color="green"
                 )
 
         if ritual_tracking:
@@ -1364,7 +1364,7 @@ class Ursula(Teacher, Character, Operator):
             operator_address=self.operator_address,
             rest_url=self.rest_url(),
             timestamp=self.timestamp,
-            domain=domain,
+            domain=str(domain),
             version=version,
             fleet_state=fleet_state,
             previous_fleet_states=previous_fleet_states,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -106,7 +106,7 @@ from nucypher.crypto.utils import keccak_digest
 from nucypher.network.decryption import ThresholdDecryptionClient
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
-from nucypher.network.nodes import TEACHER_NODES, NodeSprout, Teacher
+from nucypher.network.nodes import NodeSprout, Teacher
 from nucypher.network.protocols import parse_node_uri
 from nucypher.network.retrieval import PRERetrievalClient
 from nucypher.network.server import ProxyRESTServer, make_rest_app
@@ -1177,17 +1177,6 @@ class Ursula(Teacher, Character, Operator):
         seed_uri = f"{seednode_metadata.checksum_address}@{seednode_metadata.rest_host}:{seednode_metadata.rest_port}"
         return cls.from_seed_and_stake_info(seed_uri=seed_uri, *args, **kwargs)
 
-    @classmethod
-    def seednode_for_domain(cls, domain: str, eth_endpoint: str) -> "Ursula":
-        """Returns a default seednode ursula for a given network."""
-        try:
-            url = TEACHER_NODES[domain][0]
-        except KeyError:
-            raise ValueError(f'"{domain}" is not a known domain.')
-        except IndexError:
-            raise ValueError(f'No default seednodes available for "{domain}".')
-        ursula = cls.from_seed_and_stake_info(seed_uri=url, eth_endpoint=eth_endpoint)
-        return ursula
 
     @classmethod
     def from_teacher_uri(

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1,23 +1,7 @@
 import contextlib
 import json
-import time
-from pathlib import Path
-from queue import Queue
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    List,
-    NamedTuple,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    Union,
-)
-
 import maya
+import time
 from constant_sorrow import constants
 from constant_sorrow.constants import (
     INVALIDATED,
@@ -64,13 +48,28 @@ from nucypher_core.umbral import (
     VerifiedKeyFrag,
     reencrypt,
 )
+from pathlib import Path
+from queue import Queue
 from twisted.internet import reactor
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    Union,
+)
 from web3.types import TxReceipt
 
 import nucypher
 from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import ArchivedFleetState, RemoteUrsulaStatus
-from nucypher.blockchain.eth import actors
+from nucypher.blockchain.eth import actors, domains
 from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import (
     ContractAgency,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -828,6 +828,7 @@ class Ursula(Teacher, Character, Operator):
         known_nodes: Iterable[Teacher] = None,
         **character_kwargs,
     ):
+        domain = domains.get_domain(str(domain))
         Character.__init__(
             self,
             is_me=is_me,
@@ -1134,7 +1135,7 @@ class Ursula(Teacher, Character, Operator):
         ferveo_public_key = self.public_keys(RitualisticPower)
         payload = NodeMetadataPayload(
             staking_provider_address=Address(self.canonical_address),
-            domain=self.domain,
+            domain=str(self.domain),
             timestamp_epoch=timestamp.epoch,
             verifying_key=self.public_keys(SigningPower),
             encrypting_key=self.public_keys(DecryptingPower),

--- a/nucypher/characters/unlawful.py
+++ b/nucypher/characters/unlawful.py
@@ -7,7 +7,7 @@ from nucypher_core import NodeMetadata
 
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Alice, Ursula
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import CryptoPower
 from nucypher.exceptions import DevelopmentInstallationRequired
 from nucypher.policy.payment import FreeReencryptions
@@ -66,7 +66,7 @@ class Vladimir(Ursula):
         vladimir = cls(
             is_me=True,
             crypto_power=crypto_power,
-            domain=TEMPORARY_DOMAIN,
+            domain=TEMPORARY_DOMAIN_NAME,
             rest_host=target_ursula.rest_interface.host,
             rest_port=target_ursula.rest_interface.port,
             certificate=target_ursula.certificate,

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -6,7 +6,7 @@ import click
 from tabulate import tabulate
 from web3.main import Web3
 
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.signers.base import Signer
 from nucypher.cli.actions.configure import get_config_filepaths
@@ -104,7 +104,7 @@ def select_client_account(
 def select_domain(emitter: StdoutEmitter, message: Optional[str] = None) -> str:
     """Interactively select a domain from TACo domain inventory list"""
     emitter.message(message=message or str(), color="yellow")
-    domain_list = TACoDomain.SUPPORTED_DOMAIN_NAMES
+    domain_list = domains.SUPPORTED_DOMAIN_NAMES
     rows = [[n] for n in domain_list]
     emitter.echo(tabulate(rows, showindex="always"))
     choice = click.prompt(

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -64,7 +64,7 @@ def select_client_account(
     blockchain = BlockchainInterfaceFactory.get_interface(endpoint=polygon_endpoint)
 
     if signer_uri and not signer:
-        testnet = domain != domains.MAINNET.name
+        testnet = str(domain) != str(domains.MAINNET)
         signer = Signer.from_signer_uri(signer_uri, testnet=testnet)
 
     enumerated_accounts = dict(enumerate(signer.accounts))

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -64,7 +64,7 @@ def select_client_account(
     blockchain = BlockchainInterfaceFactory.get_interface(endpoint=polygon_endpoint)
 
     if signer_uri and not signer:
-        testnet = domain != TACoDomain.MAINNET.name
+        testnet = domain != domains.MAINNET.name
         signer = Signer.from_signer_uri(signer_uri, testnet=testnet)
 
     enumerated_accounts = dict(enumerate(signer.accounts))

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -104,7 +104,7 @@ def select_client_account(
 def select_domain(emitter: StdoutEmitter, message: Optional[str] = None) -> str:
     """Interactively select a domain from TACo domain inventory list"""
     emitter.message(message=message or str(), color="yellow")
-    domain_list = domains.SUPPORTED_DOMAIN_NAMES
+    domain_list = list(domains.SUPPORTED_DOMAINS)
     rows = [[n] for n in domain_list]
     emitter.echo(tabulate(rows, showindex="always"))
     choice = click.prompt(

--- a/nucypher/cli/actions/select.py
+++ b/nucypher/cli/actions/select.py
@@ -64,8 +64,8 @@ def select_client_account(
     blockchain = BlockchainInterfaceFactory.get_interface(endpoint=polygon_endpoint)
 
     if signer_uri and not signer:
-        testnet = str(domain) != str(domains.MAINNET)
-        signer = Signer.from_signer_uri(signer_uri, testnet=testnet)
+        domain = domains.get_domain(str(domain))
+        signer = Signer.from_signer_uri(signer_uri, testnet=domain.is_testnet)
 
     enumerated_accounts = dict(enumerate(signer.accounts))
     if len(enumerated_accounts) < 1:

--- a/nucypher/cli/commands/taco.py
+++ b/nucypher/cli/commands/taco.py
@@ -47,7 +47,7 @@ option_domain = click.option(
     "--domain",
     help="TACo Domain",
     type=click.STRING,
-    default=click.Choice(domains.SUPPORTED_DOMAIN_NAMES),
+    default=click.Choice(domains.SUPPORTED_DOMAINS),
     required=True,
 )
 

--- a/nucypher/cli/commands/taco.py
+++ b/nucypher/cli/commands/taco.py
@@ -5,6 +5,7 @@ import maya
 from tabulate import tabulate
 from web3 import Web3
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     CoordinatorAgent,
@@ -14,7 +15,7 @@ from nucypher.blockchain.eth.constants import (
     AVERAGE_BLOCK_TIME_IN_SECONDS,
     TACO_CONTRACT_NAMES,
 )
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.utils import truncate_checksum_address
 from nucypher.cli.config import group_general_config
 from nucypher.cli.options import (
@@ -46,7 +47,7 @@ option_domain = click.option(
     "--domain",
     help="TACo Domain",
     type=click.STRING,
-    default=click.Choice(TACoDomain.SUPPORTED_DOMAIN_NAMES),
+    default=click.Choice(domains.SUPPORTED_DOMAIN_NAMES),
     required=True,
 )
 

--- a/nucypher/cli/commands/taco.py
+++ b/nucypher/cli/commands/taco.py
@@ -15,7 +15,6 @@ from nucypher.blockchain.eth.constants import (
     AVERAGE_BLOCK_TIME_IN_SECONDS,
     TACO_CONTRACT_NAMES,
 )
-from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.utils import truncate_checksum_address
 from nucypher.cli.config import group_general_config
 from nucypher.cli.options import (

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -56,7 +56,7 @@ from nucypher.cli.utils import make_cli_character, setup_emitter
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD,
-    TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN_NAME,
 )
 from nucypher.config.migrations import MIGRATIONS
 from nucypher.config.migrations.common import (
@@ -110,7 +110,7 @@ class UrsulaConfigOptions:
             return UrsulaConfiguration(
                 emitter=emitter,
                 dev_mode=True,
-                domain=TEMPORARY_DOMAIN,
+                domain=TEMPORARY_DOMAIN_NAME,
                 poa=self.poa,
                 light=self.light,
                 registry_filepath=self.registry_filepath,

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -165,6 +165,7 @@ class UrsulaConfigOptions:
             self.operator_address = select_client_account(
                 emitter=emitter,
                 prompt=prompt,
+                domain=self.domain,
                 polygon_endpoint=self.polygon_endpoint,
                 signer_uri=self.signer_uri,
             )

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -97,9 +97,9 @@ class NuCypherDomainName(click.ParamType):
     def convert(self, value, param, ctx):
         if self.validate:
             domain = str(value).lower()
-            if domain not in domains.SUPPORTED_DOMAIN_NAMES:
+            if str(domain) not in domains.SUPPORTED_DOMAINS:
                 self.fail(
-                    f"'{value}' is not a recognized domain. Valid options are: {list(domains.SUPPORTED_DOMAIN_NAMES)}"
+                    f"'{value}' is not a recognized domain. Valid options are: {list(domains.SUPPORTED_DOMAINS)}"
                 )
             else:
                 return domain

--- a/nucypher/cli/types.py
+++ b/nucypher/cli/types.py
@@ -10,7 +10,7 @@ from cryptography.exceptions import InternalError
 from eth_utils import to_checksum_address
 from nucypher_core.umbral import PublicKey
 
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.token import TToken
 from nucypher.policy.payment import PRE_PAYMENT_METHODS
 from nucypher.utilities.networking import InvalidOperatorIP, validate_operator_ip
@@ -97,9 +97,9 @@ class NuCypherDomainName(click.ParamType):
     def convert(self, value, param, ctx):
         if self.validate:
             domain = str(value).lower()
-            if domain not in TACoDomain.SUPPORTED_DOMAIN_NAMES:
+            if domain not in domains.SUPPORTED_DOMAIN_NAMES:
                 self.fail(
-                    f"'{value}' is not a recognized domain. Valid options are: {list(TACoDomain.SUPPORTED_DOMAIN_NAMES)}"
+                    f"'{value}' is not a recognized domain. Valid options are: {list(domains.SUPPORTED_DOMAIN_NAMES)}"
                 )
             else:
                 return domain

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -306,7 +306,7 @@ class CharacterConfiguration(BaseConfiguration):
 
     CHARACTER_CLASS = NotImplemented
     MNEMONIC_KEYSTORE = False
-    DEFAULT_DOMAIN = domains.DEFAULT_DOMAIN_NAME
+    DEFAULT_DOMAIN = domains.DEFAULT_DOMAIN
     DEFAULT_NETWORK_MIDDLEWARE = RestMiddleware
     TEMP_CONFIGURATION_DIR_PREFIX = 'tmp-nucypher'
     SIGNER_ENVVAR = None

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -1,11 +1,6 @@
 import json
 import re
 from abc import ABC, abstractmethod
-from decimal import Decimal
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Callable, List, Optional, Union
-
 from constant_sorrow.constants import (
     DEVELOPMENT_CONFIGURATION,
     LIVE_CONFIGURATION,
@@ -14,9 +9,13 @@ from constant_sorrow.constants import (
     UNINITIALIZED_CONFIGURATION,
     UNKNOWN_VERSION,
 )
+from decimal import Decimal
 from eth_utils.address import is_checksum_address
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Callable, List, Optional, Union
 
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import (
     ContractRegistry,
@@ -415,8 +414,7 @@ class CharacterConfiguration(BaseConfiguration):
         self.signer_uri = signer_uri or None
 
         # Learner
-        self.domain = domain
-        self.taco_domain_info = TACoDomain.get_domain_info(self.domain)
+        self.domain = domains.get_domain(str(domain))
         self.learn_on_same_thread = learn_on_same_thread
         self.abort_on_learning_error = abort_on_learning_error
         self.start_learning_now = start_learning_now
@@ -451,7 +449,7 @@ class CharacterConfiguration(BaseConfiguration):
                 self.log.info(f"Using local registry ({self.registry}).")
 
         self.signer = Signer.from_signer_uri(
-            self.signer_uri, testnet=self.taco_domain_info.is_testnet
+            self.signer_uri, testnet=self.domain.is_testnet
         )
 
         #
@@ -662,7 +660,7 @@ class CharacterConfiguration(BaseConfiguration):
             keystore_path=keystore_path,
 
             # Behavior
-            domain=self.domain,
+            domain=str(self.domain),
             learn_on_same_thread=self.learn_on_same_thread,
             abort_on_learning_error=self.abort_on_learning_error,
             start_learning_now=self.start_learning_now,
@@ -834,7 +832,7 @@ class CharacterConfiguration(BaseConfiguration):
         if pre_payment_class.ONCHAIN:
             # on-chain payment strategies require a blockchain connection
             pre_payment_strategy = pre_payment_class(
-                domain=self.taco_domain_info.name,
+                domain=str(self.domain),
                 blockchain_endpoint=self.polygon_endpoint,
                 registry=self.registry,
             )

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -306,7 +306,7 @@ class CharacterConfiguration(BaseConfiguration):
 
     CHARACTER_CLASS = NotImplemented
     MNEMONIC_KEYSTORE = False
-    DEFAULT_DOMAIN = TACoDomain.DEFAULT_DOMAIN_NAME
+    DEFAULT_DOMAIN = domains.DEFAULT_DOMAIN_NAME
     DEFAULT_NETWORK_MIDDLEWARE = RestMiddleware
     TEMP_CONFIGURATION_DIR_PREFIX = 'tmp-nucypher'
     SIGNER_ENVVAR = None

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -1,6 +1,11 @@
 import json
 import re
 from abc import ABC, abstractmethod
+from decimal import Decimal
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Callable, List, Optional, Union
+
 from constant_sorrow.constants import (
     DEVELOPMENT_CONFIGURATION,
     LIVE_CONFIGURATION,
@@ -9,11 +14,7 @@ from constant_sorrow.constants import (
     UNINITIALIZED_CONFIGURATION,
     UNKNOWN_VERSION,
 )
-from decimal import Decimal
 from eth_utils.address import is_checksum_address
-from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Callable, List, Optional, Union
 
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
@@ -832,7 +833,7 @@ class CharacterConfiguration(BaseConfiguration):
         if pre_payment_class.ONCHAIN:
             # on-chain payment strategies require a blockchain connection
             pre_payment_strategy = pre_payment_class(
-                domain=str(self.domain),
+                domain=self.domain,
                 blockchain_endpoint=self.polygon_endpoint,
                 registry=self.registry,
             )

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -1,8 +1,9 @@
 import json
-from cryptography.x509 import Certificate
-from eth_utils import is_checksum_address
 from pathlib import Path
 from typing import Dict, List, Optional
+
+from cryptography.x509 import Certificate
+from eth_utils import is_checksum_address
 
 from nucypher.config.base import CharacterConfiguration
 from nucypher.config.constants import (

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -1,9 +1,8 @@
 import json
-from pathlib import Path
-from typing import Dict, List, Optional
-
 from cryptography.x509 import Certificate
 from eth_utils import is_checksum_address
+from pathlib import Path
+from typing import Dict, List, Optional
 
 from nucypher.config.base import CharacterConfiguration
 from nucypher.config.constants import (
@@ -70,7 +69,7 @@ class UrsulaConfiguration(CharacterConfiguration):
     def configure_condition_blockchain_endpoints(self) -> None:
         """Configure default condition provider URIs for eth and polygon network."""
         # Polygon
-        polygon_chain_id = self.taco_domain_info.polygon_chain.id
+        polygon_chain_id = self.domain.polygon_chain.id
         polygon_endpoints = self.condition_blockchain_endpoints.get(
             polygon_chain_id, []
         )
@@ -81,7 +80,7 @@ class UrsulaConfiguration(CharacterConfiguration):
             polygon_endpoints.append(self.polygon_endpoint)
 
         # Ethereum
-        staking_chain_id = self.taco_domain_info.eth_chain.id
+        staking_chain_id = self.domain.eth_chain.id
         staking_chain_endpoints = self.condition_blockchain_endpoints.get(
             staking_chain_id, []
         )

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -52,7 +52,7 @@ MAX_UPLOAD_CONTENT_LENGTH = 1024 * 50
 
 
 # Dev Mode
-TEMPORARY_DOMAIN = ":temporary-domain:"  # for use with `--dev` node runtimes
+TEMPORARY_DOMAIN_NAME = ":temporary-domain:"  # for use with `--dev` node runtimes
 
 
 # Event Blocks Throttling

--- a/nucypher/config/migrations/configuration_v5_to_v6.py
+++ b/nucypher/config/migrations/configuration_v5_to_v6.py
@@ -1,15 +1,15 @@
 from typing import Dict
 
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.config.migrations.common import perform_migration
 
 
 def __migration(config: Dict) -> Dict:
-    taco_domain_info = TACoDomain.get_domain_info(config["domain"])
+    domain = domains.get_domain(config["domain"])
     eth_provider = config["eth_provider_uri"]
-    eth_chain_id = taco_domain_info.eth_chain.id
+    eth_chain_id = domain.eth_chain.id
     polygon_provider = config["payment_provider"]
-    polygon_chain_id = taco_domain_info.polygon_chain.id
+    polygon_chain_id = domain.polygon_chain.id
     if "condition_provider_uris" in config:
         return config
     config["condition_provider_uris"] = {

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -29,6 +29,7 @@ from nucypher.acumen.perception import FleetSensor
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import ContractAgency, TACoApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.config.constants import SeednodeMetadata
 from nucypher.config.storages import ForgetfulNodeStorage
@@ -251,7 +252,6 @@ class Learner:
         """
 
     def __init__(self,
-                 domain: str,
                  node_class: object = None,
                  network_middleware: RestMiddleware = None,
                  start_learning_now: bool = False,
@@ -269,7 +269,6 @@ class Learner:
         self.log = Logger("learning-loop")  # type: Logger
 
         self.learning_deferred = Deferred()
-        self.domain = domains.get_domain(str(domain))
         default_middleware = self.__DEFAULT_MIDDLEWARE_CLASS(
             registry=self.registry, eth_endpoint=self.eth_endpoint
         )
@@ -280,7 +279,7 @@ class Learner:
 
         self._abort_on_learning_error = abort_on_learning_error
 
-        self.__known_nodes = self.tracker_class(domain=domain, this_node=self if include_self_in_the_state else None)
+        self.__known_nodes = self.tracker_class(domain=self.domain, this_node=self if include_self_in_the_state else None)
         self._verify_node_bonding = verify_node_bonding
 
         self.lonely = lonely
@@ -969,12 +968,9 @@ class Teacher:
     __DEFAULT_MIN_SEED_STAKE = 0
 
     def __init__(self,
-                 domain: str,  # TODO: Consider using a Domain type
                  certificate: Certificate,
                  certificate_filepath: Path,
                  ) -> None:
-
-        self.domain = domain
 
         #
         # Identity

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -26,6 +26,7 @@ from twisted.internet.defer import Deferred
 from nucypher import characters
 from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import FleetSensor
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import ContractAgency, TACoApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.domains import TACoDomain
@@ -269,8 +270,7 @@ class Learner:
         self.log = Logger("learning-loop")  # type: Logger
 
         self.learning_deferred = Deferred()
-        self.domain = domain
-        self.taco_domain_info = TACoDomain.get_domain_info(self.domain)
+        self.domain = domains.get_domain(str(domain))
         default_middleware = self.__DEFAULT_MIDDLEWARE_CLASS(
             registry=self.registry, eth_endpoint=self.eth_endpoint
         )
@@ -352,7 +352,7 @@ class Learner:
         discovered = []
 
         if self.domain:
-            canonical_sage_uris = TEACHER_NODES.get(self.domain, ())
+            canonical_sage_uris = TEACHER_NODES.get(str(self.domain), ())
 
             for uri in canonical_sage_uris:
                 try:

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1,12 +1,8 @@
-import time
 from collections import defaultdict, deque
-from contextlib import suppress
-from pathlib import Path
-from queue import Queue
-from typing import Callable, List, Optional, Set, Tuple
 
 import maya
 import requests
+import time
 from constant_sorrow.constants import (
     CERTIFICATE_NOT_SAVED,
     FLEET_STATES_MATCH,
@@ -14,14 +10,18 @@ from constant_sorrow.constants import (
     NOT_SIGNED,
     RELAX,
 )
+from contextlib import suppress
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import Certificate, load_der_x509_certificate
 from eth_utils import to_checksum_address
 from nucypher_core import MetadataResponse, MetadataResponsePayload, NodeMetadata
 from nucypher_core.umbral import Signature
+from pathlib import Path
+from queue import Queue
 from requests.exceptions import SSLError
 from twisted.internet import reactor, task
 from twisted.internet.defer import Deferred
+from typing import Callable, List, Optional, Set, Tuple
 
 from nucypher import characters
 from nucypher.acumen.nicknames import Nickname
@@ -29,7 +29,6 @@ from nucypher.acumen.perception import FleetSensor
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import ContractAgency, TACoApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
-from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.config.constants import SeednodeMetadata
 from nucypher.config.storages import ForgetfulNodeStorage
@@ -47,13 +46,13 @@ from nucypher.network.protocols import InterfaceInfo, SuspiciousActivity
 from nucypher.utilities.logging import Logger
 
 TEACHER_NODES = {
-    TACoDomain.MAINNET.name: (
+    domains.MAINNET: (
         'https://closest-seed.nucypher.network:9151',
         'https://seeds.nucypher.network',
         'https://mainnet.nucypher.network:9151',
     ),
-    TACoDomain.LYNX.name: ("https://lynx.nucypher.network:9151",),
-    TACoDomain.TAPIR.name: ("https://tapir.nucypher.network:9151",),
+    domains.LYNX: ("https://lynx.nucypher.network:9151",),
+    domains.TAPIR: ("https://tapir.nucypher.network:9151",),
 }
 
 
@@ -352,7 +351,7 @@ class Learner:
         discovered = []
 
         if self.domain:
-            canonical_sage_uris = TEACHER_NODES.get(str(self.domain), ())
+            canonical_sage_uris = TEACHER_NODES.get(self.domain, ())
 
             for uri in canonical_sage_uris:
                 try:
@@ -411,7 +410,7 @@ class Learner:
         restored_from_disk = []
         invalid_nodes = defaultdict(list)
         for node in stored_nodes:
-            if node.domain != self.domain:
+            if str(node.domain) != str(self.domain):
                 invalid_nodes[node.domain].append(node)
                 continue
             restored_node = self.remember_node(node, record_fleet_state=False)  # TODO: Validity status 1866

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -29,6 +29,7 @@ from nucypher.acumen.perception import FleetSensor
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import ContractAgency, TACoApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.config.constants import SeednodeMetadata
 from nucypher.config.storages import ForgetfulNodeStorage
@@ -250,22 +251,24 @@ class Learner:
         it does not have the proper attributes for learning or verification.
         """
 
-    def __init__(self,
-                 node_class: object = None,
-                 network_middleware: RestMiddleware = None,
-                 start_learning_now: bool = False,
-                 learn_on_same_thread: bool = False,
-                 known_nodes: tuple = None,
-                 seed_nodes: Tuple[tuple] = None,
-                 node_storage=None,
-                 save_metadata: bool = False,
-                 abort_on_learning_error: bool = False,
-                 lonely: bool = False,
-                 verify_node_bonding: bool = True,
-                 include_self_in_the_state: bool = False,
-                 ) -> None:
-
+    def __init__(
+        self,
+        domain: TACoDomain,
+        node_class: object = None,
+        network_middleware: RestMiddleware = None,
+        start_learning_now: bool = False,
+        learn_on_same_thread: bool = False,
+        known_nodes: tuple = None,
+        seed_nodes: Tuple[tuple] = None,
+        node_storage=None,
+        save_metadata: bool = False,
+        abort_on_learning_error: bool = False,
+        lonely: bool = False,
+        verify_node_bonding: bool = True,
+        include_self_in_the_state: bool = False,
+    ) -> None:
         self.log = Logger("learning-loop")  # type: Logger
+        self.domain = domain
 
         self.learning_deferred = Deferred()
         default_middleware = self.__DEFAULT_MIDDLEWARE_CLASS(

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1,8 +1,12 @@
+import time
 from collections import defaultdict, deque
+from contextlib import suppress
+from pathlib import Path
+from queue import Queue
+from typing import Callable, List, Optional, Set, Tuple
 
 import maya
 import requests
-import time
 from constant_sorrow.constants import (
     CERTIFICATE_NOT_SAVED,
     FLEET_STATES_MATCH,
@@ -10,18 +14,14 @@ from constant_sorrow.constants import (
     NOT_SIGNED,
     RELAX,
 )
-from contextlib import suppress
 from cryptography.hazmat.backends import default_backend
 from cryptography.x509 import Certificate, load_der_x509_certificate
 from eth_utils import to_checksum_address
 from nucypher_core import MetadataResponse, MetadataResponsePayload, NodeMetadata
 from nucypher_core.umbral import Signature
-from pathlib import Path
-from queue import Queue
 from requests.exceptions import SSLError
 from twisted.internet import reactor, task
 from twisted.internet.defer import Deferred
-from typing import Callable, List, Optional, Set, Tuple
 
 from nucypher import characters
 from nucypher.acumen.nicknames import Nickname
@@ -29,7 +29,6 @@ from nucypher.acumen.perception import FleetSensor
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import ContractAgency, TACoApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
-from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.config.constants import SeednodeMetadata
 from nucypher.config.storages import ForgetfulNodeStorage
@@ -279,7 +278,9 @@ class Learner:
 
         self._abort_on_learning_error = abort_on_learning_error
 
-        self.__known_nodes = self.tracker_class(domain=self.domain, this_node=self if include_self_in_the_state else None)
+        self.__known_nodes = self.tracker_class(
+            domain=self.domain, this_node=self if include_self_in_the_state else None
+        )
         self._verify_node_bonding = verify_node_bonding
 
         self.lonely = lonely

--- a/nucypher/policy/payment.py
+++ b/nucypher/policy/payment.py
@@ -73,7 +73,7 @@ class ContractPayment(PaymentMethod, ABC):
     ):
         super().__init__(*args, **kwargs)
         self.blockchain_endpoint = blockchain_endpoint
-        self.domain = domains.get_domain(str(domain))
+        self.domain = domain
         if not registry:
             registry = ContractRegistry.from_latest_publication(domain=self.domain)
         self.registry = registry

--- a/nucypher/policy/payment.py
+++ b/nucypher/policy/payment.py
@@ -1,10 +1,10 @@
-import maya
 from abc import ABC, abstractmethod
-from nucypher_core import ReencryptionRequest
 from typing import Dict, NamedTuple, Optional
+
+import maya
+from nucypher_core import ReencryptionRequest
 from web3.types import ChecksumAddress, Timestamp, TxReceipt, Wei
 
-from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import ContractAgency, SubscriptionManagerAgent
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry

--- a/nucypher/policy/payment.py
+++ b/nucypher/policy/payment.py
@@ -1,10 +1,10 @@
-from abc import ABC, abstractmethod
-from typing import Dict, NamedTuple, Optional
-
 import maya
+from abc import ABC, abstractmethod
 from nucypher_core import ReencryptionRequest
+from typing import Dict, NamedTuple, Optional
 from web3.types import ChecksumAddress, Timestamp, TxReceipt, Wei
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import ContractAgency, SubscriptionManagerAgent
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
@@ -66,16 +66,16 @@ class ContractPayment(PaymentMethod, ABC):
     def __init__(
         self,
         blockchain_endpoint: str,
-        domain: str,
+        domain: TACoDomain,
         registry: Optional[ContractRegistry] = None,
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self.blockchain_endpoint = blockchain_endpoint
-        self.taco_domain_info = TACoDomain.get_domain_info(domain)
+        self.domain = domains.get_domain(str(domain))
         if not registry:
-            registry = ContractRegistry.from_latest_publication(domain=domain)
+            registry = ContractRegistry.from_latest_publication(domain=self.domain)
         self.registry = registry
         self.__agent = None  # delay blockchain/registry reads until later
 

--- a/scripts/hooks/nucypher_agents.py
+++ b/scripts/hooks/nucypher_agents.py
@@ -45,8 +45,8 @@ emitter = StdoutEmitter(verbosity=2)
     "--domain",
     "domain",
     help="TACo domain",
-    type=click.Choice(domains.SUPPORTED_DOMAINS),
-    default=domains.LYNX.name,
+    type=click.Choice(list(domains.SUPPORTED_DOMAINS)),
+    default=str(domains.LYNX),
 )
 @click.option(
     "--eth-endpoint",
@@ -67,6 +67,7 @@ def nucypher_agents(
     eth_endpoint,
     polygon_endpoint,
 ):
+    domain = domains.get_domain(str(domain))
     registry = ContractRegistry.from_latest_publication(domain=domain)
     emitter.echo(f"NOTICE: Connecting to {domain} domain", color="yellow")
 

--- a/scripts/hooks/nucypher_agents.py
+++ b/scripts/hooks/nucypher_agents.py
@@ -27,7 +27,7 @@ from nucypher.blockchain.eth.agents import (
     TACoApplicationAgent,
     TACoChildApplicationAgent,
 )
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.utilities.emitters import StdoutEmitter
 from nucypher.utilities.logging import GlobalLoggerSettings
@@ -45,8 +45,8 @@ emitter = StdoutEmitter(verbosity=2)
     "--domain",
     "domain",
     help="TACo domain",
-    type=click.Choice(TACoDomain.SUPPORTED_DOMAIN_NAMES),
-    default=TACoDomain.LYNX.name,
+    type=click.Choice(domains.SUPPORTED_DOMAIN_NAMES),
+    default=domains.LYNX.name,
 )
 @click.option(
     "--eth-endpoint",

--- a/scripts/hooks/nucypher_agents.py
+++ b/scripts/hooks/nucypher_agents.py
@@ -45,7 +45,7 @@ emitter = StdoutEmitter(verbosity=2)
     "--domain",
     "domain",
     help="TACo domain",
-    type=click.Choice(domains.SUPPORTED_DOMAIN_NAMES),
+    type=click.Choice(domains.SUPPORTED_DOMAINS),
     default=domains.LYNX.name,
 )
 @click.option(

--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -46,8 +46,8 @@ def get_transacting_power(signer: Signer):
     "--domain",
     "domain",
     help="TACo Domain",
-    type=click.Choice([domains.TAPIR.name, domains.LYNX.name]),
-    default=domains.LYNX.name,
+    type=click.Choice([str(domains.TAPIR), str(domains.LYNX)]),
+    default=str(domains.LYNX),
 )
 @click.option(
     "--eth-endpoint",

--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -1,17 +1,16 @@
-import random
-import time
-
 import click
 import maya
+import random
+import time
 from nucypher_core.ferveo import DkgPublicKey
 from web3 import Web3
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     CoordinatorAgent,
     TACoApplicationAgent,
 )
-from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import InMemorySigner, Signer
 from nucypher.characters.lawful import Bob, Enrico
@@ -47,8 +46,8 @@ def get_transacting_power(signer: Signer):
     "--domain",
     "domain",
     help="TACo Domain",
-    type=click.Choice([TACoDomain.TAPIR.name, TACoDomain.LYNX.name]),
-    default=TACoDomain.LYNX.name,
+    type=click.Choice([domains.TAPIR.name, domains.LYNX.name]),
+    default=domains.LYNX.name,
 )
 @click.option(
     "--eth-endpoint",
@@ -154,7 +153,7 @@ def nucypher_dkg(
                 ),
             )
 
-    taco_domain_info = TACoDomain.get_domain_info(domain)
+    domain = domains.get_domain(domain)
     registry = ContractRegistry.from_latest_publication(domain=domain)
     coordinator_agent = ContractAgency.get_agent(
         agent_class=CoordinatorAgent,
@@ -191,7 +190,7 @@ def nucypher_dkg(
 
         emitter.echo("--------- Initiating Ritual ---------", color="yellow")
         emitter.echo(
-            f"Commencing DKG Ritual(s) on {taco_domain_info.polygon_chain.name} using {account_address}",
+            f"Commencing DKG Ritual(s) on {domain.polygon_chain.name} using {account_address}",
             color="green",
         )
 

--- a/tests/acceptance/characters/test_decentralized_grant.py
+++ b/tests/acceptance/characters/test_decentralized_grant.py
@@ -4,7 +4,7 @@ import os
 import maya
 from nucypher_core import EncryptedKeyFrag
 
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.policy.payment import SubscriptionManagerPayment
 from tests.constants import TEST_ETH_PROVIDER_URI
 
@@ -30,7 +30,7 @@ def check(policy, bob, ursulas):
 
 def test_grant_subscription_manager(alice, bob, ursulas):
     pre_payment_method = SubscriptionManagerPayment(
-        blockchain_endpoint=TEST_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN
+        blockchain_endpoint=TEST_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN_NAME
     )
     alice.pre_payment_method = pre_payment_method
     policy = alice.grant(

--- a/tests/acceptance/characters/test_fault_tolerance.py
+++ b/tests/acceptance/characters/test_fault_tolerance.py
@@ -6,7 +6,7 @@ from twisted.logger import LogLevel, globalLogPublisher
 from nucypher.acumen.perception import FleetSensor
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.signers.software import Web3Signer
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import TransactingPower
 from tests.constants import TEST_ETH_PROVIDER_URI
 from tests.utils.ursula import make_ursulas, start_pytest_ursula_services
@@ -30,7 +30,7 @@ def test_ursula_stamp_verification_tolerance(ursulas, mocker):
     unsigned._metadata = None
 
     # Wipe known nodes!
-    lonely_learner._Learner__known_nodes = FleetSensor(domain=TEMPORARY_DOMAIN)
+    lonely_learner._Learner__known_nodes = FleetSensor(domain=TEMPORARY_DOMAIN_NAME)
     lonely_learner._current_teacher_node = teacher
     lonely_learner.remember_node(teacher)
 

--- a/tests/acceptance/characters/test_transacting_power.py
+++ b/tests/acceptance/characters/test_transacting_power.py
@@ -5,7 +5,7 @@ from nucypher_core.ferveo import Keypair
 
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Character
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import TransactingPower
 from nucypher.crypto.utils import verify_eip_191
 from tests.conftest import LOCK_FUNCTION
@@ -20,7 +20,7 @@ def test_character_transacting_power_signing(testerchain, test_registry):
     eth_address = testerchain.etherbase_account
     signer = Character(
         is_me=True,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=TEST_ETH_PROVIDER_URI,
         registry=test_registry,
         checksum_address=eth_address,

--- a/tests/acceptance/cli/test_ursula_init.py
+++ b/tests/acceptance/cli/test_ursula_init.py
@@ -14,7 +14,7 @@ from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
     NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD,
-    TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN_NAME,
 )
 from nucypher.crypto.powers import TransactingPower
 from tests.constants import (
@@ -124,7 +124,7 @@ def test_ursula_and_local_keystore_signer_integration(
         "ursula",
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--operator-address",
         worker_account.address,
         "--config-root",

--- a/tests/acceptance/cli/test_ursula_run.py
+++ b/tests/acceptance/cli/test_ursula_run.py
@@ -13,7 +13,7 @@ from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
-    TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN_NAME,
 )
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
 from tests.constants import (
@@ -27,7 +27,7 @@ from tests.utils.ursula import select_test_port, start_pytest_ursula_services
 
 @mock.patch('glob.glob', return_value=list())
 def test_missing_configuration_file(_default_filepath_mock, click_runner):
-    cmd_args = ("ursula", "run", "--domain", TEMPORARY_DOMAIN)
+    cmd_args = ("ursula", "run", "--domain", TEMPORARY_DOMAIN_NAME)
     result = click_runner.invoke(nucypher_cli, cmd_args, catch_exceptions=False)
     assert result.exit_code != 0
     configuration_type = UrsulaConfiguration.NAME
@@ -183,7 +183,7 @@ def test_persistent_node_storage_integration(
         "--operator-address",
         another_ursula,
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--rest-host",
         MOCK_IP_ADDRESS,
         "--config-root",

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -21,7 +21,7 @@ from tests.constants import (
     INSECURE_DEVELOPMENT_PASSWORD,
     MIN_OPERATOR_SECONDS,
     TEST_ETH_PROVIDER_URI,
-    TESTERCHAIN_CHAIN_ID,
+    TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN,
 )
 from tests.utils.blockchain import TesterBlockchain
 from tests.utils.registry import ApeRegistrySource
@@ -273,10 +273,10 @@ def deployed_contracts(
 
 
 @pytest.fixture(scope="module", autouse=True)
-def test_registry(deployed_contracts, module_mocker, temporary_domain):
+def test_registry(deployed_contracts, module_mocker):
     with tests.utils.registry.mock_registry_sources(mocker=module_mocker):
         RegistrySourceManager._FALLBACK_CHAIN = (ApeRegistrySource,)
-        source = ApeRegistrySource(domain=temporary_domain)
+        source = ApeRegistrySource(domain=TEMPORARY_DOMAIN)
         registry = ContractRegistry(source=source)
         yield registry
 
@@ -403,7 +403,7 @@ def multichain_ursulas(ursulas, multichain_ids, mock_rpc_condition):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker, temporary_domain):
+def mock_condition_blockchains(module_mocker):
     """adds testerchain's chain ID to permitted conditional chains"""
     module_mocker.patch.dict(
         "nucypher.policy.conditions.evm._CONDITION_CHAINS",
@@ -412,7 +412,7 @@ def mock_condition_blockchains(module_mocker, temporary_domain):
 
     module_mocker.patch(
         "nucypher.blockchain.eth.domains.get_domain",
-        return_value=temporary_domain
+        return_value=TEMPORARY_DOMAIN
     )
 
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -13,7 +13,7 @@ from nucypher.blockchain.eth.agents import (
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry, RegistrySourceManager
 from nucypher.blockchain.eth.signers.software import Web3Signer
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import TransactingPower
 from nucypher.policy.conditions.evm import RPCCondition
 from nucypher.utilities.logging import Logger
@@ -277,7 +277,7 @@ def deployed_contracts(
 def test_registry(deployed_contracts, module_mocker):
     with tests.utils.registry.mock_registry_sources(mocker=module_mocker):
         RegistrySourceManager._FALLBACK_CHAIN = (ApeRegistrySource,)
-        source = ApeRegistrySource(domain=TEMPORARY_DOMAIN)
+        source = ApeRegistrySource(domain=TEMPORARY_DOMAIN_NAME)
         registry = ContractRegistry(source=source)
         yield registry
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,5 +1,6 @@
-import pytest
 import random
+
+import pytest
 from web3 import Web3
 
 import tests
@@ -20,8 +21,9 @@ from tests.constants import (
     BONUS_TOKENS_FOR_TESTS,
     INSECURE_DEVELOPMENT_PASSWORD,
     MIN_OPERATOR_SECONDS,
+    TEMPORARY_DOMAIN,
     TEST_ETH_PROVIDER_URI,
-    TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN,
+    TESTERCHAIN_CHAIN_ID,
 )
 from tests.utils.blockchain import TesterBlockchain
 from tests.utils.registry import ApeRegistrySource
@@ -411,8 +413,7 @@ def mock_condition_blockchains(module_mocker):
     )
 
     module_mocker.patch(
-        "nucypher.blockchain.eth.domains.get_domain",
-        return_value=TEMPORARY_DOMAIN
+        "nucypher.blockchain.eth.domains.get_domain", return_value=TEMPORARY_DOMAIN
     )
 
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,6 +1,5 @@
-import random
-
 import pytest
+import random
 from web3 import Web3
 
 import tests
@@ -10,10 +9,6 @@ from nucypher.blockchain.eth.agents import (
     CoordinatorAgent,
     TACoApplicationAgent,
     TACoChildApplicationAgent,
-)
-from nucypher.blockchain.eth.domains import (
-    DomainInfo,
-    TACoDomain,
 )
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry, RegistrySourceManager
@@ -28,7 +23,6 @@ from tests.constants import (
     MIN_OPERATOR_SECONDS,
     TEST_ETH_PROVIDER_URI,
     TESTERCHAIN_CHAIN_ID,
-    TESTERCHAIN_CHAIN_INFO,
 )
 from tests.utils.blockchain import TesterBlockchain
 from tests.utils.registry import ApeRegistrySource
@@ -410,19 +404,16 @@ def multichain_ursulas(ursulas, multichain_ids, mock_rpc_condition):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker):
+def mock_condition_blockchains(module_mocker, temporary_domain):
     """adds testerchain's chain ID to permitted conditional chains"""
     module_mocker.patch.dict(
         "nucypher.policy.conditions.evm._CONDITION_CHAINS",
         {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
     )
 
-    test_domain_info = DomainInfo(
-        TEMPORARY_DOMAIN, TESTERCHAIN_CHAIN_INFO, TESTERCHAIN_CHAIN_INFO
-    )
-
-    module_mocker.patch.object(
-        TACoDomain, "get_domain_info", return_value=test_domain_info
+    module_mocker.patch(
+        "nucypher.blockchain.eth.domains.get_domain",
+        return_value=temporary_domain
     )
 
 

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -13,7 +13,6 @@ from nucypher.blockchain.eth.agents import (
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry, RegistrySourceManager
 from nucypher.blockchain.eth.signers.software import Web3Signer
-from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import TransactingPower
 from nucypher.policy.conditions.evm import RPCCondition
 from nucypher.utilities.logging import Logger
@@ -274,10 +273,10 @@ def deployed_contracts(
 
 
 @pytest.fixture(scope="module", autouse=True)
-def test_registry(deployed_contracts, module_mocker):
+def test_registry(deployed_contracts, module_mocker, temporary_domain):
     with tests.utils.registry.mock_registry_sources(mocker=module_mocker):
         RegistrySourceManager._FALLBACK_CHAIN = (ApeRegistrySource,)
-        source = ApeRegistrySource(domain=TEMPORARY_DOMAIN_NAME)
+        source = ApeRegistrySource(domain=temporary_domain)
         registry = ContractRegistry(source=source)
         yield registry
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,7 @@ def disable_check_grant_requirements(session_mocker):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker, temporary_domain):
+def mock_condition_blockchains(module_mocker):
     """adds testerchain's chain ID to permitted conditional chains"""
     module_mocker.patch.dict(
         "nucypher.policy.conditions.evm._CONDITION_CHAINS",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,11 +144,6 @@ def mock_condition_blockchains(module_mocker, temporary_domain):
         {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
     )
 
-    module_mocker.patch(
-        "nucypher.blockchain.eth.domains.get_domain",
-        return_value=temporary_domain
-    )
-
 
 @pytest.fixture(scope="module", autouse=True)
 def mock_multichain_configuration(module_mocker, testerchain):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,18 +4,12 @@ import pytest
 from eth_utils.crypto import keccak
 
 from nucypher.blockchain.eth.actors import Operator
-from nucypher.blockchain.eth.domains import (
-    DomainInfo,
-    TACoDomain,
-)
-from nucypher.config.constants import TEMPORARY_DOMAIN
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Learner
 from nucypher.utilities.logging import GlobalLoggerSettings
 from tests.constants import (
     MOCK_IP_ADDRESS,
     TESTERCHAIN_CHAIN_ID,
-    TESTERCHAIN_CHAIN_INFO,
 )
 
 # Don't re-lock accounts in the background while making commitments
@@ -143,18 +137,16 @@ def disable_check_grant_requirements(session_mocker):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker):
+def mock_condition_blockchains(module_mocker, temporary_domain):
     """adds testerchain's chain ID to permitted conditional chains"""
     module_mocker.patch.dict(
         "nucypher.policy.conditions.evm._CONDITION_CHAINS",
         {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
     )
-    test_domain_info = DomainInfo(
-        TEMPORARY_DOMAIN, TESTERCHAIN_CHAIN_INFO, TESTERCHAIN_CHAIN_INFO
-    )
 
-    module_mocker.patch.object(
-        TACoDomain, "get_domain_info", return_value=test_domain_info
+    module_mocker.patch(
+        "nucypher.blockchain.eth.domains.get_domain",
+        return_value=temporary_domain
     )
 
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -7,11 +7,11 @@ from random import SystemRandom
 from hexbytes import HexBytes
 from web3 import Web3
 
-from nucypher.blockchain.eth.domains import ChainInfo
+from nucypher.blockchain.eth.domains import ChainInfo, TACoDomain
 from nucypher.blockchain.eth.token import NU
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
-    NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD,
+    NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD, TEMPORARY_DOMAIN_NAME,
 )
 
 #
@@ -73,6 +73,12 @@ NUMBER_OF_ALLOCATIONS_IN_TESTS = 50  # TODO: Move to constants
 TESTERCHAIN_CHAIN_ID = 131277322940537
 
 TESTERCHAIN_CHAIN_INFO = ChainInfo(131277322940537, "eth-tester")
+
+TEMPORARY_DOMAIN = TACoDomain(
+    name=TEMPORARY_DOMAIN_NAME,
+    eth_chain=TESTERCHAIN_CHAIN_INFO,
+    polygon_chain=TESTERCHAIN_CHAIN_INFO,
+)
 
 
 #

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -11,7 +11,8 @@ from nucypher.blockchain.eth.domains import ChainInfo, TACoDomain
 from nucypher.blockchain.eth.token import NU
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
-    NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD, TEMPORARY_DOMAIN_NAME,
+    NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD,
+    TEMPORARY_DOMAIN_NAME,
 )
 
 #

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,24 +1,24 @@
 import contextlib
 import json
+import maya
 import os
+import pytest
 import shutil
 import tempfile
-from datetime import timedelta
-from functools import partial
-from pathlib import Path
-from typing import Tuple
-
-import maya
-import pytest
 from click.testing import CliRunner
+from datetime import timedelta
 from eth_account import Account
 from eth_utils import to_checksum_address
+from functools import partial
 from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Keypair, Validator
+from pathlib import Path
 from twisted.internet.task import Clock
+from typing import Tuple
 from web3 import Web3
 
 import tests
 from nucypher.blockchain.eth.actors import Operator
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.signers.software import KeystoreSigner
 from nucypher.blockchain.eth.trackers.dkg import EventScannerTask
@@ -305,6 +305,15 @@ def lonely_ursula_maker(ursula_test_config, testerchain):
 #
 # Blockchain
 #
+
+@pytest.fixture(scope='session')
+def temporary_domain():
+    _domain = TACoDomain(
+        name=TEMPORARY_DOMAIN_NAME,
+        eth_chain=TESTERCHAIN_CHAIN_INFO,
+        polygon_chain=TESTERCHAIN_CHAIN_INFO,
+    )
+    return _domain
 
 
 @pytest.fixture(scope="module")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -18,7 +18,6 @@ from web3 import Web3
 
 import tests
 from nucypher.blockchain.eth.actors import Operator
-from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.signers.software import KeystoreSigner
 from nucypher.blockchain.eth.trackers.dkg import EventScannerTask
@@ -50,8 +49,7 @@ from tests.constants import (
     MOCK_CUSTOM_INSTALLATION_PATH_2,
     MOCK_ETH_PROVIDER_URI,
     TEST_ETH_PROVIDER_URI,
-    TESTERCHAIN_CHAIN_ID, TESTERCHAIN_CHAIN_INFO,
-)
+    TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN, )
 from tests.mock.interfaces import MockBlockchain
 from tests.mock.performance_mocks import (
     mock_cert_generation,
@@ -306,15 +304,6 @@ def lonely_ursula_maker(ursula_test_config, testerchain):
 # Blockchain
 #
 
-@pytest.fixture(scope='session')
-def temporary_domain():
-    _domain = TACoDomain(
-        name=TEMPORARY_DOMAIN_NAME,
-        eth_chain=TESTERCHAIN_CHAIN_INFO,
-        polygon_chain=TESTERCHAIN_CHAIN_INFO,
-    )
-    return _domain
-
 
 @pytest.fixture(scope="module")
 def mock_registry_sources(module_mocker):
@@ -547,9 +536,9 @@ def worker_configuration_file_location(custom_filepath) -> Path:
 
 
 @pytest.fixture(autouse=True)
-def mock_teacher_nodes(mocker, temporary_domain):
+def mock_teacher_nodes(mocker):
     mock_nodes = tuple(u.rest_url() for u in MOCK_KNOWN_URSULAS_CACHE.values())[0:2]
-    mocker.patch.dict(TEACHER_NODES, {temporary_domain: mock_nodes}, clear=True)
+    mocker.patch.dict(TEACHER_NODES, {TEMPORARY_DOMAIN: mock_nodes}, clear=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,19 +1,20 @@
 import contextlib
 import json
-import maya
 import os
-import pytest
 import shutil
 import tempfile
-from click.testing import CliRunner
 from datetime import timedelta
+from functools import partial
+from pathlib import Path
+from typing import Tuple
+
+import maya
+import pytest
+from click.testing import CliRunner
 from eth_account import Account
 from eth_utils import to_checksum_address
-from functools import partial
 from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Keypair, Validator
-from pathlib import Path
 from twisted.internet.task import Clock
-from typing import Tuple
 from web3 import Web3
 
 import tests
@@ -48,8 +49,10 @@ from tests.constants import (
     MOCK_CUSTOM_INSTALLATION_PATH,
     MOCK_CUSTOM_INSTALLATION_PATH_2,
     MOCK_ETH_PROVIDER_URI,
+    TEMPORARY_DOMAIN,
     TEST_ETH_PROVIDER_URI,
-    TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN, )
+    TESTERCHAIN_CHAIN_ID,
+)
 from tests.mock.interfaces import MockBlockchain
 from tests.mock.performance_mocks import (
     mock_cert_generation,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -28,7 +28,7 @@ from nucypher.config.characters import (
     BobConfiguration,
     UrsulaConfiguration,
 )
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.ferveo import dkg
 from nucypher.crypto.keystore import Keystore
 from nucypher.network.nodes import TEACHER_NODES
@@ -50,7 +50,7 @@ from tests.constants import (
     MOCK_CUSTOM_INSTALLATION_PATH_2,
     MOCK_ETH_PROVIDER_URI,
     TEST_ETH_PROVIDER_URI,
-    TESTERCHAIN_CHAIN_ID,
+    TESTERCHAIN_CHAIN_ID, TESTERCHAIN_CHAIN_INFO,
 )
 from tests.mock.interfaces import MockBlockchain
 from tests.mock.performance_mocks import (
@@ -336,7 +336,7 @@ def light_ursula(temp_dir_path, random_account, mocker):
         KeystoreSigner, "_KeystoreSigner__get_signer", return_value=random_account
     )
     pre_payment_method = SubscriptionManagerPayment(
-        blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN
+        blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN_NAME
     )
 
     mocker.patch.object(
@@ -346,7 +346,7 @@ def light_ursula(temp_dir_path, random_account, mocker):
     ursula = Ursula(
         rest_host=LOOPBACK_ADDRESS,
         rest_port=select_test_port(),
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         pre_payment_method=pre_payment_method,
         checksum_address=random_account.address,
         operator_address=random_account.address,
@@ -449,7 +449,7 @@ def highperf_mocked_alice(
 ):
     config = AliceConfiguration(
         dev_mode=True,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=TEST_ETH_PROVIDER_URI,
         checksum_address=testerchain.alice_account,
         network_middleware=MockRestMiddlewareForLargeFleetTests(
@@ -472,7 +472,7 @@ def highperf_mocked_bob(fleet_of_highperf_mocked_ursulas):
     config = BobConfiguration(
         dev_mode=True,
         eth_endpoint=TEST_ETH_PROVIDER_URI,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         network_middleware=MockRestMiddlewareForLargeFleetTests(
             eth_endpoint=TEST_ETH_PROVIDER_URI
         ),
@@ -510,7 +510,7 @@ def click_runner():
 def nominal_configuration_fields():
     config = UrsulaConfiguration(
         dev_mode=True,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=TEST_ETH_PROVIDER_URI,
     )
     config_fields = config.static_payload()
@@ -549,7 +549,7 @@ def worker_configuration_file_location(custom_filepath) -> Path:
 @pytest.fixture(autouse=True)
 def mock_teacher_nodes(mocker):
     mock_nodes = tuple(u.rest_url() for u in MOCK_KNOWN_URSULAS_CACHE.values())[0:2]
-    mocker.patch.dict(TEACHER_NODES, {TEMPORARY_DOMAIN: mock_nodes}, clear=True)
+    mocker.patch.dict(TEACHER_NODES, {TEMPORARY_DOMAIN_NAME: mock_nodes}, clear=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -547,9 +547,9 @@ def worker_configuration_file_location(custom_filepath) -> Path:
 
 
 @pytest.fixture(autouse=True)
-def mock_teacher_nodes(mocker):
+def mock_teacher_nodes(mocker, temporary_domain):
     mock_nodes = tuple(u.rest_url() for u in MOCK_KNOWN_URSULAS_CACHE.values())[0:2]
-    mocker.patch.dict(TEACHER_NODES, {TEMPORARY_DOMAIN_NAME: mock_nodes}, clear=True)
+    mocker.patch.dict(TEACHER_NODES, {temporary_domain: mock_nodes}, clear=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/integration/characters/test_bob_joins_policy_and_retrieves.py
@@ -7,7 +7,7 @@ import pytest
 from twisted.internet.task import Clock
 
 from nucypher.characters.lawful import Bob, Enrico
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from tests.constants import (
     MOCK_ETH_PROVIDER_URI,
     NUMBER_OF_URSULAS_IN_DEVELOPMENT_DOMAIN,
@@ -47,7 +47,7 @@ def test_bob_retrieves(alice, ursulas, certificates_tempdir):
 
     # Bob becomes
     bob = Bob(
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         start_learning_now=True,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         network_middleware=MockRestMiddleware(eth_endpoint=MOCK_ETH_PROVIDER_URI),

--- a/tests/integration/characters/test_dkg_and_testnet_bypass.py
+++ b/tests/integration/characters/test_dkg_and_testnet_bypass.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.chaotic import (
     NiceGuyEddie,
@@ -23,7 +23,7 @@ def _attempt_decryption(BobClass, plaintext, testerchain):
     enrico = NiceGuyEddie(encrypting_key=trinket, signer=signer)
     bob = BobClass(
         registry=MOCK_REGISTRY_FILEPATH,
-        domain=TACoDomain.LYNX.name,
+        domain=domains.LYNX,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
     )
 

--- a/tests/integration/characters/test_ursula_startup.py
+++ b/tests/integration/characters/test_ursula_startup.py
@@ -1,11 +1,11 @@
 import pytest
 
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 
 
 def test_new_ursula_announces_herself(lonely_ursula_maker):
     ursula_in_a_house, ursula_with_a_mouse = lonely_ursula_maker(
-        quantity=2, domain=TEMPORARY_DOMAIN
+        quantity=2, domain=TEMPORARY_DOMAIN_NAME
     )
 
     # Neither Ursula knows about the other.
@@ -38,7 +38,7 @@ def test_goerli_and_mumbai_as_conditions_providers(lonely_ursula_maker):
     with pytest.raises(NotImplementedError):
         _ursula_who_tries_to_connect_to_an_invalid_chain = lonely_ursula_maker(
             quantity=1,
-            domain=TEMPORARY_DOMAIN,
+            domain=TEMPORARY_DOMAIN_NAME,
             condition_blockchain_endpoints={
                 INVALID_CHAIN_ID: "this is a provider URI, but it doesn't matter what we pass here because the chain_id is invalid."
             },

--- a/tests/integration/cli/actions/test_config_actions.py
+++ b/tests/integration/cli/actions/test_config_actions.py
@@ -21,7 +21,7 @@ from nucypher.cli.literature import (
     SUCCESSFUL_UPDATE_CONFIGURATION_VALUES,
 )
 from nucypher.config.base import CharacterConfiguration
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from tests.constants import YES
 
 BAD_CONFIG_FILE_CONTENTS = (
@@ -80,7 +80,7 @@ def test_forget_cli_action(alice_test_config, test_emitter, mock_stdin, mocker, 
 
 def test_update_configuration_cli_action(config, test_emitter, capsys):
     config_class, config_file = config.__class__, config.filepath
-    updates = dict(domain=TEMPORARY_DOMAIN)
+    updates = dict(domain=TEMPORARY_DOMAIN_NAME)
     get_or_update_configuration(emitter=test_emitter, config_class=config_class, filepath=config_file, updates=updates)
     config.update.assert_called_once_with(**updates)
     configure.handle_invalid_configuration_file.assert_not_called()
@@ -94,7 +94,7 @@ def test_handle_update_missing_configuration_file_cli_action(config,
                                                              mocker):
     config_class, config_file = config.__class__, config.filepath
     mocker.patch.object(config_class, '_read_configuration_file', side_effect=FileNotFoundError)
-    updates = dict(domain=TEMPORARY_DOMAIN)
+    updates = dict(domain=TEMPORARY_DOMAIN_NAME)
     with pytest.raises(click.FileError):
         get_or_update_configuration(emitter=test_emitter,
                                     config_class=config_class,
@@ -112,7 +112,7 @@ def test_handle_update_invalid_configuration_file_cli_action(config,
     config_class = config.__class__
     config_file = config.filepath
     mocker.patch.object(config_class, '_read_configuration_file', side_effect=config_class.ConfigurationError)
-    updates = dict(domain=TEMPORARY_DOMAIN)
+    updates = dict(domain=TEMPORARY_DOMAIN_NAME)
     with pytest.raises(config_class.ConfigurationError):
         get_or_update_configuration(emitter=test_emitter,
                                     config_class=config_class,

--- a/tests/integration/cli/actions/test_select_client_account.py
+++ b/tests/integration/cli/actions/test_select_client_account.py
@@ -30,6 +30,7 @@ def test_select_client_account(
         emitter=test_emitter,
         signer=Web3Signer(testerchain.client),
         polygon_endpoint=MOCK_ETH_PROVIDER_URI,
+        domain=TEMPORARY_DOMAIN_NAME,
     )
     assert selected_account, "Account selection returned Falsy instead of an address"
     assert isinstance(selected_account, str), "Selection is not a str"
@@ -55,6 +56,7 @@ def test_select_client_account_with_no_accounts(
             emitter=test_emitter,
             signer=Web3Signer(testerchain.client),
             polygon_endpoint=MOCK_ETH_PROVIDER_URI,
+            domain=TEMPORARY_DOMAIN_NAME,
         )
     captured = capsys.readouterr()
     assert NO_ACCOUNTS in captured.out
@@ -95,7 +97,9 @@ def test_select_client_account_valid_sources(
         KeystoreSigner, "from_signer_uri", return_value=Web3Signer(testerchain.client)
     )
     selected_account = select_client_account(
-        emitter=test_emitter, signer_uri=MOCK_SIGNER_URI
+        domain=TEMPORARY_DOMAIN_NAME,
+        emitter=test_emitter,
+        signer_uri=MOCK_SIGNER_URI,
     )
     expected_account = testerchain.client.accounts[selection]
     assert selected_account == expected_account
@@ -111,7 +115,9 @@ def test_select_client_account_valid_sources(
     mock_stdin.line(str(selection))
     expected_account = testerchain.client.accounts[selection]
     selected_account = select_client_account(
-        emitter=test_emitter, signer=Web3Signer(testerchain.client)
+        domain=TEMPORARY_DOMAIN_NAME,
+        emitter=test_emitter,
+        signer=Web3Signer(testerchain.client),
     )
     assert selected_account == expected_account
     assert mock_stdin.empty()
@@ -125,7 +131,9 @@ def test_select_client_account_valid_sources(
     mock_stdin.line(str(selection))
     expected_account = testerchain.client.accounts[selection]
     selected_account = select_client_account(
-        emitter=test_emitter, polygon_endpoint=MOCK_ETH_PROVIDER_URI
+        domain=TEMPORARY_DOMAIN_NAME,
+        emitter=test_emitter,
+        polygon_endpoint=MOCK_ETH_PROVIDER_URI,
     )
     assert selected_account == expected_account
     assert mock_stdin.empty()
@@ -145,7 +153,9 @@ def test_select_client_account_valid_sources(
         BlockchainInterfaceFactory, "get_interface", return_value=testerchain
     )
     selected_account = select_client_account(
-        emitter=test_emitter, polygon_endpoint=MOCK_ETH_PROVIDER_URI
+        domain=TEMPORARY_DOMAIN_NAME,
+        emitter=test_emitter,
+        polygon_endpoint=MOCK_ETH_PROVIDER_URI,
     )
     assert selected_account == expected_account
     assert mock_stdin.empty()

--- a/tests/integration/cli/actions/test_select_client_account.py
+++ b/tests/integration/cli/actions/test_select_client_account.py
@@ -11,7 +11,7 @@ from nucypher.blockchain.eth.signers import KeystoreSigner
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.cli.actions.select import select_client_account
 from nucypher.cli.literature import GENERIC_SELECT_ACCOUNT, NO_ACCOUNTS
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from tests.constants import (
     MOCK_ETH_PROVIDER_URI,
     MOCK_SIGNER_URI,
@@ -183,7 +183,7 @@ def test_select_client_account_with_balance_display(
     mock_stdin.line(str(selection))
     selected_account = select_client_account(
         emitter=test_emitter,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         show_matic_balance=show_matic,
         polygon_endpoint=MOCK_ETH_PROVIDER_URI,
     )

--- a/tests/integration/cli/actions/test_select_network.py
+++ b/tests/integration/cli/actions/test_select_network.py
@@ -1,9 +1,9 @@
 import pytest
 
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.cli.actions.select import select_domain
 
-__DOMAINS = TACoDomain.SUPPORTED_DOMAIN_NAMES
+__DOMAINS = domains.SUPPORTED_DOMAIN_NAMES
 
 
 @pytest.mark.parametrize("user_input", range(0, len(__DOMAINS) - 1))

--- a/tests/integration/cli/actions/test_select_network.py
+++ b/tests/integration/cli/actions/test_select_network.py
@@ -3,7 +3,7 @@ import pytest
 from nucypher.blockchain.eth import domains
 from nucypher.cli.actions.select import select_domain
 
-__DOMAINS = domains.SUPPORTED_DOMAIN_NAMES
+__DOMAINS = list(domains.SUPPORTED_DOMAINS)
 
 
 @pytest.mark.parametrize("user_input", range(0, len(__DOMAINS) - 1))

--- a/tests/integration/cli/test_cli_config.py
+++ b/tests/integration/cli/test_cli_config.py
@@ -8,7 +8,7 @@ from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
-    TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN_NAME,
 )
 from tests.constants import (
     FAKE_PASSWORD_CONFIRMED,
@@ -41,7 +41,7 @@ def test_initialize_via_cli(
         command,
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--eth-endpoint",
         MOCK_ETH_PROVIDER_URI,
         "--polygon-endpoint",

--- a/tests/integration/cli/test_mixed_config.py
+++ b/tests/integration/cli/test_mixed_config.py
@@ -8,7 +8,7 @@ from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
-    TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN_NAME,
 )
 from nucypher.crypto.keystore import InvalidPassword
 from tests.constants import (
@@ -69,7 +69,7 @@ def test_corrupted_configuration(
         "--operator-address",
         another_ursula,
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--rest-host",
         MOCK_IP_ADDRESS,
         "--config-root",
@@ -104,7 +104,7 @@ def test_corrupted_configuration(
         "ursula",
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--eth-endpoint",
         MOCK_ETH_PROVIDER_URI,
         "--polygon-endpoint",

--- a/tests/integration/cli/test_ursula_cli_ip_detection.py
+++ b/tests/integration/cli/test_ursula_cli_ip_detection.py
@@ -5,7 +5,7 @@ from nucypher.blockchain.eth.trackers.dkg import ActiveRitualTracker
 from nucypher.cli.commands import ursula
 from nucypher.cli.main import nucypher_cli
 from nucypher.config.characters import UrsulaConfiguration
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.utilities.networking import UnknownIPAddress
 from tests.constants import (
     FAKE_PASSWORD_CONFIRMED,
@@ -35,7 +35,7 @@ def test_ursula_startup_ip_checkup(click_runner, mocker):
         "ursula",
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--eth-endpoint",
         MOCK_ETH_PROVIDER_URI,
         "--polygon-endpoint",
@@ -53,7 +53,7 @@ def test_ursula_startup_ip_checkup(click_runner, mocker):
         "ursula",
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--force",
         "--eth-endpoint",
         MOCK_ETH_PROVIDER_URI,
@@ -71,7 +71,7 @@ def test_ursula_startup_ip_checkup(click_runner, mocker):
         "ursula",
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--force",
         "--eth-endpoint",
         MOCK_ETH_PROVIDER_URI,

--- a/tests/integration/cli/test_ursula_config_cli.py
+++ b/tests/integration/cli/test_ursula_config_cli.py
@@ -20,7 +20,7 @@ from nucypher.config.constants import (
     APP_DIR,
     DEFAULT_CONFIG_ROOT,
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
-    TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN_NAME,
 )
 from nucypher.crypto.keystore import Keystore
 from tests.constants import (
@@ -59,7 +59,7 @@ def test_interactive_initialize_ursula(click_runner, mocker, tmpdir):
         "ursula",
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--eth-endpoint",
         MOCK_ETH_PROVIDER_URI,
         "--polygon-endpoint",
@@ -92,7 +92,7 @@ def test_initialize_custom_configuration_root(
         "ursula",
         "init",
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--config-root",
         str(custom_filepath.absolute()),
         "--rest-host",

--- a/tests/integration/cli/test_ursula_local_keystore_cli_functionality.py
+++ b/tests/integration/cli/test_ursula_local_keystore_cli_functionality.py
@@ -11,7 +11,7 @@ from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_KEYSTORE_PASSWORD,
     NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD,
-    TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN_NAME,
 )
 from tests.constants import MOCK_IP_ADDRESS
 from tests.utils.ursula import select_test_port
@@ -49,7 +49,7 @@ def test_ursula_init_with_local_keystore_signer(
         "init",
         # Layer 1
         "--domain",
-        TEMPORARY_DOMAIN,
+        TEMPORARY_DOMAIN_NAME,
         "--eth-endpoint",
         testerchain.endpoint,
         # Layer 2

--- a/tests/integration/config/test_character_configuration.py
+++ b/tests/integration/config/test_character_configuration.py
@@ -74,7 +74,7 @@ def test_development_character_configurations(
     assert len(thing_one.checksum_address) == 42
 
     # Domain
-    assert TEMPORARY_DOMAIN_NAME == thing_one.domain
+    assert TEMPORARY_DOMAIN_NAME == str(thing_one.domain)
 
     # Node Storage
     assert isinstance(thing_one.node_storage, ForgetfulNodeStorage)

--- a/tests/integration/config/test_character_configuration.py
+++ b/tests/integration/config/test_character_configuration.py
@@ -14,7 +14,7 @@ from nucypher.config.characters import (
     BobConfiguration,
     UrsulaConfiguration,
 )
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.config.storages import ForgetfulNodeStorage
 from nucypher.crypto.keystore import Keystore
 from tests.constants import (
@@ -47,7 +47,7 @@ def test_development_character_configurations(
     params = dict(
         dev_mode=True,
         lonely=True,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         checksum_address=testerchain.unassigned_accounts[0],
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         polygon_endpoint=MOCK_ETH_PROVIDER_URI,
@@ -74,7 +74,7 @@ def test_development_character_configurations(
     assert len(thing_one.checksum_address) == 42
 
     # Domain
-    assert TEMPORARY_DOMAIN == thing_one.domain
+    assert TEMPORARY_DOMAIN_NAME == thing_one.domain
 
     # Node Storage
     assert isinstance(thing_one.node_storage, ForgetfulNodeStorage)
@@ -101,7 +101,7 @@ def test_default_character_configuration_preservation(
 ):
     configuration_class.DEFAULT_CONFIG_ROOT = Path("/tmp")
     fake_address = "0xdeadbeef"
-    domain = TEMPORARY_DOMAIN
+    domain = TEMPORARY_DOMAIN_NAME
 
     expected_filename = (
         f"{configuration_class.NAME}.{configuration_class._CONFIG_FILE_EXTENSION}"
@@ -170,7 +170,7 @@ def test_ursula_development_configuration(testerchain):
         dev_mode=True,
         checksum_address=testerchain.unassigned_accounts[0],
         operator_address=testerchain.unassigned_accounts[1],
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         polygon_endpoint=MOCK_ETH_PROVIDER_URI,
     )

--- a/tests/integration/config/test_configuration_persistence.py
+++ b/tests/integration/config/test_configuration_persistence.py
@@ -4,7 +4,7 @@ import maya
 
 from nucypher.characters.lawful import Bob
 from nucypher.config.characters import AliceConfiguration
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import DecryptingPower, SigningPower
 from tests.constants import INSECURE_DEVELOPMENT_PASSWORD, MOCK_ETH_PROVIDER_URI
 from tests.utils.middleware import MockRestMiddleware
@@ -17,7 +17,7 @@ def test_alices_powers_are_persistent(ursulas, temp_dir_path, testerchain):
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         config_root=config_root,
         network_middleware=MockRestMiddleware(eth_endpoint=MOCK_ETH_PROVIDER_URI),
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         checksum_address=testerchain.alice_account,
         start_learning_now=False,
         save_metadata=False,
@@ -55,7 +55,7 @@ def test_alices_powers_are_persistent(ursulas, temp_dir_path, testerchain):
 
     bob = Bob(
         start_learning_now=False,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         network_middleware=MockRestMiddleware(eth_endpoint=MOCK_ETH_PROVIDER_URI),
     )
@@ -96,7 +96,7 @@ def test_alices_powers_are_persistent(ursulas, temp_dir_path, testerchain):
 
     # Bob's eldest brother, Roberto, appears too
     roberto = Bob(
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         start_learning_now=False,
         network_middleware=MockRestMiddleware(eth_endpoint=MOCK_ETH_PROVIDER_URI),

--- a/tests/integration/config/test_keystore_integration.py
+++ b/tests/integration/config/test_keystore_integration.py
@@ -12,7 +12,7 @@ from nucypher_core.umbral import SecretKey, Signer
 
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Alice, Bob, Enrico, Ursula
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.ferveo.dkg import FerveoVariant
 from nucypher.crypto.keystore import Keystore
 from nucypher.crypto.powers import (
@@ -74,13 +74,13 @@ def test_characters_use_keystore(temp_dir_path, testerchain):
     keystore.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     pre_payment_method = SubscriptionManagerPayment(
-        blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN
+        blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN_NAME
     )
 
     alice = Alice(
         start_learning_now=False,
         keystore=keystore,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         polygon_endpoint=MOCK_ETH_PROVIDER_URI,
         checksum_address=testerchain.alice_account,
@@ -90,7 +90,7 @@ def test_characters_use_keystore(temp_dir_path, testerchain):
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
         start_learning_now=False,
         keystore=keystore,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
     )
     Ursula(
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
@@ -99,7 +99,7 @@ def test_characters_use_keystore(temp_dir_path, testerchain):
         keystore=keystore,
         rest_host=LOOPBACK_ADDRESS,
         rest_port=12345,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         pre_payment_method=pre_payment_method,
         operator_address=testerchain.ursulas_accounts[0],
         signer=Web3Signer(testerchain.client),
@@ -122,7 +122,7 @@ def test_tls_hosting_certificate_remains_the_same(temp_dir_path, mocker):
         keystore=keystore,
         rest_host=LOOPBACK_ADDRESS,
         rest_port=rest_port,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
     )
 
     assert ursula.keystore is keystore
@@ -138,7 +138,7 @@ def test_tls_hosting_certificate_remains_the_same(temp_dir_path, mocker):
         keystore=keystore,
         rest_host=LOOPBACK_ADDRESS,
         rest_port=rest_port,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
     )
 
     assert recreated_ursula.keystore is keystore
@@ -160,7 +160,7 @@ def test_ritualist(temp_dir_path, testerchain, dkg_public_key):
     keystore.unlock(password=INSECURE_DEVELOPMENT_PASSWORD)
 
     pre_payment_method = SubscriptionManagerPayment(
-        blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN
+        blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN_NAME
     )
 
     ursula = Ursula(
@@ -168,7 +168,7 @@ def test_ritualist(temp_dir_path, testerchain, dkg_public_key):
         keystore=keystore,
         rest_host=LOOPBACK_ADDRESS,
         rest_port=12345,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         pre_payment_method=pre_payment_method,
         operator_address=testerchain.ursulas_accounts[0],
         signer=Web3Signer(testerchain.client),

--- a/tests/integration/config/test_storages.py
+++ b/tests/integration/config/test_storages.py
@@ -2,7 +2,7 @@ import pytest
 
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Ursula
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.config.storages import ForgetfulNodeStorage, TemporaryFileBasedNodeStorage
 from nucypher.policy.payment import SubscriptionManagerPayment
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
@@ -35,7 +35,7 @@ class BaseTestNodeStorageBackends:
         assert ursula == node_from_storage, "Node storage {} failed".format(node_storage)
 
         pre_payment_method = SubscriptionManagerPayment(
-            blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN
+            blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN_NAME
         )
 
         # Save more nodes
@@ -44,7 +44,7 @@ class BaseTestNodeStorageBackends:
             node = Ursula(
                 rest_host=LOOPBACK_ADDRESS,
                 rest_port=select_test_port(),
-                domain=TEMPORARY_DOMAIN,
+                domain=TEMPORARY_DOMAIN_NAME,
                 signer=signer,
                 eth_endpoint=MOCK_ETH_PROVIDER_URI,
                 polygon_endpoint=MOCK_ETH_PROVIDER_URI,

--- a/tests/integration/config/test_storages.py
+++ b/tests/integration/config/test_storages.py
@@ -6,7 +6,7 @@ from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.config.storages import ForgetfulNodeStorage, TemporaryFileBasedNodeStorage
 from nucypher.policy.payment import SubscriptionManagerPayment
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
-from tests.constants import MOCK_ETH_PROVIDER_URI
+from tests.constants import MOCK_ETH_PROVIDER_URI, TESTERCHAIN_CHAIN_ID
 from tests.utils.ursula import select_test_port
 
 ADDITIONAL_NODES_TO_LEARN_ABOUT = 10

--- a/tests/integration/config/test_storages.py
+++ b/tests/integration/config/test_storages.py
@@ -6,7 +6,7 @@ from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.config.storages import ForgetfulNodeStorage, TemporaryFileBasedNodeStorage
 from nucypher.policy.payment import SubscriptionManagerPayment
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
-from tests.constants import MOCK_ETH_PROVIDER_URI, TESTERCHAIN_CHAIN_ID
+from tests.constants import MOCK_ETH_PROVIDER_URI
 from tests.utils.ursula import select_test_port
 
 ADDITIONAL_NODES_TO_LEARN_ABOUT = 10

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,7 @@ from tests.constants import (
     KEYFILE_NAME_TEMPLATE,
     MOCK_KEYSTORE_PATH,
     NUMBER_OF_MOCK_KEYSTORE_ACCOUNTS,
-    TESTERCHAIN_CHAIN_ID,
+    TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN,
 )
 from tests.mock.interfaces import MockBlockchain
 from tests.mock.io import MockStdinWrapper
@@ -129,9 +129,9 @@ def mock_interface(module_mocker):
 
 
 @pytest.fixture(scope='module')
-def test_registry(module_mocker, temporary_domain):
+def test_registry(module_mocker):
     with mock_registry_sources(mocker=module_mocker):
-        mock_source = MockRegistrySource(domain=temporary_domain)
+        mock_source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
         registry = ContractRegistry(source=mock_source)
         yield registry
 
@@ -276,7 +276,7 @@ def monkeypatch_get_staking_provider_from_operator(monkeymodule):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker, temporary_domain):
+def mock_condition_blockchains(module_mocker):
     """adds testerchain's chain ID to permitted conditional chains"""
     module_mocker.patch.dict(
         "nucypher.policy.conditions.evm._CONDITION_CHAINS",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,9 @@
 import os
-import pytest
-from eth_account.account import Account
 from pathlib import Path
 from typing import Iterable, Optional
+
+import pytest
+from eth_account.account import Account
 
 from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import (
@@ -31,7 +32,8 @@ from tests.constants import (
     KEYFILE_NAME_TEMPLATE,
     MOCK_KEYSTORE_PATH,
     NUMBER_OF_MOCK_KEYSTORE_ACCOUNTS,
-    TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN,
+    TEMPORARY_DOMAIN,
+    TESTERCHAIN_CHAIN_ID,
 )
 from tests.mock.interfaces import MockBlockchain
 from tests.mock.io import MockStdinWrapper

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,6 @@ from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.types import ChecksumAddress
 from nucypher.config.characters import UrsulaConfiguration
-from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Teacher
 from tests.constants import (
@@ -284,10 +283,6 @@ def mock_condition_blockchains(module_mocker, temporary_domain):
         {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
     )
 
-    module_mocker.patch(
-        "nucypher.blockchain.eth.domains.get_domain",
-        return_value=temporary_domain
-    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -25,7 +25,7 @@ from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Ursula
 from nucypher.cli.types import ChecksumAddress
 from nucypher.config.characters import UrsulaConfiguration
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Teacher
 from tests.constants import (
@@ -130,9 +130,9 @@ def mock_interface(module_mocker):
 
 
 @pytest.fixture(scope='module')
-def test_registry(module_mocker):
+def test_registry(module_mocker, temporary_domain):
     with mock_registry_sources(mocker=module_mocker):
-        mock_source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
+        mock_source = MockRegistrySource(domain=temporary_domain)
         registry = ContractRegistry(source=mock_source)
         yield registry
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,8 @@
 import os
-from pathlib import Path
-from typing import Iterable, Optional
-
 import pytest
 from eth_account.account import Account
+from pathlib import Path
+from typing import Iterable, Optional
 
 from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import (
@@ -14,10 +13,6 @@ from nucypher.blockchain.eth.agents import (
     TACoChildApplicationAgent,
 )
 from nucypher.blockchain.eth.clients import EthereumClient
-from nucypher.blockchain.eth.domains import (
-    DomainInfo,
-    TACoDomain,
-)
 from nucypher.blockchain.eth.interfaces import (
     BlockchainInterface,
     BlockchainInterfaceFactory,
@@ -38,7 +33,6 @@ from tests.constants import (
     MOCK_KEYSTORE_PATH,
     NUMBER_OF_MOCK_KEYSTORE_ACCOUNTS,
     TESTERCHAIN_CHAIN_ID,
-    TESTERCHAIN_CHAIN_INFO,
 )
 from tests.mock.interfaces import MockBlockchain
 from tests.mock.io import MockStdinWrapper
@@ -283,19 +277,16 @@ def monkeypatch_get_staking_provider_from_operator(monkeymodule):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker):
+def mock_condition_blockchains(module_mocker, temporary_domain):
     """adds testerchain's chain ID to permitted conditional chains"""
     module_mocker.patch.dict(
         "nucypher.policy.conditions.evm._CONDITION_CHAINS",
         {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
     )
 
-    test_domain_info = DomainInfo(
-        TEMPORARY_DOMAIN, TESTERCHAIN_CHAIN_INFO, TESTERCHAIN_CHAIN_INFO
-    )
-
-    module_mocker.patch.object(
-        TACoDomain, "get_domain_info", return_value=test_domain_info
+    module_mocker.patch(
+        "nucypher.blockchain.eth.domains.get_domain",
+        return_value=temporary_domain
     )
 
 

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -1,5 +1,6 @@
-import pytest
 from pathlib import Path
+
+import pytest
 
 import tests
 from nucypher.acumen.perception import FleetSensor
@@ -8,7 +9,7 @@ from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.characters.lawful import Ursula
 from nucypher.config.storages import LocalFileBasedNodeStorage
 from nucypher.network.nodes import TEACHER_NODES
-from tests.constants import TESTERCHAIN_CHAIN_INFO, TEMPORARY_DOMAIN
+from tests.constants import TEMPORARY_DOMAIN, TESTERCHAIN_CHAIN_INFO
 from tests.utils.registry import MockRegistrySource
 from tests.utils.ursula import make_ursulas
 
@@ -29,7 +30,6 @@ def domain_2():
         eth_chain=TESTERCHAIN_CHAIN_INFO,
         polygon_chain=TESTERCHAIN_CHAIN_INFO,
     )
-
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -8,7 +8,7 @@ from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.characters.lawful import Ursula
 from nucypher.config.storages import LocalFileBasedNodeStorage
 from nucypher.network.nodes import TEACHER_NODES
-from tests.constants import TESTERCHAIN_CHAIN_INFO
+from tests.constants import TESTERCHAIN_CHAIN_INFO, TEMPORARY_DOMAIN
 from tests.utils.registry import MockRegistrySource
 from tests.utils.ursula import make_ursulas
 
@@ -33,9 +33,9 @@ def domain_2():
 
 
 @pytest.fixture(scope="module")
-def test_registry(module_mocker, domain_1, domain_2, temporary_domain):
+def test_registry(module_mocker, domain_1, domain_2):
     with tests.utils.registry.mock_registry_sources(
-        mocker=module_mocker, _domains=[domain_1, domain_2, temporary_domain]
+        mocker=module_mocker, _domains=[domain_1, domain_2, TEMPORARY_DOMAIN]
     ):
         # doesn't really matter what domain is used here
         registry = ContractRegistry(MockRegistrySource(domain=domain_1))

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -35,7 +35,7 @@ def domain_2():
 @pytest.fixture(scope="module")
 def test_registry(module_mocker, domain_1, domain_2, temporary_domain):
     with tests.utils.registry.mock_registry_sources(
-        mocker=module_mocker, domains=[domain_1, domain_2, temporary_domain]
+        mocker=module_mocker, _domains=[domain_1, domain_2, temporary_domain]
     ):
         # doesn't really matter what domain is used here
         registry = ContractRegistry(MockRegistrySource(domain=domain_1))

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -1,31 +1,41 @@
-from pathlib import Path
-
 import pytest
+from pathlib import Path
 
 import tests
 from nucypher.acumen.perception import FleetSensor
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.characters.lawful import Ursula
 from nucypher.config.storages import LocalFileBasedNodeStorage
 from nucypher.network.nodes import TEACHER_NODES
+from tests.constants import TESTERCHAIN_CHAIN_INFO
 from tests.utils.registry import MockRegistrySource
 from tests.utils.ursula import make_ursulas
 
 
 @pytest.fixture(scope="module")
 def domain_1():
-    return "domain_uno"
+    return TACoDomain(
+        name="domain_uno",
+        eth_chain=TESTERCHAIN_CHAIN_INFO,
+        polygon_chain=TESTERCHAIN_CHAIN_INFO,
+    )
 
 
 @pytest.fixture(scope="module")
 def domain_2():
-    return "domain_dos"
+    return TACoDomain(
+        name="domain_dos",
+        eth_chain=TESTERCHAIN_CHAIN_INFO,
+        polygon_chain=TESTERCHAIN_CHAIN_INFO,
+    )
+
 
 
 @pytest.fixture(scope="module")
-def test_registry(module_mocker, domain_1, domain_2):
+def test_registry(module_mocker, domain_1, domain_2, temporary_domain):
     with tests.utils.registry.mock_registry_sources(
-        mocker=module_mocker, domain_names=[domain_1, domain_2]
+        mocker=module_mocker, domains=[domain_1, domain_2, temporary_domain]
     ):
         # doesn't really matter what domain is used here
         registry = ContractRegistry(MockRegistrySource(domain=domain_1))

--- a/tests/integration/learning/test_firstula_circumstances.py
+++ b/tests/integration/learning/test_firstula_circumstances.py
@@ -3,17 +3,17 @@ from functools import partial
 import pytest_twisted as pt
 from twisted.internet.threads import deferToThread
 
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.network.middleware import RestMiddleware
 from tests.constants import MOCK_ETH_PROVIDER_URI
 
 
 def test_proper_seed_node_instantiation(lonely_ursula_maker):
     _lonely_ursula_maker = partial(lonely_ursula_maker, quantity=1)
-    firstula = _lonely_ursula_maker(domain=TEMPORARY_DOMAIN).pop()
+    firstula = _lonely_ursula_maker(domain=TEMPORARY_DOMAIN_NAME).pop()
     firstula_as_seed_node = firstula.seed_node_metadata()
     any_other_ursula = _lonely_ursula_maker(
-        seed_nodes=[firstula_as_seed_node], domain=TEMPORARY_DOMAIN
+        seed_nodes=[firstula_as_seed_node], domain=TEMPORARY_DOMAIN_NAME
     ).pop()
 
     assert not any_other_ursula.known_nodes

--- a/tests/integration/network/test_network_actors.py
+++ b/tests/integration/network/test_network_actors.py
@@ -5,7 +5,7 @@ from twisted.logger import LogLevel, globalLogPublisher
 from nucypher.acumen.nicknames import Nickname
 from nucypher.acumen.perception import FleetSensor
 from nucypher.characters.unlawful import Vladimir
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from tests.constants import MOCK_ETH_PROVIDER_URI
 from tests.utils.middleware import MockRestMiddleware
 
@@ -31,7 +31,7 @@ def test_all_ursulas_know_about_all_other_ursulas(ursulas, test_registry):
 
 def test_alice_finds_ursula_via_rest(alice, ursulas):
     # Imagine alice knows of nobody.
-    alice._Learner__known_nodes = FleetSensor(domain=TEMPORARY_DOMAIN)
+    alice._Learner__known_nodes = FleetSensor(domain=TEMPORARY_DOMAIN_NAME)
 
     alice.remember_node(ursulas[0])
     alice.learn_from_teacher_node()

--- a/tests/metrics/grant_availability.py
+++ b/tests/metrics/grant_availability.py
@@ -54,7 +54,7 @@ except KeyError:
     raise RuntimeError(message)
 
 # Alice Configuration
-TACO_DOMAIN: str = LYNX.name  # mainnet
+TACO_DOMAIN: str = str(LYNX)  # mainnet
 DEFAULT_SEEDNODE_URIS: List[str] = [
     *TEACHER_NODES[TACO_DOMAIN],
 ]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,7 @@ from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import ContractAgency
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.ferveo import dkg
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Teacher

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -9,6 +9,7 @@ from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.ferveo import dkg
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Teacher
+from tests.constants import TEMPORARY_DOMAIN
 from tests.mock.interfaces import MockBlockchain, MockEthereumClient
 from tests.utils.registry import MockRegistrySource, mock_registry_sources
 
@@ -19,9 +20,9 @@ def pytest_addhooks(pluginmanager):
 
 
 @pytest.fixture(scope='module')
-def test_registry(module_mocker, temporary_domain):
+def test_registry(module_mocker):
     with mock_registry_sources(mocker=module_mocker):
-        source = MockRegistrySource(domain=temporary_domain)
+        source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
         yield ContractRegistry(source=source)
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -17,10 +17,11 @@ def pytest_addhooks(pluginmanager):
     pluginmanager.set_blocked('ape_test')
 
 
+
 @pytest.fixture(scope='module')
-def test_registry(module_mocker):
+def test_registry(module_mocker, temporary_domain):
     with mock_registry_sources(mocker=module_mocker):
-        source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
+        source = MockRegistrySource(domain=temporary_domain)
         yield ContractRegistry(source=source)
 
 

--- a/tests/unit/registry/test_registry_basics.py
+++ b/tests/unit/registry/test_registry_basics.py
@@ -2,7 +2,7 @@ import pytest
 
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
-from tests.constants import TESTERCHAIN_CHAIN_ID
+from tests.constants import TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN
 from tests.utils.registry import MockRegistrySource
 
 
@@ -34,8 +34,8 @@ def data(record):
 
 
 @pytest.fixture(scope="function")
-def source(data, temporary_domain):
-    source = MockRegistrySource(domain=temporary_domain)
+def source(data):
+    source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
     source.data = data
     return source
 
@@ -77,9 +77,9 @@ def test_local_registry_unknown_contract_name_search(registry):
         )
 
 
-def test_local_contract_registry_ambiguous_search_terms(data, name, record, address, temporary_domain):
+def test_local_contract_registry_ambiguous_search_terms(data, name, record, address):
     data[TESTERCHAIN_CHAIN_ID]["fakeContract"] = record[name]
-    source = MockRegistrySource(domain=temporary_domain)
+    source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
     source.data = data
     registry = ContractRegistry(source=source)
     with pytest.raises(ContractRegistry.AmbiguousSearchTerms):

--- a/tests/unit/registry/test_registry_basics.py
+++ b/tests/unit/registry/test_registry_basics.py
@@ -1,7 +1,7 @@
 import pytest
 
 from nucypher.blockchain.eth.registry import ContractRegistry
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from tests.constants import TESTERCHAIN_CHAIN_ID
 from tests.utils.registry import MockRegistrySource
 

--- a/tests/unit/registry/test_registry_basics.py
+++ b/tests/unit/registry/test_registry_basics.py
@@ -34,8 +34,8 @@ def data(record):
 
 
 @pytest.fixture(scope="function")
-def source(data):
-    source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
+def source(data, temporary_domain):
+    source = MockRegistrySource(domain=temporary_domain)
     source.data = data
     return source
 
@@ -77,9 +77,9 @@ def test_local_registry_unknown_contract_name_search(registry):
         )
 
 
-def test_local_contract_registry_ambiguous_search_terms(data, name, record, address):
+def test_local_contract_registry_ambiguous_search_terms(data, name, record, address, temporary_domain):
     data[TESTERCHAIN_CHAIN_ID]["fakeContract"] = record[name]
-    source = MockRegistrySource(domain=TEMPORARY_DOMAIN)
+    source = MockRegistrySource(domain=temporary_domain)
     source.data = data
     registry = ContractRegistry(source=source)
     with pytest.raises(ContractRegistry.AmbiguousSearchTerms):

--- a/tests/unit/registry/test_registry_soures.py
+++ b/tests/unit/registry/test_registry_soures.py
@@ -11,7 +11,7 @@ from nucypher.blockchain.eth.registry import (
     RegistrySource,
     RegistrySourceManager,
 )
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 
 
 @pytest.fixture(scope="function")
@@ -46,34 +46,40 @@ def test_registry_filepath(tmpdir, registry_data):
 
 
 @pytest.mark.usefixtures("mock_200_response")
-def test_github_registry_source(registry_data):
-    source = GithubRegistrySource(domain=TEMPORARY_DOMAIN)
-    assert source.domain == TEMPORARY_DOMAIN
+def test_github_registry_source(registry_data, temporary_domain):
+    source = GithubRegistrySource(domain=temporary_domain)
+    assert source.domain.name == TEMPORARY_DOMAIN_NAME
+    assert str(source.domain) == TEMPORARY_DOMAIN_NAME
+    assert bytes(source.domain) == TEMPORARY_DOMAIN_NAME.encode("utf-8")
     data = source.get()
     assert data == registry_data
     assert source.data == registry_data
     assert data == source.data
 
 
-def test_local_registry_source(registry_data, test_registry_filepath):
+def test_local_registry_source(registry_data, test_registry_filepath, temporary_domain):
     source = LocalRegistrySource(
-        filepath=test_registry_filepath, domain=TEMPORARY_DOMAIN
+        filepath=test_registry_filepath, domain=temporary_domain
     )
-    assert source.domain == TEMPORARY_DOMAIN
+    assert source.domain.name == TEMPORARY_DOMAIN_NAME
+    assert str(source.domain) == TEMPORARY_DOMAIN_NAME
+    assert bytes(source.domain) == TEMPORARY_DOMAIN_NAME.encode("utf-8")
     data = source.get()
     assert data == registry_data
     assert source.data == registry_data
     assert data == source.data
 
 
-def test_embedded_registry_source(registry_data, test_registry_filepath, mocker):
+def test_embedded_registry_source(registry_data, test_registry_filepath, mocker, temporary_domain):
     mocker.patch.object(
         EmbeddedRegistrySource,
         "get_publication_endpoint",
         return_value=test_registry_filepath,
     )
-    source = EmbeddedRegistrySource(domain=TEMPORARY_DOMAIN)
-    assert source.domain == TEMPORARY_DOMAIN
+    source = EmbeddedRegistrySource(domain=temporary_domain)
+    assert source.domain.name == TEMPORARY_DOMAIN_NAME
+    assert str(source.domain) == TEMPORARY_DOMAIN_NAME
+    assert bytes(source.domain) == TEMPORARY_DOMAIN_NAME.encode("utf-8")
     data = source.get()
     assert data == registry_data
     assert source.data == registry_data
@@ -81,7 +87,7 @@ def test_embedded_registry_source(registry_data, test_registry_filepath, mocker)
 
 
 def test_registry_source_manager_fallback(
-    registry_data, test_registry_filepath, mocker
+    registry_data, test_registry_filepath, mocker, temporary_domain
 ):
     github_source_get = mocker.patch.object(
         GithubRegistrySource, "get", side_effect=RegistrySource.Unavailable
@@ -96,8 +102,10 @@ def test_registry_source_manager_fallback(
         GithubRegistrySource,
         EmbeddedRegistrySource,
     )
-    source_manager = RegistrySourceManager(domain=TEMPORARY_DOMAIN)
-    assert source_manager.domain == TEMPORARY_DOMAIN
+    source_manager = RegistrySourceManager(domain=temporary_domain)
+    assert source_manager.domain.name == TEMPORARY_DOMAIN_NAME
+    assert str(source_manager.domain) == TEMPORARY_DOMAIN_NAME
+    assert bytes(source_manager.domain) == TEMPORARY_DOMAIN_NAME.encode("utf-8")
 
     primary_sources = source_manager.get_primary_sources()
     assert len(primary_sources) == 1

--- a/tests/unit/registry/test_registry_soures.py
+++ b/tests/unit/registry/test_registry_soures.py
@@ -12,6 +12,7 @@ from nucypher.blockchain.eth.registry import (
     RegistrySourceManager,
 )
 from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
+from tests.constants import TEMPORARY_DOMAIN
 
 
 @pytest.fixture(scope="function")
@@ -46,8 +47,8 @@ def test_registry_filepath(tmpdir, registry_data):
 
 
 @pytest.mark.usefixtures("mock_200_response")
-def test_github_registry_source(registry_data, temporary_domain):
-    source = GithubRegistrySource(domain=temporary_domain)
+def test_github_registry_source(registry_data):
+    source = GithubRegistrySource(domain=TEMPORARY_DOMAIN)
     assert source.domain.name == TEMPORARY_DOMAIN_NAME
     assert str(source.domain) == TEMPORARY_DOMAIN_NAME
     assert bytes(source.domain) == TEMPORARY_DOMAIN_NAME.encode("utf-8")
@@ -57,9 +58,9 @@ def test_github_registry_source(registry_data, temporary_domain):
     assert data == source.data
 
 
-def test_local_registry_source(registry_data, test_registry_filepath, temporary_domain):
+def test_local_registry_source(registry_data, test_registry_filepath):
     source = LocalRegistrySource(
-        filepath=test_registry_filepath, domain=temporary_domain
+        filepath=test_registry_filepath, domain=TEMPORARY_DOMAIN
     )
     assert source.domain.name == TEMPORARY_DOMAIN_NAME
     assert str(source.domain) == TEMPORARY_DOMAIN_NAME
@@ -70,13 +71,13 @@ def test_local_registry_source(registry_data, test_registry_filepath, temporary_
     assert data == source.data
 
 
-def test_embedded_registry_source(registry_data, test_registry_filepath, mocker, temporary_domain):
+def test_embedded_registry_source(registry_data, test_registry_filepath, mocker):
     mocker.patch.object(
         EmbeddedRegistrySource,
         "get_publication_endpoint",
         return_value=test_registry_filepath,
     )
-    source = EmbeddedRegistrySource(domain=temporary_domain)
+    source = EmbeddedRegistrySource(domain=TEMPORARY_DOMAIN)
     assert source.domain.name == TEMPORARY_DOMAIN_NAME
     assert str(source.domain) == TEMPORARY_DOMAIN_NAME
     assert bytes(source.domain) == TEMPORARY_DOMAIN_NAME.encode("utf-8")
@@ -87,7 +88,7 @@ def test_embedded_registry_source(registry_data, test_registry_filepath, mocker,
 
 
 def test_registry_source_manager_fallback(
-    registry_data, test_registry_filepath, mocker, temporary_domain
+    registry_data, test_registry_filepath, mocker
 ):
     github_source_get = mocker.patch.object(
         GithubRegistrySource, "get", side_effect=RegistrySource.Unavailable
@@ -102,7 +103,7 @@ def test_registry_source_manager_fallback(
         GithubRegistrySource,
         EmbeddedRegistrySource,
     )
-    source_manager = RegistrySourceManager(domain=temporary_domain)
+    source_manager = RegistrySourceManager(domain=TEMPORARY_DOMAIN)
     assert source_manager.domain.name == TEMPORARY_DOMAIN_NAME
     assert str(source_manager.domain) == TEMPORARY_DOMAIN_NAME
     assert bytes(source_manager.domain) == TEMPORARY_DOMAIN_NAME.encode("utf-8")

--- a/tests/unit/test_character_sign_and_verify.py
+++ b/tests/unit/test_character_sign_and_verify.py
@@ -5,7 +5,7 @@ from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import CryptoPower, NoSigningPower, SigningPower
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.policy.payment import FreeReencryptions
-from tests.constants import MOCK_ETH_PROVIDER_URI
+from tests.constants import MOCK_ETH_PROVIDER_URI, TEMPORARY_DOMAIN
 
 """
 Chapter 1: SIGNING
@@ -21,7 +21,7 @@ def test_actor_without_signing_power_cannot_sign():
     non_signer = Character(
         crypto_power=cannot_sign,
         start_learning_now=False,
-        domain=TEMPORARY_DOMAIN_NAME,
+        domain=TEMPORARY_DOMAIN,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
     )
 
@@ -46,7 +46,7 @@ def test_actor_with_signing_power_can_sign():
         crypto_power_ups=[SigningPower],
         is_me=True,
         start_learning_now=False,
-        domain=TEMPORARY_DOMAIN_NAME,
+        domain=TEMPORARY_DOMAIN,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
     )
     stamp_of_the_signer = signer.stamp

--- a/tests/unit/test_character_sign_and_verify.py
+++ b/tests/unit/test_character_sign_and_verify.py
@@ -1,7 +1,7 @@
 import pytest
 
 from nucypher.characters.lawful import Alice, Character
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.powers import CryptoPower, NoSigningPower, SigningPower
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.policy.payment import FreeReencryptions
@@ -21,7 +21,7 @@ def test_actor_without_signing_power_cannot_sign():
     non_signer = Character(
         crypto_power=cannot_sign,
         start_learning_now=False,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
     )
 
@@ -46,7 +46,7 @@ def test_actor_with_signing_power_can_sign():
         crypto_power_ups=[SigningPower],
         is_me=True,
         start_learning_now=False,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
     )
     stamp_of_the_signer = signer.stamp
@@ -70,7 +70,7 @@ def test_anybody_can_verify(random_address):
     # Alice can sign by default, by dint of her _default_crypto_powerups.
     alice = Alice(
         start_learning_now=False,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         checksum_address=random_address,
         pre_payment_method=FreeReencryptions(),
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
@@ -79,7 +79,7 @@ def test_anybody_can_verify(random_address):
     # So, our story is fairly simple: an everyman meets Alice.
     somebody = Character(
         start_learning_now=False,
-        domain=TEMPORARY_DOMAIN,
+        domain=TEMPORARY_DOMAIN_NAME,
         eth_endpoint=MOCK_ETH_PROVIDER_URI,
     )
 

--- a/tests/unit/test_taco_domains.py
+++ b/tests/unit/test_taco_domains.py
@@ -9,7 +9,7 @@ from nucypher.blockchain.eth.domains import (
 
 @pytest.fixture(scope="module")
 def test_registry(module_mocker):
-    # override fixture which mocks SUPPORTED_DOMAIN_NAMES
+    # override fixture which mocks SUPPORTED_DOMAINS
     yield
 
 
@@ -82,5 +82,5 @@ def test_get_domain(domain_name_test):
 
 
 def test_get_domain_unrecognized_domain_name():
-    with pytest.raises(domains.Unrecognized):
-        domains.get_domain(domain="5am_In_Toronto")
+    with pytest.raises(domains.UnrecognizedTacoDomain):
+        domains.get_domain("5am_In_Toronto")

--- a/tests/unit/test_taco_domains.py
+++ b/tests/unit/test_taco_domains.py
@@ -1,9 +1,9 @@
 import pytest
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.domains import (
     EthChain,
     PolygonChain,
-    TACoDomain,
 )
 
 
@@ -15,7 +15,7 @@ def test_registry(module_mocker):
 
 @pytest.fixture(scope="module", autouse=True)
 def mock_condition_blockchains(module_mocker):
-    # override fixture which mocks get_domain_info
+    # override fixture which mocks get_domain
     yield
 
 
@@ -49,9 +49,9 @@ def test_polygon_chains(poly_chain_test):
 @pytest.mark.parametrize(
     "taco_domain_test",
     (
-        (TACoDomain.MAINNET, "mainnet", EthChain.MAINNET, PolygonChain.MAINNET),
-        (TACoDomain.LYNX, "lynx", EthChain.GOERLI, PolygonChain.MUMBAI),
-        (TACoDomain.TAPIR, "tapir", EthChain.SEPOLIA, PolygonChain.MUMBAI),
+        (domains.MAINNET, "mainnet", EthChain.MAINNET, PolygonChain.MAINNET),
+        (domains.LYNX, "lynx", EthChain.GOERLI, PolygonChain.MUMBAI),
+        (domains.TAPIR, "tapir", EthChain.SEPOLIA, PolygonChain.MUMBAI),
     ),
 )
 def test_taco_domain_info(taco_domain_test):
@@ -71,16 +71,16 @@ def test_taco_domain_info(taco_domain_test):
 @pytest.mark.parametrize(
     "domain_name_test",
     (
-        ("mainnet", TACoDomain.MAINNET),
-        ("lynx", TACoDomain.LYNX),
-        ("tapir", TACoDomain.TAPIR),
+        ("mainnet", domains.MAINNET),
+        ("lynx", domains.LYNX),
+        ("tapir", domains.TAPIR),
     ),
 )
-def test_get_domain_info(domain_name_test):
+def test_get_domain(domain_name_test):
     domain_name, expected_domain_info = domain_name_test
-    assert TACoDomain.get_domain_info(domain_name) == expected_domain_info
+    assert domains.get_domain(domain_name) == expected_domain_info
 
 
-def test_get_domain_info_unrecognized_domain_name():
-    with pytest.raises(TACoDomain.Unrecognized):
-        TACoDomain.get_domain_info(domain="5am_In_Toronto")
+def test_get_domain_unrecognized_domain_name():
+    with pytest.raises(domains.Unrecognized):
+        domains.get_domain(domain="5am_In_Toronto")

--- a/tests/unit/test_teacher_nodes.py
+++ b/tests/unit/test_teacher_nodes.py
@@ -1,6 +1,6 @@
 import pytest
 
-from nucypher.blockchain.eth.domains import TACoDomain
+from nucypher.blockchain.eth import domains
 from nucypher.network.nodes import TEACHER_NODES
 
 
@@ -17,6 +17,6 @@ def test_registry(module_mocker):
 
 
 def test_default_teacher_seednodes_defined():
-    for domain in TACoDomain.SUPPORTED_DOMAIN_NAMES:
-        teacher_nodes = TEACHER_NODES[domain]
+    for domain in domains.SUPPORTED_DOMAINS:
+        teacher_nodes = TEACHER_NODES[domain.name]
         assert len(teacher_nodes) > 0

--- a/tests/unit/test_teacher_nodes.py
+++ b/tests/unit/test_teacher_nodes.py
@@ -18,5 +18,5 @@ def test_registry(module_mocker):
 
 def test_default_teacher_seednodes_defined():
     for domain in domains.SUPPORTED_DOMAINS:
-        teacher_nodes = TEACHER_NODES[domain.name]
+        teacher_nodes = TEACHER_NODES[domain]
         assert len(teacher_nodes) > 0

--- a/tests/unit/test_teacher_nodes.py
+++ b/tests/unit/test_teacher_nodes.py
@@ -12,11 +12,11 @@ def mock_teacher_nodes(mocker):
 
 @pytest.fixture(scope="module")
 def test_registry(module_mocker):
-    # override fixture which mocks SUPPORTED_DOMAIN_NAMES
+    # override fixture which mocks SUPPORTED_DOMAINS
     yield
 
 
 def test_default_teacher_seednodes_defined():
-    for domain in domains.SUPPORTED_DOMAINS:
+    for name, domain in domains.SUPPORTED_DOMAINS.items():
         teacher_nodes = TEACHER_NODES[domain]
         assert len(teacher_nodes) > 0

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -9,13 +9,13 @@ from nucypher.config.characters import (
     BobConfiguration,
     UrsulaConfiguration,
 )
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from tests.utils.middleware import MockRestMiddleware
 from tests.utils.ursula import select_test_port
 
 TEST_CHARACTER_CONFIG_BASE_PARAMS = dict(
     dev_mode=True,
-    domain=TEMPORARY_DOMAIN,
+    domain=TEMPORARY_DOMAIN_NAME,
     start_learning_now=False,
     abort_on_learning_error=True,
     save_metadata=False,

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -1,6 +1,5 @@
-from typing import List
-
 from eth_typing import ChecksumAddress
+from typing import List
 
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.characters.lawful import Ursula

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -17,9 +17,9 @@ from tests.constants import TESTERCHAIN_CHAIN_INFO
 
 
 @contextmanager
-def mock_registry_sources(mocker, domains: List[TACoDomain] = None):
-    if not domains:
-        domains = [
+def mock_registry_sources(mocker, _domains: List[TACoDomain] = None):
+    if not _domains:
+        _domains = [
             TACoDomain(
                 name=TEMPORARY_DOMAIN_NAME,
                 eth_chain=TESTERCHAIN_CHAIN_INFO,
@@ -29,7 +29,7 @@ def mock_registry_sources(mocker, domains: List[TACoDomain] = None):
 
     supported_domains = []
     supported_domain_names = []
-    for domain in domains:
+    for domain in _domains:
         test_domain = TACoDomain(
             name=str(domain),
             eth_chain=TESTERCHAIN_CHAIN_INFO,
@@ -45,7 +45,7 @@ def mock_registry_sources(mocker, domains: List[TACoDomain] = None):
     _supported_domain_names = mocker.patch('nucypher.blockchain.eth.domains.SUPPORTED_DOMAIN_NAMES', new_callable=list)
     _supported_domain_names.extend(supported_domain_names)
 
-    mocker.patch.object(MockRegistrySource, "ALLOWED_DOMAINS", list(map(str, domains)))
+    mocker.patch.object(MockRegistrySource, "ALLOWED_DOMAINS", list(map(str, _domains)))
     mocker.patch.object(RegistrySourceManager, "_FALLBACK_CHAIN", (MockRegistrySource,))
 
     yield  # run the test

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -5,7 +5,6 @@ from contextlib import contextmanager
 from eth_utils import to_checksum_address
 from typing import List
 
-from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import (
     RegistryData,
@@ -27,23 +26,18 @@ def mock_registry_sources(mocker, _domains: List[TACoDomain] = None):
             )
         ]
 
-    supported_domains = []
-    supported_domain_names = []
+    supported_domains = dict()
     for domain in _domains:
         test_domain = TACoDomain(
             name=str(domain),
             eth_chain=TESTERCHAIN_CHAIN_INFO,
             polygon_chain=TESTERCHAIN_CHAIN_INFO,
         )
-        supported_domains.append(test_domain)
-        supported_domain_names.append(str(domain))
+        supported_domains[str(domain)] = test_domain
 
 
-    _supported_domains = mocker.patch('nucypher.blockchain.eth.domains.SUPPORTED_DOMAINS', new_callable=list)
-    _supported_domains.extend(supported_domains)
-
-    _supported_domain_names = mocker.patch('nucypher.blockchain.eth.domains.SUPPORTED_DOMAIN_NAMES', new_callable=list)
-    _supported_domain_names.extend(supported_domain_names)
+    _supported_domains = mocker.patch('nucypher.blockchain.eth.domains.SUPPORTED_DOMAINS', new_callable=dict)
+    _supported_domains.update(supported_domains)
 
     mocker.patch.object(MockRegistrySource, "ALLOWED_DOMAINS", list(map(str, _domains)))
     mocker.patch.object(RegistrySourceManager, "_FALLBACK_CHAIN", (MockRegistrySource,))

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -12,37 +12,22 @@ from nucypher.blockchain.eth.registry import (
     RegistrySourceManager,
 )
 from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
-from tests.constants import TESTERCHAIN_CHAIN_INFO
+from tests.constants import TEMPORARY_DOMAIN
 
 
 @contextmanager
 def mock_registry_sources(mocker, _domains: List[TACoDomain] = None):
     if not _domains:
-        _domains = [
-            TACoDomain(
-                name=TEMPORARY_DOMAIN_NAME,
-                eth_chain=TESTERCHAIN_CHAIN_INFO,
-                polygon_chain=TESTERCHAIN_CHAIN_INFO,
-            )
-        ]
+        _domains = [TEMPORARY_DOMAIN]
 
-    supported_domains = dict()
-    for domain in _domains:
-        test_domain = TACoDomain(
-            name=str(domain),
-            eth_chain=TESTERCHAIN_CHAIN_INFO,
-            polygon_chain=TESTERCHAIN_CHAIN_INFO,
-        )
-        supported_domains[str(domain)] = test_domain
-
-
-    _supported_domains = mocker.patch('nucypher.blockchain.eth.domains.SUPPORTED_DOMAINS', new_callable=dict)
-    _supported_domains.update(supported_domains)
+    _supported_domains = mocker.patch.dict(
+        'nucypher.blockchain.eth.domains.SUPPORTED_DOMAINS',
+        {domain.name: domain for domain in _domains},
+    )
 
     mocker.patch.object(MockRegistrySource, "ALLOWED_DOMAINS", list(map(str, _domains)))
     mocker.patch.object(RegistrySourceManager, "_FALLBACK_CHAIN", (MockRegistrySource,))
-
-    yield  # run the test
+    yield
 
 
 class MockRegistrySource(RegistrySource):

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -14,14 +14,14 @@ from nucypher.blockchain.eth.registry import (
     RegistrySource,
     RegistrySourceManager,
 )
-from nucypher.config.constants import TEMPORARY_DOMAIN
+from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from tests.constants import TESTERCHAIN_CHAIN_INFO
 
 
 @contextmanager
 def mock_registry_sources(mocker, domain_names: List[str] = None):
     if not domain_names:
-        domain_names = [TEMPORARY_DOMAIN]
+        domain_names = [TEMPORARY_DOMAIN_NAME]
 
     supported_domains = []
     supported_domain_names = []
@@ -76,10 +76,10 @@ class ApeRegistrySource(RegistrySource):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.domain != TEMPORARY_DOMAIN:
+        if self.domain != TEMPORARY_DOMAIN_NAME:
             raise ValueError(
                 f"Somehow, ApeRegistrySource is trying to get a registry for '{self.domain}'. "
-                f"Only '{TEMPORARY_DOMAIN}' is supported.'"
+                f"Only '{TEMPORARY_DOMAIN_NAME}' is supported.'"
             )
         if self._DEPLOYMENTS is None:
             raise ValueError(

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from eth_utils import to_checksum_address
 from typing import List
 
+from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import (
     RegistryData,

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
+from contextlib import contextmanager
+from typing import List
 
 from ape.contracts import ContractInstance
-from contextlib import contextmanager
 from eth_utils import to_checksum_address
-from typing import List
 
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.registry import (
@@ -21,7 +21,7 @@ def mock_registry_sources(mocker, _domains: List[TACoDomain] = None):
         _domains = [TEMPORARY_DOMAIN]
 
     _supported_domains = mocker.patch.dict(
-        'nucypher.blockchain.eth.domains.SUPPORTED_DOMAINS',
+        "nucypher.blockchain.eth.domains.SUPPORTED_DOMAINS",
         {str(domain): domain for domain in _domains},
     )
 

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -46,7 +46,7 @@ class MockRegistrySource(RegistrySource):
 
     @property
     def registry_name(self) -> str:
-        return self.domain
+        return str(self.domain)
 
     def get_publication_endpoint(self) -> str:
         return f":mock-registry-source:/{self.registry_name}"

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -42,14 +42,14 @@ def mock_registry_sources(mocker, domain_names: List[str] = None):
 
 
 class MockRegistrySource(RegistrySource):
-    ALLOWED_DOMAINS = [TEMPORARY_DOMAIN]
+    ALLOWED_DOMAINS = [TEMPORARY_DOMAIN_NAME]
 
     name = "Mock Registry Source"
     is_primary = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.domain not in self.ALLOWED_DOMAINS:
+        if self.domain.name not in self.ALLOWED_DOMAINS:
             raise ValueError(
                 f"Somehow, MockRegistrySource is trying to get a registry for '{self.domain}'. "
                 f"Only '{','.join(self.ALLOWED_DOMAINS)}' are supported.'"

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -22,7 +22,7 @@ def mock_registry_sources(mocker, _domains: List[TACoDomain] = None):
 
     _supported_domains = mocker.patch.dict(
         'nucypher.blockchain.eth.domains.SUPPORTED_DOMAINS',
-        {domain.name: domain for domain in _domains},
+        {str(domain): domain for domain in _domains},
     )
 
     mocker.patch.object(MockRegistrySource, "ALLOWED_DOMAINS", list(map(str, _domains)))


### PR DESCRIPTION
**Type of PR:**
Rework

**Required reviews:** 
2

**What this does:**
- Imagine this as the 2nd submission of a 3-part PR: 
    1. follows #3271
    2. this PR
    3. continued in #3318 
- integrates `TACoDomain` with internal/external APIs 
- Maintains backwards compatibility for string domains for characters (strings are eagerly converted to instances for character creation)
- collapses `DomainInfo` into `TACoDomain`
- simplifies `domains.py` for use as module-level constant (new conventional usage `from nucypher.blockchain.eth import domains`)
- renames `<type>.taco_domain_info` -> `<type>.domain` for `Ursula`, `Character`, `Actor`, `ContractRegistry`, etc.
- renames `TEMPORARY_DOMAIN` -> `TEMPORARY_DOMAIN_NAME`
- resolves several codebase `TODO`s

Example usage of `domains`:
```python
from nucypher.blockchain.eth import domains

# any of these will work
domain = 'lynx'
domain = domains.LYNX
domain = TACoDomain(...)

# duck typing with str()
domain: TACoDomain = domains.get_domain(str(domain))
```

Note: Based over #3317 

