### PR TITLE
Prometheus Update

### DIFF
--- a/newsfragments/3388.feature.rst
+++ b/newsfragments/3388.feature.rst
@@ -1,0 +1,1 @@
+Make prometheus optional, and allow fine tuning of collection interval.

--- a/nucypher/acumen/perception.py
+++ b/nucypher/acumen/perception.py
@@ -203,7 +203,7 @@ class FleetState:
 
 class FleetSensor:
     """
-    A representation of a fleet of NuCypher nodes.
+    A representation of a fleet of nodes.
 
     If `this_node` is provided, it will be included in the state checksum
     (but not returned during iteration/lookups).

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -390,10 +390,22 @@ def forget(general_config, config_options, config_file):
 @option_force
 @group_general_config
 @click.option(
+    "--prometheus",
+    help="Enable the prometheus metrics exporter",
+    is_flag=True,
+    default=False,
+)
+@click.option(
     "--metrics-port",
-    help="Specify the HTTP port of the Prometheus metrics exporter",
+    help="Specify the HTTP port of the Prometheus metrics exporter (if prometheus enabled)",
     default=9101,
     type=NETWORK_PORT,
+)
+@click.option(
+    "--metrics-interval",
+    help="The frequency of metrics collection (if prometheus enabled)",
+    type=click.INT,
+    default=90,
 )
 @click.option(
     "--ip-checkup/--no-ip-checkup",
@@ -405,7 +417,9 @@ def run(
     character_options,
     config_file,
     dry_run,
+    prometheus,
     metrics_port,
+    metrics_interval,
     force,
     ip_checkup,
 ):
@@ -417,7 +431,11 @@ def run(
 
     _pre_launch_warnings(emitter, dev=dev_mode, force=None)
 
-    prometheus_config = PrometheusMetricsConfig(port=metrics_port)
+    prometheus_config = None
+    if prometheus:
+        prometheus_config = PrometheusMetricsConfig(
+            port=metrics_port, collection_interval=metrics_interval
+        )
 
     ursula_config, URSULA = character_options.create_character(
         emitter=emitter, config_file=config_file, json_ipc=general_config.json_ipc

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -403,7 +403,7 @@ def forget(general_config, config_options, config_file):
 )
 @click.option(
     "--metrics-interval",
-    help="The frequency of metrics collection (if prometheus enabled)",
+    help="The frequency of metrics collection in seconds (if prometheus enabled)",
     type=click.INT,
     default=90,
 )

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -70,12 +70,12 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
     def initialize(self, registry: CollectorRegistry) -> None:
         self.metrics = {
             "client_info": Info("client", "TACo node client info", registry=registry),
-            "discovery_status_gauge": Gauge(
+            "discovery_status": Gauge(
                 "node_discovery_running",
                 "Node discovery loop status",
                 registry=registry,
             ),
-            "known_nodes_gauge": Gauge(
+            "known_nodes": Gauge(
                 "known_nodes",
                 "Number of currently known nodes",
                 registry=registry,
@@ -86,7 +86,7 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
         # info
         payload = {
             "app": "TACo",
-            "app_version": nucypher.__version__,
+            "version": nucypher.__version__,
             "host": str(self.ursula.rest_interface),
             "domain": str(self.ursula.domain),
             "nickname": str(self.ursula.nickname),
@@ -96,8 +96,8 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
         }
 
         self.metrics["client_info"].info(payload)
-        self.metrics["discovery_status_gauge"].set(self.ursula._learning_task.running)
-        self.metrics["known_nodes_gauge"].set(len(self.ursula.known_nodes))
+        self.metrics["discovery_status"].set(self.ursula._learning_task.running)
+        self.metrics["known_nodes"].set(len(self.ursula.known_nodes))
 
 
 class BlockchainMetricsCollector(BaseMetricsCollector):
@@ -161,7 +161,7 @@ class StakingProviderMetricsCollector(BaseMetricsCollector):
 
     def initialize(self, registry: CollectorRegistry) -> None:
         self.metrics = {
-            "active_stake_gauge": Gauge(
+            "active_stake": Gauge(
                 "active_stake",
                 "Total amount of T staked",
                 registry=registry,
@@ -187,7 +187,7 @@ class StakingProviderMetricsCollector(BaseMetricsCollector):
         authorized = application_agent.get_authorized_stake(
             staking_provider=self.staking_provider_address
         )
-        self.metrics["active_stake_gauge"].set(int(authorized))
+        self.metrics["active_stake"].set(int(authorized))
 
         staking_provider_info = application_agent.get_staking_provider_info(
             staking_provider=self.staking_provider_address

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -14,6 +14,7 @@ from nucypher.characters import lawful
 from nucypher.utilities.prometheus.collector import (
     BlockchainMetricsCollector,
     MetricsCollector,
+    OperatorMetricsCollector,
     StakingProviderMetricsCollector,
     UrsulaInfoMetricsCollector,
 )
@@ -153,23 +154,22 @@ def start_prometheus_exporter(
 
 def create_metrics_collectors(ursula: "lawful.Ursula") -> List[MetricsCollector]:
     """Create collectors used to obtain metrics."""
-    collectors: List[MetricsCollector] = [UrsulaInfoMetricsCollector(ursula=ursula)]
-
-    # Blockchain prometheus
-    collectors.append(
+    collectors: List[MetricsCollector] = [
+        UrsulaInfoMetricsCollector(ursula=ursula),
         BlockchainMetricsCollector(
             root_net_endpoint=ursula.eth_endpoint,
             child_net_endpoint=ursula.polygon_endpoint,
-        )
-    )
-
-    # Staking Provider prometheus
-    collectors.append(
+        ),
         StakingProviderMetricsCollector(
             staking_provider_address=ursula.checksum_address,
             contract_registry=ursula.registry,
             eth_endpoint=ursula.eth_endpoint,
+        ),
+        OperatorMetricsCollector(
+            operator_address=ursula.operator_address,
+            contract_registry=ursula.registry,
+            polygon_endpoint=ursula.polygon_endpoint,
         )
-    )
+    ]
 
     return collectors

--- a/tests/acceptance/cli/test_ursula_run.py
+++ b/tests/acceptance/cli/test_ursula_run.py
@@ -36,31 +36,6 @@ def test_missing_configuration_file(_default_filepath_mock, click_runner):
 
 
 @pt.inlineCallbacks
-def test_ursula_run_with_prometheus_but_no_metrics_port(click_runner):
-    args = (
-        "ursula",
-        "run",  # Stat Ursula Command
-        "--debug",  # Display log output; Do not attach console
-        "--dev",  # Run in development mode (local ephemeral node)
-        "--dry-run",  # Disable twisted reactor in subprocess
-        "--lonely",  # Do not load seednodes
-        "--prometheus",  # Specify collection of prometheus metrics
-        "--eth-endpoint",
-        TEST_ETH_PROVIDER_URI,
-        "--polygon-endpoint",
-        TEST_POLYGON_PROVIDER_URI,
-    )
-
-    result = yield threads.deferToThread(
-        click_runner.invoke, nucypher_cli, args, catch_exceptions=False
-    )
-
-    assert result.exit_code != 0
-    expected_error = "Error: --metrics-port is required when using --prometheus"
-    assert expected_error in result.output
-
-
-@pt.inlineCallbacks
 def test_run_lone_default_development_ursula(click_runner, ursulas, testerchain):
     deploy_port = select_test_port()
     args = (

--- a/tests/integration/cli/test_ursula_cli_prometheus.py
+++ b/tests/integration/cli/test_ursula_cli_prometheus.py
@@ -74,7 +74,7 @@ def test_ursula_cli_prometheus(
     ), "Wrong value for start_now in prometheus_config"
 
 
-def test_ursula_cli_prometheus_metrics_port(
+def test_ursula_cli_prometheus_metrics_non_default_port_and_interval(
     click_runner,
     mocker,
     ursulas,
@@ -84,6 +84,7 @@ def test_ursula_cli_prometheus_metrics_port(
     mock_prometheus,
 ):
     port = 6666
+    interval = 30
 
     mock_ursula_run(mocker, ursulas, monkeypatch, ursula_test_config, mock_prometheus)
 
@@ -97,6 +98,8 @@ def test_ursula_cli_prometheus_metrics_port(
         "--prometheus",
         "--metrics-port",
         str(port),
+        "--metrics-interval",
+        str(interval),
     )
 
     result = click_runner.invoke(
@@ -117,7 +120,8 @@ def test_ursula_cli_prometheus_metrics_port(
         mock_prometheus.call_args.kwargs["prometheus_config"].listen_address == ""
     ), "Wrong listen address set in prometheus_config"
     assert (
-        mock_prometheus.call_args.kwargs["prometheus_config"].collection_interval == 90
+        mock_prometheus.call_args.kwargs["prometheus_config"].collection_interval
+        == interval
     ), "Wrong collection interval set in prometheus_config"
     assert (
         mock_prometheus.call_args.kwargs["prometheus_config"].start_now is False

--- a/tests/integration/cli/test_ursula_cli_prometheus.py
+++ b/tests/integration/cli/test_ursula_cli_prometheus.py
@@ -43,6 +43,7 @@ def test_ursula_cli_prometheus(
     run_args = (
         "ursula",
         "run",
+        "--prometheus",
         "--dry-run",
         "--debug",
         "--config-file",
@@ -93,6 +94,7 @@ def test_ursula_cli_prometheus_metrics_port(
         "--debug",
         "--config-file",
         str(tempfile_path.absolute()),
+        "--prometheus",
         "--metrics-port",
         str(port),
     )

--- a/tests/unit/test_prometheus.py
+++ b/tests/unit/test_prometheus.py
@@ -38,7 +38,7 @@ def test_prometheus_metrics_config():
 
     prometheus_config = PrometheusMetricsConfig(port=port)
 
-    assert prometheus_config.port == 2020
+    assert prometheus_config.port == port
 
     # defaults
     assert prometheus_config.collection_interval == 90


### PR DESCRIPTION
Allow metrics-port to be specified via cli option.

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Make prometheus optional via `--prometheus` CLI flag (undoes requirement from #3294)
- Allow `--metrics-port` to be specified via cli option.
- Allow `--metrics-interval` to be specified via cli option (with default value of 90s)
- Rename `app_version` to `version`
- Remove `_gauge` suffix from metric names
- Collect `operator_confirmed` on Polygon (Child) instead of Ethereum (Root)
- Collect operator metric for MATIC balance (fixes #3380, related to #3236)


**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
