### PR TITLE
Do not retry unrecoverable ferveo errors

### DIFF
--- a/newsfragments/3524.bugfix.rst
+++ b/newsfragments/3524.bugfix.rst
@@ -1,0 +1,1 @@
+Do not continuously retry ritual actions when unrecoverable ferveo error occurs during ritual ceremony.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -633,11 +633,10 @@ class Operator(BaseActor):
                 ritual_id=ritual.id,
             )
         except Exception as e:
-            # TODO: Handle this better #3096
             self.log.critical(
                 f"Failed to generate a transcript for ritual #{ritual.id}: {str(e)}"
             )
-            raise e
+            return
 
         # publish the transcript and store the receipt
         self.dkg_storage.store_validators(ritual_id=ritual.id, validators=validators)
@@ -724,10 +723,10 @@ class Operator(BaseActor):
                 transcripts=messages,
             )
         except Exception as e:
-            self.log.debug(
+            self.log.critical(
                 f"Failed to aggregate transcripts for ritual #{ritual.id}: {str(e)}"
             )
-            raise e
+            return
 
         # publish the transcript with network-wide jitter to avoid tx congestion
         time.sleep(random.randint(0, self.AGGREGATION_SUBMISSION_MAX_DELAY))

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -633,8 +633,9 @@ class Operator(BaseActor):
                 ritual_id=ritual.id,
             )
         except Exception as e:
+            stack_trace = traceback.format_stack()
             self.log.critical(
-                f"Failed to generate a transcript for ritual #{ritual.id}: {str(e)}"
+                f"Failed to generate a transcript for ritual #{ritual.id}: {str(e)}\n{stack_trace}"
             )
             return
 
@@ -723,8 +724,9 @@ class Operator(BaseActor):
                 transcripts=messages,
             )
         except Exception as e:
+            stack_trace = traceback.format_stack()
             self.log.critical(
-                f"Failed to aggregate transcripts for ritual #{ritual.id}: {str(e)}"
+                f"Failed to aggregate transcripts for ritual #{ritual.id}: {str(e)}\n{stack_trace}"
             )
             return
 


### PR DESCRIPTION
Required Reviews
2

**What this does**
Do not attempt to retry transcript generation if a cryptographic error bubbles up from ferveo itself.  This is a unrecoverable situation so there is no point in retrying.  Currently, nodes re-attempt transcript generation even in unrecoverable circumstances which temporarily blocks the node from participating in other DKG ceremonies.