### PR TITLE
Update `nucypher` based on latest changes from `nucypher-contracts` #171

### DIFF
--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -307,8 +307,9 @@ class TACoChildApplicationAgent(EthereumContractAgent):
         """Matching StakingProviderInfo struct from TACoChildApplication contract."""
 
         operator: ChecksumAddress
-        operator_confirmed: bool
         authorized: int
+        operator_confirmed: bool
+        index: int
 
     @contract_api(CONTRACT_CALL)
     def staking_provider_from_operator(


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
PR https://github.com/nucypher/nucypher-contracts/pull/171 made two changes that affected `nucypher`:
- The data returned from `TACoApplication.getActiveStakingProviders` changed format
- `StakingProviderInfo` struct in `TACoChildApplication` changed

This PR makes the appropriate updates.

**NOTE: ** Once changes from this PR are merged, `nucypher` will no longer be able to do python sampling on old contracts.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
