### PR TITLE
Migration from Polygon Mumbai to Polygon Amoy

### DIFF
--- a/.github/workflows/lynx.yml
+++ b/.github/workflows/lynx.yml
@@ -12,7 +12,7 @@ on:
 
 env: # TODO: Use variables when GH supports it for forks. See https://github.com/orgs/community/discussions/44322
   DEMO_L1_PROVIDER_URI: "https://sepolia.infura.io/v3/3747007a284045d483c342fb39889a30"
-  DEMO_L2_PROVIDER_URI: "https://polygon-mumbai.infura.io/v3/3747007a284045d483c342fb39889a30"
+  DEMO_L2_PROVIDER_URI: "https://polygon-amoy.infura.io/v3/3747007a284045d483c342fb39889a30"
   COLLECT_PROFILER_STATS: ""  # any value is fine
 
 jobs:

--- a/examples/testnet_compound_multichain_taco.py
+++ b/examples/testnet_compound_multichain_taco.py
@@ -4,6 +4,7 @@ from nucypher_core.ferveo import DkgPublicKey
 
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import CoordinatorAgent
+from nucypher.blockchain.eth.domains import EthChain, PolygonChain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.characters.lawful import Bob, Enrico
@@ -61,28 +62,28 @@ conditions = {
         "operands": [
             {
                 "conditionType": ConditionType.RPC.value,
-                "chain": 1,
+                "chain": EthChain.MAINNET.id,
                 "method": "eth_getBalance",
                 "parameters": ["0x210eeAC07542F815ebB6FD6689637D8cA2689392", "latest"],
                 "returnValueTest": {"comparator": "==", "value": 0},
             },
             {
                 "conditionType": ConditionType.RPC.value,
-                "chain": 137,
+                "chain": PolygonChain.MAINNET.id,
                 "method": "eth_getBalance",
                 "parameters": ["0x210eeAC07542F815ebB6FD6689637D8cA2689392", "latest"],
                 "returnValueTest": {"comparator": "==", "value": 0},
             },
             {
                 "conditionType": ConditionType.RPC.value,
-                "chain": 11155111,
+                "chain": EthChain.SEPOLIA.id,
                 "method": "eth_getBalance",
                 "parameters": ["0x210eeAC07542F815ebB6FD6689637D8cA2689392", "latest"],
                 "returnValueTest": {"comparator": ">", "value": 1},
             },
             {
                 "conditionType": ConditionType.RPC.value,
-                "chain": 80001,
+                "chain": PolygonChain.AMOY.id,
                 "method": "eth_getBalance",
                 "parameters": ["0x210eeAC07542F815ebB6FD6689637D8cA2689392", "latest"],
                 "returnValueTest": {"comparator": "==", "value": 0},

--- a/examples/testnet_compound_multichain_taco.py
+++ b/examples/testnet_compound_multichain_taco.py
@@ -39,7 +39,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 5  # got this from a side channel
+ritual_id = 0  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
 # known authorized encryptor for ritual 3

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -4,6 +4,7 @@ from nucypher_core.ferveo import DkgPublicKey
 
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import CoordinatorAgent
+from nucypher.blockchain.eth.domains import PolygonChain
 from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.characters.lawful import Bob, Enrico
@@ -58,7 +59,7 @@ eth_balance_condition = {
     "version": ConditionLingo.VERSION,
     "condition": {
         "conditionType": ConditionType.RPC.value,
-        "chain": 80001,
+        "chain": PolygonChain.AMOY.id,
         "method": "eth_getBalance",
         "parameters": ["0x210eeAC07542F815ebB6FD6689637D8cA2689392", "latest"],
         "returnValueTest": {"comparator": "==", "value": 0},

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -40,7 +40,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 5  # got this from a side channel
+ritual_id = 0  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
 # known authorized encryptor for ritual 3

--- a/newsfragments/3468.misc.rst
+++ b/newsfragments/3468.misc.rst
@@ -1,0 +1,1 @@
+Migrate ``Lynx`` and ``Tapir`` testnets from Polygon Mumbai to Polygon Amoy.

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -54,7 +54,8 @@ PUBLIC_CHAINS = {
     100: "xDai",
     137: "Polygon/Mainnet",
     11155111: "Sepolia",
-    80001: "Polygon/Mumbai"
+    80001: "Polygon/Mumbai",
+    80002: "Polygon/Amoy",
 }
 
 LOCAL_CHAINS = {
@@ -73,6 +74,7 @@ POA_CHAINS = {
     10200,  # gnosis/chiado,
     137,  # Polygon/Mainnet
     80001,  # "Polygon/Mumbai"
+    80002,  # "Polygon/Amoy"
 }
 
 

--- a/nucypher/blockchain/eth/contract_registry/lynx.json
+++ b/nucypher/blockchain/eth/contract_registry/lynx.json
@@ -1,3644 +1,4 @@
 {
-    "80001": {
-        "BetaProgramInitiator": {
-            "address": "0xb6e6512F4c9A74Ef1b742d832852769F3CEE646c",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "contract Coordinator"
-                        },
-                        {
-                            "name": "_executor",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "AddressEmptyCode",
-                    "inputs": [
-                        {
-                            "name": "target",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "AddressInsufficientBalance",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "FailedInnerCall",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "SafeERC20FailedOperation",
-                    "inputs": [
-                        {
-                            "name": "token",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "FailedRequestRefunded",
-                    "inputs": [
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": true
-                        },
-                        {
-                            "name": "refundAmount",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RequestCanceled",
-                    "inputs": [
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RequestExecuted",
-                    "inputs": [
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": true
-                        },
-                        {
-                            "name": "ritualId",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RequestRegistered",
-                    "inputs": [
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": true
-                        },
-                        {
-                            "name": "providers",
-                            "type": "address[]",
-                            "internalType": "address[]",
-                            "indexed": false
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": false
-                        },
-                        {
-                            "name": "duration",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": false
-                        },
-                        {
-                            "name": "accessController",
-                            "type": "address",
-                            "internalType": "contract IEncryptionAuthorizer",
-                            "indexed": false
-                        },
-                        {
-                            "name": "payment",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "NO_RITUAL",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "cancelInitiationRequest",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "coordinator",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract Coordinator"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "currency",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "executeInitiationRequest",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "executor",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getProviders",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRequestsLength",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "refundFailedRequest",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "registerInitiationRequest",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "providers",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "duration",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "accessController",
-                            "type": "address",
-                            "internalType": "contract IEncryptionAuthorizer"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "requestIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "requests",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "duration",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "accessController",
-                            "type": "address",
-                            "internalType": "contract IEncryptionAuthorizer"
-                        },
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "payment",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0xa96fa3337c1259b97b31b86afa8f8a606d1d8ef8529d570a404c28cac5f4f0fd",
-            "block_number": 44702414,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-        },
-        "Coordinator": {
-            "address": "0x530608219a8A671FD183534b17E2a2CE09e782a4",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_application",
-                            "type": "address",
-                            "internalType": "contract ITACoChildApplication"
-                        },
-                        {
-                            "name": "_currency",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        },
-                        {
-                            "name": "_feeRatePerSecond",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "AccessControlBadConfirmation",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "AccessControlEnforcedDefaultAdminDelay",
-                    "inputs": [
-                        {
-                            "name": "schedule",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "AccessControlEnforcedDefaultAdminRules",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "AccessControlInvalidDefaultAdmin",
-                    "inputs": [
-                        {
-                            "name": "defaultAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "AccessControlUnauthorizedAccount",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "neededRole",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "AddressEmptyCode",
-                    "inputs": [
-                        {
-                            "name": "target",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "AddressInsufficientBalance",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "FailedInnerCall",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "InvalidInitialization",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "NotInitializing",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "SafeCastOverflowedUintDowncast",
-                    "inputs": [
-                        {
-                            "name": "bits",
-                            "type": "uint8",
-                            "internalType": "uint8"
-                        },
-                        {
-                            "name": "value",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "SafeERC20FailedOperation",
-                    "inputs": [
-                        {
-                            "name": "token",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "AggregationPosted",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "node",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "aggregatedTranscriptDigest",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminDelayChangeCanceled",
-                    "inputs": [],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminDelayChangeScheduled",
-                    "inputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        },
-                        {
-                            "name": "effectSchedule",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminTransferCanceled",
-                    "inputs": [],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "DefaultAdminTransferScheduled",
-                    "inputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "acceptSchedule",
-                            "type": "uint48",
-                            "internalType": "uint48",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "EndRitual",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "successful",
-                            "type": "bool",
-                            "internalType": "bool",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Initialized",
-                    "inputs": [
-                        {
-                            "name": "version",
-                            "type": "uint64",
-                            "internalType": "uint64",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "MaxDkgSizeChanged",
-                    "inputs": [
-                        {
-                            "name": "oldSize",
-                            "type": "uint16",
-                            "internalType": "uint16",
-                            "indexed": false
-                        },
-                        {
-                            "name": "newSize",
-                            "type": "uint16",
-                            "internalType": "uint16",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "ParticipantPublicKeySet",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "participant",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "publicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word2",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G2Point",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "ReimbursementPoolSet",
-                    "inputs": [
-                        {
-                            "name": "pool",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RitualAuthorityTransferred",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "previousAuthority",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newAuthority",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleAdminChanged",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "previousAdminRole",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newAdminRole",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleGranted",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "RoleRevoked",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "sender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "StartAggregationRound",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "StartRitual",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "participants",
-                            "type": "address[]",
-                            "internalType": "address[]",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "TimeoutChanged",
-                    "inputs": [
-                        {
-                            "name": "oldTimeout",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": false
-                        },
-                        {
-                            "name": "newTimeout",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "TranscriptPosted",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32",
-                            "indexed": true
-                        },
-                        {
-                            "name": "node",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "transcriptDigest",
-                            "type": "bytes32",
-                            "internalType": "bytes32",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "DEFAULT_ADMIN_ROLE",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "INITIATOR_ROLE",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "TREASURY_ROLE",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "acceptDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "application",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoChildApplication"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "beginDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "cancelDefaultAdminTransfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "changeDefaultAdminDelay",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "cohortFingerprint",
-                    "stateMutability": "pure",
-                    "inputs": [
-                        {
-                            "name": "nodes",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "currency",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdmin",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdminDelay",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "defaultAdminDelayIncreaseWait",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "feeDeduction",
-                    "stateMutability": "pure",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "feeRatePerSecond",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getAuthority",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getParticipant",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "provider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "transcript",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "provider",
-                                    "type": "address",
-                                    "internalType": "address"
-                                },
-                                {
-                                    "name": "aggregated",
-                                    "type": "bool",
-                                    "internalType": "bool"
-                                },
-                                {
-                                    "name": "transcript",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                },
-                                {
-                                    "name": "decryptionRequestStaticKey",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                }
-                            ],
-                            "internalType": "struct Coordinator.Participant"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getParticipantFromProvider",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "provider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "provider",
-                                    "type": "address",
-                                    "internalType": "address"
-                                },
-                                {
-                                    "name": "aggregated",
-                                    "type": "bool",
-                                    "internalType": "bool"
-                                },
-                                {
-                                    "name": "transcript",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                },
-                                {
-                                    "name": "decryptionRequestStaticKey",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                }
-                            ],
-                            "internalType": "struct Coordinator.Participant"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getParticipants",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "provider",
-                                    "type": "address",
-                                    "internalType": "address"
-                                },
-                                {
-                                    "name": "aggregated",
-                                    "type": "bool",
-                                    "internalType": "bool"
-                                },
-                                {
-                                    "name": "transcript",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                },
-                                {
-                                    "name": "decryptionRequestStaticKey",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                }
-                            ],
-                            "internalType": "struct Coordinator.Participant[]"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getParticipants",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "startIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "maxParticipants",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "includeTranscript",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple[]",
-                            "components": [
-                                {
-                                    "name": "provider",
-                                    "type": "address",
-                                    "internalType": "address"
-                                },
-                                {
-                                    "name": "aggregated",
-                                    "type": "bool",
-                                    "internalType": "bool"
-                                },
-                                {
-                                    "name": "transcript",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                },
-                                {
-                                    "name": "decryptionRequestStaticKey",
-                                    "type": "bytes",
-                                    "internalType": "bytes"
-                                }
-                            ],
-                            "internalType": "struct Coordinator.Participant[]"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getProviderPublicKey",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "provider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "ritualId",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word2",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G2Point"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getProviders",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getPublicKeyFromRitualId",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRitualIdFromPublicKey",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "dkgPublicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRitualInitiationCost",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "providers",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        },
-                        {
-                            "name": "duration",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRitualState",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint8",
-                            "internalType": "enum Coordinator.RitualState"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getRoleAdmin",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getThresholdForRitualSize",
-                    "stateMutability": "pure",
-                    "inputs": [
-                        {
-                            "name": "size",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "grantRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "hasRole",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "initialize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_timeout",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "_maxDkgSize",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "_admin",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "initiateRitual",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "providers",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "duration",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "accessController",
-                            "type": "address",
-                            "internalType": "contract IEncryptionAuthorizer"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isEncryptionAuthorized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "evidence",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "ciphertextHeader",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isInitiationPublic",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isParticipant",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "provider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isProviderPublicKeySet",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "provider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isRitualActive",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "makeInitiationPublic",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "maxDkgSize",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "numberOfRituals",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingDefaultAdmin",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "newAdmin",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "schedule",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingDefaultAdminDelay",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "newDelay",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        },
-                        {
-                            "name": "schedule",
-                            "type": "uint48",
-                            "internalType": "uint48"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "pendingFees",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "postAggregation",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "aggregatedTranscript",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "dkgPublicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        },
-                        {
-                            "name": "decryptionRequestStaticKey",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "postTranscript",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "transcript",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "processPendingFee",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "refundableFee",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "revokeRole",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "role",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        },
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "rituals",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "initiator",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "initTimestamp",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "endTimestamp",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "totalTranscripts",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "totalAggregations",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "authority",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "dkgSize",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "threshold",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        },
-                        {
-                            "name": "aggregationMismatch",
-                            "type": "bool",
-                            "internalType": "bool"
-                        },
-                        {
-                            "name": "accessController",
-                            "type": "address",
-                            "internalType": "contract IEncryptionAuthorizer"
-                        },
-                        {
-                            "name": "publicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes16",
-                                    "internalType": "bytes16"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G1Point"
-                        },
-                        {
-                            "name": "aggregatedTranscript",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "rollbackDefaultAdminDelay",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setMaxDkgSize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newSize",
-                            "type": "uint16",
-                            "internalType": "uint16"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setProviderPublicKey",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "publicKey",
-                            "type": "tuple",
-                            "components": [
-                                {
-                                    "name": "word0",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word1",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                },
-                                {
-                                    "name": "word2",
-                                    "type": "bytes32",
-                                    "internalType": "bytes32"
-                                }
-                            ],
-                            "internalType": "struct BLS12381.G2Point"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setReimbursementPool",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "pool",
-                            "type": "address",
-                            "internalType": "contract IReimbursementPool"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setTimeout",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newTimeout",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "supportsInterface",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "interfaceId",
-                            "type": "bytes4",
-                            "internalType": "bytes4"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "timeout",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "totalPendingFees",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferRitualAuthority",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "newAuthority",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "withdrawTokens",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "token",
-                            "type": "address",
-                            "internalType": "contract IERC20"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0xc2fd6f00ad2881cf3fd6b3440746dda9811c2cde625ef6c6d9acf47886bf5b77",
-            "block_number": 42479020,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-        },
-        "GlobalAllowList": {
-            "address": "0xA02d71363258bB2468c5482e97580B6072D682fF",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "contract Coordinator"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "ECDSAInvalidSignature",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "ECDSAInvalidSignatureLength",
-                    "inputs": [
-                        {
-                            "name": "length",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "ECDSAInvalidSignatureS",
-                    "inputs": [
-                        {
-                            "name": "s",
-                            "type": "bytes32",
-                            "internalType": "bytes32"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "authorize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "addresses",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "coordinator",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract Coordinator"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "deauthorize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "addresses",
-                            "type": "address[]",
-                            "internalType": "address[]"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "isAddressAuthorized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "encryptor",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "isAuthorized",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "ritualId",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "evidence",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "ciphertextHeader",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0x7611c330e52936ee7022a2dc972d46335611414a36a3d73048e1b3c826a483f4",
-            "block_number": 42479041,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-        },
-        "LynxRitualToken": {
-            "address": "0x6DED3A2DCaC9dcB62253F063D765F323D6E4be82",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_totalSupplyOfTokens",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "event",
-                    "name": "Approval",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "value",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Transfer",
-                    "inputs": [
-                        {
-                            "name": "from",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "value",
-                            "type": "uint256",
-                            "internalType": "uint256",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "allowance",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "owner",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "approve",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "balanceOf",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "account",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "decimals",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint8",
-                            "internalType": "uint8"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "decreaseAllowance",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "subtractedValue",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "increaseAllowance",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "spender",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "addedValue",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "name",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string",
-                            "internalType": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "symbol",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "string",
-                            "internalType": "string"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "totalSupply",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transfer",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "transferFrom",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "from",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "to",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0x01457fcb28352bfb2cf6f39871f2de00601122cdf7c7a5a0e98fccea88b16b60",
-            "block_number": 40514238,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-        },
-        "MockPolygonChild": {
-            "address": "0x45e06A2EaC4D928C8773A64b9eFe9d757B17F04D",
-            "abi": [
-                {
-                    "type": "event",
-                    "name": "AuthorizationUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorConfirmed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OwnershipTransferred",
-                    "inputs": [
-                        {
-                            "name": "previousOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "childApplication",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoRootToChild"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "confirmOperatorAddress",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "owner",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "renounceOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "setChildApplication",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_childApplication",
-                            "type": "address",
-                            "internalType": "contract ITACoRootToChild"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "transferOwnership",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "newOwner",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateAuthorization",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_amount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateOperator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0x05c20dd9661b89048e50304d6b4cf626167c44bb64b0137aeb88155d277b9c94",
-            "block_number": 40514106,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-        },
-        "OpenAccessAuthorizer": {
-            "address": "0x23177458642a0Cf50000d8EAE53B0248475D3EdE",
-            "abi": [
-                {
-                    "type": "function",
-                    "name": "isAuthorized",
-                    "stateMutability": "pure",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint32",
-                            "internalType": "uint32"
-                        },
-                        {
-                            "name": "",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        },
-                        {
-                            "name": "",
-                            "type": "bytes",
-                            "internalType": "bytes"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "bool",
-                            "internalType": "bool"
-                        }
-                    ]
-                }
-            ],
-            "tx_hash": "0x9ca790512e619a8cb9729c9be3a3e9a4f8d35b9b4a107aceb34ec3fc47b1a106",
-            "block_number": 41671721,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-        },
-        "SubscriptionManager": {
-            "address": "0xb9015d7B35Ce7c81ddE38eF7136Baa3B1044f313",
-            "abi": [
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "oldFeeRate",
-                            "type": "uint256"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "newFeeRate",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "FeeRateUpdated",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes16",
-                            "name": "policyId",
-                            "type": "bytes16"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sponsor",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "owner",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint16",
-                            "name": "size",
-                            "type": "uint16"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint32",
-                            "name": "startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint32",
-                            "name": "endTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "cost",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "PolicyCreated",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "previousAdminRole",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "newAdminRole",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "RoleAdminChanged",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sender",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "RoleGranted",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sender",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "RoleRevoked",
-                    "type": "event"
-                },
-                {
-                    "inputs": [],
-                    "name": "DEFAULT_ADMIN_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "SET_RATE_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "WITHDRAW_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes16",
-                            "name": "_policyId",
-                            "type": "bytes16"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "_policyOwner",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint16",
-                            "name": "_size",
-                            "type": "uint16"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_endTimestamp",
-                            "type": "uint32"
-                        }
-                    ],
-                    "name": "createPolicy",
-                    "outputs": [],
-                    "stateMutability": "payable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "feeRate",
-                    "outputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes16",
-                            "name": "_policyID",
-                            "type": "bytes16"
-                        }
-                    ],
-                    "name": "getPolicy",
-                    "outputs": [
-                        {
-                            "components": [
-                                {
-                                    "internalType": "address payable",
-                                    "name": "sponsor",
-                                    "type": "address"
-                                },
-                                {
-                                    "internalType": "uint32",
-                                    "name": "startTimestamp",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "internalType": "uint32",
-                                    "name": "endTimestamp",
-                                    "type": "uint32"
-                                },
-                                {
-                                    "internalType": "uint16",
-                                    "name": "size",
-                                    "type": "uint16"
-                                },
-                                {
-                                    "internalType": "address",
-                                    "name": "owner",
-                                    "type": "address"
-                                }
-                            ],
-                            "internalType": "struct SubscriptionManager.Policy",
-                            "name": "",
-                            "type": "tuple"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "uint16",
-                            "name": "_size",
-                            "type": "uint16"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_endTimestamp",
-                            "type": "uint32"
-                        }
-                    ],
-                    "name": "getPolicyCost",
-                    "outputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "getRoleAdmin",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "grantRole",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "hasRole",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "_feeRate",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "initialize",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes16",
-                            "name": "_policyID",
-                            "type": "bytes16"
-                        }
-                    ],
-                    "name": "isPolicyActive",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "renounceRole",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "revokeRole",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "_ratePerSecond",
-                            "type": "uint256"
-                        }
-                    ],
-                    "name": "setFeeRate",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "bytes4",
-                            "name": "interfaceId",
-                            "type": "bytes4"
-                        }
-                    ],
-                    "name": "supportsInterface",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
-                            "internalType": "address payable",
-                            "name": "recipient",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "sweep",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
-                }
-            ],
-            "tx_hash": "0xf502961a38a98d7a59abe4c28d354fbcd213a967447a548af7441c3fe9547422",
-            "block_number": 25203956,
-            "deployer": "0xA5DC704642d9630636dc7d4976da9e46dcEd8BCD"
-        },
-        "TACoChildApplication": {
-            "address": "0x8BFB087C4427387dFA217599EA0b860b3F3C49A3",
-            "abi": [
-                {
-                    "type": "constructor",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_rootApplication",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        },
-                        {
-                            "name": "_minimumAuthorization",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "error",
-                    "name": "InvalidInitialization",
-                    "inputs": []
-                },
-                {
-                    "type": "error",
-                    "name": "NotInitializing",
-                    "inputs": []
-                },
-                {
-                    "type": "event",
-                    "name": "AuthorizationUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "Initialized",
-                    "inputs": [
-                        {
-                            "name": "version",
-                            "type": "uint64",
-                            "internalType": "uint64",
-                            "indexed": false
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorConfirmed",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "event",
-                    "name": "OperatorUpdated",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address",
-                            "indexed": true
-                        }
-                    ],
-                    "anonymous": false
-                },
-                {
-                    "type": "function",
-                    "name": "authorizedStake",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "confirmOperatorAddress",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "coordinator",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getActiveStakingProviders",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "_startIndex",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        },
-                        {
-                            "name": "_maxStakingProviders",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "allAuthorizedTokens",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "activeStakingProviders",
-                            "type": "bytes32[]",
-                            "internalType": "bytes32[]"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "getStakingProvidersLength",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "initialize",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "_coordinator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "minimumAuthorization",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "operatorToStakingProvider",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "rootApplication",
-                    "stateMutability": "view",
-                    "inputs": [],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "contract ITACoChildToRoot"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviderInfo",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "authorized",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        },
-                        {
-                            "name": "operatorConfirmed",
-                            "type": "bool",
-                            "internalType": "bool"
-                        },
-                        {
-                            "name": "index",
-                            "type": "uint248",
-                            "internalType": "uint248"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "stakingProviders",
-                    "stateMutability": "view",
-                    "inputs": [
-                        {
-                            "name": "",
-                            "type": "uint256",
-                            "internalType": "uint256"
-                        }
-                    ],
-                    "outputs": [
-                        {
-                            "name": "",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ]
-                },
-                {
-                    "type": "function",
-                    "name": "updateAuthorization",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "amount",
-                            "type": "uint96",
-                            "internalType": "uint96"
-                        }
-                    ],
-                    "outputs": []
-                },
-                {
-                    "type": "function",
-                    "name": "updateOperator",
-                    "stateMutability": "nonpayable",
-                    "inputs": [
-                        {
-                            "name": "stakingProvider",
-                            "type": "address",
-                            "internalType": "address"
-                        },
-                        {
-                            "name": "operator",
-                            "type": "address",
-                            "internalType": "address"
-                        }
-                    ],
-                    "outputs": []
-                }
-            ],
-            "tx_hash": "0xbc45b42b3aa4b774ee7f67c4a7a3c7fda14fa871d5ee851359c4accb44ac6fb2",
-            "block_number": 42478969,
-            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
-        }
-    },
     "11155111": {
         "LynxStakingToken": {
             "address": "0x347370278531Db455Aec3BFD0F30d57e41422353",
@@ -5930,6 +2290,3780 @@
             ],
             "tx_hash": "0xeb083a1906cd8825653e4077cccc9caae00007624f4ac0dba29f49d82ec41ea2",
             "block_number": 4886812,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        }
+    },
+    "80002": {
+        "BetaProgramInitiator": {
+            "address": "0xf47dde316D994a050b8b4e5986e0790309979697",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_coordinator",
+                            "type": "address",
+                            "internalType": "contract Coordinator"
+                        },
+                        {
+                            "name": "_executor",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressEmptyCode",
+                    "inputs": [
+                        {
+                            "name": "target",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressInsufficientBalance",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "FailedInnerCall",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "SafeERC20FailedOperation",
+                    "inputs": [
+                        {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "FailedRequestRefunded",
+                    "inputs": [
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": true
+                        },
+                        {
+                            "name": "refundAmount",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RequestCanceled",
+                    "inputs": [
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RequestExecuted",
+                    "inputs": [
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": true
+                        },
+                        {
+                            "name": "ritualId",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RequestRegistered",
+                    "inputs": [
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": true
+                        },
+                        {
+                            "name": "providers",
+                            "type": "address[]",
+                            "internalType": "address[]",
+                            "indexed": false
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": false
+                        },
+                        {
+                            "name": "duration",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": false
+                        },
+                        {
+                            "name": "accessController",
+                            "type": "address",
+                            "internalType": "contract IEncryptionAuthorizer",
+                            "indexed": false
+                        },
+                        {
+                            "name": "payment",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "NO_RITUAL",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "cancelInitiationRequest",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "coordinator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract Coordinator"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "currency",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "executeInitiationRequest",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "executor",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRequestsLength",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "refundFailedRequest",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "registerInitiationRequest",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "providers",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "duration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "accessController",
+                            "type": "address",
+                            "internalType": "contract IEncryptionAuthorizer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "requestIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "requests",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "duration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "accessController",
+                            "type": "address",
+                            "internalType": "contract IEncryptionAuthorizer"
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "payment",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                }
+            ],
+            "tx_hash": "0xbc06258dbf24b6da9d45619a3048e6894a2779a198d4b7e6cdc48470e8e93ee6",
+            "block_number": 5199800,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        },
+        "Coordinator": {
+            "address": "0xE9e94499bB0f67b9DBD75506ec1735486DE57770",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_application",
+                            "type": "address",
+                            "internalType": "contract ITACoChildApplication"
+                        },
+                        {
+                            "name": "_currency",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        },
+                        {
+                            "name": "_feeRatePerSecond",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlBadConfirmation",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlEnforcedDefaultAdminDelay",
+                    "inputs": [
+                        {
+                            "name": "schedule",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlEnforcedDefaultAdminRules",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlInvalidDefaultAdmin",
+                    "inputs": [
+                        {
+                            "name": "defaultAdmin",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "neededRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressEmptyCode",
+                    "inputs": [
+                        {
+                            "name": "target",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "AddressInsufficientBalance",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "FailedInnerCall",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "SafeCastOverflowedUintDowncast",
+                    "inputs": [
+                        {
+                            "name": "bits",
+                            "type": "uint8",
+                            "internalType": "uint8"
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "SafeERC20FailedOperation",
+                    "inputs": [
+                        {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "AggregationPosted",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "node",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "aggregatedTranscriptDigest",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminDelayChangeCanceled",
+                    "inputs": [],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminDelayChangeScheduled",
+                    "inputs": [
+                        {
+                            "name": "newDelay",
+                            "type": "uint48",
+                            "internalType": "uint48",
+                            "indexed": false
+                        },
+                        {
+                            "name": "effectSchedule",
+                            "type": "uint48",
+                            "internalType": "uint48",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminTransferCanceled",
+                    "inputs": [],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "DefaultAdminTransferScheduled",
+                    "inputs": [
+                        {
+                            "name": "newAdmin",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "acceptSchedule",
+                            "type": "uint48",
+                            "internalType": "uint48",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "EndRitual",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "successful",
+                            "type": "bool",
+                            "internalType": "bool",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "MaxDkgSizeChanged",
+                    "inputs": [
+                        {
+                            "name": "oldSize",
+                            "type": "uint16",
+                            "internalType": "uint16",
+                            "indexed": false
+                        },
+                        {
+                            "name": "newSize",
+                            "type": "uint16",
+                            "internalType": "uint16",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "ParticipantPublicKeySet",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "participant",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "publicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word2",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G2Point",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "ReimbursementPoolSet",
+                    "inputs": [
+                        {
+                            "name": "pool",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RitualAuthorityTransferred",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousAuthority",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newAuthority",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleAdminChanged",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleGranted",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleRevoked",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "StartAggregationRound",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "StartRitual",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "participants",
+                            "type": "address[]",
+                            "internalType": "address[]",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "TimeoutChanged",
+                    "inputs": [
+                        {
+                            "name": "oldTimeout",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": false
+                        },
+                        {
+                            "name": "newTimeout",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "TranscriptPosted",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "node",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "transcriptDigest",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "DEFAULT_ADMIN_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "INITIATOR_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "TREASURY_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "acceptDefaultAdminTransfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "application",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoChildApplication"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "beginDefaultAdminTransfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newAdmin",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "cancelDefaultAdminTransfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "changeDefaultAdminDelay",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newDelay",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "cohortFingerprint",
+                    "stateMutability": "pure",
+                    "inputs": [
+                        {
+                            "name": "nodes",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "currency",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "defaultAdmin",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "defaultAdminDelay",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "defaultAdminDelayIncreaseWait",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "feeDeduction",
+                    "stateMutability": "pure",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "feeRatePerSecond",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getAuthority",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getParticipant",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "provider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "transcript",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "provider",
+                                    "type": "address",
+                                    "internalType": "address"
+                                },
+                                {
+                                    "name": "aggregated",
+                                    "type": "bool",
+                                    "internalType": "bool"
+                                },
+                                {
+                                    "name": "transcript",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                },
+                                {
+                                    "name": "decryptionRequestStaticKey",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Coordinator.Participant"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getParticipantFromProvider",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "provider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "provider",
+                                    "type": "address",
+                                    "internalType": "address"
+                                },
+                                {
+                                    "name": "aggregated",
+                                    "type": "bool",
+                                    "internalType": "bool"
+                                },
+                                {
+                                    "name": "transcript",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                },
+                                {
+                                    "name": "decryptionRequestStaticKey",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Coordinator.Participant"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getParticipants",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple[]",
+                            "components": [
+                                {
+                                    "name": "provider",
+                                    "type": "address",
+                                    "internalType": "address"
+                                },
+                                {
+                                    "name": "aggregated",
+                                    "type": "bool",
+                                    "internalType": "bool"
+                                },
+                                {
+                                    "name": "transcript",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                },
+                                {
+                                    "name": "decryptionRequestStaticKey",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Coordinator.Participant[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getParticipants",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "maxParticipants",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "includeTranscript",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple[]",
+                            "components": [
+                                {
+                                    "name": "provider",
+                                    "type": "address",
+                                    "internalType": "address"
+                                },
+                                {
+                                    "name": "aggregated",
+                                    "type": "bool",
+                                    "internalType": "bool"
+                                },
+                                {
+                                    "name": "transcript",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                },
+                                {
+                                    "name": "decryptionRequestStaticKey",
+                                    "type": "bytes",
+                                    "internalType": "bytes"
+                                }
+                            ],
+                            "internalType": "struct Coordinator.Participant[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getProviderPublicKey",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "provider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "ritualId",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word2",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G2Point"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getPublicKeyFromRitualId",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRitualIdFromPublicKey",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "dkgPublicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRitualInitiationCost",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "providers",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        },
+                        {
+                            "name": "duration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRitualState",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint8",
+                            "internalType": "enum Coordinator.RitualState"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRoleAdmin",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getThresholdForRitualSize",
+                    "stateMutability": "pure",
+                    "inputs": [
+                        {
+                            "name": "size",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "grantRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "hasRole",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_timeout",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "_maxDkgSize",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "_admin",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "initiateRitual",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "providers",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "duration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "accessController",
+                            "type": "address",
+                            "internalType": "contract IEncryptionAuthorizer"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isEncryptionAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "evidence",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "ciphertextHeader",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isInitiationPublic",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isParticipant",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "provider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isProviderPublicKeySet",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "provider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isRitualActive",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "makeInitiationPublic",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "maxDkgSize",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "numberOfRituals",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingDefaultAdmin",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "newAdmin",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "schedule",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingDefaultAdminDelay",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "newDelay",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        },
+                        {
+                            "name": "schedule",
+                            "type": "uint48",
+                            "internalType": "uint48"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "pendingFees",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "postAggregation",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "aggregatedTranscript",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "dkgPublicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        },
+                        {
+                            "name": "decryptionRequestStaticKey",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "postTranscript",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "transcript",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "processPendingFee",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "refundableFee",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "revokeRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "rituals",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "initiator",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "initTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "totalTranscripts",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "totalAggregations",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "authority",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "dkgSize",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "threshold",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "aggregationMismatch",
+                            "type": "bool",
+                            "internalType": "bool"
+                        },
+                        {
+                            "name": "accessController",
+                            "type": "address",
+                            "internalType": "contract IEncryptionAuthorizer"
+                        },
+                        {
+                            "name": "publicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes16",
+                                    "internalType": "bytes16"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G1Point"
+                        },
+                        {
+                            "name": "aggregatedTranscript",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rollbackDefaultAdminDelay",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setMaxDkgSize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newSize",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setProviderPublicKey",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "publicKey",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "word0",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word1",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                },
+                                {
+                                    "name": "word2",
+                                    "type": "bytes32",
+                                    "internalType": "bytes32"
+                                }
+                            ],
+                            "internalType": "struct BLS12381.G2Point"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setReimbursementPool",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "pool",
+                            "type": "address",
+                            "internalType": "contract IReimbursementPool"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setTimeout",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newTimeout",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "supportsInterface",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "interfaceId",
+                            "type": "bytes4",
+                            "internalType": "bytes4"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "timeout",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "totalPendingFees",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferRitualAuthority",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "newAuthority",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "withdrawTokens",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "token",
+                            "type": "address",
+                            "internalType": "contract IERC20"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0x4207f1fd038945ef7d5da06a0989446d3ed2eb031adad1233c7e3a61951652a1",
+            "block_number": 5198668,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        },
+        "GlobalAllowList": {
+            "address": "0xfDBA7100B015586270B62bA116920b78F4ff6930",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_coordinator",
+                            "type": "address",
+                            "internalType": "contract Coordinator"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ECDSAInvalidSignature",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "ECDSAInvalidSignatureLength",
+                    "inputs": [
+                        {
+                            "name": "length",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ECDSAInvalidSignatureS",
+                    "inputs": [
+                        {
+                            "name": "s",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "AddressAuthorizationSet",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "_address",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "isAuthorized",
+                            "type": "bool",
+                            "internalType": "bool",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "authorize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "addresses",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "coordinator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract Coordinator"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "deauthorize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "addresses",
+                            "type": "address[]",
+                            "internalType": "address[]"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "isAddressAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "encryptor",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "isAuthorized",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "ritualId",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "evidence",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "ciphertextHeader",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                }
+            ],
+            "tx_hash": "0xe1f8d7d3afac631312665faab5e45a4a8bbbfa7180f22014b5ad2dc0497edf72",
+            "block_number": 5198678,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        },
+        "LynxRitualToken": {
+            "address": "0x064Be2a9740e565729BC0d47bC616c5bb8Cc87B9",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_totalSupplyOfTokens",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ERC20InsufficientAllowance",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "allowance",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "needed",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ERC20InsufficientBalance",
+                    "inputs": [
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "balance",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "needed",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ERC20InvalidApprover",
+                    "inputs": [
+                        {
+                            "name": "approver",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ERC20InvalidReceiver",
+                    "inputs": [
+                        {
+                            "name": "receiver",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ERC20InvalidSender",
+                    "inputs": [
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "ERC20InvalidSpender",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "Approval",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Transfer",
+                    "inputs": [
+                        {
+                            "name": "from",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "allowance",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "approve",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "spender",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "balanceOf",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "decimals",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint8",
+                            "internalType": "uint8"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "name",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "string",
+                            "internalType": "string"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "symbol",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "string",
+                            "internalType": "string"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "totalSupply",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transfer",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "transferFrom",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "from",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "to",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "value",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                }
+            ],
+            "tx_hash": "0x3fa59f2ab18ce9017f5760b31bd7b132b387f1dd6e8c5d3fb8e58a553411ed69",
+            "block_number": 5198656,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        },
+        "MockPolygonChild": {
+            "address": "0x4FD23FAB4A09F85872bf240ABBd484cb4F9a5F79",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableInvalidOwner",
+                    "inputs": [
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "OwnableUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OwnershipTransferred",
+                    "inputs": [
+                        {
+                            "name": "previousOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "childApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "owner",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setChildApplication",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_childApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoRootToChild"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "transferOwnership",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "newOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_amount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0xee32aa290b2ea1a03cc01412e9089897ec92cabd3561664c26bf2c1e5e9247d4",
+            "block_number": 5198636,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        },
+        "OpenAccessAuthorizer": {
+            "address": "0x33270a0B88d0Ffb6B0b4FBA119ca6a7263DeF675",
+            "abi": [
+                {
+                    "type": "function",
+                    "name": "isAuthorized",
+                    "stateMutability": "pure",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        },
+                        {
+                            "name": "",
+                            "type": "bytes",
+                            "internalType": "bytes"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                }
+            ],
+            "tx_hash": "0x8bbd39406559c99b6dc35df89c604c645b0996aac2908ce9e75f2d38367d294a",
+            "block_number": 5196868,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        },
+        "SubscriptionManager": {
+            "address": "0x811389558a2C0B65ff56652d5E5bBF5DbC9A4358",
+            "abi": [
+                {
+                    "type": "error",
+                    "name": "AccessControlBadConfirmation",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlUnauthorizedAccount",
+                    "inputs": [
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "neededRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "event",
+                    "name": "FeeRateUpdated",
+                    "inputs": [
+                        {
+                            "name": "oldFeeRate",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        },
+                        {
+                            "name": "newFeeRate",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "PolicyCreated",
+                    "inputs": [
+                        {
+                            "name": "policyId",
+                            "type": "bytes16",
+                            "internalType": "bytes16",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sponsor",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "size",
+                            "type": "uint16",
+                            "internalType": "uint16",
+                            "indexed": false
+                        },
+                        {
+                            "name": "startTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": false
+                        },
+                        {
+                            "name": "endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32",
+                            "indexed": false
+                        },
+                        {
+                            "name": "cost",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleAdminChanged",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleGranted",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleRevoked",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "DEFAULT_ADMIN_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "SET_RATE_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "WITHDRAW_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "createPolicy",
+                    "stateMutability": "payable",
+                    "inputs": [
+                        {
+                            "name": "_policyId",
+                            "type": "bytes16",
+                            "internalType": "bytes16"
+                        },
+                        {
+                            "name": "_policyOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_size",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "_startTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "_endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "feeRate",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getPolicy",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_policyID",
+                            "type": "bytes16",
+                            "internalType": "bytes16"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
+                            "components": [
+                                {
+                                    "name": "sponsor",
+                                    "type": "address",
+                                    "internalType": "address payable"
+                                },
+                                {
+                                    "name": "startTimestamp",
+                                    "type": "uint32",
+                                    "internalType": "uint32"
+                                },
+                                {
+                                    "name": "endTimestamp",
+                                    "type": "uint32",
+                                    "internalType": "uint32"
+                                },
+                                {
+                                    "name": "size",
+                                    "type": "uint16",
+                                    "internalType": "uint16"
+                                },
+                                {
+                                    "name": "owner",
+                                    "type": "address",
+                                    "internalType": "address"
+                                }
+                            ],
+                            "internalType": "struct SubscriptionManager.Policy"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getPolicyCost",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_size",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "_startTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "_endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getRoleAdmin",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "grantRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "hasRole",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_feeRate",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "isPolicyActive",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_policyID",
+                            "type": "bytes16",
+                            "internalType": "bytes16"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "renounceRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "callerConfirmation",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "revokeRole",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "setFeeRate",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_ratePerSecond",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "supportsInterface",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "interfaceId",
+                            "type": "bytes4",
+                            "internalType": "bytes4"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "sweep",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "recipient",
+                            "type": "address",
+                            "internalType": "address payable"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0x9a02db05c96318d8b0abfd5030c98cd013d670f46012ac1fbabf1564d40d2b6c",
+            "block_number": 5347313,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
+        },
+        "TACoChildApplication": {
+            "address": "0x42F30AEc1A36995eEFaf9536Eb62BD751F982D32",
+            "abi": [
+                {
+                    "type": "constructor",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_rootApplication",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        },
+                        {
+                            "name": "_minimumAuthorization",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "event",
+                    "name": "AuthorizationUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorConfirmed",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "OperatorUpdated",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "authorizedStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "confirmOperatorAddress",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "coordinator",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getActiveStakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_maxStakingProviders",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "allAuthorizedTokens",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "activeStakingProviders",
+                            "type": "bytes32[]",
+                            "internalType": "bytes32[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getStakingProvidersLength",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "initialize",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "_coordinator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "minimumAuthorization",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "operatorToStakingProvider",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "rootApplication",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "contract ITACoChildToRoot"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviderInfo",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "operatorConfirmed",
+                            "type": "bool",
+                            "internalType": "bool"
+                        },
+                        {
+                            "name": "index",
+                            "type": "uint248",
+                            "internalType": "uint248"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "stakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "amount",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateOperator",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "operator",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": []
+                }
+            ],
+            "tx_hash": "0x4a1de1566b64df4f11a782939b4b694cb193df9bb06b307835a87e2420f37e81",
+            "block_number": 5198646,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         }
     }

--- a/nucypher/blockchain/eth/contract_registry/tapir.json
+++ b/nucypher/blockchain/eth/contract_registry/tapir.json
@@ -2334,9 +2334,9 @@
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         }
     },
-    "80001": {
+    "80002": {
         "BetaProgramInitiator": {
-            "address": "0x070fbc5a82776A1fd9945824d0719E4E7a5Ac01c",
+            "address": "0x418e991fD07cfA950855F820023AF6191E18B6df",
             "abi": [
                 {
                     "type": "constructor",
@@ -2700,12 +2700,12 @@
                     ]
                 }
             ],
-            "tx_hash": "0x78cd0d69f29577ce123a19e8a67ffbd945206b19f488f3989e9e75d331df1389",
-            "block_number": 44702626,
+            "tx_hash": "0x21d379cc84b0b373497a5da3bd1da00a1cc8706f6efef21316cfba2a82cde7e2",
+            "block_number": 5393140,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
         "Coordinator": {
-            "address": "0xdED71c37e4e17aF2c825c2A4441Dd6BF5A98D194",
+            "address": "0xE690b6bCC0616Dc5294fF84ff4e00335cA52C388",
             "abi": [
                 {
                     "type": "constructor",
@@ -4480,12 +4480,12 @@
                     "outputs": []
                 }
             ],
-            "tx_hash": "0x4e7afe59ed54ded86f68bc3044357f80d2e8175c60548f8d40871e8ef2c11206",
-            "block_number": 44554907,
+            "tx_hash": "0xc1b97df91385ff99feb29f80b9a6c8d861544b8fa1693bc980a6c7324fdc8899",
+            "block_number": 5392992,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
         "GlobalAllowList": {
-            "address": "0xd5D1A0259A18774CFe7Eb0b183C99839383Be4f0",
+            "address": "0xcc537b292d142dABe2424277596d8FFCC3e6A12D",
             "abi": [
                 {
                     "type": "constructor",
@@ -4653,12 +4653,12 @@
                     ]
                 }
             ],
-            "tx_hash": "0x758af74bcedd32f238f2b1460532f75a3c5dcecc3e42caae0bf1ff32289cf020",
-            "block_number": 44554922,
+            "tx_hash": "0xad3cb8e085c8da332b9513edbde0f90ed8ca0be1e9dfe3f28082fe2770e7df17",
+            "block_number": 5393004,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
         "MockPolygonChild": {
-            "address": "0xBD367FeeB095D6612724814E27F3fbc7BCCFd80D",
+            "address": "0x970b5f6A299813cA9DC45Be8446929b6513903f9",
             "abi": [
                 {
                     "type": "constructor",
@@ -4872,12 +4872,12 @@
                     "outputs": []
                 }
             ],
-            "tx_hash": "0x49bac49c127eeadcfdd0939470a2c433ebbe9307921387188c53cba41eb88118",
-            "block_number": 44554858,
+            "tx_hash": "0xafc4b19b2620836601adf59c140edc206fd87a26f926014f77b2432c516b1624",
+            "block_number": 5392963,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
         "OpenAccessAuthorizer": {
-            "address": "0x23177458642a0Cf50000d8EAE53B0248475D3EdE",
+            "address": "0x33270a0B88d0Ffb6B0b4FBA119ca6a7263DeF675",
             "abi": [
                 {
                     "type": "function",
@@ -4909,497 +4909,541 @@
                     ]
                 }
             ],
-            "tx_hash": "0x9ca790512e619a8cb9729c9be3a3e9a4f8d35b9b4a107aceb34ec3fc47b1a106",
-            "block_number": 41671721,
+            "tx_hash": "0x8bbd39406559c99b6dc35df89c604c645b0996aac2908ce9e75f2d38367d294a",
+            "block_number": 5196868,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
         "SubscriptionManager": {
-            "address": "0xb9015d7B35Ce7c81ddE38eF7136Baa3B1044f313",
+            "address": "0x811389558a2C0B65ff56652d5E5bBF5DbC9A4358",
             "abi": [
                 {
-                    "anonymous": false,
+                    "type": "error",
+                    "name": "AccessControlBadConfirmation",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "AccessControlUnauthorizedAccount",
                     "inputs": [
                         {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "oldFeeRate",
-                            "type": "uint256"
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
                         },
                         {
-                            "indexed": false,
-                            "internalType": "uint256",
-                            "name": "newFeeRate",
-                            "type": "uint256"
+                            "name": "neededRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
                         }
-                    ],
+                    ]
+                },
+                {
+                    "type": "error",
+                    "name": "InvalidInitialization",
+                    "inputs": []
+                },
+                {
+                    "type": "error",
+                    "name": "NotInitializing",
+                    "inputs": []
+                },
+                {
+                    "type": "event",
                     "name": "FeeRateUpdated",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
                     "inputs": [
                         {
-                            "indexed": true,
-                            "internalType": "bytes16",
-                            "name": "policyId",
-                            "type": "bytes16"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sponsor",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "owner",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint16",
-                            "name": "size",
-                            "type": "uint16"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint32",
-                            "name": "startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "indexed": false,
-                            "internalType": "uint32",
-                            "name": "endTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "indexed": false,
+                            "name": "oldFeeRate",
+                            "type": "uint256",
                             "internalType": "uint256",
-                            "name": "cost",
-                            "type": "uint256"
+                            "indexed": false
+                        },
+                        {
+                            "name": "newFeeRate",
+                            "type": "uint256",
+                            "internalType": "uint256",
+                            "indexed": false
                         }
                     ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "Initialized",
+                    "inputs": [
+                        {
+                            "name": "version",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
                     "name": "PolicyCreated",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
                     "inputs": [
                         {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "previousAdminRole",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "newAdminRole",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "name": "RoleAdminChanged",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sender",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "RoleGranted",
-                    "type": "event"
-                },
-                {
-                    "anonymous": false,
-                    "inputs": [
-                        {
-                            "indexed": true,
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
-                        },
-                        {
-                            "indexed": true,
-                            "internalType": "address",
-                            "name": "sender",
-                            "type": "address"
-                        }
-                    ],
-                    "name": "RoleRevoked",
-                    "type": "event"
-                },
-                {
-                    "inputs": [],
-                    "name": "DEFAULT_ADMIN_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "SET_RATE_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "WITHDRAW_ROLE",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
-                },
-                {
-                    "inputs": [
-                        {
+                            "name": "policyId",
+                            "type": "bytes16",
                             "internalType": "bytes16",
-                            "name": "_policyId",
-                            "type": "bytes16"
+                            "indexed": true
                         },
                         {
+                            "name": "sponsor",
+                            "type": "address",
                             "internalType": "address",
-                            "name": "_policyOwner",
-                            "type": "address"
+                            "indexed": true
                         },
                         {
+                            "name": "owner",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "size",
+                            "type": "uint16",
                             "internalType": "uint16",
-                            "name": "_size",
-                            "type": "uint16"
+                            "indexed": false
                         },
                         {
+                            "name": "startTimestamp",
+                            "type": "uint32",
                             "internalType": "uint32",
-                            "name": "_startTimestamp",
-                            "type": "uint32"
+                            "indexed": false
                         },
                         {
+                            "name": "endTimestamp",
+                            "type": "uint32",
                             "internalType": "uint32",
-                            "name": "_endTimestamp",
-                            "type": "uint32"
-                        }
-                    ],
-                    "name": "createPolicy",
-                    "outputs": [],
-                    "stateMutability": "payable",
-                    "type": "function"
-                },
-                {
-                    "inputs": [],
-                    "name": "feeRate",
-                    "outputs": [
+                            "indexed": false
+                        },
                         {
+                            "name": "cost",
+                            "type": "uint256",
                             "internalType": "uint256",
-                            "name": "",
-                            "type": "uint256"
+                            "indexed": false
                         }
                     ],
-                    "stateMutability": "view",
-                    "type": "function"
+                    "anonymous": false
                 },
                 {
+                    "type": "event",
+                    "name": "RoleAdminChanged",
                     "inputs": [
                         {
-                            "internalType": "bytes16",
-                            "name": "_policyID",
-                            "type": "bytes16"
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "previousAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "newAdminRole",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
                         }
                     ],
-                    "name": "getPolicy",
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleGranted",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "event",
+                    "name": "RoleRevoked",
+                    "inputs": [
+                        {
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32",
+                            "indexed": true
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        },
+                        {
+                            "name": "sender",
+                            "type": "address",
+                            "internalType": "address",
+                            "indexed": true
+                        }
+                    ],
+                    "anonymous": false
+                },
+                {
+                    "type": "function",
+                    "name": "DEFAULT_ADMIN_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
                     "outputs": [
                         {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "SET_RATE_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "WITHDRAW_ROLE",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "createPolicy",
+                    "stateMutability": "payable",
+                    "inputs": [
+                        {
+                            "name": "_policyId",
+                            "type": "bytes16",
+                            "internalType": "bytes16"
+                        },
+                        {
+                            "name": "_policyOwner",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_size",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "_startTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "_endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "feeRate",
+                    "stateMutability": "view",
+                    "inputs": [],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getPolicy",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_policyID",
+                            "type": "bytes16",
+                            "internalType": "bytes16"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "tuple",
                             "components": [
                                 {
-                                    "internalType": "address payable",
                                     "name": "sponsor",
-                                    "type": "address"
+                                    "type": "address",
+                                    "internalType": "address payable"
                                 },
                                 {
-                                    "internalType": "uint32",
                                     "name": "startTimestamp",
-                                    "type": "uint32"
+                                    "type": "uint32",
+                                    "internalType": "uint32"
                                 },
                                 {
-                                    "internalType": "uint32",
                                     "name": "endTimestamp",
-                                    "type": "uint32"
+                                    "type": "uint32",
+                                    "internalType": "uint32"
                                 },
                                 {
-                                    "internalType": "uint16",
                                     "name": "size",
-                                    "type": "uint16"
+                                    "type": "uint16",
+                                    "internalType": "uint16"
                                 },
                                 {
-                                    "internalType": "address",
                                     "name": "owner",
-                                    "type": "address"
+                                    "type": "address",
+                                    "internalType": "address"
                                 }
                             ],
-                            "internalType": "struct SubscriptionManager.Policy",
-                            "name": "",
-                            "type": "tuple"
+                            "internalType": "struct SubscriptionManager.Policy"
                         }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
+                    ]
                 },
                 {
-                    "inputs": [
-                        {
-                            "internalType": "uint16",
-                            "name": "_size",
-                            "type": "uint16"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_startTimestamp",
-                            "type": "uint32"
-                        },
-                        {
-                            "internalType": "uint32",
-                            "name": "_endTimestamp",
-                            "type": "uint32"
-                        }
-                    ],
+                    "type": "function",
                     "name": "getPolicyCost",
-                    "outputs": [
-                        {
-                            "internalType": "uint256",
-                            "name": "",
-                            "type": "uint256"
-                        }
-                    ],
                     "stateMutability": "view",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
+                            "name": "_size",
+                            "type": "uint16",
+                            "internalType": "uint16"
+                        },
+                        {
+                            "name": "_startTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        },
+                        {
+                            "name": "_endTimestamp",
+                            "type": "uint32",
+                            "internalType": "uint32"
                         }
                     ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "getRoleAdmin",
-                    "outputs": [
-                        {
-                            "internalType": "bytes32",
-                            "name": "",
-                            "type": "bytes32"
-                        }
-                    ],
                     "stateMutability": "view",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "bytes32",
                             "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
+                            "type": "bytes32",
+                            "internalType": "bytes32"
                         }
                     ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "grantRole",
-                    "outputs": [],
                     "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "bytes32",
                             "name": "role",
-                            "type": "bytes32"
+                            "type": "bytes32",
+                            "internalType": "bytes32"
                         },
                         {
-                            "internalType": "address",
                             "name": "account",
-                            "type": "address"
+                            "type": "address",
+                            "internalType": "address"
                         }
                     ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
                     "name": "hasRole",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
                     "stateMutability": "view",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "uint256",
-                            "name": "_feeRate",
-                            "type": "uint256"
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
                         }
                     ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "initialize",
-                    "outputs": [],
                     "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "bytes16",
-                            "name": "_policyID",
-                            "type": "bytes16"
+                            "name": "_feeRate",
+                            "type": "uint256",
+                            "internalType": "uint256"
                         }
                     ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
                     "name": "isPolicyActive",
-                    "outputs": [
-                        {
-                            "internalType": "bool",
-                            "name": "",
-                            "type": "bool"
-                        }
-                    ],
                     "stateMutability": "view",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "bytes32",
-                            "name": "role",
-                            "type": "bytes32"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
+                            "name": "_policyID",
+                            "type": "bytes16",
+                            "internalType": "bytes16"
                         }
                     ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "bool",
+                            "internalType": "bool"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "renounceRole",
-                    "outputs": [],
                     "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "bytes32",
                             "name": "role",
-                            "type": "bytes32"
+                            "type": "bytes32",
+                            "internalType": "bytes32"
                         },
                         {
-                            "internalType": "address",
-                            "name": "account",
-                            "type": "address"
+                            "name": "callerConfirmation",
+                            "type": "address",
+                            "internalType": "address"
                         }
                     ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
                     "name": "revokeRole",
-                    "outputs": [],
                     "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "uint256",
-                            "name": "_ratePerSecond",
-                            "type": "uint256"
+                            "name": "role",
+                            "type": "bytes32",
+                            "internalType": "bytes32"
+                        },
+                        {
+                            "name": "account",
+                            "type": "address",
+                            "internalType": "address"
                         }
                     ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
                     "name": "setFeeRate",
-                    "outputs": [],
                     "stateMutability": "nonpayable",
-                    "type": "function"
-                },
-                {
                     "inputs": [
                         {
-                            "internalType": "bytes4",
-                            "name": "interfaceId",
-                            "type": "bytes4"
+                            "name": "_ratePerSecond",
+                            "type": "uint256",
+                            "internalType": "uint256"
                         }
                     ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
                     "name": "supportsInterface",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "interfaceId",
+                            "type": "bytes4",
+                            "internalType": "bytes4"
+                        }
+                    ],
                     "outputs": [
                         {
-                            "internalType": "bool",
                             "name": "",
-                            "type": "bool"
+                            "type": "bool",
+                            "internalType": "bool"
                         }
-                    ],
-                    "stateMutability": "view",
-                    "type": "function"
+                    ]
                 },
                 {
+                    "type": "function",
+                    "name": "sweep",
+                    "stateMutability": "nonpayable",
                     "inputs": [
                         {
-                            "internalType": "address payable",
                             "name": "recipient",
-                            "type": "address"
+                            "type": "address",
+                            "internalType": "address payable"
                         }
                     ],
-                    "name": "sweep",
-                    "outputs": [],
-                    "stateMutability": "nonpayable",
-                    "type": "function"
+                    "outputs": []
                 }
             ],
-            "tx_hash": "0xf502961a38a98d7a59abe4c28d354fbcd213a967447a548af7441c3fe9547422",
-            "block_number": 25203956,
-            "deployer": "0xA5DC704642d9630636dc7d4976da9e46dcEd8BCD"
+            "tx_hash": "0x9a02db05c96318d8b0abfd5030c98cd013d670f46012ac1fbabf1564d40d2b6c",
+            "block_number": 5347313,
+            "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
         "TACoChildApplication": {
-            "address": "0x3a0Cd9EeF5A812Dc62f81D3b705daAf21561E33c",
+            "address": "0x489287Ed5BdF7a35fEE411FBdCc47331093D0769",
             "abi": [
                 {
                     "type": "constructor",
@@ -5859,12 +5903,12 @@
                     "outputs": []
                 }
             ],
-            "tx_hash": "0xdf1f50af284e50c3d2554c70f346e1a38e9d00d85012b5117d13acec2ce42f73",
-            "block_number": 44554870,
+            "tx_hash": "0x79cd34db513606db9080a729ce0012077a89ecc3f5eaf5fa524e8682eff37767",
+            "block_number": 5392971,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         },
         "TapirRitualToken": {
-            "address": "0xc154D3D874664792c145d055Cc0C3BC961a75aA6",
+            "address": "0xf91afFE7cf1d9c367Cb56eDd70C0941a4E8570d9",
             "abi": [
                 {
                     "type": "constructor",
@@ -6186,8 +6230,8 @@
                     ]
                 }
             ],
-            "tx_hash": "0xe835713bde2ff3daf48bfb3f7e5c0af1e64f5a44490d5d196c34fc512e3f3ff4",
-            "block_number": 44554884,
+            "tx_hash": "0x15c88783abe5dfb38592ebd99e76571a19b5a2e76922bd89becf88ea7d97bc41",
+            "block_number": 5392980,
             "deployer": "0x3B42d26E19FF860bC4dEbB920DD8caA53F93c600"
         }
     }

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -20,7 +20,7 @@ class EthChain(ChainInfo, Enum):
 
 class PolygonChain(ChainInfo, Enum):
     MAINNET = (137, "polygon")
-    MUMBAI = (80001, "mumbai")
+    AMOY = (80002, "amoy")
 
 
 class TACoDomain:
@@ -83,11 +83,11 @@ MAINNET = TACoDomain(
 LYNX = TACoDomain(
     name="lynx",
     eth_chain=EthChain.SEPOLIA,
-    polygon_chain=PolygonChain.MUMBAI,
+    polygon_chain=PolygonChain.AMOY,
     condition_chains=(
         EthChain.MAINNET,
         EthChain.SEPOLIA,
-        PolygonChain.MUMBAI,
+        PolygonChain.AMOY,
         PolygonChain.MAINNET,
     ),
 )
@@ -95,8 +95,8 @@ LYNX = TACoDomain(
 TAPIR = TACoDomain(
     name="tapir",
     eth_chain=EthChain.SEPOLIA,
-    polygon_chain=PolygonChain.MUMBAI,
-    condition_chains=(EthChain.SEPOLIA, PolygonChain.MUMBAI),
+    polygon_chain=PolygonChain.AMOY,
+    condition_chains=(EthChain.SEPOLIA, PolygonChain.AMOY),
 )
 
 

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -588,7 +588,7 @@ class BlockchainInterface:
                 f"({max_cost} @ {max_price_gwei} gwei)",
                 color="yellow",
             )
-        signed_raw_transaction = transacting_power.sign_transaction(transaction_dict)
+        signed_transaction = transacting_power.sign_transaction(transaction_dict)
 
         #
         # Broadcast

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -585,17 +585,16 @@ class BlockchainInterface:
         if transacting_power.is_device:
             emitter.message(
                 f"Confirm transaction {transaction_name} on hardware wallet... "
-                f"({max_cost} ETH @ {max_price_gwei} gwei)",
+                f"({max_cost} @ {max_price_gwei} gwei)",
                 color="yellow",
             )
-        signed_transaction = transacting_power.sign_transaction(transaction_dict)
+        signed_raw_transaction = transacting_power.sign_transaction(transaction_dict)
 
         #
         # Broadcast
         #
-
         emitter.message(
-            f"Broadcasting {transaction_name} {tx_type} Transaction ({max_cost} ETH @ {max_price_gwei} gwei)",
+            f"Broadcasting {transaction_name} {tx_type} Transaction ({max_cost} @ {max_price_gwei} gwei)",
             color="yellow",
         )
         try:

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -49,7 +49,7 @@ _CONDITION_CHAINS = {
     1: "ethereum/mainnet",
     11155111: "ethereum/sepolia",
     137: "polygon/mainnet",
-    80001: "polygon/mumbai",
+    80002: "polygon/amoy",
     # TODO: Permit support for these chains
     # 100: "gnosis/mainnet",
     # 10200: "gnosis/chiado",

--- a/tests/unit/registry/test_registry_sources.py
+++ b/tests/unit/registry/test_registry_sources.py
@@ -59,7 +59,6 @@ def test_github_registry_source(registry_data):
     assert data == source.data
 
 
-@pytest.mark.skip("Skip until contract registry updated to use amoy instead of mumbai")
 @pytest.mark.parametrize("domain", list(domains.SUPPORTED_DOMAINS.values()))
 def test_get_actual_github_registry_file(domain):
     source = GithubRegistrySource(domain=domain)

--- a/tests/unit/registry/test_registry_soures.py
+++ b/tests/unit/registry/test_registry_soures.py
@@ -59,6 +59,7 @@ def test_github_registry_source(registry_data):
     assert data == source.data
 
 
+@pytest.mark.skip("Skip until contract registry updated to use amoy instead of mumbai")
 @pytest.mark.parametrize("domain", list(domains.SUPPORTED_DOMAINS.values()))
 def test_get_actual_github_registry_file(domain):
     source = GithubRegistrySource(domain=domain)

--- a/tests/unit/test_taco_domains.py
+++ b/tests/unit/test_taco_domains.py
@@ -36,7 +36,7 @@ def test_eth_chains(eth_chain_test):
     "poly_chain_test",
     (
         (PolygonChain.MAINNET, "polygon", 137),
-        (PolygonChain.MUMBAI, "mumbai", 80001),
+        (PolygonChain.AMOY, "amoy", 80002),
     ),
 )
 def test_polygon_chains(poly_chain_test):
@@ -59,11 +59,11 @@ def test_polygon_chains(poly_chain_test):
             domains.LYNX,
             "lynx",
             EthChain.SEPOLIA,
-            PolygonChain.MUMBAI,
+            PolygonChain.AMOY,
             (
                 EthChain.MAINNET,
                 EthChain.SEPOLIA,
-                PolygonChain.MUMBAI,
+                PolygonChain.AMOY,
                 PolygonChain.MAINNET,
             ),
         ),
@@ -71,8 +71,8 @@ def test_polygon_chains(poly_chain_test):
             domains.TAPIR,
             "tapir",
             EthChain.SEPOLIA,
-            PolygonChain.MUMBAI,
-            (EthChain.SEPOLIA, PolygonChain.MUMBAI),
+            PolygonChain.AMOY,
+            (EthChain.SEPOLIA, PolygonChain.AMOY),
         ),
     ),
 )


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

- [X] Deprecates the use of Polygon Mumbai in favour of Polygon Amoy for Lynx and Tapir
- [X] Updates examples, workflows etc. to use Polygon Amoy
- [X] Updates contract registries based on the latest deployments to Amoy for Lynx and Tapir

Tapir and Lynx nodes are already running this code (although based over v7.2.0 for simplicity since 7.3.x hasn't really been tested as yet and has changes based on newer non-deployed versions of contracts).

**Issues fixed/closed:**
> - Fixes #...

Related to https://github.com/nucypher/nucypher-contracts/pull/251.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

Polygon Mumbai is being deprecated and Polygon Amoy should be used moving forward - https://polygon.technology/blog/introducing-the-amoy-testnet-for-polygon-pos

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

I'm not quite sure why the acceptance tests are failing - they pass locally on my machine. That being said, it is failing for the v7.3.x branch and so seems unrelated to this PR.

I will look deeper into the issue another time - which also includes possibly updating the ape version being used.

[UPDATE] Tests pass via https://github.com/nucypher/nucypher/pull/3473.
