### PR TITLE
Ignore lynx delinquents

### DIFF
--- a/scripts/hooks/nucypher_dkg.py
+++ b/scripts/hooks/nucypher_dkg.py
@@ -230,6 +230,18 @@ def nucypher_dkg(
             ) = child_application_agent.get_all_active_staking_providers()
             staking_providers = list(staking_providers_dict.keys())
 
+            if domain == domains.LYNX:
+                # Ignore delinquent lynx providers
+                exclude_staking_providers = [
+                    "0x24dbb0BEE134C3773D2C1791d65d99e307Fe86CF",
+                    "0xE4c8d3bcf8C87D73CE38Ab2DC288d309072ee4E7",
+                ]
+                for provider in exclude_staking_providers:
+                    try:
+                        staking_providers.remove(provider)
+                    except ValueError:
+                        pass
+
             # sample then sort
             dkg_staking_providers = random.sample(staking_providers, dkg_size)
             dkg_staking_providers.sort()


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Two providers on lynx don't have running nodes - not naming any names ... *cough*... @cygnusv ...*cough* j/k 😜 ; don't bother using them for sampling in the `nucypher_dkg` script.

We ignore them for now, but we should probably look into how they can be excluded from being considered "active" by the TACoChildApplication.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
