### PR TITLE
Add --metrics-listen-address CLI Prometheus option

### DIFF
--- a/newsfragments/3478.bugfix.rst
+++ b/newsfragments/3478.bugfix.rst
@@ -1,0 +1,1 @@
+Add --metrics-listen-address CLI Prometheus option

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -645,9 +645,9 @@ class Bob(Character):
                 requester_public_key=requester_public_key,
             )
             shared_secrets[ursula_checksum_address] = shared_secret
-            decryption_request_mapping[
-                ursula_checksum_address
-            ] = encrypted_decryption_request
+            decryption_request_mapping[ursula_checksum_address] = (
+                encrypted_decryption_request
+            )
 
         decryption_client = self._threshold_decryption_client_class(learner=self)
         successes, failures = decryption_client.gather_encrypted_decryption_shares(
@@ -996,10 +996,9 @@ class Ursula(Teacher, Character, Operator):
                 ursula=self, prometheus_config=prometheus_config
             )
             if emitter:
-                if prometheus_config.listen_address:
-                    prometheus_addr = prometheus_config.listen_address
-                else:
-                    prometheus_addr = self.rest_interface.host
+                prometheus_addr = (
+                    prometheus_config.listen_address or self.rest_interface.host
+                )
                 emitter.message(
                     f"✓ Prometheus Exporter http://{prometheus_addr}:"
                     f"{prometheus_config.port}/metrics",

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -996,8 +996,12 @@ class Ursula(Teacher, Character, Operator):
                 ursula=self, prometheus_config=prometheus_config
             )
             if emitter:
+                if prometheus_config.listen_address:
+                    prometheus_addr = prometheus_config.listen_address
+                else:
+                    prometheus_addr = self.rest_interface.host
                 emitter.message(
-                    f"✓ Prometheus Exporter http://{self.rest_interface.host}:"
+                    f"✓ Prometheus Exporter http://{prometheus_addr}:"
                     f"{prometheus_config.port}/metrics",
                     color="green",
                 )

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -390,6 +390,11 @@ def destroy(general_config, config_options, config_file, force):
     type=NETWORK_PORT,
 )
 @click.option(
+    "--metrics-listen-address",
+    help="Run a Prometheus metrics exporter on specified IP address",
+    default="",
+)
+@click.option(
     "--metrics-interval",
     help="The frequency of metrics collection in seconds (if prometheus enabled)",
     type=click.INT,
@@ -407,6 +412,7 @@ def run(
     dry_run,
     prometheus,
     metrics_port,
+    metrics_listen_address,
     metrics_interval,
     force,
     ip_checkup,
@@ -422,7 +428,9 @@ def run(
     prometheus_config = None
     if prometheus:
         prometheus_config = PrometheusMetricsConfig(
-            port=metrics_port, collection_interval=metrics_interval
+            port=metrics_port,
+            listen_address=metrics_listen_address,
+            collection_interval=metrics_interval,
         )
 
     ursula_config, URSULA = character_options.create_character(

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -391,7 +391,7 @@ def destroy(general_config, config_options, config_file, force):
 )
 @click.option(
     "--metrics-listen-address",
-    help="Run a Prometheus metrics exporter on specified IP address",
+    help="Run a Prometheus metrics exporter on the specified IP address",
     default="",
 )
 @click.option(

--- a/tests/integration/cli/test_ursula_cli_prometheus.py
+++ b/tests/integration/cli/test_ursula_cli_prometheus.py
@@ -77,7 +77,7 @@ def test_ursula_cli_prometheus(
     ), "Wrong value for start_now in prometheus_config"
 
 
-def test_ursula_cli_prometheus_metrics_non_default_port_and_interval(
+def test_ursula_cli_prometheus_metrics_non_default_config(
     click_runner,
     mocker,
     ursulas,
@@ -88,6 +88,7 @@ def test_ursula_cli_prometheus_metrics_non_default_port_and_interval(
 ):
     port = 6666
     interval = 30
+    listen_address = "192.0.2.101"
 
     mock_ursula_run(mocker, ursulas, monkeypatch, ursula_test_config, mock_prometheus)
 
@@ -101,6 +102,8 @@ def test_ursula_cli_prometheus_metrics_non_default_port_and_interval(
         "--prometheus",
         "--metrics-port",
         str(port),
+        "--metrics-listen-address",
+        listen_address,
         "--metrics-interval",
         str(interval),
     )
@@ -111,8 +114,7 @@ def test_ursula_cli_prometheus_metrics_non_default_port_and_interval(
 
     assert result.exit_code == 0, result.output
     assert (
-        f"✓ Prometheus Exporter http://{MOCK_IP_ADDRESS}:{port}/metrics"
-        in result.output
+        f"✓ Prometheus Exporter http://{listen_address}:{port}/metrics" in result.output
     ), "CLI didn't print Prometheus exporter check"
 
     mock_prometheus.assert_called_once()
@@ -120,7 +122,8 @@ def test_ursula_cli_prometheus_metrics_non_default_port_and_interval(
         mock_prometheus.call_args.kwargs["prometheus_config"].port == port
     ), "Wrong port set in prometheus_config"
     assert (
-        mock_prometheus.call_args.kwargs["prometheus_config"].listen_address == ""
+        mock_prometheus.call_args.kwargs["prometheus_config"].listen_address
+        == listen_address
     ), "Wrong listen address set in prometheus_config"
     assert (
         mock_prometheus.call_args.kwargs["prometheus_config"].collection_interval


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix

**Required reviews:** 
- [X] 2

**What this does:**
It enables a CLI option to specify which of the IP network interfaces available in the machine will be used to expose the metrics (Prometheus exporter).

**Issues fixed/closed:**
Fixes #3451.
