### PR TITLE
Only sleep during `block_until_ready` on startup when not (bonded and funded)

### DIFF
--- a/newsfragments/3366.bugfix.rst
+++ b/newsfragments/3366.bugfix.rst
@@ -1,0 +1,1 @@
+Don't needlessly block during ``block_until_ready`` on node startup if node is deemed to be bonded and funded.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -797,7 +797,8 @@ class Operator(BaseActor):
                             color="yellow",
                         )
 
-            time.sleep(poll_rate)
+            if not (funded and bonded):
+                time.sleep(poll_rate)
 
         coordinator_address = self.coordinator_agent.contract_address
         emitter.message(

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -127,7 +127,7 @@ def ritual_token(project, deployer_account):
 
 @pytest.fixture(scope="module")
 def t_token(nucypher_dependency, deployer_account):
-    _t_token = deployer_account.deploy(nucypher_dependency.TToken, TOTAL_SUPPLY)
+    _t_token = deployer_account.deploy(nucypher_dependency.TestToken, TOTAL_SUPPLY)
     return _t_token
 
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Issue found by @cygnusv :
```
I restarted my node and noticed that it spend 2 minutes in some intermediary step
```

Related to https://github.com/nucypher/nucypher/pull/3364.

Now that the `poll_rate` is longer, this bug is more evident. There is no reason to `sleep` during `block_until_ready` if already node is already bonded and funded. 

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
