### PR TITLE
Configurable Node Operational Timeouts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,10 @@ repos:
     rev: 1.7.2
     hooks:
     -   id: darker
+        args: ["--check"]
+        stages: [push]
+    -   id: darker
+        stages: [commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: 'v0.1.4'

--- a/newsfragments/3337.feature.rst
+++ b/newsfragments/3337.feature.rst
@@ -1,0 +1,1 @@
+Allow Bob / ThresholdAccessControlClient decryption and reencryption operations to specify timeouts.

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -147,7 +147,7 @@ class DKGOmniscientDecryptionClient(ThresholdDecryptionClient):
         self,
         encrypted_requests: Dict[ChecksumAddress, EncryptedThresholdDecryptionRequest],
         threshold: int,
-        timeout: int = 15,
+        timeout: int = ThresholdDecryptionClient.DEFAULT_DECRYPTION_TIMEOUT,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],
@@ -221,7 +221,7 @@ class DoomedDecryptionClient(ThresholdDecryptionClient):
         self,
         encrypted_requests,
         threshold: int,
-        timeout: int = 15,
+        timeout: int = ThresholdDecryptionClient.DEFAULT_DECRYPTION_TIMEOUT,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -23,21 +23,6 @@ class FakeNode:
         self.checksum_address = checksum_address
 
 
-class _ParticipantKeyDict(dict):
-    def __init__(self, threshold_request_decrypting_power, *args, **kwargs):
-        self.threshold_request_decrypting_power = threshold_request_decrypting_power
-        super().__init__(*args, **kwargs)
-
-    def __getitem__(self, _item):
-        # Everybody has the same public key at the moment.
-        fifty_fiver = (
-            self.threshold_request_decrypting_power._get_static_secret_from_ritual_id(
-                55
-            )
-        )
-        return fifty_fiver.public_key()
-
-
 class Uncoordinated:
     """
     A stand-in for some of the logic that is normally handled (and verified) by use of a Coordinator contract.
@@ -59,9 +44,16 @@ class Uncoordinated:
         self.threshold_request_decrypting_power = ThresholdRequestDecryptingPower(
             session_secret_factory=secret_factory
         )
-        self.participant_public_keys = _ParticipantKeyDict(
-            self.threshold_request_decrypting_power
+        # All participants have the same public key.
+        fifty_fiver_public_key = (
+            self.threshold_request_decrypting_power._get_static_secret_from_ritual_id(
+                55
+            ).public_key()
         )
+        self.participant_public_keys = {
+            checksum_address: fifty_fiver_public_key
+            for checksum_address in checksum_addresses
+        }
 
 
 class DKGOmniscient:

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -155,7 +155,7 @@ class DKGOmniscientDecryptionClient(ThresholdDecryptionClient):
         self,
         encrypted_requests: Dict[ChecksumAddress, EncryptedThresholdDecryptionRequest],
         threshold: int,
-        timeout: float = 10,
+        timeout: int = 15,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],
@@ -229,7 +229,7 @@ class DoomedDecryptionClient(ThresholdDecryptionClient):
         self,
         encrypted_requests,
         threshold: int,
-        timeout: float = 10,
+        timeout: int = 15,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -510,7 +510,7 @@ class Bob(Character):
         alice_verifying_key: PublicKey,  # KeyFrag signer's key
         encrypted_treasure_map: EncryptedTreasureMap,
         publisher_verifying_key: Optional[PublicKey] = None,
-        timeout: int = 10,
+        timeout: int = PRERetrievalClient.DEFAULT_RETRIEVAL_TIMEOUT,
         **context,  # TODO: dont use one context to rule them all
     ) -> List[PolicyMessageKit]:
         """
@@ -707,7 +707,7 @@ class Bob(Character):
         threshold_message_kit: ThresholdMessageKit,
         context: Optional[dict] = None,
         ursulas: Optional[List["Ursula"]] = None,
-        decryption_timeout: int = 15,
+        decryption_timeout: int = ThresholdDecryptionClient.DEFAULT_DECRYPTION_TIMEOUT,
     ) -> bytes:
         ritual_id = self.get_ritual_id_from_public_key(
             public_key=threshold_message_kit.acp.public_key

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -510,6 +510,7 @@ class Bob(Character):
         alice_verifying_key: PublicKey,  # KeyFrag signer's key
         encrypted_treasure_map: EncryptedTreasureMap,
         publisher_verifying_key: Optional[PublicKey] = None,
+        timeout: int = 10,
         **context,  # TODO: dont use one context to rule them all
     ) -> List[PolicyMessageKit]:
         """
@@ -567,6 +568,7 @@ class Bob(Character):
             alice_verifying_key=alice_verifying_key,
             bob_encrypting_key=self.public_keys(DecryptingPower),
             bob_verifying_key=self.stamp.as_umbral_pubkey(),
+            timeout=timeout,
             **context,
         )
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -611,14 +611,21 @@ class Bob(Character):
             self.block_until_specific_nodes_are_known(
                 addresses=validators,
                 timeout=timeout,
-                allow_missing=0,
+                allow_missing=(ritual.dkg_size - ritual.threshold),
             )
 
         cohort = list()
         for staking_provider_address, transcript_bytes in ritual.transcripts:
+            if staking_provider_address not in self.known_nodes:
+                continue
             remote_operator = self.known_nodes[staking_provider_address]
             remote_operator.mature()
             cohort.append(remote_operator)
+
+        if len(cohort) < ritual.threshold:
+            raise Ursula.NotEnoughUrsulas(
+                f"Unable to learn about a threshold, {ritual.threshold}-of-{ritual.dkg_size} Ursulas for ritual"
+            )
 
         return cohort
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -568,8 +568,8 @@ class Bob(Character):
             alice_verifying_key=alice_verifying_key,
             bob_encrypting_key=self.public_keys(DecryptingPower),
             bob_verifying_key=self.stamp.as_umbral_pubkey(),
+            context=context,
             timeout=timeout,
-            **context,
         )
 
         # Refill message kits with newly retrieved capsule frags

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -646,6 +646,7 @@ class Bob(Character):
         participant_public_keys: Dict[ChecksumAddress, SessionStaticKey],
         cohort: List["Ursula"],
         threshold: int,
+        timeout: int,
     ) -> Dict[
         ChecksumAddress, Union[DecryptionShareSimple, DecryptionSharePrecomputed]
     ]:
@@ -670,7 +671,9 @@ class Bob(Character):
 
         decryption_client = self._threshold_decryption_client_class(learner=self)
         successes, failures = decryption_client.gather_encrypted_decryption_shares(
-            encrypted_requests=decryption_request_mapping, threshold=threshold
+            encrypted_requests=decryption_request_mapping,
+            threshold=threshold,
+            timeout=timeout,
         )
 
         if len(successes) < threshold:
@@ -724,6 +727,7 @@ class Bob(Character):
         context: Optional[dict] = None,
         ursulas: Optional[List["Ursula"]] = None,
         peering_timeout: int = 60,
+        decryption_timeout: int = 15,
     ) -> bytes:
         ritual_id = self.get_ritual_id_from_public_key(
             public_key=threshold_message_kit.acp.public_key
@@ -757,6 +761,7 @@ class Bob(Character):
             participant_public_keys=participant_public_keys,
             cohort=ursulas,
             threshold=ritual.threshold,
+            timeout=decryption_timeout,
         )
 
         return self.__decrypt(

--- a/nucypher/network/client.py
+++ b/nucypher/network/client.py
@@ -16,7 +16,7 @@ class ThresholdAccessControlClient:
         self.log = Logger(self.__class__.__name__)
 
     def _ensure_ursula_availability(
-        self, ursulas: List[ChecksumAddress], threshold: int, timeout=10
+        self, ursulas: List[ChecksumAddress], threshold: int, timeout: int
     ):
         """
         Make sure we know enough nodes;

--- a/nucypher/network/client.py
+++ b/nucypher/network/client.py
@@ -19,7 +19,7 @@ class ThresholdAccessControlClient:
         self, ursulas: List[ChecksumAddress], threshold: int, timeout=10
     ):
         """
-        Make sure we know enough nodes from the treasure map to decrypt;
+        Make sure we know enough nodes;
         otherwise block and wait for them to come online.
         """
 

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -35,7 +35,7 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
         self._ensure_ursula_availability(
             ursulas=list(encrypted_requests.keys()),
             threshold=threshold,
-            timeout=timeout,
+            timeout=timeout,  # TODO this was 60s (peering timeout) before
         )
 
         def worker(

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -12,6 +12,8 @@ from nucypher.utilities.concurrency import BatchValueFactory, WorkerPool
 
 
 class ThresholdDecryptionClient(ThresholdAccessControlClient):
+    DEFAULT_DECRYPTION_TIMEOUT = 15
+
     class ThresholdDecryptionRequestFailed(Exception):
         """Raised when a decryption request returns a non-zero status code."""
 
@@ -27,7 +29,7 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
         self,
         encrypted_requests: Dict[ChecksumAddress, EncryptedThresholdDecryptionRequest],
         threshold: int,
-        timeout: int = 15,
+        timeout: int = DEFAULT_DECRYPTION_TIMEOUT,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -27,7 +27,7 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
         self,
         encrypted_requests: Dict[ChecksumAddress, EncryptedThresholdDecryptionRequest],
         threshold: int,
-        timeout: float = 15,
+        timeout: int = 15,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -293,7 +293,7 @@ class RestMiddleware:
         self,
         ursula: "characters.lawful.Ursula",
         reencryption_request_bytes: bytes,
-        timeout: int = 10,
+        timeout: int,
     ):
         response = self.client.post(
             node_or_sprout=ursula,
@@ -307,7 +307,7 @@ class RestMiddleware:
         self,
         ursula: "characters.lawful.Ursula",
         decryption_request_bytes: bytes,
-        timeout: int = 15,
+        timeout: int,
     ):
         response = self.client.post(
             node_or_sprout=ursula,

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -293,7 +293,7 @@ class RestMiddleware:
         self,
         ursula: "characters.lawful.Ursula",
         reencryption_request_bytes: bytes,
-        timeout=8,
+        timeout: int = 8,
     ):
         response = self.client.post(
             node_or_sprout=ursula,
@@ -307,7 +307,7 @@ class RestMiddleware:
         self,
         ursula: "characters.lawful.Ursula",
         decryption_request_bytes: bytes,
-        timeout=8,
+        timeout: int = 15,
     ):
         response = self.client.post(
             node_or_sprout=ursula,

--- a/nucypher/network/middleware.py
+++ b/nucypher/network/middleware.py
@@ -293,7 +293,7 @@ class RestMiddleware:
         self,
         ursula: "characters.lawful.Ursula",
         reencryption_request_bytes: bytes,
-        timeout: int = 8,
+        timeout: int = 10,
     ):
         response = self.client.post(
             node_or_sprout=ursula,

--- a/nucypher/network/retrieval.py
+++ b/nucypher/network/retrieval.py
@@ -262,8 +262,8 @@ class PRERetrievalClient(ThresholdAccessControlClient):
         alice_verifying_key: PublicKey,  # KeyFrag signer's key
         bob_encrypting_key: PublicKey,  # User's public key (reencryption target)
         bob_verifying_key: PublicKey,
+        context: Dict,
         timeout: int = DEFAULT_RETRIEVAL_TIMEOUT,
-        **context,
     ) -> Tuple[List[RetrievalResult], List[RetrievalError]]:
         ursulas_in_map = treasure_map.destinations.keys()
 

--- a/nucypher/network/retrieval.py
+++ b/nucypher/network/retrieval.py
@@ -180,6 +180,8 @@ class PRERetrievalClient(ThresholdAccessControlClient):
     Capsule frag retrieval machinery shared between Bob and Porter.
     """
 
+    DEFAULT_RETRIEVAL_TIMEOUT = 10
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -260,7 +262,7 @@ class PRERetrievalClient(ThresholdAccessControlClient):
         alice_verifying_key: PublicKey,  # KeyFrag signer's key
         bob_encrypting_key: PublicKey,  # User's public key (reencryption target)
         bob_verifying_key: PublicKey,
-        timeout: int = 10,
+        timeout: int = DEFAULT_RETRIEVAL_TIMEOUT,
         **context,
     ) -> Tuple[List[RetrievalResult], List[RetrievalError]]:
         ursulas_in_map = treasure_map.destinations.keys()

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -227,7 +227,6 @@ def test_ursula_ritualist(
         ):
             _ = bob.threshold_decrypt(
                 threshold_message_kit=threshold_message_kit,
-                peering_timeout=0,
             )
         print("========= UNAUTHORIZED DECRYPTION UNSUCCESSFUL =========")
 
@@ -247,7 +246,6 @@ def test_ursula_ritualist(
         bob.start_learning_loop(now=True)
         cleartext = bob.threshold_decrypt(
             threshold_message_kit=threshold_message_kit,
-            peering_timeout=0,
         )
         assert bytes(cleartext) == PLAINTEXT.encode()
         print("==================== DECRYPTION SUCCESSFUL ====================")

--- a/tests/acceptance/ape-config.yaml
+++ b/tests/acceptance/ape-config.yaml
@@ -12,7 +12,7 @@ dependencies:
     version: 5.0.0
 
 solidity:
-  version: 0.8.22
+  version: 0.8.23
   evm_version: paris
   import_remapping:
     - "@openzeppelin/contracts=openzeppelin/v5.0.0"

--- a/tests/integration/blockchain/test_integration_dkg_ritual.py
+++ b/tests/integration/blockchain/test_integration_dkg_ritual.py
@@ -223,7 +223,6 @@ def test_ursula_ritualist(
                     ):
                         bob.threshold_decrypt(
                             threshold_message_kit=threshold_message_kit,
-                            peering_timeout=0,
                         )
                 print("========= UNAUTHORIZED DECRYPTION UNSUCCESSFUL =========")
 
@@ -238,7 +237,6 @@ def test_ursula_ritualist(
                     ):
                         bob.threshold_decrypt(
                             threshold_message_kit=threshold_message_kit,
-                            peering_timeout=0,
                         )
                 print("======== EXPIRED RITUAL DECRYPTION UNSUCCESSFUL ========")
 
@@ -268,7 +266,6 @@ def test_ursula_ritualist(
             ):
                 cleartext = bob.threshold_decrypt(
                     threshold_message_kit=threshold_message_kit,
-                    peering_timeout=0,
                 )
                 assert bytes(cleartext) == PLAINTEXT.encode()
 

--- a/tests/integration/network/test_middleware.py
+++ b/tests/integration/network/test_middleware.py
@@ -52,5 +52,5 @@ def test_middleware_response_status_code_processing(
     )
     with pytest.raises(expected_exception_class):
         mock_rest_middleware.reencrypt(
-            ursula=ursula, reencryption_request_bytes=b"reencryption_request"
+            ursula=ursula, reencryption_request_bytes=b"reencryption_request", timeout=2
         )

--- a/tests/utils/middleware.py
+++ b/tests/utils/middleware.py
@@ -18,8 +18,6 @@ class BadTestUrsulas(RuntimeError):
 
 
 class _TestMiddlewareClient(NucypherMiddlewareClient):
-    timeout = None
-
     @staticmethod
     def response_cleaner(response):
         response.content = response.data
@@ -62,9 +60,11 @@ class _TestMiddlewareClient(NucypherMiddlewareClient):
         return host, port, mock_client
 
     def invoke_method(self, method, url, *args, **kwargs):
+        self.clean_params(kwargs)
+
         _cert_location = kwargs.pop("verify")  # TODO: Is this something that can be meaningfully tested?
         kwargs.pop("timeout", None)  # Just get rid of timeout; not needed for the test client.
-        response = super().invoke_method(method, url, *args, **kwargs)
+        response = method(url, *args, **kwargs)
         return response
 
     def clean_params(self, request_kwargs):


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Allows timeouts to be programmatically specified for TACo operations when connecting to nodes i.e. `threshold_decrypt` / `retrieve_and_decrypt` (PRE).

It would allow the ability for Porter to accept timeout parameters in requests that go through Porter - so then apps can potentially use their own timeout (note: for apps to do that `nucypher-ts` (`taco-api`) may need to be modified.


**Issues fixed/closed:**
> - Fixes #...

Related to:
- #3153 
- https://github.com/nucypher/nucypher-porter/issues/49

Fixes #3155 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
