### PR TITLE
Reduce the eagerness of the ActiveRitualTracker

### DIFF
--- a/newsfragments/3416.misc.rst
+++ b/newsfragments/3416.misc.rst
@@ -1,0 +1,1 @@
+Scan for ritual events less often to be more efficient with RPC requests.

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -51,7 +51,7 @@ class EventActuator(EventScanner):
 class EventScannerTask(SimpleTask):
     """Task that runs the event scanner in a looping call."""
 
-    INTERVAL = 20  # seconds
+    INTERVAL = 120  # seconds
 
     def __init__(self, scanner: Callable, *args, **kwargs):
         self.scanner = scanner


### PR DESCRIPTION
[![IMAGE ALT TEXT HERE](https://img.youtube.com/vi/X-yIEMduRXk/0.jpg)](https://www.youtube.com/watch?v=X-yIEMduRXk)

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**

Set interval of `ActiveRitualTracker` to 120s for scanning instead of 20s. O
Fixes #3403 .

See "Notes for reviewers" section.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

120s is a suggestion - open to other ideas. On the surface this will make ritual initialization less performant.

It's a balance between how performant we want nodes to be once rituals are requested, and that ritual inititations may be more spread out. 
