### PR TITLE
Decryption requests metrics

### DIFF
--- a/newsfragments/3397.feature.rst
+++ b/newsfragments/3397.feature.rst
@@ -1,0 +1,1 @@
+Add prometheus metrics for tracking total threshold decryption requests and errors.

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -4,6 +4,7 @@ import time
 from typing import Callable, List, Optional, Tuple
 
 import maya
+from prometheus_client import REGISTRY, Gauge
 from twisted.internet import threads
 from web3.datastructures import AttributeDict
 
@@ -64,6 +65,13 @@ class EventScannerTask(SimpleTask):
         if not self._task.running:
             self.log.warn("Restarting event scanner task!")
             self.start(now=False)  # take a breather
+
+
+LAST_SCANNED_BLOCK_METRIC = Gauge(
+    "ritual_events_last_scanned_block_number",
+    "Last scanned block number for ritual events",
+    registry=REGISTRY,
+)
 
 
 class ActiveRitualTracker:
@@ -417,14 +425,16 @@ class ActiveRitualTracker:
         Because there might have been a minor Ethereum chain reorganisations since the last scan ended,
         we need to discard the last few blocks from the previous scan results.
         """
-        self.scanner.delete_potentially_forked_block_data(
-            self.state.get_last_scanned_block() - self.scanner.chain_reorg_rescan_window
-        )
+        last_scanned_block = self.scanner.get_last_scanned_block()
+        LAST_SCANNED_BLOCK_METRIC.set(last_scanned_block)
 
-        if self.scanner.get_last_scanned_block() == 0:
+        if last_scanned_block == 0:
             # first run so calculate starting block number based on dkg timeout
             suggested_start_block = self._get_first_scan_start_block_number()
         else:
+            self.scanner.delete_potentially_forked_block_data(
+                last_scanned_block - self.scanner.chain_reorg_rescan_window
+            )
             suggested_start_block = self.scanner.get_suggested_scan_start_block()
 
         end_block = self.scanner.get_suggested_scan_end_block()

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -67,13 +67,6 @@ class EventScannerTask(SimpleTask):
             self.start(now=False)  # take a breather
 
 
-LAST_SCANNED_BLOCK_METRIC = Gauge(
-    "ritual_events_last_scanned_block_number",
-    "Last scanned block number for ritual events",
-    registry=REGISTRY,
-)
-
-
 class ActiveRitualTracker:
 
     MAX_CHUNK_SIZE = 10000
@@ -83,6 +76,12 @@ class ActiveRitualTracker:
 
     # what's the buffer for potentially receiving repeated events - 10mins?
     _RITUAL_TIMEOUT_ADDITIONAL_TTL_BUFFER = 60 * 10
+
+    _LAST_SCANNED_BLOCK_METRIC = Gauge(
+        "ritual_events_last_scanned_block_number",
+        "Last scanned block number for ritual events",
+        registry=REGISTRY,
+    )
 
     class ParticipationState:
         def __init__(
@@ -426,7 +425,7 @@ class ActiveRitualTracker:
         we need to discard the last few blocks from the previous scan results.
         """
         last_scanned_block = self.scanner.get_last_scanned_block()
-        LAST_SCANNED_BLOCK_METRIC.set(last_scanned_block)
+        self._LAST_SCANNED_BLOCK_METRIC.set(last_scanned_block)
 
         if last_scanned_block == 0:
             # first run so calculate starting block number based on dkg timeout

--- a/nucypher/blockchain/eth/trackers/prometheus.py
+++ b/nucypher/blockchain/eth/trackers/prometheus.py
@@ -1,0 +1,24 @@
+from typing import List
+
+from nucypher.utilities.prometheus.collector import MetricsCollector
+from nucypher.utilities.task import SimpleTask
+
+
+class PrometheusMetricsTracker(SimpleTask):
+    def __init__(self, collectors: List[MetricsCollector], interval: float):
+        self.metrics_collectors = collectors
+        super().__init__(interval=interval)
+
+    def run(self):
+        for collector in self.metrics_collectors:
+            collector.collect()
+
+    def handle_errors(self, *args, **kwargs):
+        self.log.warn(
+            "Error during prometheus metrics collection: {}".format(
+                args[0].getTraceback()
+            )
+        )
+        if not self._task.running:
+            self.log.warn("Restarting prometheus metrics task!")
+            self.start(now=False)  # take a breather

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -890,6 +890,8 @@ class Ursula(Teacher, Character, Operator):
             certificate_filepath=certificate_filepath,
         )
 
+        self._prometheus_metrics_tracker = None
+
     def _substantiate_stamp(self):
         transacting_power = self.transacting_power
         signature = transacting_power.sign_message(message=bytes(self.stamp))
@@ -1009,7 +1011,9 @@ class Ursula(Teacher, Character, Operator):
             emitter.message("✓ Start Operator Bonded Tracker", color="green")
 
         if prometheus_config:
-            start_prometheus_exporter(ursula=self, prometheus_config=prometheus_config)
+            self._prometheus_metrics_tracker = start_prometheus_exporter(
+                ursula=self, prometheus_config=prometheus_config
+            )
             if emitter:
                 emitter.message(
                     f"✓ Prometheus Exporter http://{self.rest_interface.host}:"
@@ -1061,6 +1065,8 @@ class Ursula(Teacher, Character, Operator):
             self.stop_learning_loop()
             self._operator_bonded_tracker.stop()
             self.ritual_tracker.stop()
+            if self._prometheus_metrics_tracker:
+                self._prometheus_metrics_tracker.stop()
         if halt_reactor:
             reactor.stop()
 

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -29,13 +29,18 @@ from nucypher.policy.conditions.utils import (
 from nucypher.utilities.logging import Logger
 
 DECRYPTION_REQUESTS = Counter(
-    "threshold_decryption_requests",
+    "threshold_decryption_num_requests",
     "Number of threshold decryption requests",
     registry=REGISTRY,
 )
-DECRYPTION_REQUESTS_ERRORS = Counter(
-    "threshold_decryption_errors",
-    "Number of threshold decryption errors",
+DECRYPTION_REQUESTS_SUCCESSES = Counter(
+    "threshold_decryption_num_successes",
+    "Number of threshold decryption successes",
+    registry=REGISTRY,
+)
+DECRYPTION_REQUESTS_FAILURES = Counter(
+    "threshold_decryption_num_failures",
+    "Number of threshold decryption failures",
     registry=REGISTRY,
 )
 
@@ -164,7 +169,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
     def threshold_decrypt():
         DECRYPTION_REQUESTS.inc()
         try:
-            with DECRYPTION_REQUESTS_ERRORS.count_exceptions():
+            with DECRYPTION_REQUESTS_FAILURES.count_exceptions():
                 encrypted_request = EncryptedThresholdDecryptionRequest.from_bytes(
                     request.data
                 )
@@ -172,6 +177,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
                     encrypted_request
                 )
 
+            DECRYPTION_REQUESTS_SUCCESSES.inc()
             response = Response(
                 response=bytes(encrypted_response),
                 status=HTTPStatus.OK,

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -75,7 +75,7 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
     def initialize(self, registry: CollectorRegistry) -> None:
         self.metrics = {
             "client_info": Info("client", "TACo node client info", registry=registry),
-            "discovery_status": Gauge(
+            "node_discovery_running": Gauge(
                 "node_discovery_running",
                 "Node discovery loop status",
                 registry=registry,
@@ -101,7 +101,7 @@ class UrsulaInfoMetricsCollector(BaseMetricsCollector):
         }
 
         self.metrics["client_info"].info(payload)
-        self.metrics["discovery_status"].set(self.ursula._learning_task.running)
+        self.metrics["node_discovery_running"].set(self.ursula._learning_task.running)
         self.metrics["known_nodes"].set(len(self.ursula.known_nodes))
 
 

--- a/nucypher/utilities/prometheus/collector.py
+++ b/nucypher/utilities/prometheus/collector.py
@@ -187,7 +187,7 @@ class StakingProviderMetricsCollector(BaseMetricsCollector):
         authorized = application_agent.get_authorized_stake(
             staking_provider=self.staking_provider_address
         )
-        self.metrics["active_stake"].set(int(authorized))
+        self.metrics["active_stake"].set(Web3.from_wei(authorized, "ether"))
 
         staking_provider_info = application_agent.get_staking_provider_info(
             staking_provider=self.staking_provider_address

--- a/nucypher/utilities/prometheus/metrics.py
+++ b/nucypher/utilities/prometheus/metrics.py
@@ -125,9 +125,9 @@ def start_prometheus_exporter(
     """Configure, collect, and serve prometheus metrics."""
 
     # Disabling default collector metrics
-    REGISTRY.unregister(GC_COLLECTOR)
-    REGISTRY.unregister(PLATFORM_COLLECTOR)
-    REGISTRY.unregister(PROCESS_COLLECTOR)
+    registry.unregister(GC_COLLECTOR)
+    registry.unregister(PLATFORM_COLLECTOR)
+    registry.unregister(PROCESS_COLLECTOR)
 
     metrics_collectors = create_metrics_collectors(ursula)
     # initialize collectors

--- a/nucypher/utilities/task.py
+++ b/nucypher/utilities/task.py
@@ -12,7 +12,8 @@ class SimpleTask(ABC):
     INTERVAL = 60  # 60s default
     CLOCK = reactor
 
-    def __init__(self):
+    def __init__(self, interval: float = INTERVAL):
+        self.interval = interval
         self.log = Logger(self.__class__.__name__)
         self._task = LoopingCall(self.run)
         # self.__task.clock = self.CLOCK
@@ -25,7 +26,7 @@ class SimpleTask(ABC):
     def start(self, now: bool = False):
         """Start task."""
         if not self.running:
-            d = self._task.start(interval=self.INTERVAL, now=now)
+            d = self._task.start(interval=self.interval, now=now)
             d.addErrback(self.handle_errors)
             # return d
 

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -197,6 +197,11 @@ def test_ursula_ritualist(
         for ursula in cohort:
             assert ursula.dkg_storage.get_transcript(RITUAL_ID) is not None
 
+        last_scanned_block = REGISTRY.get_sample_value(
+            "ritual_events_last_scanned_block_number"
+        )
+        assert last_scanned_block > 0
+
     def test_encrypt(_):
         """Encrypts a message and returns the ciphertext and conditions"""
         print("==================== DKG ENCRYPTION ====================")

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -297,7 +297,7 @@ def test_ursula_ritualist(
         "threshold_decryption_num_successes_total"
     )
     num_decryption_requests = REGISTRY.get_sample_value(
-        "threshold_decryption_num_requests_total"
+        "decryption_request_processing_count"
     )
     assert num_decryption_requests == (
         num_decryption_successes + num_decryption_failures

--- a/tests/acceptance/characters/test_start_prometheus_exporter.py
+++ b/tests/acceptance/characters/test_start_prometheus_exporter.py
@@ -1,0 +1,44 @@
+from prometheus_client import REGISTRY
+from web3 import Web3
+
+from nucypher.utilities.prometheus.metrics import (
+    PrometheusMetricsConfig,
+    start_prometheus_exporter,
+)
+from tests.utils.ursula import select_test_port
+
+
+def test_start_prometheus_exporter(ursulas, testerchain):
+    ursula = ursulas[0]
+    task = None
+    try:
+        port = select_test_port()
+        config = PrometheusMetricsConfig(
+            port=port, start_now=True, collection_interval=5
+        )
+        task = start_prometheus_exporter(ursula, config, REGISTRY)
+        REGISTRY.collect()
+
+        assert bool(REGISTRY.get_sample_value("operator_confirmed"))
+
+        authorized_stake = ursula.application_agent.get_authorized_stake(
+            staking_provider=ursula.checksum_address
+        )
+        assert REGISTRY.get_sample_value("active_stake") == float(
+            Web3.from_wei(authorized_stake, "ether")
+        )
+        assert (
+            REGISTRY.get_sample_value("root_net_chain_id")
+            == ursula.application_agent.blockchain.client.chain_id
+        )
+        assert (
+            REGISTRY.get_sample_value("child_net_chain_id")
+            == ursula.child_application_agent.blockchain.client.chain_id
+        )
+        assert REGISTRY.get_sample_value("known_nodes") == len(ursula.known_nodes)
+        assert (
+            bool(REGISTRY.get_sample_value("node_discovery_running"))
+            == ursula._learning_task.running
+        )
+    finally:
+        task.stop()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -685,11 +685,6 @@ def control_time():
     return clock
 
 
-@pytest.fixture(scope="session", autouse=True)
-def mock_prometheus(session_mocker):
-    return session_mocker.patch("nucypher.characters.lawful.start_prometheus_exporter")
-
-
 @pytest.fixture(scope="module")
 def ursulas(testerchain, ursula_test_config, staking_providers):
     if MOCK_KNOWN_URSULAS_CACHE:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -296,3 +296,8 @@ def multichain_ids(module_mocker):
 def multichain_ursulas(ursulas, multichain_ids):
     setup_multichain_ursulas(ursulas=ursulas, chain_ids=multichain_ids)
     return ursulas
+
+
+@pytest.fixture(scope="module")
+def mock_prometheus(module_mocker):
+    return module_mocker.patch("nucypher.characters.lawful.start_prometheus_exporter")

--- a/tests/integration/utilities/test_prometheus_collectors.py
+++ b/tests/integration/utilities/test_prometheus_collectors.py
@@ -145,10 +145,11 @@ def test_staking_provider_metrics_collector(test_registry, staking_providers):
     active_stake = collector_registry.get_sample_value("active_stake")
     # only floats can be stored
     assert active_stake == float(
-        int(
+        Web3.from_wei(
             taco_application_agent.get_authorized_stake(
                 staking_provider=staking_provider_address
-            )
+            ),
+            "ether",
         )
     )
 

--- a/tests/unit/test_operator_bonded_tracker.py
+++ b/tests/unit/test_operator_bonded_tracker.py
@@ -66,7 +66,7 @@ def test_operator_bonded_but_becomes_unbonded(mocker, get_random_checksum_addres
         tracker.stop()
 
 
-def test_operator_handle_errors(mocker, get_random_checksum_address):
+def test_operator_handle_errors(mocker):
     ursula = mocker.Mock()
     tracker = OperatorBondedTracker(ursula=ursula)
 

--- a/tests/unit/test_prometheus_metrics_tracker.py
+++ b/tests/unit/test_prometheus_metrics_tracker.py
@@ -1,0 +1,35 @@
+import pytest_twisted
+from twisted.internet import threads
+
+from nucypher.blockchain.eth.trackers.prometheus import PrometheusMetricsTracker
+from nucypher.utilities.prometheus.collector import MetricsCollector
+
+
+@pytest_twisted.inlineCallbacks
+def test_execution_of_collectors(mocker):
+    collectors = []
+    for i in range(4):
+        collectors.append(mocker.Mock(spec=MetricsCollector))
+
+    tracker = PrometheusMetricsTracker(collectors=collectors, interval=45)
+    try:
+        d = threads.deferToThread(tracker.start)
+        yield d
+
+        d = threads.deferToThread(tracker.run)
+        yield d
+
+        for collector in collectors:
+            collector.collect.assert_called_once()
+    finally:
+        tracker.stop()
+
+
+def test_handle_errors(mocker):
+    tracker = PrometheusMetricsTracker(
+        collectors=[mocker.Mock(spec=MetricsCollector)], interval=45
+    )
+    f = mocker.Mock()
+    f.getTraceback.return_value = "traceback"
+
+    tracker.handle_errors(f)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
- Add metrics for decryption requests: total, successes, failures.
    - `threshold_decryption_num_successes_total`
    - `threshold_decryption_num_failures_total`
    - `decryption_request_processing_count`
    - `decryption_request_processing_sum`
 - Add metric for ritual events last scanned block number:
    - `ritual_events_last_scanned_block_number` 
- Update `active_stake` value to be denominated in "ether" instead of "wei".

Fixes #3236 

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
