### PR TITLE
Fix failing test and Threshold Rounding

### DIFF
--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -1,3 +1,4 @@
+import math
 from http import HTTPStatus
 from random import shuffle
 from typing import Dict, List, Tuple
@@ -88,11 +89,13 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
             worker=worker,
             value_factory=self.ThresholdDecryptionRequestFactory(
                 ursulas_to_contact=requests,
-                batch_size=int(threshold * 1.25),
+                batch_size=math.ceil(threshold * 1.25),
                 threshold=threshold,
             ),
             target_successes=threshold,
-            threadpool_size=int(threshold * 1.5),  # TODO should we cap this (say 40?)
+            threadpool_size=math.ceil(
+                threshold * 1.5
+            ),  # TODO should we cap this (say 40?)
             timeout=timeout,
             stagger_timeout=stagger_timeout,
         )

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -268,7 +268,10 @@ def test_ursula_ritualist(
         num_successes = REGISTRY.get_sample_value(
             "threshold_decryption_num_successes_total"
         )
-        assert len(cohort) == int(num_successes)  # each ursula in cohort had a success
+
+        ritual = coordinator_agent.get_ritual(RITUAL_ID)
+        # at least a threshold of ursulas were successful (concurrency)
+        assert int(num_successes) >= ritual.threshold
         print("==================== DECRYPTION SUCCESSFUL ====================")
 
     def error_handler(e):


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
- Fix test since the number of successful decryption requests can vary because of concurrency, and how the threshold decryption client executes the requests in parallel (thread pool size etc.)
- Round up the value of batch size and thread pool size which are both decimal factors of the threshold (1.25 and 1.5 respectively); without rounding up small threshold values (eg.  2-of-3 or 3-of-4) can experience slower decryption executions for associated ritual.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
