### PR TITLE
Improve cache effectiveness for dkg protocol / threshold decryption

### DIFF
--- a/newsfragments/3428.misc.rst
+++ b/newsfragments/3428.misc.rst
@@ -1,0 +1,1 @@
+Improve caching of data needed for threshold decryption by the node - reduces RPC calls and decryption time.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -295,7 +295,7 @@ class Operator(BaseActor):
 
     def _resolve_ritual(self, ritual_id: int) -> Coordinator.Ritual:
         if not self.coordinator_agent.is_ritual_active(ritual_id=ritual_id):
-            self.dkg_storage.clear_active_ritual(ritual_id)
+            self.dkg_storage.clear(ritual_id)
             raise self.ActorError(f"Ritual #{ritual_id} is not active.")
 
         ritual = self.dkg_storage.get_active_ritual(ritual_id)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -595,10 +595,6 @@ class Operator(BaseActor):
         if not self.coordinator_agent.is_ritual_active(ritual_id=ritual_id):
             raise self.ActorError(f"Ritual #{ritual_id} is not active.")
 
-        decryption_share = self.dkg_storage.get_decryption_share(ritual_id)
-        if decryption_share:
-            return decryption_share
-
         ritual = self.coordinator_agent.get_ritual(ritual_id)
 
         validators = self._resolve_validators(ritual)
@@ -623,7 +619,6 @@ class Operator(BaseActor):
             aad=aad,
             variant=variant
         )
-        self.dkg_storage.store_decryption_share(ritual_id, decryption_share)
         return decryption_share
 
     def decrypt_threshold_decryption_request(

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -295,6 +295,7 @@ class Operator(BaseActor):
 
     def _resolve_ritual(self, ritual_id: int) -> Coordinator.Ritual:
         if not self.coordinator_agent.is_ritual_active(ritual_id=ritual_id):
+            self.dkg_storage.clear_active_ritual(ritual_id)
             raise self.ActorError(f"Ritual #{ritual_id} is not active.")
 
         ritual = self.dkg_storage.get_active_ritual(ritual_id)

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -272,7 +272,7 @@ class RitualisticPower(KeyPairBasedPower):
         ritual_id: int,
         shares: int,
         threshold: int,
-        nodes: list,
+        nodes: List[Validator],
         aggregated_transcript: AggregatedTranscript,
         ciphertext_header: CiphertextHeader,
         aad: bytes,

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -88,9 +88,3 @@ class DKGStorage:
 
     def get_active_ritual(self, ritual_id: int) -> Optional[Coordinator.Ritual]:
         return self.data[self.KEY_ACTIVE_RITUAL].get(ritual_id)
-
-    def clear_active_ritual(self, ritual_id: int) -> None:
-        try:
-            del self.data[self.KEY_ACTIVE_RITUAL][ritual_id]
-        except KeyError:
-            pass

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -92,4 +92,4 @@ class DKGStorage:
     def get_decryption_share(
         self, ritual_id: int
     ) -> Optional[Union[DecryptionShareSimple, DecryptionSharePrecomputed]]:
-        self.data[self.KEY_DECRYPTION_SHARE].get(ritual_id)
+        return self.data[self.KEY_DECRYPTION_SHARE].get(ritual_id)

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -1,11 +1,9 @@
 from collections import defaultdict
-from typing import List, Optional, Union
+from typing import List, Optional
 
 from hexbytes import HexBytes
 from nucypher_core.ferveo import (
     AggregatedTranscript,
-    DecryptionSharePrecomputed,
-    DecryptionShareSimple,
     Validator,
 )
 
@@ -19,15 +17,12 @@ class DKGStorage:
     # round 2
     KEY_AGGREGATED_TXS = "aggregation_tx_hashes"
     KEY_AGGREGATED_TRANSCRIPTS = "aggregated_transcripts"
-    # active rituals
-    KEY_DECRYPTION_SHARE = "decryption_share"
 
     _KEYS = [
         KEY_TRANSCRIPT_TXS,
         KEY_VALIDATORS,
         KEY_AGGREGATED_TXS,
         KEY_AGGREGATED_TRANSCRIPTS,
-        KEY_DECRYPTION_SHARE,
     ]
 
     def __init__(self):
@@ -96,18 +91,3 @@ class DKGStorage:
 
     def get_aggregation_txhash(self, ritual_id: int) -> Optional[HexBytes]:
         return self.data[self.KEY_AGGREGATED_TXS].get(ritual_id)
-
-    #
-    # Active Rituals
-    #
-    def store_decryption_share(
-        self,
-        ritual_id: int,
-        decryption_share: Union[DecryptionShareSimple, DecryptionSharePrecomputed],
-    ) -> None:
-        self.data[self.KEY_DECRYPTION_SHARE][ritual_id] = decryption_share
-
-    def get_decryption_share(
-        self, ritual_id: int
-    ) -> Optional[Union[DecryptionShareSimple, DecryptionSharePrecomputed]]:
-        return self.data[self.KEY_DECRYPTION_SHARE].get(ritual_id)

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -1,45 +1,66 @@
 from collections import defaultdict
-from typing import Optional
+from typing import List, Optional, Union
 
 from hexbytes import HexBytes
-from nucypher_core.ferveo import AggregatedTranscript, Transcript
+from nucypher_core.ferveo import (
+    AggregatedTranscript,
+    DecryptionSharePrecomputed,
+    DecryptionShareSimple,
+    Validator,
+)
 
 
 class DKGStorage:
     """A simple in-memory storage for DKG data"""
 
+    # round 1
+    KEY_TRANSCRIPT_TXS = "transcript_tx_hashes"
+    KEY_VALIDATORS = "validators"
+    # round 2
+    KEY_AGGREGATED_TXS = "aggregation_tx_hashes"
+    KEY_AGGREGATED_TRANSCRIPTS = "aggregated_transcripts"
+    # active rituals
+    KEY_DECRYPTION_SHARE = "decryption_share"
+
     def __init__(self):
         self.data = defaultdict(dict)
 
-    def store_transcript(self, ritual_id: int, transcript: Transcript) -> None:
-        self.data["transcripts"][ritual_id] = bytes(transcript)
-
-    def get_transcript(self, ritual_id: int) -> Optional[Transcript]:
-        data = self.data["transcripts"].get(ritual_id)
-        if not data:
-            return None
-        transcript = Transcript.from_bytes(data)
-        return transcript
-
+    #
+    # DKG Round 1 - Transcripts
+    #
     def store_transcript_txhash(self, ritual_id: int, txhash: HexBytes) -> None:
-        self.data["transcript_tx_hashes"][ritual_id] = txhash
+        self.data[self.KEY_TRANSCRIPT_TXS][ritual_id] = txhash
 
     def clear_transcript_txhash(self, ritual_id: int, txhash: HexBytes) -> bool:
         if self.get_transcript_txhash(ritual_id) == txhash:
-            del self.data["transcript_tx_hashes"][ritual_id]
+            del self.data[self.KEY_TRANSCRIPT_TXS][ritual_id]
             return True
         return False
 
     def get_transcript_txhash(self, ritual_id: int) -> Optional[HexBytes]:
-        return self.data["transcript_tx_hashes"].get(ritual_id)
+        return self.data[self.KEY_TRANSCRIPT_TXS].get(ritual_id)
 
-    def store_aggregated_transcript(self, ritual_id: int, aggregated_transcript: AggregatedTranscript) -> None:
-        self.data["aggregated_transcripts"][ritual_id] = bytes(aggregated_transcript)
+    def store_validators(self, ritual_id: int, validators: List[Validator]) -> None:
+        self.data[self.KEY_VALIDATORS][ritual_id] = list(validators)
+
+    def get_validators(self, ritual_id: int) -> Optional[List[Validator]]:
+        validators = self.data[self.KEY_VALIDATORS].get(ritual_id)
+        return list(validators)
+
+    #
+    # DKG Round 2 - Aggregation
+    #
+    def store_aggregated_transcript(
+        self, ritual_id: int, aggregated_transcript: AggregatedTranscript
+    ) -> None:
+        self.data[self.KEY_AGGREGATED_TRANSCRIPTS][ritual_id] = bytes(
+            aggregated_transcript
+        )
 
     def get_aggregated_transcript(
         self, ritual_id: int
     ) -> Optional[AggregatedTranscript]:
-        data = self.data["aggregated_transcripts"].get(ritual_id)
+        data = self.data[self.KEY_AGGREGATED_TRANSCRIPTS].get(ritual_id)
         if not data:
             return None
 
@@ -47,19 +68,28 @@ class DKGStorage:
         return aggregated_transcript
 
     def store_aggregation_txhash(self, ritual_id: int, txhash: HexBytes) -> None:
-        self.data["aggregation_tx_hashes"][ritual_id] = txhash
+        self.data[self.KEY_AGGREGATED_TXS][ritual_id] = txhash
 
     def clear_aggregated_txhash(self, ritual_id: int, txhash: HexBytes) -> bool:
         if self.get_aggregation_txhash(ritual_id) == txhash:
-            del self.data["aggregation_tx_hashes"][ritual_id]
+            del self.data[self.KEY_AGGREGATED_TXS][ritual_id]
             return True
         return False
 
     def get_aggregation_txhash(self, ritual_id: int) -> Optional[HexBytes]:
-        return self.data["aggregation_tx_hashes"].get(ritual_id)
+        return self.data[self.KEY_AGGREGATED_TXS].get(ritual_id)
 
-    def store_public_key(self, ritual_id: int, public_key: bytes) -> None:
-        self.data["public_keys"][ritual_id] = public_key
+    #
+    # Completed DKG
+    #
+    def store_decryption_share(
+        self,
+        ritual_id: int,
+        decryption_share: Union[DecryptionShareSimple, DecryptionSharePrecomputed],
+    ) -> None:
+        self.data[self.KEY_DECRYPTION_SHARE][ritual_id] = decryption_share
 
-    def get_public_key(self, ritual_id: int) -> Optional[bytes]:
-        return self.data["public_keys"].get(ritual_id)
+    def get_decryption_share(
+        self, ritual_id: int
+    ) -> Optional[Union[DecryptionShareSimple, DecryptionSharePrecomputed]]:
+        self.data[self.KEY_DECRYPTION_SHARE].get(ritual_id)

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -22,8 +22,23 @@ class DKGStorage:
     # active rituals
     KEY_DECRYPTION_SHARE = "decryption_share"
 
+    _KEYS = [
+        KEY_TRANSCRIPT_TXS,
+        KEY_VALIDATORS,
+        KEY_AGGREGATED_TXS,
+        KEY_AGGREGATED_TRANSCRIPTS,
+        KEY_DECRYPTION_SHARE,
+    ]
+
     def __init__(self):
         self.data = defaultdict(dict)
+
+    def clear(self, ritual_id):
+        for key in self._KEYS:
+            try:
+                del self.data[key][ritual_id]
+            except KeyError:
+                continue
 
     #
     # DKG Round 1 - Transcripts
@@ -45,6 +60,9 @@ class DKGStorage:
 
     def get_validators(self, ritual_id: int) -> Optional[List[Validator]]:
         validators = self.data[self.KEY_VALIDATORS].get(ritual_id)
+        if not validators:
+            return None
+
         return list(validators)
 
     #
@@ -80,7 +98,7 @@ class DKGStorage:
         return self.data[self.KEY_AGGREGATED_TXS].get(ritual_id)
 
     #
-    # Completed DKG
+    # Active Rituals
     #
     def store_decryption_share(
         self,

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -88,3 +88,9 @@ class DKGStorage:
 
     def get_active_ritual(self, ritual_id: int) -> Optional[Coordinator.Ritual]:
         return self.data[self.KEY_ACTIVE_RITUAL].get(ritual_id)
+
+    def clear_active_ritual(self, ritual_id: int) -> None:
+        try:
+            del self.data[self.KEY_ACTIVE_RITUAL][ritual_id]
+        except KeyError:
+            pass

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -110,8 +110,6 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
 
     @rest_app.route('/node_metadata', methods=["POST"])
     def node_metadata_exchange():
-        response_headers = {"Content-Type": "application/octet-stream"}
-
         try:
             metadata_request = MetadataRequest.from_bytes(request.data)
         except ValueError as e:
@@ -120,16 +118,16 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             return Response(str(e), status=HTTPStatus.BAD_REQUEST)
 
         # If these nodes already have the same fleet state, no exchange is necessary.
+        response_headers = {"Content-Type": "application/octet-stream"}
 
         if metadata_request.fleet_state_checksum == this_node.known_nodes.checksum:
             # log.debug("Learner already knew fleet state {}; doing nothing.".format(learner_fleet_state))  # 1712
-            headers = {'Content-Type': 'application/octet-stream'}
             # No nodes in the response: same fleet state
             response_payload = MetadataResponsePayload(timestamp_epoch=this_node.known_nodes.timestamp.epoch,
                                                        announce_nodes=[])
             response = MetadataResponse(this_node.stamp.as_umbral_signer(),
                                         response_payload)
-            return Response(bytes(response), headers=headers)
+            return Response(bytes(response), headers=response_headers)
 
         if metadata_request.announce_nodes:
             for metadata in metadata_request.announce_nodes:

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -198,7 +198,11 @@ def test_ursula_ritualist(
         status = coordinator_agent.get_ritual_status(RITUAL_ID)
         assert status == Coordinator.RitualStatus.ACTIVE
         for ursula in cohort:
-            assert ursula.dkg_storage.get_transcript(RITUAL_ID) is not None
+            participant = coordinator_agent.get_participant(
+                RITUAL_ID, ursula.checksum_address, True
+            )
+            assert participant.transcript
+            assert participant.aggregated
 
         last_scanned_block = REGISTRY.get_sample_value(
             "ritual_events_last_scanned_block_number"

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -312,16 +312,10 @@ def test_ursula_ritualist(
             0
         ].dkg_storage.get_aggregated_transcript(RITUAL_ID)
 
-        original_decryption_shares = []
         for ursula in cohort:
-            original_decryption_shares.append(
-                ursula.dkg_storage.get_decryption_share(RITUAL_ID)
-            )
-
             ursula.dkg_storage.clear(RITUAL_ID)
             assert ursula.dkg_storage.get_validators(RITUAL_ID) is None
             assert ursula.dkg_storage.get_aggregated_transcript(RITUAL_ID) is None
-            assert ursula.dkg_storage.get_decryption_share(RITUAL_ID) is None
 
         bob.start_learning_loop(now=True)
         cleartext = bob.threshold_decrypt(
@@ -348,11 +342,6 @@ def test_ursula_ritualist(
                 original_aggregated_transcript
             )
             assert bytes(cached_aggregated_transcript) == ritual.aggregated_transcript
-
-            assert ursula.dkg_storage.get_decryption_share(RITUAL_ID)
-
-            # TODO not working for some reason
-            # assert bytes(ursula.dkg_storage.get_decryption_share(ritual_id)) == bytes(original_decryption_shares[ursula_index])
         assert num_used_ursulas >= ritual.threshold
         print("===================== DECRYPTION SUCCESSFUL =====================")
 

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -296,11 +296,19 @@ def test_ursula_ritualist(
         # at least a threshold of ursulas were successful (concurrency)
         assert int(num_successes) >= ritual.threshold
 
-        # decrypt again (should use cache of decryption share)
-        cleartext = bob.threshold_decrypt(
-            threshold_message_kit=threshold_message_kit,
-        )
-        assert bytes(cleartext) == PLAINTEXT.encode()
+        # decrypt again (should only use cached values)
+        with patch.object(
+            coordinator_agent,
+            "get_provider_public_key",
+            side_effect=RuntimeError(
+                "should not be called to create validators; cache should be used"
+            ),
+        ):
+            # would like to but can't patch agent.get_ritual, since bob uses it
+            cleartext = bob.threshold_decrypt(
+                threshold_message_kit=threshold_message_kit,
+            )
+            assert bytes(cleartext) == PLAINTEXT.encode()
         print("==================== DECRYPTION SUCCESSFUL ====================")
 
         return threshold_message_kit

--- a/tests/integration/blockchain/test_integration_dkg_ritual.py
+++ b/tests/integration/blockchain/test_integration_dkg_ritual.py
@@ -195,7 +195,11 @@ def test_ursula_ritualist(
             status = mock_coordinator_agent.get_ritual_status(ritual_id)
             assert status == Coordinator.RitualStatus.ACTIVE
             for ursula in cohort:
-                assert ursula.dkg_storage.get_transcript(ritual_id) is not None
+                participant = mock_coordinator_agent.get_participant(
+                    ritual_id, ursula.checksum_address, True
+                )
+                assert participant.transcript
+                assert participant.aggregated
 
         def encrypt(_):
             """Encrypts a message and returns the ciphertext and conditions"""

--- a/tests/integration/blockchain/test_integration_dkg_ritual.py
+++ b/tests/integration/blockchain/test_integration_dkg_ritual.py
@@ -300,16 +300,10 @@ def test_ursula_ritualist(
                 0
             ].dkg_storage.get_aggregated_transcript(ritual_id)
 
-            original_decryption_shares = []
             for ursula in cohort:
-                original_decryption_shares.append(
-                    ursula.dkg_storage.get_decryption_share(ritual_id)
-                )
-
                 ursula.dkg_storage.clear(ritual_id)
                 assert ursula.dkg_storage.get_validators(ritual_id) is None
                 assert ursula.dkg_storage.get_aggregated_transcript(ritual_id) is None
-                assert ursula.dkg_storage.get_decryption_share(ritual_id) is None
 
             bob.start_learning_loop(now=True)
             cleartext = bob.threshold_decrypt(
@@ -338,11 +332,6 @@ def test_ursula_ritualist(
                 assert (
                     bytes(cached_aggregated_transcript) == ritual.aggregated_transcript
                 )
-
-                assert ursula.dkg_storage.get_decryption_share(ritual_id)
-
-                # TODO not working for some reason
-                # assert bytes(ursula.dkg_storage.get_decryption_share(ritual_id)) == bytes(original_decryption_shares[ursula_index])
             assert num_used_ursulas >= threshold
             print("===================== DECRYPTION SUCCESSFUL =====================")
 

--- a/tests/integration/blockchain/test_integration_dkg_ritual.py
+++ b/tests/integration/blockchain/test_integration_dkg_ritual.py
@@ -285,11 +285,19 @@ def test_ursula_ritualist(
                 )
                 assert bytes(cleartext) == PLAINTEXT.encode()
 
-                # decrypt again (should use cache of decryption share)
-                cleartext = bob.threshold_decrypt(
-                    threshold_message_kit=threshold_message_kit,
-                )
-                assert bytes(cleartext) == PLAINTEXT.encode()
+                # decrypt again (should only use cached values)
+                with patch.object(
+                    mock_coordinator_agent,
+                    "get_provider_public_key",
+                    side_effect=RuntimeError(
+                        "should not be called to create validators; cache should be used"
+                    ),
+                ):
+                    # would like to but can't patch agent.get_ritual, since bob uses it
+                    cleartext = bob.threshold_decrypt(
+                        threshold_message_kit=threshold_message_kit,
+                    )
+                    assert bytes(cleartext) == PLAINTEXT.encode()
             print("==================== DECRYPTION SUCCESSFUL ====================")
             return threshold_message_kit
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Based over #3419 (either review after 3419 is merged. or only review the commits added on top of 3419).

Improve caching/use of:
- Validators and their ferveo keys for a specific ritual - this was `n` rpc calls every time. This benefits round 2 and threshold decryption operations.
- Active Ritual object - without caching we would still get the ritual object from coordinator contract for things like `shares`, `threshold` etc. So we might as well cache the active ritual. Note: only active rituals are cached (not rituals that have not completed). Also the ritual is still checked for being active before returning from the cache as part of the `_resolve_ritual()` call - this benefits only threshold decryption operations.

**Issues fixed/closed:**
> - Fixes #...

Fixes #3426 .

Related to #3427 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
