### PR TITLE
Build and push package to pypi whenever a release is published

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,51 @@
+name: Publish Python 🐍 distribution 📦 to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/nucypher
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,11 +4,13 @@ include README.md
 include requirements.txt
 include dev-requirements.txt
 
+recursive-exclude tests/ *
+
 recursive-exclude * __pycache__
 global-exclude *.py[cod]
 
 recursive-include nucypher/blockchain/eth/contract_registry *.json
 recursive-include nucypher/policy/conditions *.json
 recursive-include nucypher/network/templates *.html *.mako
-recursive-include nucypher/utilities/templates *.html *.mako
+recursive-exclude nucypher/utilities/templates *.html *.mako
 recursive-include nucypher/acumen/ *json

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,13 @@ release: clean
 
 dist: clean
     # Build a source distribution and wheel
-	python setup.py sdist bdist_wheel
+	python3 -m build
 	ls -l dist
 
 smoke-test: clean
     # Build a source distribution and wheel then build a smoke test virtual env from the wheel
-	python setup.py sdist bdist_wheel
-	python scripts/release/test_package.py
+	python3 -m build
+	python3 scripts/release/test_package.py
 
 lock: clean
     # Relock dependencies

--- a/newsfragments/3433.feature.rst
+++ b/newsfragments/3433.feature.rst
@@ -1,0 +1,1 @@
+Add workflow for pushing published releases to pypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools", "setuptools-rust", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [tool.towncrier]
     package = "nucypher"
     package_dir = "nucypher"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from pathlib import Path
 from typing import Dict
 from urllib.parse import urlparse
 
-from setuptools import find_packages, setup
+from setuptools import find_namespace_packages, setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 
@@ -151,7 +151,9 @@ setup(
     extras_require=EXTRAS,
 
     # Package Data
-    packages=find_packages(exclude=["scripts"]),
+    packages=find_namespace_packages(
+        exclude=["scripts", "nucypher.utilities.templates"]
+    ),
     include_package_data=True,
     zip_safe=False,
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Feature


**Required reviews:** 
- [x] 1

When a release is published, this workflow will be triggered to build `nucypher` and push to https://pypi.org/project/nucypher/