### PR TITLE
Perform node sampling using `TACoChildApplication` instead of `TACoApplication`

### DIFF
--- a/newsfragments/3341.feature.rst
+++ b/newsfragments/3341.feature.rst
@@ -1,0 +1,1 @@
+Use ``TACoChildApplication`` contract for node sampling instead of ``TACoApplication`` contract.

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -489,14 +489,14 @@ class TACoChildApplicationAgent(StakerSamplingApplicationAgent):
         return result
 
     @contract_api(CONTRACT_CALL)
-    def get_staking_providers(self) -> List[ChecksumAddress]:
-        """Returns a list of staking provider addresses"""
-        num_providers: int = self.get_staking_providers_population()
-        providers: List[ChecksumAddress] = [
-            self.contract.functions.stakingProviders(i).call()
-            for i in range(num_providers)
-        ]
-        return providers
+    def get_staking_providers(self) -> Iterable[ChecksumAddress]:
+        """Returns an iterable of staking provider addresses"""
+        num_providers = self.get_staking_providers_population()
+        for index in range(num_providers):
+            address: ChecksumAddress = self.contract.functions.stakingProviders(
+                index
+            ).call()
+            yield address
 
     @contract_api(CONTRACT_CALL)
     def _get_active_staking_providers_raw(
@@ -585,18 +585,10 @@ class TACoApplicationAgent(StakerSamplingApplicationAgent):
         return result
 
     @contract_api(CONTRACT_CALL)
-    def get_staking_providers(self) -> List[ChecksumAddress]:
-        """Returns a list of staking provider addresses"""
-        num_providers: int = self.get_staking_providers_population()
-        providers: List[ChecksumAddress] = [
-            self.contract.functions.stakingProviders(i).call()
-            for i in range(num_providers)
-        ]
-        return providers
-
-    @contract_api(CONTRACT_CALL)
-    def swarm(self) -> Iterable[ChecksumAddress]:
-        for index in range(self.get_staking_providers_population()):
+    def get_staking_providers(self) -> Iterable[ChecksumAddress]:
+        """Returns an iterable of staking provider addresses"""
+        num_providers = self.get_staking_providers_population()
+        for index in range(num_providers):
             address: ChecksumAddress = self.contract.functions.stakingProviders(
                 index
             ).call()

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -437,6 +437,16 @@ class TACoChildApplicationAgent(StakerSamplingApplicationAgent):
         index: int
 
     @contract_api(CONTRACT_CALL)
+    def get_min_authorization(self) -> int:
+        result = self.contract.functions.minimumAuthorization().call()
+        return result
+
+    @contract_api(CONTRACT_CALL)
+    def get_authorized_stake(self, staking_provider: ChecksumAddress) -> int:
+        result = self.contract.functions.authorizedStake(staking_provider).call()
+        return result
+
+    @contract_api(CONTRACT_CALL)
     def staking_provider_from_operator(
         self, operator_address: ChecksumAddress
     ) -> ChecksumAddress:
@@ -461,6 +471,20 @@ class TACoChildApplicationAgent(StakerSamplingApplicationAgent):
         staking_provider_info = self.staking_provider_info(staking_provider)
         return staking_provider_info.operator_confirmed
 
+    @contract_api(CONTRACT_CALL)
+    def get_staking_providers_population(self) -> int:
+        result = self.contract.functions.getStakingProvidersLength().call()
+        return result
+
+    @contract_api(CONTRACT_CALL)
+    def get_staking_providers(self) -> List[ChecksumAddress]:
+        """Returns a list of staking provider addresses"""
+        num_providers: int = self.get_staking_providers_population()
+        providers: List[ChecksumAddress] = [
+            self.contract.functions.stakingProviders(i).call()
+            for i in range(num_providers)
+        ]
+        return providers
 
     @contract_api(CONTRACT_CALL)
     def _get_active_staking_providers_raw(self, start_index: int, max_results: int) -> Tuple[int, List[bytes]]:

--- a/nucypher/policy/reservoir.py
+++ b/nucypher/policy/reservoir.py
@@ -3,13 +3,13 @@ from typing import Iterable, List, Optional
 from eth_typing import ChecksumAddress
 
 from nucypher.blockchain.eth.agents import (
+    StakerSamplingApplicationAgent,
     StakingProvidersReservoir,
-    TACoApplicationAgent,
 )
 
 
 def make_staking_provider_reservoir(
-    application_agent: TACoApplicationAgent,
+    application_agent: StakerSamplingApplicationAgent,
     exclude_addresses: Optional[Iterable[ChecksumAddress]] = None,
     include_addresses: Optional[Iterable[ChecksumAddress]] = None,
     pagination_size: Optional[int] = None,

--- a/nucypher/policy/reservoir.py
+++ b/nucypher/policy/reservoir.py
@@ -22,7 +22,7 @@ def make_staking_provider_reservoir(
     without_set = set(include_addresses) | set(exclude_addresses or ())
     try:
         reservoir = application_agent.get_staking_provider_reservoir(without=without_set, pagination_size=pagination_size)
-    except TACoApplicationAgent.NotEnoughStakingProviders:
+    except application_agent.NotEnoughStakingProviders:
         # TODO: do that in `get_staking_provider_reservoir()`?
         reservoir = StakingProvidersReservoir({})
 

--- a/nucypher/policy/reservoir.py
+++ b/nucypher/policy/reservoir.py
@@ -22,7 +22,7 @@ def make_staking_provider_reservoir(
     without_set = set(include_addresses) | set(exclude_addresses or ())
     try:
         reservoir = application_agent.get_staking_provider_reservoir(without=without_set, pagination_size=pagination_size)
-    except application_agent.NotEnoughStakingProviders:
+    except StakerSamplingApplicationAgent.NotEnoughStakingProviders:
         # TODO: do that in `get_staking_provider_reservoir()`?
         reservoir = StakingProvidersReservoir({})
 

--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -1,7 +1,8 @@
-import click
-import maya
 import random
 import time
+
+import click
+import maya
 from nucypher_core.ferveo import DkgPublicKey
 from web3 import Web3
 
@@ -9,7 +10,7 @@ from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     CoordinatorAgent,
-    TACoApplicationAgent,
+    TACoChildApplicationAgent,
 )
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import InMemorySigner, Signer
@@ -161,11 +162,11 @@ def nucypher_dkg(
         blockchain_endpoint=polygon_endpoint,
     )  # type: CoordinatorAgent
 
-    application_agent = ContractAgency.get_agent(
-        agent_class=TACoApplicationAgent,
+    child_application_agent = ContractAgency.get_agent(
+        agent_class=TACoChildApplicationAgent,
         registry=registry,
-        blockchain_endpoint=eth_endpoint,
-    )  # type: TACoApplicationAgent
+        blockchain_endpoint=polygon_endpoint,
+    )  # type: TACoChildApplicationAgent
 
     #
     # Get deployer account
@@ -200,7 +201,7 @@ def nucypher_dkg(
             (
                 _,
                 staking_providers_dict,
-            ) = application_agent.get_all_active_staking_providers()
+            ) = child_application_agent.get_all_active_staking_providers()
             staking_providers = list(staking_providers_dict.keys())
 
             # sample then sort
@@ -305,7 +306,7 @@ def nucypher_dkg(
             "conditionType": ConditionType.TIME.value,
             "returnValueTest": {"value": 0, "comparator": ">"},
             "method": "blocktime",
-            "chain": application_agent.blockchain.client.chain_id,
+            "chain": child_application_agent.blockchain.client.chain_id,
         },
     }
 
@@ -368,7 +369,7 @@ def nucypher_dkg(
             )
         else:
             emitter.echo(
-                f"Enrico {enrico_account} not authorized to use DKG Ritual #{ritual_id} - expect decryption to fail",
+                f"Enrico {enrico_account} not authorized to use DKG Ritual #{ritual_id} - decryption may fail",
                 color="yellow",
             )
 

--- a/tests/acceptance/agents/test_taco_application_agent.py
+++ b/tests/acceptance/agents/test_taco_application_agent.py
@@ -141,7 +141,9 @@ def test_sample_staking_providers(taco_application_agent):
     assert len(set(providers).intersection(exclude_providers)) == 0
 
 
-def test_get_staking_provider_info(testerchain, taco_application_agent):
+def test_get_staking_provider_info(
+    testerchain, taco_application_agent, get_random_checksum_address
+):
     staking_provider_account, operator_account, *other = testerchain.unassigned_accounts
     info: TACoApplicationAgent.StakingProviderInfo = (
         taco_application_agent.get_staking_provider_info(
@@ -150,4 +152,12 @@ def test_get_staking_provider_info(testerchain, taco_application_agent):
     )
     assert info.operator_start_timestamp > 0
     assert info.operator == operator_account
-    assert not info.operator_confirmed
+    assert info.operator_confirmed is False
+
+    # non-existent staker
+    info = taco_application_agent.get_staking_provider_info(
+        get_random_checksum_address()
+    )
+    assert info.operator_start_timestamp == 0
+    assert info.operator == NULL_ADDRESS
+    assert info.operator_confirmed is False

--- a/tests/acceptance/agents/test_taco_application_agent.py
+++ b/tests/acceptance/agents/test_taco_application_agent.py
@@ -1,7 +1,5 @@
-import os
-
 import pytest
-from eth_utils import is_address, to_checksum_address
+from eth_utils import is_address
 
 from nucypher.blockchain.eth.agents import TACoApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
@@ -35,6 +33,7 @@ def test_staking_providers_and_operators_relationships(
     threshold_staking,
     taco_application,
     deployer_account,
+    get_random_checksum_address,
 ):
     staking_provider_account, operator_account, *other = testerchain.unassigned_accounts
     threshold_staking.setRoles(staking_provider_account, sender=deployer_account)
@@ -74,9 +73,8 @@ def test_staking_providers_and_operators_relationships(
     )
 
     # No staker-worker relationship
-    random_address = to_checksum_address(os.urandom(20))
     assert NULL_ADDRESS == taco_application_agent.get_operator_from_staking_provider(
-        staking_provider=random_address
+        staking_provider=get_random_checksum_address()
     )
 
 
@@ -103,7 +101,7 @@ def test_get_swarm(taco_application_agent, staking_providers):
 def test_sample_staking_providers(taco_application_agent):
     providers_population = taco_application_agent.get_staking_providers_population()
 
-    with pytest.raises(TACoApplicationAgent.NotEnoughStakingProviders):
+    with pytest.raises(taco_application_agent.NotEnoughStakingProviders):
         taco_application_agent.get_staking_provider_reservoir().draw(
             providers_population + 1
         )  # One more than we have deployed

--- a/tests/acceptance/agents/test_taco_application_agent.py
+++ b/tests/acceptance/agents/test_taco_application_agent.py
@@ -1,7 +1,6 @@
 import random
 
 import pytest
-from eth_utils import is_address
 
 from nucypher.blockchain.eth.agents import TACoApplicationAgent
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
@@ -88,21 +87,12 @@ def test_get_staker_population(taco_application_agent, staking_providers):
     )
 
 
-def test_get_swarm(taco_application_agent, staking_providers):
-    swarm = taco_application_agent.swarm()
-    swarm_addresses = list(swarm)
-    assert len(swarm_addresses) == len(staking_providers) + 1
-
-    # Grab a staker address from the swarm
-    provider_addr = swarm_addresses[0]
-    assert isinstance(provider_addr, str)
-    assert is_address(provider_addr)
-
-
 @pytest.mark.usefixtures("staking_providers", "ursulas")
 def test_sample_staking_providers(taco_application_agent):
-    all_staking_providers = taco_application_agent.get_staking_providers()
+    all_staking_providers = list(taco_application_agent.get_staking_providers())
     providers_population = taco_application_agent.get_staking_providers_population()
+
+    assert len(all_staking_providers) == providers_population
 
     with pytest.raises(taco_application_agent.NotEnoughStakingProviders):
         taco_application_agent.get_staking_provider_reservoir().draw(

--- a/tests/acceptance/agents/test_taco_child_application_agent.py
+++ b/tests/acceptance/agents/test_taco_child_application_agent.py
@@ -1,7 +1,29 @@
+import pytest
+
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 
 
-def test_staking_provider_from_operator(taco_child_application_agent, ursulas):
+def test_get_min_authorization(
+    taco_child_application_agent, taco_child_application, taco_application
+):
+    result = taco_child_application_agent.get_min_authorization()
+    assert result == taco_child_application.minimumAuthorization()
+    assert result == taco_application.minimumAuthorization()
+
+
+def test_authorized_tokens(
+    testerchain, taco_application, taco_child_application_agent, staking_providers
+):
+    provider_account = staking_providers[0]
+    authorized_amount = taco_child_application_agent.get_authorized_stake(
+        staking_provider=provider_account
+    )
+    assert authorized_amount >= taco_application.minimumAuthorization()
+
+
+def test_staking_provider_from_operator(
+    taco_child_application_agent, ursulas, get_random_checksum_address
+):
     for ursula in ursulas:
         assert (
             ursula.checksum_address
@@ -10,24 +32,32 @@ def test_staking_provider_from_operator(taco_child_application_agent, ursulas):
             )
         )
 
+    assert NULL_ADDRESS == taco_child_application_agent.staking_provider_from_operator(
+        operator_address=get_random_checksum_address()
+    )
+
 
 def test_staking_provider_info(
     taco_child_application_agent,
     ursulas,
-    taco_application,
     get_random_checksum_address,
 ):
+    staking_providers = taco_child_application_agent.get_staking_providers()
+
     for ursula in ursulas:
         provider_info = taco_child_application_agent.staking_provider_info(
             ursula.checksum_address
         )
         assert provider_info.operator_confirmed is True
         assert provider_info.operator == ursula.operator_address
-        assert provider_info.authorized >= taco_application.minimumAuthorization()
+        assert (
+            provider_info.authorized
+            >= taco_child_application_agent.get_min_authorization()
+        )
+        assert (
+            provider_info.index == staking_providers.index(ursula.checksum_address) + 1
+        )
 
-    # non-existing staking provider
-    # TODO is this right? Technically this is what the contract returns
-    #  Should returned info be "None"; although we don't really expect this situation
     provider_info = taco_child_application_agent.staking_provider_info(
         get_random_checksum_address()
     )
@@ -59,3 +89,39 @@ def test_is_operator_confirmed(
         )
         is False
     )
+
+
+def test_get_staker_population(taco_child_application_agent, staking_providers):
+    # Apart from all the providers in the fixture, we also added a new provider above
+    assert taco_child_application_agent.get_staking_providers_population() == len(
+        staking_providers
+    )
+
+
+@pytest.mark.usefixtures("staking_providers", "ursulas")
+def test_sample_staking_providers(taco_child_application_agent):
+    providers_population = (
+        taco_child_application_agent.get_staking_providers_population()
+    )
+
+    with pytest.raises(taco_child_application_agent.NotEnoughStakingProviders):
+        taco_child_application_agent.get_staking_provider_reservoir().draw(
+            providers_population + 1
+        )  # One more than we have deployed
+
+    providers = taco_child_application_agent.get_staking_provider_reservoir().draw(3)
+    assert len(providers) == 3  # Three...
+    assert len(set(providers)) == 3  # ...unique addresses
+
+    # Same but with pagination
+    providers = taco_child_application_agent.get_staking_provider_reservoir(
+        pagination_size=1
+    ).draw(3)
+    assert len(providers) == 3
+    assert len(set(providers)) == 3
+    light = taco_child_application_agent.blockchain.is_light
+    taco_child_application_agent.blockchain.is_light = not light
+    providers = taco_child_application_agent.get_staking_provider_reservoir().draw(3)
+    assert len(providers) == 3
+    assert len(set(providers)) == 3
+    taco_child_application_agent.blockchain.is_light = light

--- a/tests/acceptance/agents/test_taco_child_application_agent.py
+++ b/tests/acceptance/agents/test_taco_child_application_agent.py
@@ -44,7 +44,7 @@ def test_staking_provider_info(
     ursulas,
     get_random_checksum_address,
 ):
-    staking_providers = taco_child_application_agent.get_staking_providers()
+    staking_providers = list(taco_child_application_agent.get_staking_providers())
 
     for ursula in ursulas:
         provider_info = taco_child_application_agent.staking_provider_info(
@@ -102,10 +102,12 @@ def test_get_staker_population(taco_child_application_agent, staking_providers):
 
 @pytest.mark.usefixtures("staking_providers", "ursulas")
 def test_sample_staking_providers(taco_child_application_agent):
-    all_staking_providers = taco_child_application_agent.get_staking_providers()
+    all_staking_providers = list(taco_child_application_agent.get_staking_providers())
     providers_population = (
         taco_child_application_agent.get_staking_providers_population()
     )
+
+    assert len(all_staking_providers) == providers_population
 
     with pytest.raises(taco_child_application_agent.NotEnoughStakingProviders):
         taco_child_application_agent.get_staking_provider_reservoir().draw(


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Until we have better syncing between root and child applications, `TACoChildApplication` has the most up-to-date information for stakers , and so should be used for sampling nodes instead.

Related to `nucypher-contracts` PR - https://github.com/nucypher/nucypher-contracts/pull/171

Associated PR in `Porter` - https://github.com/nucypher/nucypher-porter/pull/55.

**NOTE:** once these child sampling PRs merged, TACo contracts need to be redeployed on testnet to the latest in `nucypher-contracts`; ideally only `lynx` to start, since redeployment implies new rituals need to be created because Coordinator was not previously updateable.


**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

- PRE does sampling when `Policy.enact(...)` is called. This causes the `application_agent` on `PolicyAuthor` (`Alice`) to be used for sampling staking providers, which is the `TACoApplication` not the `TACoChildApplication`. Since this is legacy PRE code, I purposefully avoided any changes there - if anyone feels strongly that we should change that code, please speak up. See https://github.com/nucypher/nucypher/blob/v7.0.0/nucypher/policy/policies.py#L78.

- I originally marked #3333 for v7.1.0 because of the code freeze - given the changes in this PR, we could consider merging it into 7.0.0. It is still not necessary for 7.0.0 but something to think about.