### PR TITLE
Remove unnecessary context variables `:userAddressEIP4361` and `:userAddressEIP712`

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -142,7 +142,7 @@ jobs:
       # Only upload coverage files after all tests have passed
       - name: Upload unit tests coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4.3.0
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: unit-coverage.xml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload integration tests coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4.3.0
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: integration-coverage.xml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload acceptance tests coverage to Codecov
         if: matrix.python-version == '3.12'
-        uses: codecov/codecov-action@v4.3.0
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: tests/acceptance

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -13,17 +13,13 @@ from nucypher.policy.conditions.exceptions import (
 )
 
 USER_ADDRESS_CONTEXT = ":userAddress"
-USER_ADDRESS_EIP712_CONTEXT = ":userAddressEIP712"
-USER_ADDRESS_EIP4361_CONTEXT = ":userAddressEIP4361"
 USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT = ":userAddressExternalEIP4361"
 
 CONTEXT_PREFIX = ":"
 CONTEXT_REGEX = re.compile(":[a-zA-Z_][a-zA-Z0-9_]*")
 
 USER_ADDRESS_SCHEMES = {
-    USER_ADDRESS_CONTEXT: None,  # TODO either EIP712 or EIP4361 for now, but should use the default that is eventually decided (likely EIP4361) - #tdec/178
-    USER_ADDRESS_EIP712_CONTEXT: EvmAuth.AuthScheme.EIP712.value,
-    USER_ADDRESS_EIP4361_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
+    USER_ADDRESS_CONTEXT: None,  # allow any scheme (EIP4361, EIP712) for now; eventually EIP712 will be deprecated
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT: EvmAuth.AuthScheme.EIP4361.value,
 }
 
@@ -42,7 +38,7 @@ def _resolve_user_address(user_address_context_variable, **context) -> ChecksumA
             {
                 "signature": "<signature>",
                 "address": "<address>",
-                "scheme": "EIP712" | "EIP4361" | ...
+                "scheme": "EIP4361" | ...
                 "typedData": ...
             }
     }
@@ -53,6 +49,7 @@ def _resolve_user_address(user_address_context_variable, **context) -> ChecksumA
         expected_address = to_checksum_address(user_address_info["address"])
         typed_data = user_address_info["typedData"]
 
+        # if empty assume EIP712, although EIP712 will eventually be deprecated
         scheme = user_address_info.get("scheme", EvmAuth.AuthScheme.EIP712.value)
         expected_scheme = USER_ADDRESS_SCHEMES[user_address_context_variable]
         if expected_scheme and scheme != expected_scheme:
@@ -84,13 +81,6 @@ def _resolve_user_address(user_address_context_variable, **context) -> ChecksumA
 _DIRECTIVES = {
     USER_ADDRESS_CONTEXT: partial(
         _resolve_user_address, user_address_context_variable=USER_ADDRESS_CONTEXT
-    ),
-    USER_ADDRESS_EIP712_CONTEXT: partial(
-        _resolve_user_address, user_address_context_variable=USER_ADDRESS_EIP712_CONTEXT
-    ),
-    USER_ADDRESS_EIP4361_CONTEXT: partial(
-        _resolve_user_address,
-        user_address_context_variable=USER_ADDRESS_EIP4361_CONTEXT,
     ),
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT: partial(
         _resolve_user_address,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -13,6 +13,7 @@ import maya
 import pytest
 from click.testing import CliRunner
 from eth_account import Account
+from eth_account.messages import encode_typed_data
 from eth_utils import to_checksum_address
 from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Keypair, Validator
 from siwe import SiweMessage
@@ -650,6 +651,9 @@ def rpc_condition():
 
 @pytest.fixture(scope="function")
 def valid_eip712_auth_message():
+    signer = Account.create()
+    account = signer.address
+
     data = {
         "primaryType": "Wallet",
         "types": {
@@ -673,16 +677,18 @@ def valid_eip712_auth_message():
             "salt": "0x3e6365d35fd4e53cbc00b080b0742b88f8b735352ea54c0534ed6a2e44a83ff0",
         },
         "message": {
-            "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+            "address": f"{account}",
             "blockNumber": 28117088,
             "blockHash": "0x104dfae58be4a9b15d59ce447a565302d5658914f1093f10290cd846fbe258b7",
-            "signatureText": "I'm the owner of address 0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E as of block number 28117088",
+            "signatureText": f"I'm the owner of address {account} as of block number 28117088",
         },
     }
+    signable_message = encode_typed_data(full_message=data)
+    signature = signer.sign_message(signable_message=signable_message)
 
     auth_message = {
-        "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
-        "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+        "signature": f"{signature.signature.hex()}",
+        "address": f"{account}",
         "scheme": "EIP712",
         "typedData": data,
     }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,7 +1,6 @@
 import contextlib
 import json
 import os
-import random
 import shutil
 import tempfile
 from datetime import timedelta
@@ -650,71 +649,70 @@ def rpc_condition():
 
 
 @pytest.fixture(scope="function")
-def valid_user_address_auth_message(request):
-    auth_message_type = request.param
-    if auth_message_type is None:
-        # pick one at random
-        auth_message_type = random.choice(EvmAuth.AuthScheme.values())
-
-    if auth_message_type == EvmAuth.AuthScheme.EIP712.value:
-        auth_message = {
-            "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
-            "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
-            "scheme": f"{EvmAuth.AuthScheme.EIP712.value}",
-            "typedData": {
-                "primaryType": "Wallet",
-                "types": {
-                    "EIP712Domain": [
-                        {"name": "name", "type": "string"},
-                        {"name": "version", "type": "string"},
-                        {"name": "chainId", "type": "uint256"},
-                        {"name": "salt", "type": "bytes32"},
-                    ],
-                    "Wallet": [
-                        {"name": "address", "type": "string"},
-                        {"name": "blockNumber", "type": "uint256"},
-                        {"name": "blockHash", "type": "bytes32"},
-                        {"name": "signatureText", "type": "string"},
-                    ],
-                },
-                "domain": {
-                    "name": "tDec",
-                    "version": "1",
-                    "chainId": 80001,
-                    "salt": "0x3e6365d35fd4e53cbc00b080b0742b88f8b735352ea54c0534ed6a2e44a83ff0",
-                },
-                "message": {
-                    "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
-                    "blockNumber": 28117088,
-                    "blockHash": "0x104dfae58be4a9b15d59ce447a565302d5658914f1093f10290cd846fbe258b7",
-                    "signatureText": "I'm the owner of address 0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E as of block number 28117088",
-                },
-            },
-        }
-    elif auth_message_type == EvmAuth.AuthScheme.EIP4361.value:
-        signer = InMemorySigner()
-        siwe_message_data = {
-            "domain": "login.xyz",
-            "address": f"{signer.accounts[0]}",
-            "statement": "Sign-In With Ethereum Example Statement",
-            "uri": "https://login.xyz",
+def valid_eip712_auth_message():
+    data = {
+        "primaryType": "Wallet",
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "salt", "type": "bytes32"},
+            ],
+            "Wallet": [
+                {"name": "address", "type": "string"},
+                {"name": "blockNumber", "type": "uint256"},
+                {"name": "blockHash", "type": "bytes32"},
+                {"name": "signatureText", "type": "string"},
+            ],
+        },
+        "domain": {
+            "name": "tDec",
             "version": "1",
-            "nonce": "bTyXgcQxn2htgkjJn",
-            "chain_id": 1,
-            "issued_at": f"{maya.now().iso8601()}",
-        }
-        siwe_message = SiweMessage(siwe_message_data).prepare_message()
-        signature = signer.sign_message(
-            account=signer.accounts[0], message=siwe_message.encode()
-        )
-        auth_message = {
-            "signature": f"{signature.hex()}",
-            "address": f"{signer.accounts[0]}",
-            "scheme": f"{EvmAuth.AuthScheme.EIP4361.value}",
-            "typedData": f"{siwe_message}",
-        }
-    else:
-        raise ValueError(f"No context for provided scheme, {request.param}")
+            "chainId": 80001,
+            "salt": "0x3e6365d35fd4e53cbc00b080b0742b88f8b735352ea54c0534ed6a2e44a83ff0",
+        },
+        "message": {
+            "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+            "blockNumber": 28117088,
+            "blockHash": "0x104dfae58be4a9b15d59ce447a565302d5658914f1093f10290cd846fbe258b7",
+            "signatureText": "I'm the owner of address 0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E as of block number 28117088",
+        },
+    }
+
+    auth_message = {
+        "signature": "0x488a7acefdc6d098eedf73cdfd379777c0f4a4023a660d350d3bf309a51dd4251abaad9cdd11b71c400cfb4625c14ca142f72b39165bd980c8da1ea32892ff071c",
+        "address": "0x5ce9454909639D2D17A3F753ce7d93fa0b9aB12E",
+        "scheme": "EIP712",
+        "typedData": data,
+    }
+
+    return auth_message
+
+
+@pytest.fixture(scope="function")
+def valid_eip4361_auth_message():
+    signer = InMemorySigner()
+    siwe_message_data = {
+        "domain": "login.xyz",
+        "address": f"{signer.accounts[0]}",
+        "statement": "Sign-In With Ethereum Example Statement",
+        "uri": "https://login.xyz",
+        "version": "1",
+        "nonce": "bTyXgcQxn2htgkjJn",
+        "chain_id": 1,
+        "issued_at": f"{maya.now().iso8601()}",
+    }
+    siwe_message = SiweMessage(siwe_message_data).prepare_message()
+    signature = signer.sign_message(
+        account=signer.accounts[0], message=siwe_message.encode()
+    )
+    auth_message = {
+        "signature": f"{signature.hex()}",
+        "address": f"{signer.accounts[0]}",
+        "scheme": f"{EvmAuth.AuthScheme.EIP4361.value}",
+        "typedData": f"{siwe_message}",
+    }
 
     return auth_message
 

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -6,8 +6,6 @@ import pytest
 
 from nucypher.policy.conditions.auth.evm import EvmAuth
 from nucypher.policy.conditions.context import (
-    USER_ADDRESS_EIP712_CONTEXT,
-    USER_ADDRESS_EIP4361_CONTEXT,
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
     USER_ADDRESS_SCHEMES,
     _resolve_context_variable,
@@ -135,13 +133,9 @@ def test_user_address_context_invalid_typed_data(
     list(
         zip(
             [
-                USER_ADDRESS_EIP712_CONTEXT,
-                USER_ADDRESS_EIP4361_CONTEXT,
                 USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
             ],
             [
-                EvmAuth.AuthScheme.EIP4361.value,
-                EvmAuth.AuthScheme.EIP712.value,
                 EvmAuth.AuthScheme.EIP712.value,
             ],
         )

--- a/tests/unit/conditions/test_evm_auth.py
+++ b/tests/unit/conditions/test_evm_auth.py
@@ -18,15 +18,10 @@ def test_auth_scheme():
         _ = EvmAuth.from_scheme(scheme="rando")
 
 
-@pytest.mark.parametrize(
-    "valid_user_address_auth_message", [EvmAuth.AuthScheme.EIP712.value], indirect=True
-)
-def test_authenticate_eip712(
-    valid_user_address_auth_message, get_random_checksum_address
-):
-    data = valid_user_address_auth_message["typedData"]
-    signature = valid_user_address_auth_message["signature"]
-    address = valid_user_address_auth_message["address"]
+def test_authenticate_eip712(valid_eip712_auth_message, get_random_checksum_address):
+    data = valid_eip712_auth_message["typedData"]
+    signature = valid_eip712_auth_message["signature"]
+    address = valid_eip712_auth_message["address"]
 
     # invalid data
     invalid_data = dict(data)  # make a copy


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**

Removes `:userAddressEIP4361` and `:userAddressEIP712` which are superfluous and no longer needed. They were only local to the v7.4.x branch so there are no compatibility concerns with their removal. 

We only need `:userAddress` and `:userAddressExternalEIP4361`.

Some testing updates to split EIP4361 and EIP712 test messages, so that in the future, removal of support for EIP712 will be easier.

**Issues fixed/closed:**
> - Fixes #...
- [x] Closes https://github.com/nucypher/sprints/issues/4
- [x]  Closes https://github.com/nucypher/sprints/issues/3 (althout this was basically already done in `v7.4.x` via https://github.com/derekpierre/nucypher/commit/0214471462e03529d236ec009a2a333f63112ca9 in #3508 .

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

I used a `dev` newsfragment because we are removing something we added in 7.4.x.
