### PR TITLE
set MAX_UPLOAD_CONTENT_LENGTH to 250kb

### DIFF
--- a/newsfragments/3396.bugfix.rst
+++ b/newsfragments/3396.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `MAX_UPLOAD_CONTENT_LENGTH` too small for mainnet TACo rituals

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -37,8 +37,8 @@ NUCYPHER_SENTRY_USER_ID = ""
 NUCYPHER_SENTRY_ENDPOINT = f"https://{NUCYPHER_SENTRY_PUBLIC_KEY}@sentry.io/{NUCYPHER_SENTRY_USER_ID}"
 
 # Web
-CLI_ROOT = NUCYPHER_PACKAGE / 'network' / 'templates'
-MAX_UPLOAD_CONTENT_LENGTH = 1024 * 250 # 250kb
+CLI_ROOT = NUCYPHER_PACKAGE / "network" / "templates"
+MAX_UPLOAD_CONTENT_LENGTH = 1024 * 250  # 250kb
 
 # Dev Mode
 TEMPORARY_DOMAIN_NAME = ":temporary-domain:"  # for use with `--dev` node runtimes

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -38,7 +38,7 @@ NUCYPHER_SENTRY_ENDPOINT = f"https://{NUCYPHER_SENTRY_PUBLIC_KEY}@sentry.io/{NUC
 
 # Web
 CLI_ROOT = NUCYPHER_PACKAGE / 'network' / 'templates'
-MAX_UPLOAD_CONTENT_LENGTH = 1024 * 50
+MAX_UPLOAD_CONTENT_LENGTH = 1024 * 250 # 250kb
 
 # Dev Mode
 TEMPORARY_DOMAIN_NAME = ":temporary-domain:"  # for use with `--dev` node runtimes


### PR DESCRIPTION
**Type of PR:**
- Bugfix

**Required reviews:** 
- 1

**What this does:**
- Increases `MAX_UPLOAD_CONTENT_LENGTH` to 250kb

**Why it's needed:**
- In TACo, as the threshold increases, so does the number of decryption requests. Those requests are sent in bulk to Porter, who's currently rejecting any request larger than 50kb. So for any threshold larger than ~12, this will result in HTTP `413 Request Entity Too Large`.
- Setting `MAX_UPLOAD_CONTENT_LENGTH` to 250kb should accommodate thresholds up to about 50 
(I eyeballed this one)

**Notes for reviewers:**
- Is 250kb too big/small? Could we increase it to, for example, 500kb? I don't think we're going to run rituals larger than 50-of-M anytime soon?
