### PR TITLE
Much Ado About Logging

### DIFF
--- a/newsfragments/3483.bugfix.rst
+++ b/newsfragments/3483.bugfix.rst
@@ -1,0 +1,1 @@
+Console logging was not using the correct log format, log levels were not adhered to for limiting log messages, and global log observers not correctly managed.

--- a/newsfragments/3483.bugfix.rst
+++ b/newsfragments/3483.bugfix.rst
@@ -1,1 +1,2 @@
 Console logging was not using the correct log format, log levels were not adhered to for limiting log messages, and global log observers not correctly managed.
+Improved the StdoutEmitter to better utilize the logger so that information is not lost.

--- a/newsfragments/3483.feature.rst
+++ b/newsfragments/3483.feature.rst
@@ -1,0 +1,1 @@
+Add ``--json-logs/--no-json-logs`` CLI option to enabled/disable logging to a json log file; json logging is now disabled be default.

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -158,7 +158,6 @@ class BlockchainInterface:
 
         @staticmethod
         def __default_on_broadcast(tx: PendingTx):
-            # TODO review use of emitter - #3482
             emitter = StdoutEmitter()
             max_cost, max_price_gwei, tx_type = get_tx_cost_data(tx.params)
             emitter.message(
@@ -623,7 +622,6 @@ class BlockchainInterface:
         #
         # Broadcast
         #
-        # TODO review use of emitter - #3482
         emitter.message(
             f"Broadcasting {transaction_name} {tx_type} Transaction ({max_cost} @ {max_price_gwei} gwei)",
             color="yellow",

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -23,18 +23,21 @@ class GroupGeneralConfig:
     sentry_endpoint = os.environ.get("NUCYPHER_SENTRY_DSN", NUCYPHER_SENTRY_ENDPOINT)
     log_to_sentry = get_env_bool("NUCYPHER_SENTRY_LOGS", False)
     log_to_file = get_env_bool("NUCYPHER_FILE_LOGS", True)
+    log_to_json_file = get_env_bool("NUCYPHER_JSON_LOGS", False)
 
-    def __init__(self,
-                 json_ipc: bool,
-                 verbose: bool,
-                 quiet: bool,
-                 no_logs: bool,
-                 console_logs: bool,
-                 file_logs: bool,
-                 sentry_logs: bool,
-                 log_level: bool,
-                 debug: bool):
-
+    def __init__(
+        self,
+        json_ipc: bool,
+        verbose: bool,
+        quiet: bool,
+        no_logs: bool,
+        console_logs: bool,
+        file_logs: bool,
+        json_logs: bool,
+        sentry_logs: bool,
+        log_level: bool,
+        debug: bool,
+    ):
         self.log = Logger(self.__class__.__name__)
 
         # Session Emitter for pre and post character control engagement.
@@ -66,6 +69,8 @@ class GroupGeneralConfig:
         # Defaults
         if file_logs is None:
             file_logs = self.log_to_file
+        if json_logs is None:
+            json_logs = self.log_to_json_file
         if sentry_logs is None:
             sentry_logs = self.log_to_sentry
 
@@ -78,6 +83,7 @@ class GroupGeneralConfig:
         if no_logs:
             console_logs = False
             file_logs = False
+            json_logs = False
             sentry_logs = False
         if json_ipc:
             console_logs = False
@@ -88,6 +94,7 @@ class GroupGeneralConfig:
             GlobalLoggerSettings.start_console_logging()
         if file_logs:
             GlobalLoggerSettings.start_text_file_logging()
+        if json_logs:
             GlobalLoggerSettings.start_json_file_logging()
         if sentry_logs:
             GlobalLoggerSettings.start_sentry_logging(self.sentry_endpoint)
@@ -116,7 +123,12 @@ group_general_config = group_options(
 
     file_logs=click.option(
         '--file-logs/--no-file-logs',
-        help="Enable/disable logging to file. Defaults to NUCYPHER_FILE_LOGS, or to `--file-logs` if it is not set.",
+        help="Enable/disable logging to text file. Defaults to NUCYPHER_FILE_LOGS, or to `--file-logs` if it is not set.",
+        default=None,
+    ),
+    json_logs=click.option(
+        "--json-logs/--no-json-logs",
+        help="Enable/disable logging to a json file. Defaults to NUCYPHER_JSON_LOGS, or to `--no-json-logs` if it is not set.",
         default=None),
 
     sentry_logs=click.option(

--- a/nucypher/utilities/emitters.py
+++ b/nucypher/utilities/emitters.py
@@ -1,33 +1,16 @@
-import os
-from functools import partial
-from typing import Callable
-
 import click
 
 from nucypher.utilities.logging import Logger
 
 
-def null_stream():
-    return open(os.devnull, 'w')
-
-
 class StdoutEmitter:
 
-    class MethodNotFound(BaseException):
-        """Cannot find interface method to handle request"""
-
-    transport_serializer = str
     default_color = 'white'
 
-    # sys.stdout.write() TODO: doesn't work well with click_runner's output capture
-    default_sink_callable = partial(print, flush=True)
-
     def __init__(self,
-                 sink: Callable = None,
                  verbosity: int = 1):
 
         self.name = self.__class__.__name__.lower()
-        self.sink = sink or self.default_sink_callable
         self.verbosity = verbosity
         self.log = Logger(self.name)
 
@@ -41,7 +24,12 @@ class StdoutEmitter:
                 bold: bool = False,
                 verbosity: int = 1):
         self.echo(message, color=color or self.default_color, bold=bold, verbosity=verbosity)
-        self.log.debug(message)
+        # these are application messages that are desired to be
+        #  printed to stdout (with or w/o console logging); send to logger
+        if verbosity > 1:
+            self.log.debug(message)
+        else:
+            self.log.info(message)
 
     def echo(self,
              message: str = None,
@@ -49,21 +37,18 @@ class StdoutEmitter:
              bold: bool = False,
              nl: bool = True,
              verbosity: int = 0):
+        # these are user interactions; don't send to logger
         if verbosity <= self.verbosity:
             click.secho(message=message, fg=color or self.default_color, bold=bold, nl=nl)
 
     def banner(self, banner):
+        # these are purely for banners; don't send to logger
         if self.verbosity >= 1:
             click.echo(banner)
 
     def error(self, e):
+        e_str = str(e)
         if self.verbosity >= 1:
-            e_str = str(e)
             click.echo(message=e_str, color="red")
-            self.log.info(e_str)
-
-    def get_stream(self, verbosity: int = 0):
-        if verbosity <= self.verbosity:
-            return click.get_text_stream('stdout')
-        else:
-            return null_stream()
+        # some kind of error; send to logger
+        self.log.error(e_str)

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -1,16 +1,14 @@
-
-
-
 import pathlib
+import sys
 from contextlib import contextmanager
 
 from twisted.logger import (
     FileLogObserver,
     LogLevel,
-    formatEvent,
     formatEventAsClassicLogText,
     globalLogPublisher,
     jsonFileLogObserver,
+    textFileLogObserver,
 )
 from twisted.logger import Logger as TwistedLogger
 from twisted.python.logfile import LogFile
@@ -76,11 +74,11 @@ class GlobalLoggerSettings:
 
     @classmethod
     def start_console_logging(cls):
-        globalLogPublisher.addObserver(console_observer)
+        globalLogPublisher.addObserver(textFileLogObserver(sys.stdout))
 
     @classmethod
     def stop_console_logging(cls):
-        globalLogPublisher.removeObserver(console_observer)
+        globalLogPublisher.removeObserver(textFileLogObserver(sys.stdout))
 
     @classmethod
     @contextmanager
@@ -116,11 +114,6 @@ class GlobalLoggerSettings:
     @classmethod
     def stop_sentry_logging(cls):
         globalLogPublisher.removeObserver(sentry_observer)
-
-
-def console_observer(event):
-    if event['log_level'] >= GlobalLoggerSettings.log_level:
-        print(formatEvent(event))
 
 
 class _SentryInitGuard:

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -186,5 +186,6 @@ class Logger(TwistedLogger):
         return escaped_string
 
     def emit(self, level, format=None, **kwargs):
-        clean_format = self.escape_format_string(str(format))
-        super().emit(level=level, format=clean_format, **kwargs)
+        if level >= GlobalLoggerSettings.log_level:
+            clean_format = self.escape_format_string(str(format))
+            super().emit(level=level, format=clean_format, **kwargs)

--- a/nucypher/utilities/logging.py
+++ b/nucypher/utilities/logging.py
@@ -93,7 +93,7 @@ class GlobalLoggerSettings:
     @classmethod
     def _start_logging(cls, logging_type: LoggingType):
         if cls._is_already_configured(logging_type):
-            print(f"{logging_type.value} logger already configured")
+            # no-op
             return
 
         if logging_type == cls.LoggingType.CONSOLE:
@@ -145,12 +145,17 @@ class GlobalLoggerSettings:
     @classmethod
     @contextmanager
     def pause_all_logging_while(cls):
-        former_observers = tuple(globalLogPublisher._observers)
-        for observer in former_observers:
+        all_former_observers = tuple(globalLogPublisher._observers)
+        former_global_observers = dict(cls._observers)
+        for observer in all_former_observers:
             globalLogPublisher.removeObserver(observer)
+        cls._observers.clear()
+
         yield
-        for observer in former_observers:
+        cls._observers.clear()
+        for observer in all_former_observers:
             globalLogPublisher.addObserver(observer)
+        cls._observers.update(former_global_observers)
 
 
 class _SentryInitGuard:

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -153,6 +153,20 @@ def test_even_nucypher_json_logger_is_cool():
         assert f'"log_format": "{expected_processing(string)}"' in logged_event
 
 
+def test_pause_all_logging_while():
+    # get state beforehand
+    former_global_observers = dict(GlobalLoggerSettings._observers)
+    former_registered_observers = list(globalLogPublisher._observers)
+    with GlobalLoggerSettings.pause_all_logging_while():
+        # within context manager
+        assert len(GlobalLoggerSettings._observers) == 0
+        assert len(globalLogPublisher._observers) == 0
+
+    # exited context manager
+    assert former_global_observers == GlobalLoggerSettings._observers
+    assert former_registered_observers == globalLogPublisher._observers
+
+
 @pytest.mark.parametrize("global_log_level", LogLevel._enumerants.values())
 def test_log_level_adhered_to(global_log_level):
     old_log_level = GlobalLoggerSettings.log_level.name


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Addresses various issues with logging:
- Console logging now uses a correct logging format
- Logging Levels are now properly adhered to
- When stopping logging, incorrect instances are used for removing observers; track the instances so they can be appropriately removed
- Text file logging and json file logging should not be controlled by the same flag, and should be separated from each other. Also, json file logging should be disabled by default. Users can explicitly enable it using `--json-logs`.
- The StdoutEmitter did not integrate with the underlying logger properly; 
    - calls to `message(...)` are now passed to the logger based on verbosity (`info` or `debug`)
    - calls to `echo(...)` are *NOT* passed to the logger since these are used for user interactions
    - calls to `error(...)` are passed to the logger

**Issues fixed/closed:**
> - Fixes #...

Fixed #3482 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Things to think about:
- Should we still be printing to stdout as part of `emitter.message(...)` (not the logger part, but the `click.secho` call), or should it just be the logger and console-logs enabled by default?
