### PR TITLE
Optimize use of decryption request WorkerPool

### DIFF
--- a/newsfragments/3393.dev.rst
+++ b/newsfragments/3393.dev.rst
@@ -1,0 +1,1 @@
+Optimize use of decryption request WorkerPool.

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -186,7 +186,7 @@ class RegistrySourceManager:
     def __init__(
         self,
         domain: TACoDomain,
-        sources: Optional[RegistrySource] = None,
+        sources: Optional[List[RegistrySource]] = None,
         only_primary: bool = False,
     ):
         if only_primary and sources:

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -67,10 +67,11 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
             self.log.warn(message)
             raise self.ThresholdDecryptionRequestFailed(message)
 
+        batch_size = min(int(threshold * 1.25), len(encrypted_requests))
         worker_pool = WorkerPool(
             worker=worker,
             value_factory=self.ThresholdDecryptionRequestFactory(
-                ursula_to_contact=list(encrypted_requests.keys()), threshold=threshold
+                ursulas_to_contact=list(encrypted_requests.keys()), threshold=batch_size
             ),
             target_successes=threshold,
             threadpool_size=len(

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -13,6 +13,7 @@ from nucypher.utilities.concurrency import BatchValueFactory, WorkerPool
 
 class ThresholdDecryptionClient(ThresholdAccessControlClient):
     DEFAULT_DECRYPTION_TIMEOUT = 15
+    DEFAULT_STAGGER_TIMEOUT = 10
 
     class ThresholdDecryptionRequestFailed(Exception):
         """Raised when a decryption request returns a non-zero status code."""
@@ -30,6 +31,7 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
         encrypted_requests: Dict[ChecksumAddress, EncryptedThresholdDecryptionRequest],
         threshold: int,
         timeout: int = DEFAULT_DECRYPTION_TIMEOUT,
+        stagger_timeout: int = DEFAULT_STAGGER_TIMEOUT,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],
@@ -78,6 +80,7 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
                 encrypted_requests
             ),  # TODO should we cap this (say 40?)
             timeout=timeout,
+            stagger_timeout=stagger_timeout,
         )
         worker_pool.start()
         try:

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -71,8 +71,9 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
                         response.content
                     )
             except Exception as e:
-                self.log.warn(f"Node {ursula_address} raised {e}")
-                raise
+                message = f"Node {ursula_address} raised {e}"
+                self.log.warn(message)
+                raise self.ThresholdDecryptionRequestFailed(message)
 
             message = f"Node {ursula_address} returned {response.status_code} - {response.content}."
             self.log.warn(message)

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -1,4 +1,5 @@
 from http import HTTPStatus
+from random import shuffle
 from typing import Dict, List, Tuple
 
 from eth_typing import ChecksumAddress
@@ -77,10 +78,13 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
             self.log.warn(message)
             raise self.ThresholdDecryptionRequestFailed(message)
 
+        # TODO: Find a better request order, perhaps based on latency data obtained from discovery loop - #3395
+        requests = list(encrypted_requests)
+        shuffle(requests)
         worker_pool = WorkerPool(
             worker=worker,
             value_factory=self.ThresholdDecryptionRequestFactory(
-                ursulas_to_contact=list(encrypted_requests.keys()),
+                ursulas_to_contact=requests,
                 batch_size=int(threshold * 1.25),
                 threshold=threshold,
             ),

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -18,9 +18,9 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
         """Raised when a decryption request returns a non-zero status code."""
 
     class ThresholdDecryptionRequestFactory(BatchValueFactory):
-        def __init__(self, ursula_to_contact: List[ChecksumAddress], threshold: int):
+        def __init__(self, ursulas_to_contact: List[ChecksumAddress], threshold: int):
             # TODO should we batch the ursulas to contact i.e. pass `batch_size` parameter
-            super().__init__(values=ursula_to_contact, required_successes=threshold)
+            super().__init__(values=ursulas_to_contact, required_successes=threshold)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -90,7 +90,7 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
             successes = worker_pool.get_successes()
         finally:
             worker_pool.cancel()
-            worker_pool.join()
+
         failures = worker_pool.get_failures()
 
         return successes, failures

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -13,7 +13,7 @@ from nucypher.utilities.concurrency import BatchValueFactory, WorkerPool
 
 
 class ThresholdDecryptionClient(ThresholdAccessControlClient):
-    DEFAULT_DECRYPTION_TIMEOUT = 15
+    DEFAULT_DECRYPTION_TIMEOUT = 30
     DEFAULT_STAGGER_TIMEOUT = 10
 
     class ThresholdDecryptionRequestFailed(Exception):

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -662,7 +662,9 @@ class Learner:
                     self.log.info(f"Learned about enough nodes after {rounds_undertaken} rounds.")
                     return True
                 if not self._learning_task.running:
-                    raise RuntimeError("Learning loop is not running.  Start it with start_learning().")
+                    raise RuntimeError(
+                        "Learning loop is not running.  Start it with start_learning_loop()."
+                    )
                 elif not reactor.running and not learn_on_this_thread:
                     raise RuntimeError(
                         f"The reactor isn't running, but you're trying to use it for discovery.  You need to start the Reactor in order to use {self} this way.")

--- a/nucypher/utilities/concurrency.py
+++ b/nucypher/utilities/concurrency.py
@@ -354,7 +354,7 @@ class BatchValueFactory:
 
         if batch_size is not None and batch_size <= 0:
             raise ValueError(f"Invalid batch size specified ({batch_size})")
-        self.batch_size = batch_size if batch_size else required_successes
+        self.batch_size = batch_size or required_successes
 
     def __call__(self, successes) -> Optional[List[Any]]:
         if successes >= self.required_successes:


### PR DESCRIPTION
Currently, TDec is taking roughly 15 to 20 seconds on mainnet, which is very slow. After evaluation what's happening on the 
WorkerPool, I can see that during decryption requests, the WorkerPool was not properly used causing to behave both too impatiently and too patiently at the same time. Let me explain:
* The WorkerPool creates TDec request threads in batches. Current code creates batches of `threshold` size (which is a bit tight since some of them may fail), but immediately creates a new batch since the previous batch didn't succeed right away. This was effectively firing requests to all nodes in the cohort. That's why I'm saying it's too impatient for some things. Ideally, we should wait a reasonable amount of time for each batch.
* At the same time, we were waiting for all threads to complete, even if we already had the necessary number of requests. This is why I said it's too patient for other things. This problem was compounding on the first issue, since now it had to wait for all cohort members to respond, which was effectively making the process as slow as the slowest member.

This PR does the following:
* Removes the thread `join` so we don't need to wait for more requests than necessary
* Adds a bit of stagger between batches (10 seconds)
* Makes batch size to be `threshold * 1.25`

As a result, TDec takes now ~7 seconds, instead of 15 to 20.

Note that this are all Bob/Porter optimizations, and it's unlikely we can get more on this side. Look at how long each individual TDec request takes on mainnet:
```
0xB88A62417eb9e6320AF7620BE0CFBE2dddd435A5@35.241.135.53:9151 4.139189004898071 seconds
0xBa1Ac67539c09AdDe63335635869c86f8e463514@54.220.88.216:9151 4.172182083129883 seconds
0x9C7c2B00Ea7800fbe32FD50d844645Db07C27a74@34.72.138.93:9151 4.685160160064697 seconds
0x0C635dC500222aF8a12072922C6aC5a4fc536faC@24.214.74.90:9151 4.692476987838745 seconds
0x00ACA6dFd2fBCAD074A5F116bAD0B057900230D9@34.123.25.8:9101 4.674924850463867 seconds
0xB8Ee380FD71eaCCB4948dd7CEE5B6FCB822Fc4fc@134.209.196.41:9151 4.83219313621521 seconds
0x4553dAA29662971ff6f1cA59390287E8Bc25825F@143.110.209.220:9151 4.847330093383789 seconds
0x913fC1644376dA7e125cBb87a010e7Dd3b34D67c@164.92.141.186:9151 4.903774976730347 seconds
0x456D643CD97b058Fd3bBBEB76f04B1DE3679bc6A@164.92.185.74:9151 4.907711982727051 seconds
0xb011b6794F271B1d8D2328eDf332535343CB4D44@161.35.80.83:9151 5.173793077468872 seconds
0x3070f20f86fDa706Ac380F5060D256028a46eC29@209.97.191.190:9151 5.194106817245483 seconds
0xBa03E5e2fD41092c36354435FeFAE25A322AA838@46.101.35.52:9151 5.400359869003296 seconds
0x97d065B567cc4543D20dffaa7009f9aDe64d7E26@159.223.223.241:9151 5.5115039348602295 seconds
0x378C89b5B93667A005856822e1b65e2d7C076373@135.181.92.236:9151 5.81945276260376 seconds
0x50740bEcEe506cdc0567FD4B3ea04249Fb8c8676@137.184.191.183:9151 5.861227035522461 seconds
0x9709173Ed6F194a953a77204359DbFD0e88a54D0@146.190.136.175:9151 6.582633018493652 seconds
```
As you can see, the 16th slowest node took 6.58 seconds to respond, out of the ~7 seconds the whole TDec process took. 

**Type of PR:**
Other

**Required reviews:** 
2

