### PR TITLE
Handle incoming [proxied] request IPv4 resolution

### DIFF
--- a/examples/pre/finnegans_wake_demo/finnegans-wake-demo-l2.py
+++ b/examples/pre/finnegans_wake_demo/finnegans-wake-demo-l2.py
@@ -1,8 +1,9 @@
 import datetime
-import maya
 import os
 from getpass import getpass
 from pathlib import Path
+
+import maya
 
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.signers.base import Signer

--- a/examples/pre/heartbeat_demo/alicia.py
+++ b/examples/pre/heartbeat_demo/alicia.py
@@ -17,11 +17,12 @@
 import base64
 import datetime
 import json
-import maya
 import os
 import shutil
 from getpass import getpass
 from pathlib import Path
+
+import maya
 
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.signers import Signer

--- a/examples/pre/heartbeat_demo/doctor.py
+++ b/examples/pre/heartbeat_demo/doctor.py
@@ -1,12 +1,13 @@
 import base64
 import json
-import maya
-import msgpack
 import os
 import shutil
+from timeit import default_timer as timer
+
+import maya
+import msgpack
 from nucypher_core import EncryptedTreasureMap, MessageKit
 from nucypher_core.umbral import PublicKey
-from timeit import default_timer as timer
 
 from nucypher.blockchain.eth import domains
 from nucypher.characters.lawful import Bob

--- a/newsfragments/3398.bugfix.rst
+++ b/newsfragments/3398.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure incoming request ip addresses resolution handles proxied headers.

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -27,7 +27,7 @@ from nucypher.policy.conditions.utils import (
     evaluate_condition_lingo,
 )
 from nucypher.utilities.logging import Logger
-from nucypher.utilities.networking import get_request_public_ipv4
+from nucypher.utilities.networking import get_request_global_ipv4
 
 DECRYPTION_REQUESTS_SUCCESSES = Counter(
     "threshold_decryption_num_successes",
@@ -299,7 +299,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
     @rest_app.route("/ping", methods=['GET'])
     def ping():
         """Asks this node: What is my public IPv4 address?"""
-        ipv4 = get_request_public_ipv4(request=request)
+        ipv4 = get_request_global_ipv4(request=request)
         if not ipv4:
             return Response(
                 response="No public IPv4 address detected.",

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -1,6 +1,7 @@
 import json
 import weakref
 from http import HTTPStatus
+from ipaddress import AddressValueError
 from pathlib import Path
 
 from constant_sorrow import constants
@@ -299,7 +300,13 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
     @rest_app.route("/ping", methods=['GET'])
     def ping():
         """Asks this node: What is my public IPv4 address?"""
-        ipv4 = get_global_source_ipv4(request=request)
+        try:
+            ipv4 = get_global_source_ipv4(request=request)
+        except AddressValueError as e:
+            return Response(
+                response=str(e),
+                status=HTTPStatus.BAD_REQUEST,
+            )
         if not ipv4:
             return Response(
                 response="No public IPv4 address detected.",

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -27,6 +27,7 @@ from nucypher.policy.conditions.utils import (
     evaluate_condition_lingo,
 )
 from nucypher.utilities.logging import Logger
+from nucypher.utilities.networking import get_request_public_ipv4
 
 DECRYPTION_REQUESTS_SUCCESSES = Counter(
     "threshold_decryption_num_successes",
@@ -297,9 +298,14 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
 
     @rest_app.route("/ping", methods=['GET'])
     def ping():
-        """Asks this node: What is my IP address?"""
-        requester_ip_address = request.remote_addr
-        return Response(requester_ip_address, status=HTTPStatus.OK)
+        """Asks this node: What is my public IPv4 address?"""
+        ipv4 = get_request_public_ipv4(request=request)
+        if not ipv4:
+            return Response(
+                response="No public IPv4 address detected.",
+                status=HTTPStatus.BAD_GATEWAY,
+            )
+        return Response(response=ipv4, status=HTTPStatus.OK)
 
     @rest_app.route('/status/', methods=['GET'])
     def status():

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -27,7 +27,7 @@ from nucypher.policy.conditions.utils import (
     evaluate_condition_lingo,
 )
 from nucypher.utilities.logging import Logger
-from nucypher.utilities.networking import get_request_global_ipv4
+from nucypher.utilities.networking import get_global_source_ipv4
 
 DECRYPTION_REQUESTS_SUCCESSES = Counter(
     "threshold_decryption_num_successes",
@@ -299,7 +299,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
     @rest_app.route("/ping", methods=['GET'])
     def ping():
         """Asks this node: What is my public IPv4 address?"""
-        ipv4 = get_request_global_ipv4(request=request)
+        ipv4 = get_global_source_ipv4(request=request)
         if not ipv4:
             return Response(
                 response="No public IPv4 address detected.",

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -179,6 +179,9 @@ def determine_external_ip_address(
     3. A centralized IP address service
 
     If the IP address cannot be determined for any reason UnknownIPAddress is raised.
+
+    This function is intended to be used by nodes operators running `nucypher ursula init`
+    to assist determine their global IPv4 address for configuration purposes only.
     """
     rest_host = None
 
@@ -205,7 +208,7 @@ def determine_external_ip_address(
     return rest_host
 
 
-def _is_valid_ipv4(ip: str) -> bool:
+def _is_global_ipv4(ip: str) -> bool:
     try:
         ip = ip_address(ip.strip())
         return isinstance(ip, IPv4Address) and ip.is_global
@@ -235,7 +238,7 @@ def _ip_sources(request: Request, trusted_proxies: Optional[List[str]] = None) -
     yield request.remote_addr
 
 
-def get_request_public_ipv4(
+def get_request_global_ipv4(
     request: Request, trusted_proxies: Optional[List[str]] = None
 ) -> Optional[str]:
     """
@@ -256,5 +259,5 @@ def get_request_public_ipv4(
     """
     for ip_str in _ip_sources(request=request, trusted_proxies=trusted_proxies):
         ipv4_address = _ipv6_to_ipv4(ip_str)
-        if ipv4_address and _is_valid_ipv4(ipv4_address):
+        if ipv4_address and _is_global_ipv4(ipv4_address):
             return ipv4_address

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -216,14 +216,15 @@ def _is_global_ipv4(ip: str) -> bool:
         return False
 
 
-def _ipv6_to_ipv4(ip: str) -> Optional[str]:
+def _resolve_ipv4(ip: str) -> Optional[str]:
     try:
         ip = ip_address(ip.strip())
-        if isinstance(ip, IPv6Address) and ip.ipv4_mapped:
-            return str(ip.ipv4_mapped)
     except AddressValueError:
         return None
-    return None
+    if isinstance(ip, IPv6Address) and ip.ipv4_mapped:
+        return str(ip.ipv4_mapped)
+    elif isinstance(ip, IPv4Address):
+        return str(ip)
 
 
 def _ip_sources(request: Request, trusted_proxies: Optional[List[str]] = None) -> str:
@@ -258,6 +259,6 @@ def get_request_global_ipv4(
     Optionally, a list of trusted proxies can be provided to help mitigate spoofing attacks.
     """
     for ip_str in _ip_sources(request=request, trusted_proxies=trusted_proxies):
-        ipv4_address = _ipv6_to_ipv4(ip_str)
+        ipv4_address = _resolve_ipv4(ip_str)
         if ipv4_address and _is_global_ipv4(ipv4_address):
             return ipv4_address

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -213,7 +213,7 @@ def _is_valid_ipv4(ip: str) -> bool:
         return False
 
 
-def _ipv4_to_ipv6(ip: str) -> Optional[str]:
+def _ipv6_to_ipv4(ip: str) -> Optional[str]:
     try:
         ip = ip_address(ip.strip())
         if isinstance(ip, IPv6Address) and ip.ipv4_mapped:
@@ -255,6 +255,6 @@ def get_request_public_ipv4(
     Optionally, a list of trusted proxies can be provided to help mitigate spoofing attacks.
     """
     for ip_str in _ip_sources(request=request, trusted_proxies=trusted_proxies):
-        ipv4_address = _ipv4_to_ipv6(ip_str)
+        ipv4_address = _ipv6_to_ipv4(ip_str)
         if ipv4_address and _is_valid_ipv4(ipv4_address):
             return ipv4_address

--- a/nucypher/utilities/networking.py
+++ b/nucypher/utilities/networking.py
@@ -215,8 +215,8 @@ def _resolve_ipv4(ip: str) -> Optional[IPv4Address]:
     """
     try:
         ip = ip_address(ip.strip())
-    except AddressValueError:
-        return None
+    except (AddressValueError, ValueError):
+        raise AddressValueError(f"'{ip}' does not appear to be an IPv4 or IPv6 address")
     if isinstance(ip, IPv6Address):
         return ip.ipv4_mapped  # returns IPv4Address or None
     elif isinstance(ip, IPv4Address):

--- a/tests/acceptance/characters/test_operator.py
+++ b/tests/acceptance/characters/test_operator.py
@@ -1,4 +1,5 @@
 import datetime
+
 import maya
 import pytest
 from eth_account._utils.signing import to_standard_signature_bytes

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -14,6 +14,7 @@ def _policy_info_kwargs(enacted_policy):
         alice_verifying_key=enacted_policy.publisher_verifying_key,
         )
 
+
 def test_retrieval_kit(enacted_policy, ursulas):
     messages, message_kits = make_message_kits(enacted_policy.public_key)
 

--- a/tests/integration/cli/actions/test_select_config_file.py
+++ b/tests/integration/cli/actions/test_select_config_file.py
@@ -1,8 +1,3 @@
-
-
-import os
-from pathlib import Path
-
 import click
 import pytest
 
@@ -97,24 +92,8 @@ def test_interactive_select_config_file(
         assert config_path.exists()
 
     mock_stdin.line(str(user_input))
-    result = select_config_file(emitter=test_emitter,
-                                config_class=config_class,
-                                config_root=temp_dir_path)
 
     captured = capsys.readouterr()
     for filename, account in accounts:
         assert account.address in captured.out
     assert mock_stdin.empty()
-
-    table_data = captured.out.split('\n')
-    table_addresses = [row.split()[1] for row in table_data[6:-2]]  # escape extra lines printed before table
-
-    # TODO: Finish this test
-    # for index, (filename, account) in enumerate(accounts):
-    #     assert False
-    #
-    # selection = config.filepath
-    # assert isinstance(result, str)
-    # result = Path(result)
-    # assert result.exists()
-    # assert result == selection

--- a/tests/integration/cli/actions/test_select_config_file.py
+++ b/tests/integration/cli/actions/test_select_config_file.py
@@ -57,6 +57,7 @@ def test_auto_select_config_file(
                                               config_file=str(config_path)) in captured.out
 
 
+@pytest.mark.skip("planned for removal in PR #3382")
 def test_interactive_select_config_file(
     test_emitter,
     capsys,

--- a/tests/integration/config/test_base_configuration.py
+++ b/tests/integration/config/test_base_configuration.py
@@ -1,12 +1,10 @@
 
 
 import json
-
-import os
+import shutil
 from pathlib import Path
 
 import pytest
-import shutil
 
 from nucypher.config.base import BaseConfiguration
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT

--- a/tests/integration/network/test_failure_modes.py
+++ b/tests/integration/network/test_failure_modes.py
@@ -1,6 +1,3 @@
-
-
-
 import datetime
 from functools import partial
 

--- a/tests/integration/network/test_ursula_web_status.py
+++ b/tests/integration/network/test_ursula_web_status.py
@@ -1,8 +1,5 @@
 
 
-import os
-import tempfile
-from pathlib import Path
 
 import pytest
 

--- a/tests/mock/performance_mocks.py
+++ b/tests/mock/performance_mocks.py
@@ -207,7 +207,7 @@ def _determine_good_serials(start, end):
     for i in range(start, end):
         try:
             NotAPublicKey.from_int(i).i_want_to_be_a_real_boy()
-        except Exception as e:
+        except Exception:
             continue
         else:
             good_serials.append(i)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -2,7 +2,6 @@
 from pathlib import Path
 
 import maya
-import os
 import pytest
 
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,6 +1,7 @@
 
 
 import builtins
+
 import pytest
 
 from nucypher.exceptions import DevelopmentInstallationRequired
@@ -49,7 +50,7 @@ def test_use_vladimir_without_development_installation(import_mocker, mocker):
     del EvilMiddleWare
 
     with import_mocker:
-        from nucypher.characters.unlawful import Vladimir                    # Import OK
+        from nucypher.characters.unlawful import Vladimir  # Import OK
         with pytest.raises(DevelopmentInstallationRequired, match=message):  # Expect lazy failure
             Vladimir.from_target_ursula(target_ursula=mocker.Mock())
 
@@ -63,7 +64,8 @@ def test_get_pyevm_backend_without_development_installation(import_mocker):
     del constants
 
     with import_mocker:
-        from nucypher.blockchain.eth.providers import _get_pyevm_test_backend   # Import OK
+        from nucypher.blockchain.eth.providers import (
+            _get_pyevm_test_backend,  # Import OK
+        )
         with pytest.raises(DevelopmentInstallationRequired, match=message):     # Expect lazy failure
             _get_pyevm_test_backend()
-

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,7 +5,6 @@ from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import ContractAgency
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry
-from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.ferveo import dkg
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Teacher

--- a/tests/unit/crypto/test_keccak_sanity.py
+++ b/tests/unit/crypto/test_keccak_sanity.py
@@ -4,11 +4,7 @@ import unittest
 
 from eth_utils import keccak
 
-from nucypher.crypto.utils import (
-    secure_random_range,
-    secure_random,
-    keccak_digest
-)
+from nucypher.crypto.utils import keccak_digest, secure_random, secure_random_range
 
 
 class TestCrypto(unittest.TestCase):

--- a/tests/unit/registry/test_registry_basics.py
+++ b/tests/unit/registry/test_registry_basics.py
@@ -1,8 +1,7 @@
 import pytest
 
 from nucypher.blockchain.eth.registry import ContractRegistry
-from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
-from tests.constants import TESTERCHAIN_CHAIN_ID, TEMPORARY_DOMAIN
+from tests.constants import TEMPORARY_DOMAIN, TESTERCHAIN_CHAIN_ID
 from tests.utils.registry import MockRegistrySource
 
 

--- a/tests/unit/test_block_confirmations.py
+++ b/tests/unit/test_block_confirmations.py
@@ -4,7 +4,7 @@ from unittest.mock import PropertyMock
 
 import pytest
 from hexbytes import HexBytes
-from web3.exceptions import TransactionNotFound, TimeExhausted
+from web3.exceptions import TimeExhausted, TransactionNotFound
 
 from tests.mock.interfaces import MockEthereumClient
 

--- a/tests/unit/test_blockchain_events.py
+++ b/tests/unit/test_blockchain_events.py
@@ -1,6 +1,6 @@
 
 
-from unittest.mock import Mock, MagicMock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 

--- a/tests/unit/test_blockchain_interface.py
+++ b/tests/unit/test_blockchain_interface.py
@@ -1,9 +1,7 @@
 
 
-import pytest
-from web3.gas_strategies import time_based
-
 from constant_sorrow.constants import ALL_OF_THEM
+from web3.gas_strategies import time_based
 
 from nucypher.blockchain.eth.interfaces import BlockchainInterface
 from nucypher.utilities.gas_strategies import WEB3_GAS_STRATEGIES

--- a/tests/unit/test_cli_help.py
+++ b/tests/unit/test_cli_help.py
@@ -3,7 +3,7 @@ import pytest
 
 import nucypher
 from nucypher.cli.main import ENTRY_POINTS, nucypher_cli
-from nucypher.config.constants import USER_LOG_DIR, DEFAULT_CONFIG_ROOT
+from nucypher.config.constants import DEFAULT_CONFIG_ROOT, USER_LOG_DIR
 
 
 def test_echo_nucypher_version(click_runner):

--- a/tests/unit/test_datafeeds.py
+++ b/tests/unit/test_datafeeds.py
@@ -6,7 +6,7 @@ from statistics import median
 from unittest.mock import patch
 
 import pytest
-from constant_sorrow.constants import SLOW, MEDIUM, FAST, FASTEST
+from constant_sorrow.constants import FAST, FASTEST, MEDIUM, SLOW
 from requests.exceptions import ConnectionError
 from web3 import Web3
 
@@ -15,10 +15,9 @@ from nucypher.utilities.datafeeds import (
     EtherchainGasPriceDatafeed,
     EthereumGasPriceDatafeed,
     UpvestGasPriceDatafeed,
-    ZoltuGasPriceDatafeed
+    ZoltuGasPriceDatafeed,
 )
 from nucypher.utilities.gas_strategies import construct_datafeed_median_strategy
-
 
 etherchain_json = {
     "safeLow": "99.0",
@@ -204,7 +203,6 @@ def test_zoltu():
 
 def test_datafeed_median_gas_price_strategy():
 
-    mock_etherchain_gas_price = 1000
     mock_upvest_gas_price = 2000
     mock_zoltu_gas_price = 4000
     mock_rpc_gas_price = 42

--- a/tests/unit/test_decorators.py
+++ b/tests/unit/test_decorators.py
@@ -2,7 +2,10 @@
 
 import pytest
 
-from nucypher.blockchain.eth.decorators import InvalidChecksumAddress, validate_checksum_address
+from nucypher.blockchain.eth.decorators import (
+    InvalidChecksumAddress,
+    validate_checksum_address,
+)
 
 
 def test_validate_checksum_address(get_random_checksum_address):

--- a/tests/unit/test_gas_strategies.py
+++ b/tests/unit/test_gas_strategies.py
@@ -1,13 +1,11 @@
 
 import itertools
 
-import pytest
 from web3 import Web3
 
 from nucypher.utilities.gas_strategies import (
     construct_fixed_price_gas_strategy,
     max_price_gas_strategy_wrapper,
-    GasStrategyError
 )
 
 

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -4,7 +4,8 @@ from io import StringIO
 from json.encoder import py_encode_basestring_ascii
 
 import pytest
-from twisted.logger import Logger as TwistedLogger, formatEvent, jsonFileLogObserver
+from twisted.logger import Logger as TwistedLogger
+from twisted.logger import formatEvent, jsonFileLogObserver
 
 from nucypher.utilities.logging import Logger
 

--- a/tests/unit/test_ping_requests.py
+++ b/tests/unit/test_ping_requests.py
@@ -1,0 +1,102 @@
+import pytest
+
+
+@pytest.fixture
+def simulate_request(ursulas):
+    ursula = ursulas[0]
+
+    def request_simulator(headers):
+        with ursula.rest_app.test_client() as client:
+            response = client.get("/ping", headers=headers)
+        return response
+
+    return request_simulator
+
+
+header_combinations = [
+    ({}, 502, None),
+    ({"X-Forwarded-For": "10.10.5.1, 192.168.1.1"}, 502, None),
+    ({"X-Forwarded-For": "10.10.5.1, 65.0.113.0"}, 200, b"65.0.113.0"),
+    ({"X-Real-IP": "65.0.113.0"}, 200, b"65.0.113.0"),
+    ({"X-Forwarded-For": "10.10.5.1, 192.168.1.1"}, 502, None),
+    ({"X-Forwarded-For": "10.10.5.1, 65.0.113.0"}, 200, b"65.0.113.0"),
+    ({"X-Real-IP": "65.0.113.0"}, 200, b"65.0.113.0"),
+    ({"X-Forwarded-For": "::ffff:192.168.1.1"}, 502, None),
+    ({"X-Forwarded-For": "::ffff:8.8.8.8"}, 200, b"8.8.8.8"),
+    ({"X-Real-IP": "::ffff:8.8.8.8"}, 200, b"8.8.8.8"),
+    ({"X-Forwarded-For": "invalid_ip_address"}, 400, None),
+    ({"X-Real-IP": "invalid_ip_address"}, 400, None),
+    ({"X-Forwarded-For": "172.16.0.1, ::ffff:10.0.0.1"}, 502, None),
+    ({"X-Real-IP": "172.16.0.1, ::ffff:10.0.0.1"}, 502, None),
+    ({"X-Forwarded-For": "65.0.113.100"}, 200, b"65.0.113.100"),
+    ({"X-Forwarded-For": "::ffff:65.0.113.100"}, 200, b"65.0.113.100"),
+    ({"X-Forwarded-For": "65.0.113.100, 192.168.1.1"}, 200, b"65.0.113.100"),
+    ({"X-Real-IP": "65.0.113.100, 192.168.1.1"}, 200, b"65.0.113.100"),
+    ({"X-Forwarded-For": "192.168.1.1, 203.0.113.100"}, 502, None),
+]
+
+
+@pytest.mark.parametrize("headers, expected_status, expected_data", header_combinations)
+def test_request_headers(simulate_request, headers, expected_status, expected_data):
+    response = simulate_request(headers=headers)
+    assert response.status_code == expected_status
+    if expected_data is not None:
+        assert bytes(response.data) == expected_data
+
+
+def test_request_with_private_ip_only(simulate_request):
+    response = simulate_request(headers={"X-Forwarded-For": "10.10.5.1, 192.168.1.1"})
+    assert response.status_code == 502
+
+
+def test_multi_hop_proxied_request(simulate_request):
+    response = simulate_request(
+        headers={"X-Forwarded-For": "10.10.5.1, 192.168.1.1, 65.0.113.0"}
+    )
+    assert response.status_code == 200
+    assert bytes(response.data) == b"65.0.113.0"
+
+
+def test_request_with_public_ip_only(simulate_request):
+    response = simulate_request(
+        headers={"X-Forwarded-For": "65.0.113.0", "X-Real-IP": "10.10.5.1"}
+    )
+    assert response.status_code == 200
+    assert bytes(response.data) == b"65.0.113.0"
+
+
+def test_request_with_multiple_ips(simulate_request):
+    response = simulate_request(
+        headers={
+            "X-Forwarded-For": "192.168.2.155, 205.0.113.0",
+            "X-Real-IP": "10.10.5.1",
+        }
+    )
+    assert response.status_code == 200
+    assert bytes(response.data) == b"205.0.113.0"
+
+
+def test_request_with_single_public_ip(simulate_request):
+    response = simulate_request(headers={"X-Forwarded-For": "65.0.113.0"})
+    assert response.status_code == 200
+    assert bytes(response.data) == b"65.0.113.0"
+
+
+def test_resolve_ipv4_with_private_ipv4_mapped_ipv6(simulate_request):
+    ipv4_mapped = "::ffff:192.0.2.128"
+    response = simulate_request(headers={"X-Real-IP": ipv4_mapped})
+    assert response.status_code == 502
+    assert bytes(response.data) == b"No public IPv4 address detected."
+
+
+def test_resolve_ipv4_with_public_ipv4_mapped_ipv6(simulate_request):
+    ipv4_mapped = "::ffff:65.34.5.211"
+    response = simulate_request(headers={"X-Forwarded-For": ipv4_mapped})
+    assert response.status_code == 200
+    assert bytes(response.data) == b"65.34.5.211"
+
+
+def test_resolve_ipv4_with_malformed_ipv4_mapped_ipv6(simulate_request):
+    invalid_ipv4_mapped = "::ffff:999.999.999.999"
+    response = simulate_request(headers={"X-Forwarded-For": invalid_ipv4_mapped})
+    assert response.status_code == 400

--- a/tests/unit/test_ping_utils.py
+++ b/tests/unit/test_ping_utils.py
@@ -1,12 +1,13 @@
+from ipaddress import IPv4Address
+
 import pytest
 from flask import Request
 
 from nucypher.utilities.networking import (
     LOOPBACK_ADDRESS,
     _ip_sources,
-    _is_global_ipv4,
     _resolve_ipv4,
-    get_request_global_ipv4,
+    get_global_source_ipv4,
 )
 
 
@@ -21,38 +22,12 @@ def mock_request_factory(mocker):
     return _mock_request_factory
 
 
-@pytest.mark.parametrize(
-    "ip, expected",
-    [
-        ("8.8.8.8", True),  # public IPv4
-        ("192.168.1.1", False),  # private IPv4
-        ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", False),  # IPv6
-    ],
-)
-def test_is_global_ipv4(ip, expected):
-    assert _is_global_ipv4(ip) == expected
-
-
-def test_is_global_ipv4_with_invalid_address():
-    with pytest.raises(
-        ValueError, match="'not_an_ip' does not appear to be an IPv4 or IPv6 address"
-    ):
-        _is_global_ipv4("not_an_ip")
-
-
 def test_resolve_ipv4_with_valid_ipv4():
-    assert _resolve_ipv4("8.8.8.8") == "8.8.8.8"
+    assert _resolve_ipv4("8.8.8.8") == IPv4Address("8.8.8.8")
 
 
 def test_resolve_ipv4_with_valid_mapped_ipv6():
-    assert _resolve_ipv4("::ffff:8.8.8.8") == "8.8.8.8"
-
-
-def test_resolve_ipv4_with_invalid_ip():
-    with pytest.raises(
-        ValueError, match="'not_an_ip' does not appear to be an IPv4 or IPv6 address"
-    ):
-        _is_global_ipv4("not_an_ip")
+    assert _resolve_ipv4("::ffff:8.8.8.8") == IPv4Address("8.8.8.8")
 
 
 def test_resolve_ipv4_with_non_mapped_ipv6():
@@ -81,19 +56,21 @@ def test_ip_sources_with_no_headers_but_remote_addr(mock_request_factory):
 
 def test_get_request_global_ipv4_with_forwarded_ip(mock_request_factory):
     request = mock_request_factory(headers={"X-Forwarded-For": "8.8.8.8, 192.168.1.1"})
-    assert get_request_global_ipv4(request) == "8.8.8.8"
+    assert get_global_source_ipv4(request) == "8.8.8.8"
+    assert isinstance(get_global_source_ipv4(request), str)
 
 
 def test_get_request_global_ipv4_with_private_ip_only(mock_request_factory):
     request = mock_request_factory(headers={"X-Forwarded-For": "192.168.1.1"})
-    assert get_request_global_ipv4(request) is None
+    assert get_global_source_ipv4(request) is None
 
 
 def test_get_request_global_ipv4_with_no_headers_but_valid_remote_addr(
     mock_request_factory,
 ):
     request = mock_request_factory(remote_addr="8.8.8.8")
-    assert get_request_global_ipv4(request) == "8.8.8.8"
+    assert get_global_source_ipv4(request) == "8.8.8.8"
+    assert isinstance(get_global_source_ipv4(request), str)
 
 
 def test_get_request_global_ipv4_with_invalid_remote_addr(mock_request_factory):
@@ -101,4 +78,4 @@ def test_get_request_global_ipv4_with_invalid_remote_addr(mock_request_factory):
     with pytest.raises(
         ValueError, match="'not_an_ip' does not appear to be an IPv4 or IPv6 address"
     ):
-        get_request_global_ipv4(request)
+        get_global_source_ipv4(request)

--- a/tests/unit/test_ping_utils.py
+++ b/tests/unit/test_ping_utils.py
@@ -1,0 +1,104 @@
+import pytest
+from flask import Request
+
+from nucypher.utilities.networking import (
+    LOOPBACK_ADDRESS,
+    _ip_sources,
+    _is_global_ipv4,
+    _resolve_ipv4,
+    get_request_global_ipv4,
+)
+
+
+@pytest.fixture
+def mock_request_factory(mocker):
+    def _mock_request_factory(headers=None, remote_addr=None):
+        request = mocker.MagicMock(spec=Request)
+        request.remote_addr = remote_addr or LOOPBACK_ADDRESS
+        request.headers = headers or {}
+        return request
+
+    return _mock_request_factory
+
+
+@pytest.mark.parametrize(
+    "ip, expected",
+    [
+        ("8.8.8.8", True),  # public IPv4
+        ("192.168.1.1", False),  # private IPv4
+        ("2001:0db8:85a3:0000:0000:8a2e:0370:7334", False),  # IPv6
+    ],
+)
+def test_is_global_ipv4(ip, expected):
+    assert _is_global_ipv4(ip) == expected
+
+
+def test_is_global_ipv4_with_invalid_address():
+    with pytest.raises(
+        ValueError, match="'not_an_ip' does not appear to be an IPv4 or IPv6 address"
+    ):
+        _is_global_ipv4("not_an_ip")
+
+
+def test_resolve_ipv4_with_valid_ipv4():
+    assert _resolve_ipv4("8.8.8.8") == "8.8.8.8"
+
+
+def test_resolve_ipv4_with_valid_mapped_ipv6():
+    assert _resolve_ipv4("::ffff:8.8.8.8") == "8.8.8.8"
+
+
+def test_resolve_ipv4_with_invalid_ip():
+    with pytest.raises(
+        ValueError, match="'not_an_ip' does not appear to be an IPv4 or IPv6 address"
+    ):
+        _is_global_ipv4("not_an_ip")
+
+
+def test_resolve_ipv4_with_non_mapped_ipv6():
+    assert _resolve_ipv4("2001:0db8::") is None
+
+
+def test_ip_sources_with_both_headers(mock_request_factory):
+    request = mock_request_factory(
+        headers={"X-Forwarded-For": "8.8.8.8", "X-Real-IP": "1.1.1.1"}
+    )
+    ips = list(_ip_sources(request))
+    assert ips == ["8.8.8.8", "1.1.1.1", LOOPBACK_ADDRESS]
+
+
+def test_ip_sources_with_real_ip_header(mock_request_factory):
+    request = mock_request_factory(headers={"X-Real-IP": "1.1.1.1"})
+    ips = list(_ip_sources(request))
+    assert ips == ["1.1.1.1", LOOPBACK_ADDRESS]
+
+
+def test_ip_sources_with_no_headers_but_remote_addr(mock_request_factory):
+    request = mock_request_factory(remote_addr="203.0.113.100")
+    ips = list(_ip_sources(request))
+    assert ips == ["203.0.113.100"]
+
+
+def test_get_request_global_ipv4_with_forwarded_ip(mock_request_factory):
+    request = mock_request_factory(headers={"X-Forwarded-For": "8.8.8.8, 192.168.1.1"})
+    assert get_request_global_ipv4(request) == "8.8.8.8"
+
+
+def test_get_request_global_ipv4_with_private_ip_only(mock_request_factory):
+    request = mock_request_factory(headers={"X-Forwarded-For": "192.168.1.1"})
+    assert get_request_global_ipv4(request) is None
+
+
+def test_get_request_global_ipv4_with_no_headers_but_valid_remote_addr(
+    mock_request_factory,
+):
+    request = mock_request_factory(remote_addr="8.8.8.8")
+    assert get_request_global_ipv4(request) == "8.8.8.8"
+
+
+def test_get_request_global_ipv4_with_invalid_remote_addr(mock_request_factory):
+    request = mock_request_factory(remote_addr="not_an_ip")
+    with pytest.raises(
+        ValueError, match="'not_an_ip' does not appear to be an IPv4 or IPv6 address"
+    ):
+        get_request_global_ipv4(request)

--- a/tests/unit/test_web3_middleware.py
+++ b/tests/unit/test_web3_middleware.py
@@ -3,14 +3,14 @@ from unittest.mock import Mock
 
 import pytest
 from requests import HTTPError
-from web3.types import RPCResponse, RPCError, RPCEndpoint
+from web3.types import RPCEndpoint, RPCError, RPCResponse
 
 from nucypher.blockchain.middleware.retry import (
-    RetryRequestMiddleware,
     AlchemyRetryRequestMiddleware,
-    InfuraRetryRequestMiddleware
+    InfuraRetryRequestMiddleware,
+    RetryRequestMiddleware,
 )
-from tests.constants import RPC_TOO_MANY_REQUESTS, RPC_SUCCESSFUL_RESPONSE
+from tests.constants import RPC_SUCCESSFUL_RESPONSE, RPC_TOO_MANY_REQUESTS
 
 RETRY_REQUEST_CLASSES = (RetryRequestMiddleware, AlchemyRetryRequestMiddleware, InfuraRetryRequestMiddleware)
 

--- a/tests/utils/config.py
+++ b/tests/utils/config.py
@@ -1,5 +1,6 @@
-from eth_typing import ChecksumAddress
 from typing import List
+
+from eth_typing import ChecksumAddress
 
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.characters.lawful import Ursula

--- a/tests/utils/middleware.py
+++ b/tests/utils/middleware.py
@@ -161,6 +161,12 @@ class NodeIsDownMiddleware(MockRestMiddleware):
     def all_nodes_down(self):
         self.client.ports_that_are_down = set(MOCK_KNOWN_URSULAS_CACHE)
 
+    def ping(self, node, *args, **kwargs):
+        if node.rest_interface.port in self.client.ports_that_are_down:
+            raise ConnectionRefusedError
+        else:
+            return Response(node.rest_interface.host, status=200)
+
 
 class EvilMiddleWare(MockRestMiddleware):
     """

--- a/tests/utils/middleware.py
+++ b/tests/utils/middleware.py
@@ -83,6 +83,9 @@ class MockRestMiddleware(RestMiddleware):
     class NotEnoughMockUrsulas(Ursula.NotEnoughUrsulas):
         pass
 
+    def ping(self, node, *args, **kwargs):
+        return Response(node.rest_interface.host, status=200)
+
 
 class MockRestMiddlewareForLargeFleetTests(MockRestMiddleware):
     """


### PR DESCRIPTION
**Type of PR:**
Bugfix

**Required reviews:** 
2

**What this does:**
- Handles the possibility of incoming request headers that have been mutated by intermediate network proxies, like nginx.
- Attempts to resolve IPv6 to IPv4 when possible

**Issues fixed/closed:**
- Fixes #3378 

**Why it's needed:**
- Incoming request headers were being improperly parsed and handled when a request is forwarded by a proxy, leading to a remote node's internal/private IP address being returned to the caller.
- IPv6 addresses are unsupported by the protocol.  Handles unexpected IPv6 values in /ping.

**Notes for reviewers:**
- Given that `/ping` is used both for sampling and configuration assist - what is the desired behavior when the address is invalid, private, or missing?   Currently responding with HTTP 503.
- XFF header reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#selecting_an_ip_address


