### PR TITLE
Fix use of SimpleTask class level INTERVAL value and start chunk size

### DIFF
--- a/newsfragments/3435.bugfix.rst
+++ b/newsfragments/3435.bugfix.rst
@@ -1,0 +1,1 @@
+Incorrect use of ``INTERVAL`` class variable for ``SimpleTask`` - it affected the interval for the ``EventScannerTask``.

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -301,14 +301,16 @@ class EventScanner:
         current_chunk_size = min(self.max_scan_chunk_size, current_chunk_size)
         return int(current_chunk_size)
 
-    def scan(self, start_block, end_block, start_chunk_size=20) -> Tuple[list, int]:
+    def scan(
+        self, start_block, end_block, start_chunk_size: Optional[int] = None
+    ) -> Tuple[list, int]:
         """Perform a scan for events.
 
         :param start_block: The first block included in the scan
 
         :param end_block: The last block included in the scan
 
-        :param start_chunk_size: How many blocks we try to fetch over JSON-RPC on the first attempt
+        :param start_chunk_size: How many blocks we try to fetch over JSON-RPC on the first attempt; min chunk size if not specified
 
         :return: [All processed events, number of chunks used]
         """
@@ -321,7 +323,7 @@ class EventScanner:
         current_block = start_block
 
         # Scan in chunks, commit between
-        chunk_size = start_chunk_size
+        chunk_size = start_chunk_size or self.min_scan_chunk_size
         last_scan_duration = last_logs_found = 0
         total_chunks_scanned = 0
 

--- a/nucypher/utilities/task.py
+++ b/nucypher/utilities/task.py
@@ -12,8 +12,8 @@ class SimpleTask(ABC):
     INTERVAL = 60  # 60s default
     CLOCK = reactor
 
-    def __init__(self, interval: float = INTERVAL):
-        self.interval = interval
+    def __init__(self, interval: float = None):
+        self.interval = interval or self.INTERVAL
         self.log = Logger(self.__class__.__name__)
         self._task = LoopingCall(self.run)
         # self.__task.clock = self.CLOCK

--- a/tests/unit/test_event_scanner.py
+++ b/tests/unit/test_event_scanner.py
@@ -163,9 +163,7 @@ def test_scan_when_events_always_found(chunk_size):
         scanner, start_block, end_block
     )
 
-    all_processed, total_chunks_scanned = scanner.scan(
-        start_block, end_block, start_chunk_size=chunk_size
-    )
+    all_processed, total_chunks_scanned = scanner.scan(start_block, end_block)
     assert total_chunks_scanned == len(expected_calls)
     assert scanner.scan_chunk_calls_made == expected_calls
     assert scanner.get_last_scanned_block() == end_block
@@ -197,9 +195,7 @@ def test_scan_when_events_never_found(chunk_size):
         scanner, start_block, end_block
     )
 
-    all_processed, total_chunks_scanned = scanner.scan(
-        start_block, end_block, start_chunk_size=chunk_size
-    )
+    all_processed, total_chunks_scanned = scanner.scan(start_block, end_block)
 
     assert total_chunks_scanned == len(expected_calls)
     assert len(all_processed) == 0  # no events processed
@@ -239,9 +235,7 @@ def test_scan_when_events_never_found_super_large_chunk_sizes():
         scanner, start_block, end_block
     )
 
-    all_processed, total_chunks_scanned = scanner.scan(
-        start_block, end_block, start_chunk_size=min_chunk_size
-    )
+    all_processed, total_chunks_scanned = scanner.scan(start_block, end_block)
 
     assert total_chunks_scanned == len(expected_calls)
     assert len(all_processed) == 0  # no events processed

--- a/tests/unit/test_event_scanner.py
+++ b/tests/unit/test_event_scanner.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
-from nucypher.blockchain.eth.trackers.dkg import ActiveRitualTracker
+from nucypher.blockchain.eth.trackers.dkg import ActiveRitualTracker, EventScannerTask
 from nucypher.utilities.events import EventScanner, EventScannerState, JSONifiedState
 
 CHAIN_REORG_WINDOW = ActiveRitualTracker.CHAIN_REORG_SCAN_WINDOW
@@ -293,3 +293,18 @@ class MyEventScanner(EventScanner):
     @property
     def scan_chunk_calls_made(self):
         return self.chunk_calls_made
+
+
+def test_event_scanner_task():
+    scanner = EventScanner(
+        web3=Mock(),
+        contract=Mock(),
+        state=Mock(),
+        events=[],
+        filters={},
+        chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
+    )
+    task = EventScannerTask(scanner.scan)
+
+    assert task.interval == EventScannerTask.INTERVAL
+    assert task.scanner == scanner.scan


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**

Noticed the following in logs:
```
"128.199.24.70" - - [07/Feb/2024:21:29:25 +0000] "POST /node_metadata HTTP/1.1" 200 82 "-" "python-requests/2.31.0"
(0x890069) Scanning events in block range 45666360 - 45666408
Scanned total of 0 events, in 2.137392044067383 seconds, total 2 chunk scans performed
...
(0x890069) Scanning events in block range 45666388 - 45666436
Scanned total of 0 events, in 2.069166898727417 seconds, total 2 chunk scans performed
"128.199.24.70" - - [07/Feb/2024:21:30:30 +0000] "GET /ping HTTP/1.1" 200 13 "-" "python-requests/2.31.0"
```

Two things stand out:
1. The scanner is scanning in 1-minute intervals instead of 2-minute intervals
2. 45666436 - 45666388 = 48 blocks yet with a min chunk size of 60 there were 2 chunks scans performed instead of 1.


Fixes:
- Incorrect use of class level variable - fix it. Bug introduced in https://github.com/nucypher/nucypher/pull/3294.
- Start chunk size for the scanner should not use an actual default value (it was 20) other than min chunk size. It can be overridden but the default should be the min start chunk size or else it negates the use of the min chunk size on the first scan of blocks. This was the reason 48 blocks took 2 scans, scan 1 did 20 blocks and then scan 2 used 60 as the chunk size and therefore scanned the remaining 28 blocks.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
