### PR TITLE
One more thing: Individual logging observers need to adhere to log levels

### DIFF
--- a/newsfragments/3487.misc.rst
+++ b/newsfragments/3487.misc.rst
@@ -1,0 +1,1 @@
+Ensure that log observers filter log messages by log level.

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1133,7 +1133,7 @@ class Teacher:
             if self._staking_provider_is_really_staking(
                 registry=registry, eth_endpoint=eth_endpoint
             ):  # <-- Blockchain CALL
-                self.log.info(f"Verified operator {self}")
+                self.log.debug(f"Verified operator {self}")
                 self.verified_operator = True
             else:
                 raise self.NotStaking(f"{self.checksum_address} is not staking")


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

If a separate library, say `ATxM` (which actually does this), creates their own TwistedLogger then that logger does not filter by log level, so the individual observers need to filter by log level themselves.

As a result, each global observer used by `nucypher` is now wrapped to ensure that messages are filtered by log level.

**Issues fixed/closed:**
> - Fixes #...

Related to #3483 
Fixes #1712 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
