### PR TITLE
Local/Onchain Ferveo Key Mismatch Mitigations

### DIFF
--- a/newsfragments/3529.feature.rst
+++ b/newsfragments/3529.feature.rst
@@ -1,1 +1,1 @@
-Prevents nodes from starting up or participating in DKGs if there is a local vs. onchain ferveo key mismatch.  This will assist in alerting node operators who need to relocate or recover thier hosts about the correct procedure.
+Prevents nodes from starting up or participating in DKGs if there is a local vs. onchain ferveo key mismatch.  This will assist in alerting node operators who need to relocate or recover their hosts about the correct procedure.

--- a/newsfragments/3529.feature.rst
+++ b/newsfragments/3529.feature.rst
@@ -1,0 +1,1 @@
+Prevents nodes from starting up or participating in DKGs if there is a local vs. onchain ferveo key mismatch.  This will assist in alerting node operators who need to relocate or recover thier hosts about the correct procedure.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -571,6 +571,22 @@ class Operator(BaseActor):
         Errors raised by this method are not explicitly caught and are expected
         to be handled by the EventActuator.
         """
+
+        local_ferveo_key = self.ritual_power.public_key()
+        onchain_ferveo_key = self.coordinator_agent.get_provider_public_key(
+            ritual_id=ritual_id,
+            provider=self.staking_provider_address,
+        )
+
+        if bytes(local_ferveo_key) != bytes(onchain_ferveo_key):
+            self.log.critical(
+                render_ferveo_key_mismatch_warning(
+                    local_key=local_ferveo_key, onchain_key=onchain_ferveo_key
+                )
+            )
+            self.stop()
+            exit()
+
         if self.checksum_address not in participants:
             message = (
                 f"{self.checksum_address}|{self.wallet_address} "

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -577,8 +577,8 @@ class Operator(BaseActor):
             self.check_ferveo_public_key_match()
         except FerveoKeyMismatch:
             # crash this node
-            self.stop()
-            exit()
+            self.stop(halt_reactor=True)
+            return
 
         if self.checksum_address not in participants:
             message = (

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -57,6 +57,7 @@ from nucypher.blockchain.eth.utils import (
     rpc_endpoint_health_check,
     truncate_checksum_address,
 )
+from nucypher.crypto.ferveo.exceptions import FerveoKeyMismatch
 from nucypher.crypto.powers import (
     CryptoPower,
     RitualisticPower,
@@ -1029,7 +1030,7 @@ class Operator(BaseActor):
                     onchain_key=onchain_ferveo_key,
                 )
                 self.log.critical(message)
-                raise self.ActorError(message)
+                raise FerveoKeyMismatch(message)
 
             else:
                 emitter.message(

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1013,7 +1013,7 @@ class Operator(BaseActor):
             self.check_ferveo_public_key_match()
             emitter.message(
                 f"✓ Provider's DKG participation public key already set for "
-                f"{self.staking_provider_address} on Coordinator {self.coordinator_agent.contract_address}",
+                f"{self.staking_provider_address} on Coordinator {coordinator_address}",
                 color="green",
             )
 

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -994,7 +994,11 @@ class Ursula(Teacher, Character, Operator):
             if self._prometheus_metrics_tracker:
                 self._prometheus_metrics_tracker.stop()
         if halt_reactor:
-            reactor.stop()
+            self.halt_reactor()
+
+    @staticmethod
+    def halt_reactor() -> None:
+        reactor.stop()
 
     def _finalize(self):
         """

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -1252,6 +1252,7 @@ class Ursula(Teacher, Character, Operator):
             known_nodes=known_nodes_info,
             balance_eth=balance_eth,
             block_height=self.ritual_tracker.scanner.get_last_scanned_block(),
+            ferveo_public_key=bytes(self.public_keys(RitualisticPower)).hex(),
         )
 
     def as_external_validator(self) -> Validator:
@@ -1289,6 +1290,7 @@ class LocalUrsulaStatus(NamedTuple):
     known_nodes: Optional[List[RemoteUrsulaStatus]]
     balance_eth: float
     block_height: int
+    ferveo_public_key: str
 
     def to_json(self) -> Dict[str, Any]:
         if self.known_nodes is None:
@@ -1310,6 +1312,7 @@ class LocalUrsulaStatus(NamedTuple):
             known_nodes=known_nodes_json,
             balance_eth=self.balance_eth,
             block_height=self.block_height,
+            ferveo_public_key=self.ferveo_public_key,
         )
 
 

--- a/nucypher/crypto/ferveo/exceptions.py
+++ b/nucypher/crypto/ferveo/exceptions.py
@@ -1,0 +1,5 @@
+class FerveoKeyMismatch(Exception):
+    """
+    Raised when a local ferveo public key does not match the
+    public key published to the Coordinator.
+    """

--- a/nucypher/utilities/warnings.py
+++ b/nucypher/utilities/warnings.py
@@ -1,19 +1,22 @@
 def render_ferveo_key_mismatch_warning(local_key, onchain_key):
     message = f"""
-Local Ferveo public key {bytes(local_key).hex()[:8]} does not match on-chain public key {bytes(onchain_key).hex()[:8]}!
 
-This is a critical error.  Without private keys your node will not be able to provide service for existing DKGs.
+ERROR: The local Ferveo public key {bytes(local_key).hex()[:8]} does not match the on-chain public key {bytes(onchain_key).hex()[:8]}!
 
-If you are relocating your node to a new host you must copy the keystore directory to the new host.
+This is a critical error. Without the original private keys, your node cannot service existing DKGs.
 
-If you do not have a backup of the keystore or have lost your password, you will need to recover your node using the 
-recovery phrase by running:
+IMPORTANT: Running `nucypher ursula init` will generate new private keys, which is not the correct procedure
+for relocating or restoring a TACo node.
+
+To relocate your node to a new host copy the keystore directory (~/.local/share/nucypher) to the new host.
+If you do not have a backup of the original keystore or have lost your password, you will need to recover your 
+node using the recovery phrase assigned during the initial setup by running:
 
 nucypher ursula recover
 
-If you have lost your recovery phrase please open up a support ticket in the Threshold discord server (#taco). 
-Your stake may be slashed but the punishment will be significantly smaller if you disclose the loss and a key material
-handover is completed quickly, which will restore your node and ensure the service is not disrupted.
+If you have lost your recovery phrase: Open a support ticket in the Threshold Discord server (#taco).
+Disclose the loss immediately to minimize penalties. Your stake may be slashed, but the punishment will be significantly
+reduced if a key material handover is completed quickly, ensuring the node's service is not disrupted.
 
 """
     return message

--- a/nucypher/utilities/warnings.py
+++ b/nucypher/utilities/warnings.py
@@ -1,0 +1,19 @@
+def render_ferveo_key_mismatch_warning(local_key, onchain_key):
+    message = f"""
+Local Ferveo public key {bytes(local_key).hex()[:8]} does not match on-chain public key {bytes(onchain_key).hex()[:8]}!
+
+This is a critical error.  Without private keys your node will not be able to provide service for existing DKGs.
+
+If you are relocating your node to a new host you must copy the keystore directory to the new host.
+
+If you do not have a backup of the keystore or have lost your password, you will need to recover your node using the 
+recovery phrase by running:
+
+nucypher ursula recover
+
+If you have lost your recovery phrase please open up a support ticket in the Threshold discord server (#taco). 
+Your stake may be slashed but the punishment will be significantly smaller if you disclose the loss and a key material
+handover is completed quickly, which will restore your node and ensure the service is not disrupted.
+
+"""
+    return message

--- a/tests/acceptance/actors/test_dkg_failures.py
+++ b/tests/acceptance/actors/test_dkg_failures.py
@@ -123,9 +123,13 @@ def test_dkg_failure_with_ferveo_key_mismatch(
         yield clock.advance(interval)
         yield testerchain.time_travel(seconds=1)
 
-    assert log_messages[0] == render_ferveo_key_mismatch_warning(
-        bytes(new_public_key), bytes(onchain_public_key)
+    assert (
+        render_ferveo_key_mismatch_warning(
+            bytes(new_public_key), bytes(onchain_public_key)
+        )
+        in log_messages
     )
 
     testerchain.tx_machine.stop()
     assert not testerchain.tx_machine.running
+    globalLogPublisher.removeObserver(log_trapper)

--- a/tests/acceptance/actors/test_dkg_failures.py
+++ b/tests/acceptance/actors/test_dkg_failures.py
@@ -1,0 +1,131 @@
+import pytest
+import pytest_twisted
+from twisted.logger import globalLogPublisher
+
+from nucypher.blockchain.eth.signers import InMemorySigner
+from nucypher.crypto.keypairs import RitualisticKeypair
+from nucypher.crypto.powers import RitualisticPower
+from nucypher.utilities.warnings import render_ferveo_key_mismatch_warning
+
+
+@pytest.fixture(scope="module")
+def ritual_id():
+    return 0
+
+
+@pytest.fixture(scope="module")
+def dkg_size():
+    return 4
+
+
+@pytest.fixture(scope="module")
+def duration():
+    return 48 * 60 * 60
+
+
+@pytest.fixture(scope="module")
+def plaintext():
+    return "peace at dawn"
+
+
+@pytest.fixture(scope="module")
+def interval(testerchain):
+    return testerchain.tx_machine._task.interval
+
+
+@pytest.fixture(scope="module")
+def signer():
+    return InMemorySigner()
+
+
+@pytest.fixture(scope="module")
+def cohort(testerchain, clock, coordinator_agent, ursulas, dkg_size):
+    nodes = list(sorted(ursulas[:dkg_size], key=lambda x: int(x.checksum_address, 16)))
+    assert len(nodes) == dkg_size
+    for node in nodes:
+        node.ritual_tracker.task._task.clock = clock
+        node.ritual_tracker.start()
+    return nodes
+
+
+@pytest_twisted.inlineCallbacks
+def test_dkg_failure_with_ferveo_key_mismatch(
+    coordinator_agent,
+    ritual_id,
+    cohort,
+    clock,
+    interval,
+    testerchain,
+    initiator,
+    global_allow_list,
+    duration,
+    accounts,
+    ritual_token,
+):
+
+    bad_ursula = cohort[0]
+    old_public_key = bad_ursula.public_keys(RitualisticPower)
+    new_keypair = RitualisticKeypair()
+    new_public_key = new_keypair.pubkey
+
+    bad_ursula._crypto_power._CryptoPower__power_ups[RitualisticPower].keypair = (
+        new_keypair
+    )
+
+    assert bytes(old_public_key) != bytes(new_public_key)
+    assert bytes(old_public_key) != bytes(bad_ursula.public_keys(RitualisticPower))
+    assert bytes(new_public_key) == bytes(bad_ursula.public_keys(RitualisticPower))
+
+    onchain_public_key = coordinator_agent.get_provider_public_key(
+        ritual_id=ritual_id, provider=bad_ursula.checksum_address
+    )
+
+    assert bytes(onchain_public_key) == bytes(old_public_key)
+    assert bytes(onchain_public_key) != bytes(new_public_key)
+    assert bytes(onchain_public_key) != bytes(bad_ursula.public_keys(RitualisticPower))
+    print(f"BAD URSULA: {bad_ursula.checksum_address}")
+
+    print("==================== INITIALIZING ====================")
+
+    cohort_staking_provider_addresses = list(u.checksum_address for u in cohort)
+
+    # Approve the ritual token for the coordinator agent to spend
+    amount = coordinator_agent.get_ritual_initiation_cost(
+        providers=cohort_staking_provider_addresses, duration=duration
+    )
+    ritual_token.approve(
+        coordinator_agent.contract_address,
+        amount,
+        sender=accounts[initiator.transacting_power.account],
+    )
+
+    receipt = coordinator_agent.initiate_ritual(
+        providers=cohort_staking_provider_addresses,
+        authority=initiator.transacting_power.account,
+        duration=duration,
+        access_controller=global_allow_list.address,
+        transacting_power=initiator.transacting_power,
+    )
+
+    testerchain.time_travel(seconds=1)
+    testerchain.wait_for_receipt(receipt["transactionHash"])
+
+    log_messages = []
+
+    def log_trapper(event):
+        log_messages.append(event["log_format"])
+
+    globalLogPublisher.addObserver(log_trapper)
+
+    print("==================== AWAITING DKG FAILURE ====================")
+    while len(log_messages) == 0:
+
+        yield clock.advance(interval)
+        yield testerchain.time_travel(seconds=1)
+
+    assert log_messages[0] == render_ferveo_key_mismatch_warning(
+        bytes(new_public_key), bytes(onchain_public_key)
+    )
+
+    testerchain.tx_machine.stop()
+    assert not testerchain.tx_machine.running

--- a/tests/acceptance/cli/test_ursula_run.py
+++ b/tests/acceptance/cli/test_ursula_run.py
@@ -6,6 +6,7 @@ import pytest_twisted as pt
 from eth_account import Account
 from twisted.internet import threads
 
+from nucypher.blockchain.eth.actors import Operator
 from nucypher.characters.base import Learner
 from nucypher.cli.literature import NO_CONFIGURATIONS_ON_DISK
 from nucypher.cli.main import nucypher_cli
@@ -35,6 +36,10 @@ def test_missing_configuration_file(_default_filepath_mock, click_runner):
 def test_run_lone_default_development_ursula(click_runner, mocker, ursulas, accounts):
     deploy_port = select_test_port()
     operator_address = ursulas[0].operator_address
+
+    # mock key mismatch detection
+    mocker.patch.object(Operator, "check_ferveo_public_key_match", return_value=None)
+
     args = (
         "ursula",
         "run",  # Stat Ursula Command

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -836,3 +836,8 @@ def mock_async_hooks(mocker):
     )
 
     return hooks
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_halt_reactor(session_mocker):
+    session_mocker.patch.object(Ursula, "halt_reactor")

--- a/tests/integration/actors/test_integration_operator.py
+++ b/tests/integration/actors/test_integration_operator.py
@@ -6,6 +6,7 @@ from web3 import Web3
 from nucypher.blockchain.eth.actors import BaseActor, Operator
 from nucypher.blockchain.eth.clients import EthereumClient
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.crypto.powers import RitualisticPower
 
 
 @pytest.fixture(scope="function")
@@ -116,6 +117,13 @@ def test_operator_block_until_ready_success(
         get_random_checksum_address(),
         ursula.checksum_address,
     ]
+
+    # mock key commitment
+    mocker.patch.object(
+        ursula.coordinator_agent,
+        "get_provider_public_key",
+        return_value=bytes(ursula.public_keys(RitualisticPower)),
+    )
 
     log_messages = []
 


### PR DESCRIPTION
**Type of PR:**
- [X] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
- prevents nodes from starting up of there is a local vs. onchain ferveo public key mismatch
- intentionally crashes nodes participating in DKG ceremonies if there is a local vs. onchain ferveo public key mismatch
- renders a detailed warning for node operators with a ferveo key mismatch
- exposes ferveo public key hex in JSON node status endpoint
- reproduces `InvalidTranscriptAggregate` as observed on mainnet in an automated test due to ferveo key mismatch
- introduces automated testing/mocking for startup and DKG prevention in the case of key mismatch
- removes "precomputed" ferveo variant test cases

**Why it's needed:**

Ferveo private keys are expected to be secured by node operators following the documented protocol. 

Without the private keys, nodes are unable to participate in new DKGs and are also unable to service any existing DKGs they have previously participated in.  This is a node operator protocol violation and slashable offense.  Preventing these nodes from starting up will assist in alerting node operators to their violation and guide them to the correct recovery procedure.


