### PR TITLE
Auto migration of outdated configuration files

### DIFF
--- a/newsfragments/3432.feature.rst
+++ b/newsfragments/3432.feature.rst
@@ -1,0 +1,1 @@
+Automatically migrate configuration files if detected as using an older version.

--- a/nucypher/cli/actions/migrate.py
+++ b/nucypher/cli/actions/migrate.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+
+import click
+
+from nucypher.config.migrations import MIGRATIONS
+from nucypher.config.migrations.common import (
+    InvalidMigration,
+    WrongConfigurationVersion,
+)
+from nucypher.utilities.emitters import StdoutEmitter
+
+
+def migrate(emitter: StdoutEmitter, config_file: Path):
+    for jump, migration in MIGRATIONS.items():
+        old, new = jump
+        emitter.message(f"Checking migration {old} -> {new}")
+        if not migration:
+            emitter.echo(
+                f"Migration {old} -> {new} not found.",
+                color="yellow",
+                verbosity=1,
+            )
+            continue  # no migration script
+        try:
+            migration(config_file)
+            emitter.echo(
+                f"Successfully ran migration {old} -> {new}",
+                color="green",
+                verbosity=1,
+            )
+
+        except WrongConfigurationVersion:
+            emitter.echo(
+                f"Migration {old} -> {new} not required.",
+                color="yellow",
+                verbosity=1,
+            )
+            continue  # already migrated
+
+        except InvalidMigration as e:
+            emitter.error(f"Migration {old} -> {new} failed: {str(e)}")
+            raise click.Abort()
+
+    emitter.echo("Done! ✨", color="green", verbosity=1)

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -120,9 +120,12 @@ class UrsulaConfigOptions:
             )
         else:
             if not config_file:
-                config_file = select_config_file(emitter=emitter,
-                                                 checksum_address=self.operator_address,
-                                                 config_class=UrsulaConfiguration)
+                config_file = select_config_file(
+                    emitter=emitter,
+                    checksum_address=self.operator_address,
+                    config_class=UrsulaConfiguration,
+                    do_auto_migrate=True,
+                )
             try:
                 return UrsulaConfiguration.from_configuration_file(
                     emitter=emitter,

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -38,8 +38,16 @@ SUCCESSFUL_DESTRUCTION = "Successfully destroyed nucypher configuration"
 CONFIRM_FORGET_NODES = "Permanently delete all known node data?"
 SUCCESSFUL_FORGET_NODES = "Removed all stored known nodes metadata and certificates"
 
+IGNORE_OLD_CONFIGURATION = """
+Ignoring configuration file '{config_file}' whose version is too old ('{version}').
+Run `nucypher ursula config migrate --config-file '{config_file}'` to update it.
+"""
 MIGRATE_OLD_CONFIGURATION = """
 Migrating configuration file '{config_file}' whose version ('{version}') is too old.
+"""
+PROMPT_TO_MIGRATE = """
+Detected configuration file '{config_file}' with old version ('{version}'). Would you 
+like to migrate this file to the newest version? 
 """
 DEFAULT_TO_LONE_CONFIG_FILE = "Defaulting to {config_class} configuration file: '{config_file}'"
 

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -38,9 +38,8 @@ SUCCESSFUL_DESTRUCTION = "Successfully destroyed nucypher configuration"
 CONFIRM_FORGET_NODES = "Permanently delete all known node data?"
 SUCCESSFUL_FORGET_NODES = "Removed all stored known nodes metadata and certificates"
 
-IGNORE_OLD_CONFIGURATION = """
-Ignoring configuration file '{config_file}' - version is too old,
-Run `nucypher ursula config migrate --config-file '{config_file}'` to update it.
+MIGRATE_OLD_CONFIGURATION = """
+Migrating configuration file '{config_file}' whose version ('{version}') is too old.
 """
 DEFAULT_TO_LONE_CONFIG_FILE = "Defaulting to {config_class} configuration file: '{config_file}'"
 

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -106,7 +106,9 @@ class BaseConfiguration(ABC):
         pass
 
     class OldVersion(InvalidConfiguration):
-        pass
+        def __init__(self, version: int, *args, **kwargs):
+            self.version = version
+            super().__init__(*args, *kwargs)
 
     def __init__(
         self,
@@ -301,8 +303,9 @@ class BaseConfiguration(ABC):
         if version != cls.VERSION:
             label = f"'{payload_label}' " if payload_label else ""
             raise cls.OldVersion(
+                version,
                 f"Configuration {label} is the wrong version "
-                f"Expected version {cls.VERSION}; Got version {version}"
+                f"Expected version {cls.VERSION}; Got version {version}",
             )
 
         deserialized_payload = cast_paths_from(cls, deserialized_payload)

--- a/tests/integration/cli/actions/test_select_config_file.py
+++ b/tests/integration/cli/actions/test_select_config_file.py
@@ -1,10 +1,15 @@
+from unittest.mock import patch
+
 import click
 import pytest
 
 from nucypher.cli.actions.select import select_config_file
 from nucypher.cli.literature import (
     DEFAULT_TO_LONE_CONFIG_FILE,
+    IGNORE_OLD_CONFIGURATION,
+    MIGRATE_OLD_CONFIGURATION,
     NO_CONFIGURATIONS_ON_DISK,
+    PROMPT_TO_MIGRATE,
 )
 
 
@@ -98,3 +103,155 @@ def test_interactive_select_config_file(
     for filename, account in accounts:
         assert account.address in captured.out
     assert mock_stdin.empty()
+
+
+def test_confirm_prompt_to_migrate_select_config_file(
+    test_emitter, capsys, alice_test_config, temp_dir_path, mock_stdin
+):
+    config_class = alice_test_config
+    config_path = temp_dir_path / config_class.generate_filename()
+    # Make one configuration
+    config_class.to_configuration_file(filepath=config_path, override=True)
+    assert config_path.exists()
+
+    old_version = config_class.VERSION - 1
+    mock_stdin.line("Y")
+    with patch.object(
+        config_class,
+        "address_from_filepath",
+        side_effect=[
+            config_class.OldVersion(old_version, "too old"),
+            alice_test_config.checksum_address,
+        ],
+    ):
+        result = select_config_file(
+            emitter=test_emitter, config_class=config_class, config_root=temp_dir_path
+        )
+
+    # ... ensure the correct account was selected
+    assert result == config_path
+
+    captured = capsys.readouterr()
+    assert (
+        PROMPT_TO_MIGRATE.format(config_file=str(config_path), version=old_version)
+        in captured.out
+    )
+    assert (
+        MIGRATE_OLD_CONFIGURATION.format(
+            config_file=str(config_path), version=old_version
+        )
+        in captured.out
+    )
+    assert (
+        DEFAULT_TO_LONE_CONFIG_FILE.format(
+            config_class=config_class.NAME.capitalize(), config_file=str(config_path)
+        )
+        in captured.out
+    )
+
+
+def test_deny_prompt_to_migrate_select_config_file(
+    test_emitter, capsys, alice_test_config, temp_dir_path, mock_stdin
+):
+    config_class = alice_test_config
+    config_path = temp_dir_path / config_class.generate_filename()
+
+    # Make one configuration
+    config_class.to_configuration_file(filepath=config_path, override=True)
+    assert config_path.exists()
+
+    old_version = config_class.VERSION - 1
+    mock_stdin.line("N")
+    # expect abort because no configuration files available
+    with pytest.raises(click.Abort):
+        with patch.object(
+            config_class,
+            "address_from_filepath",
+            side_effect=[
+                config_class.OldVersion(old_version, "too old"),
+                alice_test_config.checksum_address,
+            ],
+        ):
+            _ = select_config_file(
+                emitter=test_emitter,
+                config_class=config_class,
+                config_root=temp_dir_path,
+            )
+
+    captured = capsys.readouterr()
+    assert (
+        PROMPT_TO_MIGRATE.format(config_file=str(config_path), version=old_version)
+        in captured.out
+    )
+    assert (
+        IGNORE_OLD_CONFIGURATION.format(
+            config_file=str(config_path), version=old_version
+        )
+        in captured.out
+    )
+    assert (
+        NO_CONFIGURATIONS_ON_DISK.format(
+            name=config_class.NAME.capitalize(), command=config_class.NAME
+        )
+        in captured.out
+    )
+
+    assert (
+        MIGRATE_OLD_CONFIGURATION.format(
+            config_file=str(config_path), version=old_version
+        )
+        not in captured.out
+    )
+
+
+def test_dont_prompt_to_migrate_select_config_file(
+    test_emitter, capsys, alice_test_config, temp_dir_path, mock_stdin
+):
+    """Only one configuration was found, so it was chosen automatically"""
+    config_class = alice_test_config
+    config_path = temp_dir_path / config_class.generate_filename()
+
+    # Make one configuration
+    config_class.to_configuration_file(filepath=config_path, override=True)
+    assert config_path.exists()
+
+    old_version = config_class.VERSION - 1
+    with patch.object(
+        config_class,
+        "address_from_filepath",
+        side_effect=[
+            config_class.OldVersion(old_version, "too old"),
+            alice_test_config.checksum_address,
+        ],
+    ):
+        result = select_config_file(
+            emitter=test_emitter,
+            config_class=config_class,
+            config_root=temp_dir_path,
+            do_auto_migrate=True,
+        )
+
+    # ... ensure the correct account was selected
+    assert result == config_path
+
+    # ... the user was *not* prompted
+    # If they were, `mock_stdin` would complain.
+
+    captured = capsys.readouterr()
+    assert (
+        PROMPT_TO_MIGRATE.format(config_file=str(config_path), version=old_version)
+        not in captured.out
+    )
+
+    assert (
+        MIGRATE_OLD_CONFIGURATION.format(
+            config_file=str(config_path), version=old_version
+        )
+        in captured.out
+    )
+    assert (
+        DEFAULT_TO_LONE_CONFIG_FILE.format(
+            config_class=config_class.NAME.capitalize(), config_file=str(config_path)
+        )
+        in captured.out
+    )


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**

After an upgrade that included changing the configuration file, lynx nodes were failing:
```
No Ursula configurations found. Run 'nucypher ursula init' then try again.

Ignoring configuration file '/root/.local/share/nucypher/ursula.json' - version is too old,
Run `nucypher ursula config migrate --config-file '/root/.local/share/nucypher/ursula.json'` to update it.

No Ursula configurations found. Run 'nucypher ursula init' then try again.
Aborted!
```

The original configuration file for lynx nodes used an old version, and the node would not startup until the configuration file was manually migrated using `nucypher ursula config migrate...`. Instead the node should detect that it has an outdated config file, and automatically migrate it so that it can start up.


**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
