### PR TITLE
Default RPC endpoints for Condition Evaluation

### DIFF
--- a/newsfragments/3496.feature.rst
+++ b/newsfragments/3496.feature.rst
@@ -1,0 +1,1 @@
+Support for default/fallback RPC endpoints from remote sources as a backup for operator-supplied RPC endpoints for condition evaluation.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -37,8 +37,7 @@ from nucypher.blockchain.eth.agents import (
     TACoApplicationAgent,
     TACoChildApplicationAgent,
 )
-from nucypher.blockchain.eth.clients import PUBLIC_CHAINS
-from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.blockchain.eth.constants import NULL_ADDRESS, DEFAULT_RPC_ENDPOINTS, PUBLIC_CHAINS
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.interfaces import (

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -54,8 +54,8 @@ from nucypher.blockchain.eth.trackers import dkg
 from nucypher.blockchain.eth.trackers.bonding import OperatorBondedTracker
 from nucypher.blockchain.eth.utils import (
     get_healthy_default_rpc_endpoints,
-    truncate_checksum_address,
     rpc_endpoint_health_check,
+    truncate_checksum_address,
 )
 from nucypher.crypto.powers import (
     CryptoPower,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -37,7 +37,10 @@ from nucypher.blockchain.eth.agents import (
     TACoApplicationAgent,
     TACoChildApplicationAgent,
 )
-from nucypher.blockchain.eth.constants import NULL_ADDRESS, DEFAULT_RPC_ENDPOINTS, PUBLIC_CHAINS
+from nucypher.blockchain.eth.constants import (
+    NULL_ADDRESS,
+    PUBLIC_CHAINS,
+)
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.blockchain.eth.interfaces import (
@@ -49,7 +52,10 @@ from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.signers import Signer
 from nucypher.blockchain.eth.trackers import dkg
 from nucypher.blockchain.eth.trackers.bonding import OperatorBondedTracker
-from nucypher.blockchain.eth.utils import truncate_checksum_address, get_healthy_default_rpc_endpoints
+from nucypher.blockchain.eth.utils import (
+    get_healthy_default_rpc_endpoints,
+    truncate_checksum_address,
+)
 from nucypher.crypto.powers import (
     CryptoPower,
     RitualisticPower,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -316,7 +316,7 @@ class Operator(BaseActor):
             _CONDITION_CHAINS[chain_id] for chain_id in providers
         )
         self.log.info(
-            f"Connected to {len(providers.values())} RPC endpoints for condition "
+            f"Connected to {sum(len(v) for v in providers.values())} RPC endpoints for condition "
             f"checking on chain IDs {humanized_chain_ids}"
         )
 

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -277,6 +277,12 @@ class Operator(BaseActor):
     ) -> DefaultDict[int, List[HTTPProvider]]:
         providers = defaultdict(list)
 
+        # de-duplicate, preserving order
+        deduplicated = {}
+        for chain_id, uris in endpoints.items():
+            deduplicated[chain_id] = list(dict.fromkeys(uris))
+        endpoints = deduplicated
+
         # check that we have endpoints for all condition chains
         if set(self.domain.condition_chain_ids) != set(endpoints):
             raise self.ActorError(

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -33,28 +33,6 @@ class Web3ClientUnexpectedVersionString(Web3ClientError):
     pass
 
 
-PUBLIC_CHAINS = {
-    1: "Mainnet",
-    137: "Polygon/Mainnet",
-    11155111: "Sepolia",
-    80002: "Polygon/Amoy",
-}
-
-# This list is not exhaustive,
-# but is sufficient for the current needs of the project.
-POA_CHAINS = {
-    4,  # Rinkeby
-    5,  # Goerli
-    42,  # Kovan
-    77,  # Sokol
-    100,  # xDAI
-    10200,  # gnosis/chiado,
-    137,  # Polygon/Mainnet
-    80001,  # "Polygon/Mumbai"
-    80002,  # "Polygon/Amoy"
-}
-
-
 class EthereumClient:
     BLOCK_CONFIRMATIONS_POLLING_TIME = 3  # seconds
     TRANSACTION_POLLING_TIME = 0.5  # seconds

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -10,7 +10,7 @@ from web3.contract.contract import Contract
 from web3.exceptions import TimeExhausted, TransactionNotFound
 from web3.types import TxReceipt, Wei
 
-from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS
+from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS, PUBLIC_CHAINS
 from nucypher.blockchain.middleware.retry import (
     AlchemyRetryRequestMiddleware,
     InfuraRetryRequestMiddleware,

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -10,7 +10,10 @@ from web3.contract.contract import Contract
 from web3.exceptions import TimeExhausted, TransactionNotFound
 from web3.types import TxReceipt, Wei
 
-from nucypher.blockchain.eth.constants import AVERAGE_BLOCK_TIME_IN_SECONDS, PUBLIC_CHAINS
+from nucypher.blockchain.eth.constants import (
+    AVERAGE_BLOCK_TIME_IN_SECONDS,
+    PUBLIC_CHAINS,
+)
 from nucypher.blockchain.middleware.retry import (
     AlchemyRetryRequestMiddleware,
     InfuraRetryRequestMiddleware,

--- a/nucypher/blockchain/eth/constants.py
+++ b/nucypher/blockchain/eth/constants.py
@@ -41,6 +41,7 @@ PUBLIC_CHAINS = {
     11155111: "Sepolia",
     80002: "Polygon/Amoy",
 }
+
 POA_CHAINS = {
     4,  # Rinkeby
     5,  # Goerli
@@ -53,32 +54,4 @@ POA_CHAINS = {
     80002,  # "Polygon/Amoy"
 }
 
-# TODO: This may be dynamic in the future, perhaps using a 3rd party API
-DEFAULT_RPC_ENDPOINTS = {
-    1: [
-        "https://cloudflare-eth.com",
-        "https://ethereum-rpc.publicnode.com",
-        "https://mainnet.gateway.tenderly.co",
-        "https://rpc.flashbots.net",
-        "https://rpc.mevblocker.io"
-    ],
-    11155111: [
-	    "https://rpc.sepolia.org",
-        "https://rpc2.sepolia.org",
-        "https://rpc-sepolia.rockx.com",
-        "https://rpc.sepolia.ethpandaops.io",
-        "https://sepolia.gateway.tenderly.co",
-        "https://ethereum-sepolia-rpc.publicnode.com",
-        "https://sepolia.drpc.org"
-    ],
-    137: [
-        "https://polygon-rpc.com",
-        "https://polygon-bor-rpc.publicnode.com",
-        "https://polygon.gateway.tenderly.co",
-        "https://polygon.drpc.org"
-    ],
-    80002: [
-        "https://rpc-amoy.polygon.technology",
-        "https://polygon-amoy-bor-rpc.publicnode.com",
-    ]
-}
+CHAINLIST_URL = "https://raw.githubusercontent.com/nucypher/chainlist/main/rpc.json"

--- a/nucypher/blockchain/eth/constants.py
+++ b/nucypher/blockchain/eth/constants.py
@@ -1,5 +1,3 @@
-
-
 #
 # Contract Names
 #
@@ -15,14 +13,12 @@ TACO_CHILD_APPLICATION_CONTRACT_NAME = "TACoChildApplication"
 COORDINATOR_CONTRACT_NAME = "Coordinator"
 SUBSCRIPTION_MANAGER_CONTRACT_NAME = "SubscriptionManager"
 
-
 TACO_CONTRACT_NAMES = (
     TACO_APPLICATION_CONTRACT_NAME,
     TACO_CHILD_APPLICATION_CONTRACT_NAME,
     COORDINATOR_CONTRACT_NAME,
     SUBSCRIPTION_MANAGER_CONTRACT_NAME
 )
-
 
 # Ethereum
 
@@ -37,3 +33,52 @@ NULL_ADDRESS = '0x' + '0' * 40
 # NuCypher
 # TODO: this is equal to HRAC.SIZE.
 POLICY_ID_LENGTH = 16
+
+
+PUBLIC_CHAINS = {
+    1: "Mainnet",
+    137: "Polygon/Mainnet",
+    11155111: "Sepolia",
+    80002: "Polygon/Amoy",
+}
+POA_CHAINS = {
+    4,  # Rinkeby
+    5,  # Goerli
+    42,  # Kovan
+    77,  # Sokol
+    100,  # xDAI
+    10200,  # gnosis/chiado,
+    137,  # Polygon/Mainnet
+    80001,  # "Polygon/Mumbai"
+    80002,  # "Polygon/Amoy"
+}
+
+# TODO: This may be dynamic in the future, perhaps using a 3rd party API
+DEFAULT_RPC_ENDPOINTS = {
+    1: [
+        "https://cloudflare-eth.com",
+        "https://ethereum-rpc.publicnode.com",
+        "https://mainnet.gateway.tenderly.co",
+        "https://rpc.flashbots.net",
+        "https://rpc.mevblocker.io"
+    ],
+    11155111: [
+	    "https://rpc.sepolia.org",
+        "https://rpc2.sepolia.org",
+        "https://rpc-sepolia.rockx.com",
+        "https://rpc.sepolia.ethpandaops.io",
+        "https://sepolia.gateway.tenderly.co",
+        "https://ethereum-sepolia-rpc.publicnode.com",
+        "https://sepolia.drpc.org"
+    ],
+    137: [
+        "https://polygon-rpc.com",
+        "https://polygon-bor-rpc.publicnode.com",
+        "https://polygon.gateway.tenderly.co",
+        "https://polygon.drpc.org"
+    ],
+    80002: [
+        "https://rpc-amoy.polygon.technology",
+        "https://polygon-amoy-bor-rpc.publicnode.com",
+    ]
+}

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -21,7 +21,8 @@ from web3.middleware import geth_poa_middleware, simple_cache_middleware
 from web3.providers import BaseProvider
 from web3.types import TxParams, TxReceipt
 
-from nucypher.blockchain.eth.clients import POA_CHAINS, EthereumClient
+from nucypher.blockchain.eth.clients import EthereumClient
+from nucypher.blockchain.eth.constants import POA_CHAINS
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.providers import (
     _get_http_provider,

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -172,7 +172,7 @@ def get_healthy_default_rpc_endpoints(chain_id: int) -> List[str]:
     healthy = [
         endpoint for endpoint in chain_endpoints if rpc_endpoint_health_check(endpoint)
     ]
-    LOGGER.info(f"Healthy RPC endpoints for chain ID {chain_id}: {healthy}")
+    LOGGER.info(f"Healthy default RPC endpoints for chain ID {chain_id}: {healthy}")
     if not healthy:
         LOGGER.warn(
             f"No healthy default RPC endpoints available for chain ID {chain_id}"

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -6,6 +6,8 @@ from web3 import Web3
 from web3.contract.contract import ContractConstructor, ContractFunction
 from web3.types import TxParams
 
+from nucypher.blockchain.eth.constants import DEFAULT_RPC_ENDPOINTS
+
 
 def prettify_eth_amount(amount, original_denomination: str = 'wei') -> str:
     """

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import List, Union
+from typing import List, Union, Dict
 
 import requests
 from eth_typing import ChecksumAddress
@@ -7,7 +7,7 @@ from web3 import Web3
 from web3.contract.contract import ContractConstructor, ContractFunction
 from web3.types import TxParams
 
-from nucypher.blockchain.eth.constants import DEFAULT_RPC_ENDPOINTS
+from nucypher.blockchain.eth.constants import CHAINLIST_URL
 
 
 def prettify_eth_amount(amount, original_denomination: str = 'wei') -> str:
@@ -89,9 +89,19 @@ def rpc_endpoint_health_check(endpoint: str) -> bool:
         return False
 
 
+def get_default_rpc_endpoints() -> Dict[int, List[str]]:
+    # TODO: Memoize?  When to refresh?
+    response = requests.get(CHAINLIST_URL)
+    if response.status_code == 200:
+        return response.json()
+    else:
+        # TODO: use an embedded fallback here?
+        return {}
+
+
 def get_healthy_default_rpc_endpoints(chain_id: int) -> List[str]:
     healthy = []
-    endpoints = DEFAULT_RPC_ENDPOINTS.get(chain_id)
+    endpoints = get_default_rpc_endpoints().get(chain_id)
     if not endpoints:
         return healthy
     for endpoint in endpoints:

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -112,8 +112,8 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
     if data["result"] is None:
         LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no block data")
         return False
-    block_data = data["result"]
 
+    block_data = data["result"]
     try:
         timestamp = int(block_data.get("timestamp"), 16)
     except TypeError:
@@ -134,7 +134,8 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
 
 def get_default_rpc_endpoints() -> Dict[int, List[str]]:
     """
-    Fetches the default RPC endpoints for various chains from the nucypher/chainlist repository.
+    Fetches the default RPC endpoints for various chains
+    from the nucypher/chainlist repository.
     """
     LOGGER.debug("Fetching default RPC endpoints from remote chainlist")
     response = requests.get(CHAINLIST_URL)
@@ -148,18 +149,25 @@ def get_default_rpc_endpoints() -> Dict[int, List[str]]:
 
 
 def get_healthy_default_rpc_endpoints(chain_id: int) -> List[str]:
-    """
-    Returns a list of healthy RPC endpoints for a given chain ID.
-    """
-    healthy = []
+    """Returns a list of healthy RPC endpoints for a given chain ID."""
+
+    healthy = list()
     endpoints = get_default_rpc_endpoints()
     chain_endpoints = endpoints.get(chain_id)
+
     if not chain_endpoints:
         LOGGER.error(f"No default RPC endpoints found for chain ID {chain_id}")
         return healthy
+
     for endpoint in chain_endpoints:
         if rpc_endpoint_health_check(endpoint=endpoint):
             healthy.append(endpoint)
 
     LOGGER.info(f"Healthy RPC endpoints for chain ID {chain_id}: {healthy}")
+
+    if len(healthy) == 0:
+        LOGGER.warn(
+            f"No healthy default RPC endpoints available for chain ID {chain_id}"
+        )
+
     return healthy

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -80,7 +80,7 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
         "jsonrpc": "2.0",
         "method": "eth_getBlockByNumber",
         "params": ["latest", False],
-        "id": 1
+        "id": 1,
     }
     LOGGER.debug(f"Checking health of RPC endpoint {endpoint}")
     try:
@@ -88,7 +88,7 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
             endpoint,
             json=query,
             headers={"Content-Type": "application/json"},
-            timeout=5
+            timeout=5,
         )
     except requests.exceptions.RequestException:
         LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: network error")
@@ -140,7 +140,9 @@ def get_default_rpc_endpoints() -> Dict[int, List[str]]:
     LOGGER.debug("Fetching default RPC endpoints from remote chainlist")
     response = requests.get(CHAINLIST_URL)
     if response.status_code == 200:
-        return {int(chain_id): endpoints for chain_id, endpoints in response.json().items()}
+        return {
+            int(chain_id): endpoints for chain_id, endpoints in response.json().items()
+        }
     else:
         LOGGER.error(
             f"Failed to fetch default RPC endpoints: {response.status_code} | {response.text}"

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -9,6 +9,9 @@ from web3.contract.contract import ContractConstructor, ContractFunction
 from web3.types import TxParams
 
 from nucypher.blockchain.eth.constants import CHAINLIST_URL
+from nucypher.utilities.logging import Logger
+
+LOGGER = Logger("utility")
 
 
 def prettify_eth_amount(amount, original_denomination: str = 'wei') -> str:
@@ -79,6 +82,7 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
         "params": ["latest", False],
         "id": 1
     }
+    LOGGER.debug(f"Checking health of RPC endpoint {endpoint}")
     try:
         response = requests.post(
             endpoint,
@@ -87,32 +91,44 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
             timeout=5
         )
     except requests.exceptions.RequestException:
+        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: network error")
         return False
 
     if response.status_code != 200:
+        LOGGER.debug(
+            f"RPC endpoint {endpoint} is unhealthy: {response.status_code} | {response.text}"
+        )
         return False
 
     try:
         data = response.json()
         if "result" not in data:
+            LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no response data")
             return False
     except requests.exceptions.RequestException:
+        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: {response.text}")
         return False
 
     if data["result"] is None:
+        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no block data")
         return False
     block_data = data["result"]
 
     try:
         timestamp = int(block_data.get("timestamp"), 16)
     except TypeError:
+        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: invalid block data")
         return False
 
     system_time = time.time()
     drift = abs(system_time - timestamp)
     if drift > max_drift_seconds:
+        LOGGER.debug(
+            f"RPC endpoint {endpoint} is unhealthy: drift too large ({drift} seconds)"
+        )
         return False
 
+    LOGGER.debug(f"RPC endpoint {endpoint} is healthy")
     return True  # finally!
 
 
@@ -120,12 +136,14 @@ def get_default_rpc_endpoints() -> Dict[int, List[str]]:
     """
     Fetches the default RPC endpoints for various chains from the nucypher/chainlist repository.
     """
-    # TODO: Memoize?  When to refresh?
+    LOGGER.debug("Fetching default RPC endpoints from remote chainlist")
     response = requests.get(CHAINLIST_URL)
     if response.status_code == 200:
         return {int(chain_id): endpoints for chain_id, endpoints in response.json().items()}
     else:
-        # TODO: use an embedded fallback here?
+        LOGGER.error(
+            f"Failed to fetch default RPC endpoints: {response.status_code} | {response.text}"
+        )
         return {}
 
 
@@ -137,8 +155,11 @@ def get_healthy_default_rpc_endpoints(chain_id: int) -> List[str]:
     endpoints = get_default_rpc_endpoints()
     chain_endpoints = endpoints.get(chain_id)
     if not chain_endpoints:
+        LOGGER.error(f"No default RPC endpoints found for chain ID {chain_id}")
         return healthy
     for endpoint in chain_endpoints:
         if rpc_endpoint_health_check(endpoint=endpoint):
             healthy.append(endpoint)
+
+    LOGGER.info(f"Healthy RPC endpoints for chain ID {chain_id}: {healthy}")
     return healthy

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -1,6 +1,5 @@
-from collections import defaultdict
 from decimal import Decimal
-from typing import Union, Dict, List
+from typing import List, Union
 
 import requests
 from eth_typing import ChecksumAddress

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -18,7 +18,7 @@ from web3.middleware import geth_poa_middleware
 from web3.providers import BaseProvider
 from web3.types import ABIFunction
 
-from nucypher.blockchain.eth.clients import POA_CHAINS
+from nucypher.blockchain.eth.constants import POA_CHAINS
 from nucypher.policy.conditions import STANDARD_ABI_CONTRACT_TYPES, STANDARD_ABIS
 from nucypher.policy.conditions.base import AccessControlCondition
 from nucypher.policy.conditions.context import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,3 +150,15 @@ def mock_multichain_configuration(module_mocker, testerchain):
     module_mocker.patch.object(
         Operator, "_make_condition_provider", return_value=testerchain.provider
     )
+
+
+@pytest.fixture(scope='module', autouse=True)
+def mock_default_rpc_endpoint_healthcheck(module_mocker):
+    module_mocker.patch(
+        'nucypher.blockchain.eth.utils.DEFAULT_RPC_ENDPOINTS',
+        {TESTERCHAIN_CHAIN_ID: ['tester://pyevm']}
+    )
+    module_mocker.patch(
+        'nucypher.blockchain.eth.utils.rpc_endpoint_health_check',
+        return_value=True
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -150,4 +150,3 @@ def mock_multichain_configuration(module_mocker, testerchain):
     module_mocker.patch.object(
         Operator, "_make_condition_provider", return_value=testerchain.provider
     )
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,14 +151,3 @@ def mock_multichain_configuration(module_mocker, testerchain):
         Operator, "_make_condition_provider", return_value=testerchain.provider
     )
 
-
-@pytest.fixture(scope='module', autouse=True)
-def mock_default_rpc_endpoint_healthcheck(module_mocker):
-    module_mocker.patch(
-        'nucypher.blockchain.eth.utils.DEFAULT_RPC_ENDPOINTS',
-        {TESTERCHAIN_CHAIN_ID: ['tester://pyevm']}
-    )
-    module_mocker.patch(
-        'nucypher.blockchain.eth.utils.rpc_endpoint_health_check',
-        return_value=True
-    )

--- a/tests/integration/characters/test_grant_and_revoke.py
+++ b/tests/integration/characters/test_grant_and_revoke.py
@@ -1,8 +1,7 @@
 import datetime
 
 import maya
-import pytest
-from nucypher_core import EncryptedKeyFrag, RevocationOrder
+from nucypher_core import EncryptedKeyFrag
 
 from nucypher.characters.lawful import Enrico
 

--- a/tests/unit/test_rpc_healthcheck.py
+++ b/tests/unit/test_rpc_healthcheck.py
@@ -1,0 +1,84 @@
+import requests
+
+from nucypher.blockchain.eth.utils import (
+    get_default_rpc_endpoints,
+    get_healthy_default_rpc_endpoints,
+    rpc_endpoint_health_check,
+)
+
+
+def test_rpc_endpoint_health_check(mocker):
+    mock_time = mocker.patch("time.time", return_value=1625247600)
+    mock_post = mocker.patch("requests.post")
+
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"timestamp": hex(1625247600)},
+    }
+    mock_post.return_value = mock_response
+
+    # Test a healthy endpoint
+    assert rpc_endpoint_health_check("http://mockendpoint") is True
+
+    # Test an unhealthy endpoint (drift too large)
+    mock_time.return_value = 1625247600 + 100  # System time far ahead
+    assert rpc_endpoint_health_check("http://mockendpoint") is False
+
+    # Test request exception
+    mock_post.side_effect = requests.exceptions.RequestException
+    assert rpc_endpoint_health_check("http://mockendpoint") is False
+
+
+def test_get_default_rpc_endpoints(mocker):
+    mock_get = mocker.patch("requests.get")
+
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "1": ["http://endpoint1", "http://endpoint2"],
+        "2": ["http://endpoint3", "http://endpoint4"],
+    }
+    mock_get.return_value = mock_response
+
+    expected_result = {
+        1: ["http://endpoint1", "http://endpoint2"],
+        2: ["http://endpoint3", "http://endpoint4"],
+    }
+    assert get_default_rpc_endpoints() == expected_result
+
+    # Mock a failed response
+    mock_get.return_value.status_code = 500
+    assert get_default_rpc_endpoints() == {}
+
+
+def test_get_healthy_default_rpc_endpoints(mocker):
+    mock_get_endpoints = mocker.patch(
+        "nucypher.blockchain.eth.utils.get_default_rpc_endpoints"
+    )
+    mock_get_endpoints.return_value = {
+        1: ["http://endpoint1", "http://endpoint2"],
+        2: ["http://endpoint3", "http://endpoint4"],
+    }
+
+    mock_health_check = mocker.patch(
+        "nucypher.blockchain.eth.utils.rpc_endpoint_health_check"
+    )
+    mock_health_check.side_effect = (
+        lambda endpoint: endpoint == "http://endpoint1"
+        or endpoint == "http://endpoint3"
+    )
+
+    # Test chain ID 1
+    healthy_endpoints = get_healthy_default_rpc_endpoints(1)
+    assert healthy_endpoints == ["http://endpoint1"]
+
+    # Test chain ID 2
+    healthy_endpoints = get_healthy_default_rpc_endpoints(2)
+    assert healthy_endpoints == ["http://endpoint3"]
+
+    # Test chain ID with no healthy endpoints
+    healthy_endpoints = get_healthy_default_rpc_endpoints(3)
+    assert healthy_endpoints == []


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
2

**What this does:**
Introduces default red-only RPC endpoints at node startup for use with condition evaluation only.  Performs rudimentary health checks for each endpoint.

**Issues fixed/closed:**
- #3493 

**Why it's needed:**
- Increases the availability and robustness of TACo node's ability to deliver on service requests that involve on-chain reads.

**Notes for reviewers:**
I'm unsure if this PR needs more work.  Running testnet experiments now.

