### PR TITLE
[WIP] Remove EIP712 Authentication

### DIFF
--- a/newsfragments/3515.removal.rst
+++ b/newsfragments/3515.removal.rst
@@ -1,0 +1,3 @@
+Deprecate the use of EIP712 authentication for proving wallet address ownership
+for the `:userAddress` context variable for conditions. Instead EIP4361 authentication
+messages are expected to be used.

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -13,17 +13,13 @@ from nucypher.policy.conditions.exceptions import (
 )
 
 USER_ADDRESS_CONTEXT = ":userAddress"
-USER_ADDRESS_EIP712_CONTEXT = ":userAddressEIP712"
-USER_ADDRESS_EIP4361_CONTEXT = ":userAddressEIP4361"
 USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT = ":userAddressExternalEIP4361"
 
 CONTEXT_PREFIX = ":"
 CONTEXT_REGEX = re.compile(":[a-zA-Z_][a-zA-Z0-9_]*")
 
 USER_ADDRESS_SCHEMES = {
-    USER_ADDRESS_CONTEXT: None,  # TODO either EIP712 or EIP4361 for now, but should use the default that is eventually decided (likely EIP4361) - #tdec/178
-    USER_ADDRESS_EIP712_CONTEXT: EvmAuth.AuthScheme.EIP712.value,
-    USER_ADDRESS_EIP4361_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
+    USER_ADDRESS_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
 }
 
@@ -42,7 +38,7 @@ def _resolve_user_address(user_address_context_variable, **context) -> ChecksumA
             {
                 "signature": "<signature>",
                 "address": "<address>",
-                "scheme": "EIP712" | "EIP4361" | ...
+                "scheme": "EIP4361" | ...
                 "typedData": ...
             }
     }
@@ -84,13 +80,6 @@ def _resolve_user_address(user_address_context_variable, **context) -> ChecksumA
 _DIRECTIVES = {
     USER_ADDRESS_CONTEXT: partial(
         _resolve_user_address, user_address_context_variable=USER_ADDRESS_CONTEXT
-    ),
-    USER_ADDRESS_EIP712_CONTEXT: partial(
-        _resolve_user_address, user_address_context_variable=USER_ADDRESS_EIP712_CONTEXT
-    ),
-    USER_ADDRESS_EIP4361_CONTEXT: partial(
-        _resolve_user_address,
-        user_address_context_variable=USER_ADDRESS_EIP4361_CONTEXT,
     ),
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT: partial(
         _resolve_user_address,

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -49,7 +49,7 @@ def _resolve_user_address(user_address_context_variable, **context) -> ChecksumA
         expected_address = to_checksum_address(user_address_info["address"])
         typed_data = user_address_info["typedData"]
 
-        scheme = user_address_info.get("scheme", EvmAuth.AuthScheme.EIP712.value)
+        scheme = user_address_info.get("scheme", EvmAuth.AuthScheme.EIP4361.value)
         expected_scheme = USER_ADDRESS_SCHEMES[user_address_context_variable]
         if expected_scheme and scheme != expected_scheme:
             raise UnexpectedScheme(

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,6 @@
 import contextlib
 import json
 import os
-import random
 import shutil
 import tempfile
 from datetime import timedelta
@@ -650,71 +649,70 @@ def rpc_condition():
 
 
 @pytest.fixture(scope="function")
-def valid_user_address_auth_message(request):
-    auth_message_type = request.param
-    if auth_message_type is None:
-        # pick one at random
-        auth_message_type = random.choice(EvmAuth.AuthScheme.values())
-
-    if auth_message_type == "EIP712":  # for invalid scheme testing
-        auth_message = {
-            "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
-            "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
-            "scheme": "EIP712",
-            "typedData": {
-                "primaryType": "Wallet",
-                "types": {
-                    "EIP712Domain": [
-                        {"name": "name", "type": "string"},
-                        {"name": "version", "type": "string"},
-                        {"name": "chainId", "type": "uint256"},
-                        {"name": "salt", "type": "bytes32"},
-                    ],
-                    "Wallet": [
-                        {"name": "address", "type": "string"},
-                        {"name": "blockNumber", "type": "uint256"},
-                        {"name": "blockHash", "type": "bytes32"},
-                        {"name": "signatureText", "type": "string"},
-                    ],
-                },
-                "domain": {
-                    "name": "tDec",
-                    "version": "1",
-                    "chainId": 80001,
-                    "salt": "0x3e6365d35fd4e53cbc00b080b0742b88f8b735352ea54c0534ed6a2e44a83ff0",
-                },
-                "message": {
-                    "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
-                    "blockNumber": 28117088,
-                    "blockHash": "0x104dfae58be4a9b15d59ce447a565302d5658914f1093f10290cd846fbe258b7",
-                    "signatureText": "I'm the owner of address 0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E as of block number 28117088",
-                },
-            },
-        }
-    elif auth_message_type == EvmAuth.AuthScheme.EIP4361.value:
-        signer = InMemorySigner()
-        siwe_message_data = {
-            "domain": "login.xyz",
-            "address": f"{signer.accounts[0]}",
-            "statement": "Sign-In With Ethereum Example Statement",
-            "uri": "https://login.xyz",
+def valid_but_no_longer_supported_eip712_auth_message():
+    data = {
+        "primaryType": "Wallet",
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "salt", "type": "bytes32"},
+            ],
+            "Wallet": [
+                {"name": "address", "type": "string"},
+                {"name": "blockNumber", "type": "uint256"},
+                {"name": "blockHash", "type": "bytes32"},
+                {"name": "signatureText", "type": "string"},
+            ],
+        },
+        "domain": {
+            "name": "tDec",
             "version": "1",
-            "nonce": "bTyXgcQxn2htgkjJn",
-            "chain_id": 1,
-            "issued_at": f"{maya.now().iso8601()}",
-        }
-        siwe_message = SiweMessage(siwe_message_data).prepare_message()
-        signature = signer.sign_message(
-            account=signer.accounts[0], message=siwe_message.encode()
-        )
-        auth_message = {
-            "signature": f"{signature.hex()}",
-            "address": f"{signer.accounts[0]}",
-            "scheme": f"{EvmAuth.AuthScheme.EIP4361.value}",
-            "typedData": f"{siwe_message}",
-        }
-    else:
-        raise ValueError(f"No context for provided scheme, {request.param}")
+            "chainId": 80001,
+            "salt": "0x3e6365d35fd4e53cbc00b080b0742b88f8b735352ea54c0534ed6a2e44a83ff0",
+        },
+        "message": {
+            "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+            "blockNumber": 28117088,
+            "blockHash": "0x104dfae58be4a9b15d59ce447a565302d5658914f1093f10290cd846fbe258b7",
+            "signatureText": "I'm the owner of address 0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E as of block number 28117088",
+        },
+    }
+
+    auth_message = {
+        "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
+        "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+        "scheme": "EIP712",
+        "typedData": data,
+    }
+
+    return auth_message
+
+
+@pytest.fixture(scope="function")
+def valid_eip4361_auth_message():
+    signer = InMemorySigner()
+    siwe_message_data = {
+        "domain": "login.xyz",
+        "address": f"{signer.accounts[0]}",
+        "statement": "Sign-In With Ethereum Example Statement",
+        "uri": "https://login.xyz",
+        "version": "1",
+        "nonce": "bTyXgcQxn2htgkjJn",
+        "chain_id": 1,
+        "issued_at": f"{maya.now().iso8601()}",
+    }
+    siwe_message = SiweMessage(siwe_message_data).prepare_message()
+    signature = signer.sign_message(
+        account=signer.accounts[0], message=siwe_message.encode()
+    )
+    auth_message = {
+        "signature": f"{signature.hex()}",
+        "address": f"{signer.accounts[0]}",
+        "scheme": f"{EvmAuth.AuthScheme.EIP4361.value}",
+        "typedData": f"{siwe_message}",
+    }
 
     return auth_message
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -13,6 +13,7 @@ import maya
 import pytest
 from click.testing import CliRunner
 from eth_account import Account
+from eth_account.messages import encode_typed_data
 from eth_utils import to_checksum_address
 from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Keypair, Validator
 from siwe import SiweMessage
@@ -650,6 +651,9 @@ def rpc_condition():
 
 @pytest.fixture(scope="function")
 def valid_but_no_longer_supported_eip712_auth_message():
+    signer = Account.create()
+    account = signer.address
+
     data = {
         "primaryType": "Wallet",
         "types": {
@@ -673,16 +677,19 @@ def valid_but_no_longer_supported_eip712_auth_message():
             "salt": "0x3e6365d35fd4e53cbc00b080b0742b88f8b735352ea54c0534ed6a2e44a83ff0",
         },
         "message": {
-            "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+            "address": f"{account}",
             "blockNumber": 28117088,
             "blockHash": "0x104dfae58be4a9b15d59ce447a565302d5658914f1093f10290cd846fbe258b7",
-            "signatureText": "I'm the owner of address 0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E as of block number 28117088",
+            "signatureText": f"I'm the owner of address {account} as of block number 28117088",
         },
     }
 
+    signable_message = encode_typed_data(full_message=data)
+    signature = signer.sign_message(signable_message=signable_message)
+
     auth_message = {
-        "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
-        "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+        "signature": f"{signature.signature.hex()}",
+        "address": f"{account}",
         "scheme": "EIP712",
         "typedData": data,
     }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -656,11 +656,11 @@ def valid_user_address_auth_message(request):
         # pick one at random
         auth_message_type = random.choice(EvmAuth.AuthScheme.values())
 
-    if auth_message_type == EvmAuth.AuthScheme.EIP712.value:
+    if auth_message_type == "EIP712":  # for invalid scheme testing
         auth_message = {
             "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
             "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
-            "scheme": f"{EvmAuth.AuthScheme.EIP712.value}",
+            "scheme": "EIP712",
             "typedData": {
                 "primaryType": "Wallet",
                 "types": {

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -4,7 +4,6 @@ import re
 
 import pytest
 
-from nucypher.policy.conditions.auth.evm import EvmAuth
 from nucypher.policy.conditions.context import (
     USER_ADDRESS_CONTEXT,
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
@@ -138,8 +137,8 @@ def test_user_address_context_invalid_typed_data(
                 USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
             ],
             [
-                EvmAuth.AuthScheme.EIP712.value,
-                EvmAuth.AuthScheme.EIP712.value,
+                "EIP712",
+                "EIP712",
             ],
         )
     ),
@@ -151,6 +150,12 @@ def test_user_address_context_variable_with_incompatible_auth_message(
     # scheme in message is unexpected for context variable name
     context = {context_variable_name: valid_user_address_auth_message}
     with pytest.raises(InvalidContextVariableData, match="UnexpectedScheme"):
+        get_context_value(context_variable_name, **context)
+
+    # no scheme (older clients did not use a scheme)
+    del valid_user_address_auth_message["scheme"]
+    context = {context_variable_name: valid_user_address_auth_message}
+    with pytest.raises(InvalidContextVariableData, match="Invalid EIP4361 message"):
         get_context_value(context_variable_name, **context)
 
 

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -6,8 +6,7 @@ import pytest
 
 from nucypher.policy.conditions.auth.evm import EvmAuth
 from nucypher.policy.conditions.context import (
-    USER_ADDRESS_EIP712_CONTEXT,
-    USER_ADDRESS_EIP4361_CONTEXT,
+    USER_ADDRESS_CONTEXT,
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
     USER_ADDRESS_SCHEMES,
     _resolve_context_variable,
@@ -135,12 +134,10 @@ def test_user_address_context_invalid_typed_data(
     list(
         zip(
             [
-                USER_ADDRESS_EIP712_CONTEXT,
-                USER_ADDRESS_EIP4361_CONTEXT,
+                USER_ADDRESS_CONTEXT,
                 USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
             ],
             [
-                EvmAuth.AuthScheme.EIP4361.value,
                 EvmAuth.AuthScheme.EIP712.value,
                 EvmAuth.AuthScheme.EIP712.value,
             ],


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [X] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

- Removal of the use of EIP712
- Removal of two no longer necessary context variables (`:userAddressEIP712`, `:userAddressEIP712`) - these were never released publicly so it's a removal not a deprecation.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

There will be a `taco-web` and node incompatibility. Suppose an app continued to use the old version of `taco-web` (which used EIP712 as the default), then an EIP712 auth signature would be used for `:userAddress`, and sent to nodes as proof. A node with these changes would reject it because the scheme is not supported.

If that app updated to use a newer version of `taco-web` that uses EIP4361 by default, then that problem would immediately go away.

Are we ok with forcing the `taco-web` upgrade otherwise apps that utilize `:userAddress` won't work, or should we still have nodes accept EIP712 used from older `taco-web` clients for some period of time (until a subsequent release eg. `7.5.0`). Nodes can detect older `taco-client` usages because the auth signatures would not include a "scheme" entry since "scheme" was never specified in older `taco-web` clients.

Thoughts?