### PR TITLE
Don't use gas strategies

### DIFF
--- a/newsfragments/3368.bugfix.rst
+++ b/newsfragments/3368.bugfix.rst
@@ -1,0 +1,1 @@
+Don't use web3.py gas strategies, since that switches TX mode to legacy.

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -259,7 +259,8 @@ class BlockchainInterface:
             self.log.debug('Injecting POA middleware at layer 0')
             self.client.inject_middleware(geth_poa_middleware, layer=0)
 
-        self.configure_gas_strategy()
+        # TODO:  See #2770
+        # self.configure_gas_strategy()
 
     def configure_gas_strategy(self, gas_strategy: Optional[Callable] = None) -> None:
 


### PR DESCRIPTION
Gas strategies are meant only for legacy transactions (pre-EIP1559). See https://web3py.readthedocs.io/en/stable/gas_price.html

Just by using a gas strategy, web3py understands we're switching to legacy mode. See how TX defaults change after we configure the gas strategy: 
```
(Pdb) fill_transaction_defaults(self.w3, {})
{'value': 0, 'data': b'', 'gas': 53000, 'maxFeePerGas': 1694505782, 'maxPriorityFeePerGas': 1694505750, 'chainId': 80001}
(Pdb) n
--Return--
> /root/gh/nucypher/nucypher/blockchain/eth/interfaces.py(264)attach_middleware()->None
-> self.configure_gas_strategy()
(Pdb) fill_transaction_defaults(self.w3, {})
{'value': 0, 'data': b'', 'gas': 53000, 'gasPrice': 1694505766, 'chainId': 80001}
```

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
