### PR TITLE
Node/Contract Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ secrets management and dynamic access control.*
 
 ----
 
-# TACo Access Control
+# Threshold Access Control (TACo)
 
-TACo (Threshold Access Control) is end-to-end encrypted data sharing and communication, without the requirement of
+TACo is end-to-end encrypted data sharing and communication, without the requirement of
 trusting a centralized authority, who might unilaterally deny service or even decrypt private user data. It is the only
 access control layer available to Web3 developers that can offer a decentralized service, through a live,
 well-collateralized and battle-tested network.  See more here: [https://docs.threshold.network/applications/threshold-access-control](https://docs.threshold.network/applications/threshold-access-control)
@@ -22,7 +22,7 @@ well-collateralized and battle-tested network.  See more here: [https://docs.thr
 
 NuCypher is a community-driven project and we're very open to outside contributions.
 
-All our development discussions happen in our [Discord server](https://discord.gg/7rmXa3S), where we're happy to answer
+All our development discussions happen in our [Discord server](https://discord.gg/threshold), where we're happy to answer
 technical questions, discuss feature requests,
 and accept bug reports.
 

--- a/newsfragments/3479.misc.rst
+++ b/newsfragments/3479.misc.rst
@@ -1,0 +1,1 @@
+Nodes will better handle the effects of compatible contract changes such as additions to structs and overloaded functions.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -962,13 +962,6 @@ class Operator(BaseActor):
                 color="green",
             )
 
-    def get_work_is_needed_check(self):
-        def func(self):
-            # we have not confirmed yet
-            return not self.is_confirmed
-
-        return func
-
 
 class PolicyAuthor(NucypherTokenActor):
     """Alice base class for blockchain operations, mocking up new policies!"""

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -430,11 +430,14 @@ class TACoChildApplicationAgent(StakerSamplingApplicationAgent):
     def _get_active_staking_providers_raw(
         self, start_index: int, max_results: int
     ) -> Tuple[int, List[bytes]]:
-        active_staking_providers_info = (
-            self.contract.functions.getActiveStakingProviders(
-                start_index, max_results
-            ).call()
+        get_active_providers_overloaded_function = (
+            self.contract.get_function_by_signature(
+                "getActiveStakingProviders(uint256,uint256,uint32)"
+            )
         )
+        active_staking_providers_info = get_active_providers_overloaded_function(
+            start_index, max_results, 0  # TODO address via #3458
+        ).call()
         return active_staking_providers_info
 
 
@@ -638,7 +641,10 @@ class CoordinatorAgent(EthereumContractAgent):
     ) -> Iterable[Coordinator.Participant]:
         if max_results < 0:
             raise ValueError("Max results must be greater than or equal to zero.")
-        data = self.contract.functions.getParticipants(
+        get_participants_overloaded_function = self.contract.get_function_by_signature(
+            "getParticipants(uint32,uint256,uint256,bool)"
+        )
+        data = get_participants_overloaded_function(
             ritual_id, start_index, max_results, transcripts
         ).call()
         participants = Coordinator.Ritual.make_participants(data=data)

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -398,7 +398,9 @@ class TACoChildApplicationAgent(StakerSamplingApplicationAgent):
         self, staking_provider: ChecksumAddress
     ) -> StakingProviderInfo:
         result = self.contract.functions.stakingProviderInfo(staking_provider).call()
-        return TACoChildApplicationAgent.StakingProviderInfo(*result)
+        return TACoChildApplicationAgent.StakingProviderInfo(
+            *result[0 : len(TACoChildApplicationAgent.StakingProviderInfo._fields)]
+        )
 
     @contract_api(CONTRACT_CALL)
     def is_operator_confirmed(self, operator_address: ChecksumAddress) -> bool:
@@ -495,7 +497,9 @@ class TACoApplicationAgent(StakerSamplingApplicationAgent):
         info: list = self.contract.functions.stakingProviderInfo(
             staking_provider
         ).call()
-        return TACoApplicationAgent.StakingProviderInfo(*info[0:3])
+        return TACoApplicationAgent.StakingProviderInfo(
+            *info[0 : len(TACoApplicationAgent.StakingProviderInfo._fields)]
+        )
 
     @contract_api(CONTRACT_CALL)
     def get_authorized_stake(self, staking_provider: ChecksumAddress) -> int:

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -446,11 +446,6 @@ class TACoApplicationAgent(StakerSamplingApplicationAgent):
         operator_confirmed: bool
         operator_start_timestamp: int
 
-    class OperatorInfo(NamedTuple):
-        address: ChecksumAddress
-        confirmed: bool
-        start_timestamp: Timestamp
-
     @contract_api(CONTRACT_CALL)
     def get_min_authorization(self) -> int:
         result = self.contract.functions.minimumAuthorization().call()

--- a/nucypher/blockchain/eth/contract_registry/lynx.json
+++ b/nucypher/blockchain/eth/contract_registry/lynx.json
@@ -5768,9 +5768,21 @@
                             "indexed": true
                         },
                         {
-                            "name": "amount",
+                            "name": "authorized",
                             "type": "uint96",
                             "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64",
                             "indexed": false
                         }
                     ],
@@ -5874,6 +5886,64 @@
                 },
                 {
                     "type": "function",
+                    "name": "eligibleStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_endDate",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getActiveStakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_maxStakingProviders",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_cohortDuration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "allAuthorizedTokens",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "activeStakingProviders",
+                            "type": "bytes32[]",
+                            "internalType": "bytes32[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "getActiveStakingProviders",
                     "stateMutability": "view",
                     "inputs": [
@@ -5961,6 +6031,25 @@
                 },
                 {
                     "type": "function",
+                    "name": "pendingAuthorizationDecrease",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "rootApplication",
                     "stateMutability": "view",
                     "inputs": [],
@@ -6003,6 +6092,16 @@
                             "name": "index",
                             "type": "uint248",
                             "internalType": "uint248"
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64"
                         }
                     ]
                 },
@@ -6036,9 +6135,37 @@
                             "internalType": "address"
                         },
                         {
-                            "name": "amount",
+                            "name": "authorized",
                             "type": "uint96",
                             "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64"
                         }
                     ],
                     "outputs": []

--- a/nucypher/blockchain/eth/contract_registry/mainnet.json
+++ b/nucypher/blockchain/eth/contract_registry/mainnet.json
@@ -457,6 +457,18 @@
                             "indexed": false
                         },
                         {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64",
+                            "indexed": false
+                        },
+                        {
                             "name": "operator",
                             "type": "address",
                             "internalType": "address",
@@ -918,6 +930,30 @@
                 },
                 {
                     "type": "function",
+                    "name": "eligibleStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_endDate",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "getActiveStakingProviders",
                     "stateMutability": "view",
                     "inputs": [
@@ -930,6 +966,11 @@
                             "name": "_maxStakingProviders",
                             "type": "uint256",
                             "internalType": "uint256"
+                        },
+                        {
+                            "name": "_cohortDuration",
+                            "type": "uint32",
+                            "internalType": "uint32"
                         }
                     ],
                     "outputs": [
@@ -4585,9 +4626,21 @@
                             "indexed": true
                         },
                         {
-                            "name": "amount",
+                            "name": "authorized",
                             "type": "uint96",
                             "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96",
+                            "indexed": false
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64",
                             "indexed": false
                         }
                     ],
@@ -4691,6 +4744,64 @@
                 },
                 {
                     "type": "function",
+                    "name": "eligibleStake",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "_endDate",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
+                    "name": "getActiveStakingProviders",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_startIndex",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_maxStakingProviders",
+                            "type": "uint256",
+                            "internalType": "uint256"
+                        },
+                        {
+                            "name": "_cohortDuration",
+                            "type": "uint32",
+                            "internalType": "uint32"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "allAuthorizedTokens",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "activeStakingProviders",
+                            "type": "bytes32[]",
+                            "internalType": "bytes32[]"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "getActiveStakingProviders",
                     "stateMutability": "view",
                     "inputs": [
@@ -4778,6 +4889,25 @@
                 },
                 {
                     "type": "function",
+                    "name": "pendingAuthorizationDecrease",
+                    "stateMutability": "view",
+                    "inputs": [
+                        {
+                            "name": "_stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        }
+                    ],
+                    "outputs": [
+                        {
+                            "name": "",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        }
+                    ]
+                },
+                {
+                    "type": "function",
                     "name": "rootApplication",
                     "stateMutability": "view",
                     "inputs": [],
@@ -4820,6 +4950,16 @@
                             "name": "index",
                             "type": "uint248",
                             "internalType": "uint248"
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64"
                         }
                     ]
                 },
@@ -4853,9 +4993,37 @@
                             "internalType": "address"
                         },
                         {
-                            "name": "amount",
+                            "name": "authorized",
                             "type": "uint96",
                             "internalType": "uint96"
+                        }
+                    ],
+                    "outputs": []
+                },
+                {
+                    "type": "function",
+                    "name": "updateAuthorization",
+                    "stateMutability": "nonpayable",
+                    "inputs": [
+                        {
+                            "name": "stakingProvider",
+                            "type": "address",
+                            "internalType": "address"
+                        },
+                        {
+                            "name": "authorized",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "deauthorizing",
+                            "type": "uint96",
+                            "internalType": "uint96"
+                        },
+                        {
+                            "name": "endDeauthorization",
+                            "type": "uint64",
+                            "internalType": "uint64"
                         }
                     ],
                     "outputs": []


### PR DESCRIPTION
Based over #3476 .

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
> - Fixes #...

Fixes #3466 
Related to https://github.com/nucypher/nucypher-contracts/pull/256

**Why it's needed:**
- Only retrieve struct values from contracts based on a number of expected fields in the matching Python struct. This better maintains compatibility whenever the struct in the contract adds fields. This manifests as #3466 .
- Remove old and no longer used code associated with operator information.
- Update the embedded registry based on the updated contract registry from `nucypher-contracts`. This was missed in the last update, **BUT** the mainnet nodes were fine because they pulled the registry from GitHub as a priority over the embedded registry.
- Agents need to better handle overloaded functions. Web3py does not resolve the function based on the number of args provided, so we need to resolve the function ourselves.  There are two such methods `getActiveStakingProviders` in `TACoChildApplication`, and `getParticipants` in `Coordinator`.  In some cases ("getParticipants") we've been lucky that the function we wanted to use happened to be one used instead of the other one, otherwise the call would fail due to abi <-> parameter mismatch. This change makes the method to use more explicit by using its signature to find the method first. Eventually, the old function that was overloaded will be removed from the contract and is therefore no longer a problem - however, until then, we need to properly/deterministically handle the overload case. 

For example, the issue with `getActiveStakingProviders` manifests itself whenever sampling is done from python:
```
E   web3.exceptions.Web3ValidationError:
E   Could not identify the intended function with name `getActiveStakingProviders`, positional arguments with type(s) 'int,int' and keyword arguments with type(s) '{}'.
E   Found 1 function(s) with the name `getActiveStakingProviders`: ['getActiveStakingProviders(uint256,uint256,uint32)']
E   Function invocation failed due to improper number of arguments.
```
(^ 7.2.0 code running with latest contract updates)

When nodes upgrade from older code to the latest code the original (older) overloaded functions can be removed from the contract, and then the use of a signature to differentiate the two will no longer be necessary.

We solve these specific cases for now since the use of overloaded functions is only really for backwards compatibility which can be broken once the update version of a node has been released for long enough for everyone to have upgraded i.e. the "overloading" is only needed temporarily, and using the signature for all agent functions is pretty ugly.

- Added a test to confirm that ContractCondition do not suffer the same issues as agents -> it does not.

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Lynx nodes are already running this code.
