### PR TITLE
Fix Certificate Invalidation issues on Lynx

### DIFF
--- a/newsfragments/3440.bugfix.rst
+++ b/newsfragments/3440.bugfix.rst
@@ -1,0 +1,1 @@
+Properly update ssl contexts to use updated CA cert data for a node which has been restarted.

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -538,7 +538,7 @@ class Learner:
 
         if not nodes_we_know_about:
             self.log.warn("Need some nodes to start learning from.")
-            raise self.NotEnoughTeachers("Need some nodes to start learning from.")
+            return False
 
         self.teacher_nodes.extend(nodes_we_know_about)
 

--- a/nucypher/utilities/certs.py
+++ b/nucypher/utilities/certs.py
@@ -1,4 +1,3 @@
-import socket
 import ssl
 import time
 from typing import Dict, NamedTuple
@@ -37,16 +36,8 @@ def _replace_hostname_with_ip(url: str, ip_address: str) -> str:
 
 def _fetch_server_cert(address: Address) -> Certificate:
     """Fetch the server certificate from the given address."""
-    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    context.check_hostname = False
-    context.verify_mode = ssl.CERT_NONE
-
-    with socket.create_connection(address) as sock:
-        with context.wrap_socket(sock, server_hostname=address.hostname) as ssock:
-            sock.close()  # close the insecure socket
-            certificate_bin = ssock.getpeercert(binary_form=True)
-
-    certificate = Certificate(ssl.DER_cert_to_PEM_cert(certificate_bin))
+    certificate_pem = ssl.get_server_certificate(address)
+    certificate = Certificate(certificate_pem)
     return certificate
 
 

--- a/nucypher/utilities/certs.py
+++ b/nucypher/utilities/certs.py
@@ -68,27 +68,44 @@ class CertificateCache:
         )
 
 
+class SelfSignedPoolManager(PoolManager):
+    def __init__(self, certificate_cache: CertificateCache, *args, **kwargs):
+        self.certificate_cache = certificate_cache
+        super().__init__(*args, **kwargs)
+
+    def connection_from_url(self, url, pool_kwargs=None):
+        if not pool_kwargs:
+            pool_kwargs = {}
+        ssl_context = pool_kwargs.get("ssl_context")
+        if not ssl_context:
+            ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            ssl_context.verify_mode = ssl.CERT_REQUIRED
+            ssl_context.check_hostname = False
+            pool_kwargs["ssl_context"] = ssl_context
+
+        parsed = urlparse(url)
+        host, port = parsed.hostname, parsed.port
+        cached_certificate = self.certificate_cache.get(Address(host, port))
+        if cached_certificate:
+            ssl_context.load_verify_locations(cadata=cached_certificate)
+
+        return super().connection_from_url(url, pool_kwargs=pool_kwargs)
+
+
 class SelfSignedCertificateAdapter(HTTPAdapter):
     """An adapter that verifies self-signed certificates in memory only."""
 
     log = logging.Logger(__name__)
 
-    def __init__(self, *args, **kwargs):
-        self.ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-        self.ssl_context.verify_mode = ssl.CERT_REQUIRED
-        self.ssl_context.check_hostname = False
+    def __init__(self, certificate_cache: CertificateCache, *args, **kwargs):
+        self.certificate_cache = certificate_cache
         super().__init__(*args, **kwargs)
 
     def init_poolmanager(self, *args, **kwargs) -> None:
-        """Override the default poolmanager to use the  local SSL context."""
-        self.poolmanager = PoolManager(*args, ssl_context=self.ssl_context, **kwargs)
-
-    def trust_certificate(self, certificate: Certificate) -> None:
-        """Accept the given certificate as trusted."""
-        try:
-            self.ssl_context.load_verify_locations(cadata=certificate)
-        except ssl.SSLError as e:
-            self.log.debug(f"Failed to load certificate {e}.")
+        """Override the default poolmanager to use the certificate cache."""
+        self.poolmanager = SelfSignedPoolManager(
+            self.certificate_cache, *args, **kwargs
+        )
 
 
 class P2PSession(Session):
@@ -97,8 +114,8 @@ class P2PSession(Session):
 
     def __init__(self):
         super().__init__()
-        self.adapter = SelfSignedCertificateAdapter()
-        self.cache = CertificateCache()
+        self.certificate_cache = CertificateCache()
+        self.adapter = SelfSignedCertificateAdapter(self.certificate_cache)
         self.mount("https://", self.adapter)
 
     @classmethod
@@ -110,8 +127,7 @@ class P2PSession(Session):
         return Address(hostname, parsed.port or cls._DEFAULT_PORT)
 
     def __retry_send(self, address, request, *args, **kwargs) -> Response:
-        certificate = self._refresh_certificate(address)
-        self.adapter.trust_certificate(certificate=certificate)
+        self._refresh_certificate(address)
         try:
             return super().send(request, *args, **kwargs)
         except RequestException as e:
@@ -129,8 +145,7 @@ class P2PSession(Session):
         """
 
         address = self._resolve_address(url=request.url)  # resolves dns
-        certificate = self.__get_or_refresh_certificate(address)  # cache by resolved ip
-        self.adapter.trust_certificate(certificate=certificate)
+        self.__ensure_certificate_cached_and_uptodate(address)  # cache by resolved ip
         url = _replace_with_resolved_address(url=request.url, resolved_address=address)
         request.url = url  # replace the hostname with the resolved IP address
         try:
@@ -139,13 +154,13 @@ class P2PSession(Session):
             self.adapter.log.debug(f"Request failed due to {e}, retrying...")
             return self.__retry_send(address, request, *args, **kwargs)
 
-    def __get_or_refresh_certificate(self, address: Address) -> Certificate:
-        if self.cache.should_cache_now(address):
+    def __ensure_certificate_cached_and_uptodate(self, address: Address) -> Certificate:
+        if self.certificate_cache.should_cache_now(address):
             return self._refresh_certificate(address)
-        certificate = self.cache.get(address)
+        certificate = self.certificate_cache.get(address)
         return certificate
 
     def _refresh_certificate(self, address: Address) -> Certificate:
         certificate = _fetch_server_cert(address)
-        self.cache.set(address, certificate)
+        self.certificate_cache.set(address, certificate)
         return certificate

--- a/tests/acceptance/characters/test_handling_ursula_tls_certs.py
+++ b/tests/acceptance/characters/test_handling_ursula_tls_certs.py
@@ -1,0 +1,47 @@
+from http import HTTPStatus
+
+import pytest_twisted
+from twisted.internet import threads
+
+from nucypher.crypto.powers import TLSHostingPower
+from nucypher.crypto.tls import generate_self_signed_certificate
+from nucypher.utilities.certs import P2PSession
+from nucypher.utilities.logging import GlobalLoggerSettings
+
+GlobalLoggerSettings.set_log_level(log_level_name="debug")
+GlobalLoggerSettings.start_console_logging()
+
+
+@pytest_twisted.inlineCallbacks
+def test_cert_changed_for_service(monkeypatch, ursulas):
+    ursula = ursulas[0]
+    deployer = ursula.get_deployer()
+    deployer.addServices()
+    deployer.catalogServers(deployer.hendrix)
+    deployer.start()
+
+    session = P2PSession()
+
+    def check_connection_to_ursula(node):
+        response = session.get(
+            "https://{}/public_information".format(node.rest_url()), timeout=3
+        )
+        assert response.status_code == HTTPStatus.OK
+
+    yield threads.deferToThread(check_connection_to_ursula, ursula)
+
+    yield deployer.tls_service.stopService()
+    yield deployer.hendrix.stopService()
+
+    # generate new certificate for ursula
+    certificate, key = generate_self_signed_certificate(host=ursula.rest_interface.host)
+    hosting_power = ursula._crypto_power.power_ups(TLSHostingPower)
+    hosting_power.keypair._privkey = key
+    hosting_power.keypair.certificate = certificate
+
+    deployer = ursula.get_deployer()
+    deployer.addServices()
+    deployer.catalogServers(deployer.hendrix)
+    deployer.start()
+
+    yield threads.deferToThread(check_connection_to_ursula, ursula)

--- a/tests/unit/test_memory_certs.py
+++ b/tests/unit/test_memory_certs.py
@@ -112,7 +112,7 @@ def test_https_request_with_cert_refresh():
 
     # Manually expire the cached certificate
     hostname, port = P2PSession._resolve_address(VALID_URL)
-    session.cache._expirations[(hostname, port)] = 0
+    session.certificate_cache._expirations[(hostname, port)] = 0
 
     # Send another request to the same URL (it should refresh the certificate)
     response = session.get(VALID_URL)
@@ -124,7 +124,9 @@ def test_https_request_with_invalid_cached_cert_and_refresh():
     session = P2PSession()
     hostname, port = P2PSession._resolve_address(VALID_URL)
 
-    session.cache.set(Address(hostname, port), VALID_BUT_INCORRECT_CERT_FOR_VALID_URL)
+    session.certificate_cache.set(
+        Address(hostname, port), VALID_BUT_INCORRECT_CERT_FOR_VALID_URL
+    )
 
     # Send a request (it should succeed after retrying and refreshing cert)
     response = session.get(VALID_URL)

--- a/tests/unit/test_memory_certs.py
+++ b/tests/unit/test_memory_certs.py
@@ -20,6 +20,19 @@ MIIDXTCCAkWgAwIBAgIJALm157+YvLEhMA0GCSqGSIb3DQEBCwUAMEUxCzAJBgNV
 ...
 -----END CERTIFICATE-----"""
 
+VALID_BUT_INCORRECT_CERT_FOR_VALID_URL = """-----BEGIN CERTIFICATE-----
+MIIBgzCCAQigAwIBAgIUYZMjb9wgSIv0G3H9zP6Xezi3y6kwCgYIKoZIzj0EAwQw
+GDEWMBQGA1UEAwwNMTg4LjE2Ni4yNy40NjAeFw0yNDAxMzAxMjQ0MzhaFw0yNTAx
+MjkxMjQ0MzhaMBgxFjAUBgNVBAMMDTE4OC4xNjYuMjcuNDYwdjAQBgcqhkjOPQIB
+BgUrgQQAIgNiAASnd+YYrbrV3WW/hb1+4+RRD/lWLkcgKM5JjZLjuwNU/Ndr1vEl
+qOAwbz+fcdwgJ7SAkSoK2fQOt90NnnBPDA12MCc0ScwyiQxS7Cm382B4h3No4M4Z
+E3bLLn1u69g9Y26jEzARMA8GA1UdEQQIMAaHBLymGy4wCgYIKoZIzj0EAwQDaQAw
+ZgIxAL4cpbec9Hs8O4uXB8zESJJ32err5jejFhWOFexppRTNjhM5copO9c8x24zJ
+IzqeQgIxALCe9ynrDkT/tOtBNjvPiNvR8aosRsgdsQCcbk3fUCsYXSXTuphpDgMf
+IKaHuG9nuw==
+-----END CERTIFICATE-----
+"""
+
 
 @pytest.fixture
 def cache():
@@ -104,6 +117,18 @@ def test_https_request_with_cert_refresh():
     session.cache._expirations[(hostname, port)] = 0
 
     # Send another request to the same URL (it should refresh the certificate)
+    response = session.get(VALID_URL)
+    assert response.status_code == 200
+
+
+def test_https_request_with_invalid_cached_cert_and_refresh():
+    # Create a session with certificate caching
+    session = P2PSession()
+    hostname, port = P2PSession._resolve_address(VALID_URL)
+
+    session.cache.set(Address(hostname, port), VALID_BUT_INCORRECT_CERT_FOR_VALID_URL)
+
+    # Send a request (it should succeed after retrying and refreshing cert)
     response = session.get(VALID_URL)
     assert response.status_code == 200
 

--- a/tests/unit/test_memory_certs.py
+++ b/tests/unit/test_memory_certs.py
@@ -41,8 +41,7 @@ def cache():
 
 @pytest.fixture
 def adapter(cache):
-    _adapter = SelfSignedCertificateAdapter()
-    _adapter.cert_cache = cache
+    _adapter = SelfSignedCertificateAdapter(certificate_cache=cache)
     return _adapter
 
 
@@ -81,7 +80,6 @@ def test_cache_cert(cache):
 
 
 def test_send_request(session, mocker):
-    mocker.patch.object(SelfSignedCertificateAdapter, "trust_certificate")
     mocked_refresh = mocker.patch.object(
         session, "_refresh_certificate", return_value=MOCK_CERT
     )


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**

Related to #3307 .

There were some certificate issues on Lynx after running the latest 7.2.x code.

Whenever a node, A, learns about node B, it caches B's certificate in an in memory cache. However, if B is restarted, it creates a new certificate. Since A already cached B's prior certificate, it first tries to use that certificate when connecting to B again. However the old certificate is invalid and the request fails. However, requests get retried, but for each retry even though the cached certificate is refreshed to be B's updated certificate, the SSL context used by the underlying connection does not get updated to use the updated CA data. It seems that CA data cannot be updated, and A never ends up connecting to B again, unless there is a restart.

This endless loop for connecting to B occurs:
```
Request failed due to HTTPSConnectionPool(host='167.71.226.39', port=9151): Max retries exceeded with url: /node_metadata (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1000)'))), retrying...
Request failed due to HTTPSConnectionPool(host='167.71.226.39', port=9151): Max retries exceeded with url: /node_metadata (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1000)'))), giving up.
Teacher 0xb15d5A4e2be34f4bE154A1b08a94Ab920FfD8A41@167.71.226.39:9151 is unreachable: HTTPSConnectionPool(host='167.71.226.39', port=9151): Max retries exceeded with url: /node_metadata (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1000)'))).
```

We should create a new SSL context per connection instead of reusing the same SSL context. This way the CA data can be properly updated, and the retry should subsequently work after the cache updates the cert to use for connecting to the other node.

Instead what should happen now is the following should be printed to the log, with a subsequent success after retrying
```
"128.199.24.70" - - [09/Feb/2024:17:27:25 +0000] "POST /node_metadata HTTP/1.1" 200 82 "-" "python-requests/2.31.0"
Request failed due to HTTPSConnectionPool(host='128.199.24.70', port=9151): Max retries exceeded with url: /node_metadata (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1000)'))), retrying...
Cycled teachers; New teacher is (Ursula)⇀NavajoWhite Hotel Gainsboro India↽ (0xb15d5A4e2be34f4bE154A1b08a94Ab920FfD8A41)
"128.199.24.70" - - [09/Feb/2024:17:27:29 +0000] "POST /node_metadata HTTP/1.1" 200 82 "-" "python-requests/2.31.0"
```

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Lynx nodes are currently running this code as part of the `nucypher/nucypher:experimental` docker image.
