### PR TITLE
Update EventScanner Min chunk for Polygon scans

### DIFF
--- a/newsfragments/3434.misc.rst
+++ b/newsfragments/3434.misc.rst
@@ -1,0 +1,1 @@
+Optimize EventScanner chunking for Polygon given its blocktime.


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**

- Move chunk, reorg window settings to ActiveRitualTracker - more applicable there since it has context for the chain being scanned etc. 
- Increase reorg window to 20 since we've noticed that Polygon block reorgs can be that large (sometimes larger) - https://polygonscan.com/blocks_forked
- Increase min chunk size to 60 - 60 blocks @ 2s / block = 120s of events. Using 10 was seemingly too small given Polygon's shorter block time.
- Update test to re-inforce the view that increasing min chunk size reduces rpc calls.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
