### PR TITLE
Fix version in pyproject.toml & deprecated ruff command/options

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -27,4 +27,4 @@ jobs:
           pip install .
 
       - name: Lint with Ruff
-        run: ruff --output-format=github nucypher
+        run: ruff check --output-format=github nucypher

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         stages: [push]  # required additional setup: pre-commit install && pre-commit install -t pre-push
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.5.0
     hooks:
 
       # Git
@@ -36,7 +36,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/akaihola/darker
-    rev: 1.7.2
+    rev: v2.1.1
     hooks:
     -   id: darker
         args: ["--check"]
@@ -45,6 +45,6 @@ repos:
         stages: [commit]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.1.4'
+    rev: v0.4.5
     hooks:
     - id: ruff

--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -1,6 +1,6 @@
+from _pydecimal import Decimal
 from typing import Union
 
-from _pydecimal import Decimal
 from eth_utils import currency
 
 from nucypher.types import ERC20UNits, NuNits, TuNits

--- a/nucypher/utilities/certs.py
+++ b/nucypher/utilities/certs.py
@@ -1,9 +1,9 @@
 import ssl
 import time
+from _socket import gethostbyname
 from typing import Dict, NamedTuple
 from urllib.parse import urlparse, urlunparse
 
-from _socket import gethostbyname
 from requests import PreparedRequest, Response, Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ pre-commit = '^2.12.1'
         showcontent = true
 
 [tool.ruff]
-select = ["E", "F", "I"]
-ignore = ["E501"]
+lint.select = ["E", "F", "I"]
+lint.ignore = ["E501"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["nucypher"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nucypher"
-version = "7.3.0"
+version = "7.4.0"
 authors = ["NuCypher"]
 description = "A threshold access control application to empower privacy in decentralized systems."
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [X] 1
- [ ] 2
- [ ] 3

**What this does:**
Seems like the last run of bumpversion (7.3.0 -> 7.4.0) did not update the version in the pyproject.toml file - https://github.com/nucypher/nucypher/commit/f8b2bbba9abeda6e71854d0f5f685a96d76beddd.

That seems to be causing issues with our lynx docker build CI job - https://github.com/nucypher/nucypher/actions/runs/9221829751/job/25371693885.

There are some warnings from ruff about deprecated command/options, fixed those as well - https://github.com/nucypher/nucypher/actions/runs/9269043626/job/25499013103


**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
