### PR TITLE
Repetitive calls - get events for multiple event types in one getLogs call

### DIFF
--- a/newsfragments/3444.misc.rst
+++ b/newsfragments/3444.misc.rst
@@ -1,0 +1,2 @@
+Update EventScanner to obtain events of different types as part of the same RPC
+call to reduce the volume of rpc calls.

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -132,7 +132,6 @@ class ActiveRitualTracker:
             state=self.state,
             contract=self.contract,
             events=self.events,
-            filters={"address": self.contract.address},
             # How many maximum blocks at the time we request from JSON-RPC,
             # and we are unlikely to exceed the response size limit of the JSON-RPC server
             max_chunk_scan_size=self.MAX_CHUNK_SIZE,

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -363,7 +363,7 @@ class EventScanner:
 def _fetch_events_for_contract(
     web3, contract, events, from_block: int, to_block: int
 ) -> Iterable:
-    """Get events using eth_get_logs API.
+    """Get events using eth_getLogs API.
 
     This method is detached from any contract instance.
 
@@ -398,7 +398,7 @@ def _fetch_events_for_contract(
         event_filter_params["toBlock"] = to_block
 
     logger.debug(
-        f"Querying eth_get_logs with the following parameters: {event_filter_params}"
+        f"Querying eth_getLogs with the following parameters: {event_filter_params}"
     )
 
     # Call JSON-RPC API on your Ethereum node.

--- a/tests/unit/test_event_scanner.py
+++ b/tests/unit/test_event_scanner.py
@@ -13,9 +13,7 @@ CHAIN_REORG_WINDOW = ActiveRitualTracker.CHAIN_REORG_SCAN_WINDOW
 
 
 def test_estimate_next_chunk_size():
-    scanner = EventScanner(
-        web3=Mock(), contract=Mock(), state=Mock(), events=[], filters={}
-    )
+    scanner = EventScanner(web3=Mock(), contract=Mock(), state=Mock(), events=[])
 
     # no prior events found
     current_chunk_size = 20
@@ -63,7 +61,6 @@ def test_suggested_scan_start_block():
         contract=Mock(),
         state=state,
         events=[],
-        filters={},
         chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
     )
 
@@ -94,7 +91,6 @@ def test_suggested_scan_end_block():
         contract=Mock(),
         state=Mock(),
         events=[],
-        filters={},
         chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
     )
 
@@ -112,7 +108,6 @@ def test_get_block_timestamp():
         contract=Mock(),
         state=Mock(),
         events=[],
-        filters={},
     )
 
     now = time.time()
@@ -132,7 +127,6 @@ def test_scan_invalid_start_end_block():
         contract=Mock(),
         state=Mock(),
         events=[],
-        filters={},
         chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
     )
 
@@ -153,7 +147,6 @@ def test_scan_when_events_always_found(chunk_size):
         contract=Mock(),
         state=state,
         events=[],
-        filters={},
         chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
         min_chunk_scan_size=chunk_size,
         target_end_block=end_block,
@@ -184,7 +177,6 @@ def test_scan_when_events_never_found(chunk_size):
         contract=Mock(),
         state=state,
         events=[],
-        filters={},
         chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
         min_chunk_scan_size=chunk_size,
         return_event_for_scan_chunk=False,  # min chunk size not used (but scales up)
@@ -223,7 +215,6 @@ def test_scan_when_events_never_found_super_large_chunk_sizes():
         contract=Mock(),
         state=state,
         events=[],
-        filters={},
         chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
         min_chunk_scan_size=min_chunk_size,
         max_chunk_scan_size=max_chunk_size,
@@ -295,7 +286,6 @@ def test_event_scanner_task():
         contract=Mock(),
         state=Mock(),
         events=[],
-        filters={},
         chain_reorg_rescan_window=CHAIN_REORG_WINDOW,
     )
     task = EventScannerTask(scanner.scan)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Closes #3443 

Previously we were call eth_getLogs individually for each event type: StartRitual, StartAggregationRound, EndRitual - https://github.com/nucypher/nucypher/blob/v7.2.x/nucypher/utilities/events.py#L239 . 

Instead we can make one eth_getLogs call for all 3 event types. Our volume of rpc calls should now be 1/3 of what it was previously.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
