### PR TITLE
SIWE (EIP4361) Authentication Part 2

### DIFF
--- a/newsfragments/3508.feature.rst
+++ b/newsfragments/3508.feature.rst
@@ -1,2 +1,2 @@
 Add functionality for ``:userAddressEIP712`` and ``:userAddressEIP4361`` to provide specific authentication
-support for user address context values for conditions.
+support for user address context values for conditions. ``:userAddress`` will allow any valid authentication scheme.

--- a/newsfragments/3508.feature.rst
+++ b/newsfragments/3508.feature.rst
@@ -1,0 +1,2 @@
+Add functionality for ``:userAddressEIP712`` and ``:userAddressEIP4361`` to provide specific authentication
+support for user address context values for conditions.

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -20,7 +20,7 @@ CONTEXT_PREFIX = ":"
 CONTEXT_REGEX = re.compile(":[a-zA-Z_][a-zA-Z0-9_]*")
 
 USER_ADDRESS_SCHEMES = {
-    USER_ADDRESS_CONTEXT: Auth.AuthScheme.EIP712.value,  # default to EIP712
+    USER_ADDRESS_CONTEXT: None,  # any of the available auth types
     USER_ADDRESS_EIP712_CONTEXT: Auth.AuthScheme.EIP712.value,
     USER_ADDRESS_EIP4361_CONTEXT: Auth.AuthScheme.EIP4361.value,
 }
@@ -53,7 +53,7 @@ def _resolve_user_address(user_address_context_variable, **context) -> ChecksumA
 
         scheme = user_address_info.get("scheme", Auth.AuthScheme.EIP712.value)
         expected_scheme = USER_ADDRESS_SCHEMES[user_address_context_variable]
-        if scheme != expected_scheme:
+        if expected_scheme and scheme != expected_scheme:
             raise UnexpectedScheme(
                 f"Expected {expected_scheme} authentication scheme, but received {scheme}"
             )

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -1,4 +1,5 @@
 import re
+from functools import partial
 from typing import Any, List, Union
 
 from eth_typing import ChecksumAddress
@@ -12,18 +13,30 @@ from nucypher.policy.conditions.exceptions import (
 )
 
 USER_ADDRESS_CONTEXT = ":userAddress"
+USER_ADDRESS_EIP712_CONTEXT = ":userAddressEIP712"
+USER_ADDRESS_EIP4361_CONTEXT = ":userAddressEIP4361"
 
 CONTEXT_PREFIX = ":"
 CONTEXT_REGEX = re.compile(":[a-zA-Z_][a-zA-Z0-9_]*")
 
+USER_ADDRESS_SCHEMES = {
+    USER_ADDRESS_CONTEXT: Auth.AuthScheme.EIP712.value,  # default to EIP712
+    USER_ADDRESS_EIP712_CONTEXT: Auth.AuthScheme.EIP712.value,
+    USER_ADDRESS_EIP4361_CONTEXT: Auth.AuthScheme.EIP4361.value,
+}
 
-def _recover_user_address(**context) -> ChecksumAddress:
+
+class UnexpectedScheme(Exception):
+    pass
+
+
+def _resolve_user_address(user_address_context_variable, **context) -> ChecksumAddress:
     """
     Recovers a checksum address from a signed message.
 
     Expected format:
     {
-        ":userAddress":
+        ":userAddress...":
             {
                 "signature": "<signature>",
                 "address": "<address>",
@@ -33,35 +46,50 @@ def _recover_user_address(**context) -> ChecksumAddress:
     }
     """
     try:
-        user_address_info = context[USER_ADDRESS_CONTEXT]
+        user_address_info = context[user_address_context_variable]
         signature = user_address_info["signature"]
         expected_address = to_checksum_address(user_address_info["address"])
-        type_data = user_address_info["typedData"]
+        typed_data = user_address_info["typedData"]
 
         scheme = user_address_info.get("scheme", Auth.AuthScheme.EIP712.value)
+        expected_scheme = USER_ADDRESS_SCHEMES[user_address_context_variable]
+        if scheme != expected_scheme:
+            raise UnexpectedScheme(
+                f"Expected {expected_scheme} authentication scheme, but received {scheme}"
+            )
+
         auth = Auth.from_scheme(scheme)
         auth.authenticate(
-            data=type_data, signature=signature, expected_address=expected_address
+            data=typed_data, signature=signature, expected_address=expected_address
         )
     except Auth.InvalidData as e:
         raise InvalidContextVariableData(
-            f"Invalid context variable data for '{USER_ADDRESS_CONTEXT}'; {e}"
+            f"Invalid context variable data for '{user_address_context_variable}'; {e}"
         )
     except Auth.AuthenticationFailed as e:
         raise ContextVariableVerificationFailed(
-            f"Authentication failed for '{USER_ADDRESS_CONTEXT}'; {e}"
+            f"Authentication failed for '{user_address_context_variable}'; {e}"
         )
     except Exception as e:
         # data could not be processed
         raise InvalidContextVariableData(
-            f"Invalid context variable data for '{USER_ADDRESS_CONTEXT}'; {e.__class__.__name__} - {e}"
+            f"Invalid context variable data for '{user_address_context_variable}'; {e.__class__.__name__} - {e}"
         )
 
     return expected_address
 
 
 _DIRECTIVES = {
-    USER_ADDRESS_CONTEXT: _recover_user_address,
+    USER_ADDRESS_CONTEXT: partial(
+        _resolve_user_address, user_address_context_variable=USER_ADDRESS_CONTEXT
+    ),
+    USER_ADDRESS_EIP712_CONTEXT: partial(
+        _resolve_user_address, user_address_context_variable=USER_ADDRESS_EIP712_CONTEXT
+    ),
+    USER_ADDRESS_EIP4361_CONTEXT: partial(
+        _resolve_user_address,
+        user_address_context_variable=USER_ADDRESS_EIP4361_CONTEXT,
+    ),
 }
 
 

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import os
 from unittest import mock
@@ -14,10 +13,8 @@ from nucypher.blockchain.eth.agents import (
     SubscriptionManagerAgent,
 )
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
-from nucypher.policy.conditions.auth import Auth
 from nucypher.policy.conditions.context import (
     USER_ADDRESS_CONTEXT,
-    _recover_user_address,
     get_context_value,
 )
 from nucypher.policy.conditions.evm import (
@@ -25,10 +22,7 @@ from nucypher.policy.conditions.evm import (
     RPCCondition,
 )
 from nucypher.policy.conditions.exceptions import (
-    ContextVariableVerificationFailed,
     InvalidCondition,
-    InvalidConditionContext,
-    InvalidContextVariableData,
     NoConnectionToChain,
     RequiredContextVariable,
     RPCExecutionFailed,
@@ -62,76 +56,6 @@ def test_required_context_variable(
         custom_context_variable_erc20_condition.verify(
             providers=condition_providers
         )  # no context
-
-
-@pytest.mark.parametrize("expected_entry", ["address", "signature", "typedData"])
-@pytest.mark.parametrize(
-    "valid_user_address_context", Auth.AuthScheme.values(), indirect=True
-)
-def test_user_address_context_missing_required_entries(
-    expected_entry, valid_user_address_context
-):
-    context = copy.deepcopy(valid_user_address_context)
-    del context[USER_ADDRESS_CONTEXT][expected_entry]
-    with pytest.raises(InvalidContextVariableData):
-        get_context_value(USER_ADDRESS_CONTEXT, **context)
-
-
-@pytest.mark.parametrize(
-    "valid_user_address_context", Auth.AuthScheme.values(), indirect=True
-)
-def test_user_address_context_invalid_typed_data(valid_user_address_context):
-    # invalid typed data
-    context = copy.deepcopy(valid_user_address_context)
-    context[USER_ADDRESS_CONTEXT]["typedData"] = dict(
-        randomSaying="Comparison is the thief of joy."  # -– Theodore Roosevelt
-    )
-    with pytest.raises(InvalidContextVariableData):
-        get_context_value(USER_ADDRESS_CONTEXT, **context)
-
-
-@pytest.mark.parametrize(
-    "valid_user_address_context", Auth.AuthScheme.values(), indirect=True
-)
-def test_user_address_context_variable_verification(
-    valid_user_address_context, accounts
-):
-    # call underlying directive directly (appease codecov)
-    address = _recover_user_address(**valid_user_address_context)
-    assert address == valid_user_address_context[USER_ADDRESS_CONTEXT]["address"]
-
-    # valid user address context
-    address = get_context_value(USER_ADDRESS_CONTEXT, **valid_user_address_context)
-    assert address == valid_user_address_context[USER_ADDRESS_CONTEXT]["address"]
-
-    # invalid user address context - signature does not match address
-    # internals are mutable - deepcopy
-    mismatch_with_address_context = copy.deepcopy(valid_user_address_context)
-    mismatch_with_address_context[USER_ADDRESS_CONTEXT][
-        "address"
-    ] = accounts.etherbase_account
-    with pytest.raises(ContextVariableVerificationFailed):
-        get_context_value(USER_ADDRESS_CONTEXT, **mismatch_with_address_context)
-
-    # invalid user address context - signature does not match address
-    # internals are mutable - deepcopy
-    mismatch_with_address_context = copy.deepcopy(valid_user_address_context)
-    signature = (
-        "0x93252ddff5f90584b27b5eef1915b23a8b01a703be56c8bf0660647c15cb75e9"
-        "1983bde9877eaad11da5a3ebc9b64957f1c182536931f9844d0c600f0c41293d1b"
-    )
-    mismatch_with_address_context[USER_ADDRESS_CONTEXT]["signature"] = signature
-    with pytest.raises(ContextVariableVerificationFailed):
-        get_context_value(USER_ADDRESS_CONTEXT, **mismatch_with_address_context)
-
-    # invalid signature
-    # internals are mutable - deepcopy
-    invalid_signature_context = copy.deepcopy(valid_user_address_context)
-    invalid_signature_context[USER_ADDRESS_CONTEXT][
-        "signature"
-    ] = "0xdeadbeef"  # invalid signature
-    with pytest.raises(InvalidConditionContext):
-        get_context_value(USER_ADDRESS_CONTEXT, **invalid_signature_context)
 
 
 @mock.patch(

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import os
+import random
 import shutil
 import tempfile
 from datetime import timedelta
@@ -650,7 +651,12 @@ def rpc_condition():
 
 @pytest.fixture(scope="function")
 def valid_user_address_auth_message(request):
-    if request.param == Auth.AuthScheme.EIP712.value:
+    auth_message_type = request.param
+    if auth_message_type is None:
+        # pick one at random
+        auth_message_type = random.choice(Auth.AuthScheme.values())
+
+    if auth_message_type == Auth.AuthScheme.EIP712.value:
         auth_message = {
             "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
             "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
@@ -685,7 +691,7 @@ def valid_user_address_auth_message(request):
                 },
             },
         }
-    elif request.param == Auth.AuthScheme.EIP4361.value:
+    elif auth_message_type == Auth.AuthScheme.EIP4361.value:
         signer = InMemorySigner()
         siwe_message_data = {
             "domain": "login.xyz",

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -648,8 +648,8 @@ def rpc_condition():
     return condition
 
 
-@pytest.fixture(scope="module")
-def valid_user_address_context(request):
+@pytest.fixture(scope="function")
+def valid_user_address_auth_message(request):
     if request.param == Auth.AuthScheme.EIP712.value:
         auth_message = {
             "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
@@ -685,7 +685,7 @@ def valid_user_address_context(request):
                 },
             },
         }
-    elif request.param == Auth.AuthScheme.SIWE.value:
+    elif request.param == Auth.AuthScheme.EIP4361.value:
         signer = InMemorySigner()
         siwe_message_data = {
             "domain": "login.xyz",
@@ -704,13 +704,13 @@ def valid_user_address_context(request):
         auth_message = {
             "signature": f"{signature.hex()}",
             "address": f"{signer.accounts[0]}",
-            "scheme": f"{Auth.AuthScheme.SIWE.value}",
+            "scheme": f"{Auth.AuthScheme.EIP4361.value}",
             "typedData": f"{siwe_message}",
         }
     else:
         raise ValueError(f"No context for provided scheme, {request.param}")
 
-    return {USER_ADDRESS_CONTEXT: auth_message}
+    return auth_message
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -6,7 +6,6 @@ import pytest
 
 from nucypher.policy.conditions.auth import Auth
 from nucypher.policy.conditions.context import (
-    USER_ADDRESS_CONTEXT,
     USER_ADDRESS_EIP712_CONTEXT,
     USER_ADDRESS_EIP4361_CONTEXT,
     USER_ADDRESS_SCHEMES,
@@ -135,12 +134,10 @@ def test_user_address_context_invalid_typed_data(
     list(
         zip(
             [
-                USER_ADDRESS_CONTEXT,
                 USER_ADDRESS_EIP712_CONTEXT,
                 USER_ADDRESS_EIP4361_CONTEXT,
             ],
             [
-                Auth.AuthScheme.EIP4361.value,
                 Auth.AuthScheme.EIP4361.value,
                 Auth.AuthScheme.EIP712.value,
             ],


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
- Add directives for `:userAddressEIP712` and `:userAddressEIP4361` as user address context variables that will be verified based on the relevant scheme
- `:userAddress` will default to using the EIP712 authentication scheme
- Don't do the additional _2 hour from "issued-at" stale check_ when `not-before` is used in SIWE message (#3506)

**Issues fixed/closed:**

- Fixes #3506; somewhat related although not the main focus - really a remnant from #3502.
- Follow-up from #3502 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
