### PR TITLE
Accept/Process EIP-4361 passthrough context variable used for single sign-on capabilities

### DIFF
--- a/newsfragments/3513.feature.rst
+++ b/newsfragments/3513.feature.rst
@@ -1,0 +1,2 @@
+Add ability for special context variable to handle Sign-In With Ethereum (EIP-4361)
+pre-existing sign-on signature to be reused as proof for validating a user address in conditions.

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -21,7 +21,7 @@ CONTEXT_PREFIX = ":"
 CONTEXT_REGEX = re.compile(":[a-zA-Z_][a-zA-Z0-9_]*")
 
 USER_ADDRESS_SCHEMES = {
-    USER_ADDRESS_CONTEXT: None,  # TODO either EIP712 or EIP4361 for now, but should use the default that is eventually decided (likely EIP4361)
+    USER_ADDRESS_CONTEXT: None,  # TODO either EIP712 or EIP4361 for now, but should use the default that is eventually decided (likely EIP4361) - #tdec/178
     USER_ADDRESS_EIP712_CONTEXT: EvmAuth.AuthScheme.EIP712.value,
     USER_ADDRESS_EIP4361_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -15,14 +15,16 @@ from nucypher.policy.conditions.exceptions import (
 USER_ADDRESS_CONTEXT = ":userAddress"
 USER_ADDRESS_EIP712_CONTEXT = ":userAddressEIP712"
 USER_ADDRESS_EIP4361_CONTEXT = ":userAddressEIP4361"
+USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT = ":userAddressExternalEIP4361"
 
 CONTEXT_PREFIX = ":"
 CONTEXT_REGEX = re.compile(":[a-zA-Z_][a-zA-Z0-9_]*")
 
 USER_ADDRESS_SCHEMES = {
-    USER_ADDRESS_CONTEXT: None,  # any of the available auth types
+    USER_ADDRESS_CONTEXT: None,  # TODO either EIP712 or EIP4361 for now, but should use the default that is eventually decided (likely EIP4361)
     USER_ADDRESS_EIP712_CONTEXT: EvmAuth.AuthScheme.EIP712.value,
     USER_ADDRESS_EIP4361_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
+    USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
 }
 
 
@@ -89,6 +91,10 @@ _DIRECTIVES = {
     USER_ADDRESS_EIP4361_CONTEXT: partial(
         _resolve_user_address,
         user_address_context_variable=USER_ADDRESS_EIP4361_CONTEXT,
+    ),
+    USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT: partial(
+        _resolve_user_address,
+        user_address_context_variable=USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
     ),
 }
 

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -148,7 +148,7 @@ def test_user_address_context_invalid_typed_data(
     ),
     indirect=["valid_user_address_auth_message"],
 )
-def test_user_address_context_unexpected_scheme_data(
+def test_user_address_context_variable_with_incompatible_auth_message(
     context_variable_name, valid_user_address_auth_message
 ):
     # scheme in message is unexpected for context variable name

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -8,6 +8,7 @@ from nucypher.policy.conditions.auth.evm import EvmAuth
 from nucypher.policy.conditions.context import (
     USER_ADDRESS_EIP712_CONTEXT,
     USER_ADDRESS_EIP4361_CONTEXT,
+    USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
     USER_ADDRESS_SCHEMES,
     _resolve_context_variable,
     _resolve_user_address,
@@ -136,9 +137,11 @@ def test_user_address_context_invalid_typed_data(
             [
                 USER_ADDRESS_EIP712_CONTEXT,
                 USER_ADDRESS_EIP4361_CONTEXT,
+                USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
             ],
             [
                 EvmAuth.AuthScheme.EIP4361.value,
+                EvmAuth.AuthScheme.EIP712.value,
                 EvmAuth.AuthScheme.EIP712.value,
             ],
         )


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [X] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Add capability for node to process SIWE passthrough messages/signatures that are provided via the `:userAddressExternalEIP4361` context variable.

Related to https://github.com/nucypher/taco-web/pull/529.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
