### PR TITLE
The return of simple_cache_middleware

### DIFF
--- a/newsfragments/3436.dev.rst
+++ b/newsfragments/3436.dev.rst
@@ -1,0 +1,1 @@
+Reintroduce ``simple_cache_middleware`` to cache some RPC calls like ``eth_chainId``.

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -22,7 +22,7 @@ from hexbytes.main import HexBytes
 from web3 import HTTPProvider, IPCProvider, Web3, WebsocketProvider
 from web3.contract.contract import Contract, ContractConstructor, ContractFunction
 from web3.exceptions import TimeExhausted
-from web3.middleware import geth_poa_middleware
+from web3.middleware import geth_poa_middleware, simple_cache_middleware
 from web3.providers import BaseProvider
 from web3.types import TxReceipt
 
@@ -209,7 +209,7 @@ class BlockchainInterface:
         self.endpoint = endpoint
         self._provider = provider
         self.w3 = NO_BLOCKCHAIN_CONNECTION
-        self.client = NO_BLOCKCHAIN_CONNECTION
+        self.client: EthereumClient = NO_BLOCKCHAIN_CONNECTION
         self.is_light = light
 
         # TODO: Not ready to give users total flexibility. Let's stick for the moment to known values. See #2447
@@ -258,6 +258,9 @@ class BlockchainInterface:
         if self.poa is True:
             self.log.debug('Injecting POA middleware at layer 0')
             self.client.inject_middleware(geth_poa_middleware, layer=0)
+
+        self.log.debug("Adding simple_cache_middleware")
+        self.client.add_middleware(simple_cache_middleware)
 
         # TODO:  See #2770
         # self.configure_gas_strategy()


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
* Cache certain RPC calls using web3.py's `simple_cache_middleware` 

**Issues fixed/closed:**
* Fixes #3286 

**Why it's needed:**
Currently, TACo nodes exhibit a relatively high RPC requests consumption (see #3370). This is just a small improvement, mainly reducing repeated calls to `eth_chainId`. For some reason, with v7.1.0 I've seen ~5,000 of these per day.

**Notes for reviewers:**
We had to temporarily remove `simple_cache_middleware` when @KPrasch and I detected that it shared state between multiple Web3 instances (see https://github.com/ethereum/web3.py/issues/2977 ). This was fixed by https://github.com/ethereum/web3.py/pull/2979, and released in v6.5.0 (https://web3py.readthedocs.io/en/stable/releases.html#web3-py-v6-5-0-2023-06-15). We currently pin v6.14.0.
