### PR TITLE
Node freeze fix

### DIFF
--- a/examples/testnet_compound_multichain_taco.py
+++ b/examples/testnet_compound_multichain_taco.py
@@ -38,7 +38,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 0  # got this from a side channel
+ritual_id = 5  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
 # known authorized encryptor for ritual 3

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -39,7 +39,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 0  # got this from a side channel
+ritual_id = 5  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
 # known authorized encryptor for ritual 3

--- a/newsfragments/3390.bugfix.rst
+++ b/newsfragments/3390.bugfix.rst
@@ -1,0 +1,5 @@
+Node blocks and remains unresponsive when another node in the cohort is
+unreachable during a dkg ritual because the ferveo public key is obtained from
+a node directly through node discovery. Instead, obtain ferveo public key
+from Coordinator contract so that connecting to the another node in
+the cohort is unnecessary.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1,4 +1,5 @@
 import json
+import random
 import time
 from collections import defaultdict
 from decimal import Decimal
@@ -133,6 +134,8 @@ class NucypherTokenActor(BaseActor):
 class Operator(BaseActor):
     READY_TIMEOUT = None  # (None or 0) == indefinite
     READY_POLL_RATE = 120  # seconds
+
+    AGGREGATION_SUBMISSION_MAX_DELAY = 60
 
     class OperatorError(BaseActor.ActorError):
         """Operator-specific errors."""
@@ -513,6 +516,11 @@ class Operator(BaseActor):
 
         # publish the transcript and store the receipt
         total = ritual.total_aggregations + 1
+
+        # distribute submission of aggregated transcripts - don't want all nodes submitting at
+        # the same time
+        time.sleep(random.randint(0, self.AGGREGATION_SUBMISSION_MAX_DELAY))
+
         tx_hash = self.publish_aggregated_transcript(
             ritual_id=ritual_id,
             aggregated_transcript=aggregated_transcript,

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -910,6 +910,7 @@ class CoordinatorAgent(EthereumContractAgent):
         )
         receipt = self.blockchain.send_transaction(
             contract_function=contract_function,
+            gas_estimation_multiplier=1.4,
             transacting_power=transacting_power,
             fire_and_forget=fire_and_forget,
         )

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -63,7 +63,7 @@ class EventScannerTask(SimpleTask):
         self.log.warn("Error during ritual event scanning: {}".format(args[0].getTraceback()))
         if not self._task.running:
             self.log.warn("Restarting event scanner task!")
-            self.start(now=True)
+            self.start(now=False)  # take a breather
 
 
 class ActiveRitualTracker:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 from functools import partial
 from pathlib import Path
 from typing import Tuple
+from unittest.mock import PropertyMock
 
 import maya
 import pytest
@@ -765,3 +766,14 @@ def dkg_public_key(dkg_public_key_data) -> DkgPublicKey:
 def aggregated_transcript(dkg_public_key_data) -> AggregatedTranscript:
     aggregated_transcript, _ = dkg_public_key_data
     return aggregated_transcript
+
+
+#
+# DKG Ritual Aggregation
+#
+@pytest.fixture(scope="module", autouse=True)
+def mock_operator_aggregation_delay(module_mocker):
+    module_mocker.patch(
+        "nucypher.blockchain.eth.actors.Operator.AGGREGATION_SUBMISSION_MAX_DELAY",
+        PropertyMock(return_value=1),
+    )

--- a/tests/integration/blockchain/test_integration_dkg_ritual.py
+++ b/tests/integration/blockchain/test_integration_dkg_ritual.py
@@ -12,6 +12,7 @@ from web3.datastructures import AttributeDict
 from nucypher.blockchain.eth.agents import CoordinatorAgent
 from nucypher.blockchain.eth.signers.software import Web3Signer
 from nucypher.characters.lawful import Enrico, Ursula
+from nucypher.crypto.powers import RitualisticPower
 from nucypher.policy.conditions.lingo import ConditionLingo, ConditionType
 from tests.constants import TESTERCHAIN_CHAIN_ID
 from tests.mock.coordinator import MockCoordinatorAgent
@@ -67,6 +68,9 @@ def cohort(ursulas, mock_coordinator_agent):
         # set mapping in coordinator agent
         mock_coordinator_agent._add_operator_to_staking_provider_mapping(
             {u.operator_address: u.checksum_address}
+        )
+        mock_coordinator_agent.set_provider_public_key(
+            u.public_keys(RitualisticPower), u.transacting_power
         )
         u.coordinator_agent = mock_coordinator_agent
         u.ritual_tracker.coordinator_agent = mock_coordinator_agent

--- a/tests/mock/coordinator.py
+++ b/tests/mock/coordinator.py
@@ -170,9 +170,8 @@ class MockCoordinatorAgent(MockContractAgent):
         ritual.total_aggregations += 1
         return self.blockchain.FAKE_RECEIPT
 
-    @staticmethod
-    def is_provider_public_key_set(staking_provider: ChecksumAddress) -> bool:
-        return False
+    def is_provider_public_key_set(self, staking_provider: ChecksumAddress) -> bool:
+        return staking_provider in self._participant_keys_history
 
     def set_provider_public_key(
         self, public_key: FerveoPublicKey, transacting_power: TransactingPower
@@ -187,6 +186,7 @@ class MockCoordinatorAgent(MockContractAgent):
         participant_keys = self._participant_keys_history.get(provider_address)
         if not participant_keys:
             participant_keys = []
+            self._participant_keys_history[provider_address] = participant_keys
 
         participant_keys.append(
             self.ParticipantKey(
@@ -274,7 +274,7 @@ class MockCoordinatorAgent(MockContractAgent):
     def get_provider_public_key(
         self, provider: ChecksumAddress, ritual_id: int
     ) -> FerveoPublicKey:
-        participant_keys = self._participant_keys_history.get(provider)
+        participant_keys = self._participant_keys_history[provider]
         for participant_key in reversed(participant_keys):
             if participant_key.lastRitualId <= ritual_id:
                 g2Point = participant_key.publicKey

--- a/tests/unit/test_ritualist.py
+++ b/tests/unit/test_ritualist.py
@@ -2,16 +2,23 @@ import pytest
 
 from nucypher.blockchain.eth.agents import CoordinatorAgent
 from nucypher.blockchain.eth.signers.software import Web3Signer
-from nucypher.crypto.powers import TransactingPower
+from nucypher.crypto.powers import RitualisticPower, TransactingPower
 from tests.constants import MOCK_ETH_PROVIDER_URI
 from tests.mock.coordinator import MockCoordinatorAgent
 
 
 @pytest.fixture(scope="module")
-def agent(mock_contract_agency) -> MockCoordinatorAgent:
+def agent(mock_contract_agency, ursulas) -> MockCoordinatorAgent:
     coordinator_agent: CoordinatorAgent = mock_contract_agency.get_agent(
         CoordinatorAgent, registry=None, blockchain_endpoint=MOCK_ETH_PROVIDER_URI
     )
+
+    def mock_get_provider_public_key(provider, ritual_id):
+        for ursula in ursulas:
+            if ursula.checksum_address == provider:
+                return ursula.public_keys(RitualisticPower)
+
+    coordinator_agent.get_provider_public_key = mock_get_provider_public_key
     return coordinator_agent
 
 


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Nodes should not block learning about nodes to obtain ferveo public keys - these can be obtained from the Coordinator contract/CoordinatorAgent.

- [x] Obtain node's ferveo key from Coordinator
- [x] Better handle race condition of posting aggregation and not knowing whether they will be the last one to submit their aggregated transcript or not (related to #3391) - the node that is last incurs higher gas when submitting their transcript. Issue is exacerbated by a high number of nodes in the cohort all responding at the same time. Reduce probability of race condition by:
     1. Increasing multiplier for post aggregation transaction
     2. Add random stagger to nodes when submitting aggregated transcript to Coordinator 
- [x] When EventScanner restarts due to crash, don't start immediately but wait one interval before starting - just to take  breather.

**Issues fixed/closed:**
> - Fixes #...

Fixes #3389 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
