### PR TITLE
Ritual tx starvation protection

### DIFF
--- a/newsfragments/3489.misc.rst
+++ b/newsfragments/3489.misc.rst
@@ -1,0 +1,1 @@
+Prevent ritual tx starvation when broadcast failures occur by proactively removing problematic tx from the ATxM queue, and resubmitting a fresh tx.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -385,6 +385,13 @@ class Operator(BaseActor):
                 f"{tx_type} async tx {tx.id} for DKG ritual# {phase_id.ritual_id} "
                 f"failed to broadcast {e}; the same tx will be retried"
             )
+            # either multiple retries already completed for recoverable error,
+            # or simply a non-recoverable error - remove and resubmit
+            # (analogous action to a node restart of old)
+            self.coordinator_agent.blockchain.tx_machine.remove_queued_transaction(tx)
+
+            # submit a new one
+            resubmit_tx()
 
         def on_fault(tx: FaultedTx):
             # fault means that tx was removed from atxm


### PR DESCRIPTION
Based over #3487 .

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

The `on_broadcast_failure` callback gets called from ATxM because of one of 2 scenarios:
1. recoverable error occurred 3 times
2. non-recoverable error

but the tx is not removed from the atxm queue and is continuously retried until a timeout, which means that this problematic ritual tx can cause starvation for other ritual txs in the queue waiting to be executed. (shout out to @KPrasch for thinking about this).

Instead when `on_broadcast_failure` is called for a specific ritual tx, have it remove the tx from the queue, and queue a fresh tx.

**Issues fixed/closed:**
> - Fixes #...

Fixes #3488 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
