### PR TITLE
Fix ATxM use of web3 instance provided by `nucypher`

### DIFF
--- a/newsfragments/3531.bugfix.rst
+++ b/newsfragments/3531.bugfix.rst
@@ -1,0 +1,1 @@
+ATxM instance did not pass correct web3 instance to underlying strategies.

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -94,7 +94,7 @@ class EthereumClient:
             self.add_middleware(RetryRequestMiddleware)
 
         # poa middleware
-        chain_id = int(self.chain_id)
+        chain_id = self.chain_id
         is_poa = chain_id in POA_CHAINS
 
         self.log.debug(

--- a/nucypher/blockchain/eth/clients.py
+++ b/nucypher/blockchain/eth/clients.py
@@ -8,10 +8,12 @@ from web3 import Web3
 from web3._utils.threads import Timeout
 from web3.contract.contract import Contract
 from web3.exceptions import TimeExhausted, TransactionNotFound
+from web3.middleware import geth_poa_middleware, simple_cache_middleware
 from web3.types import TxReceipt, Wei
 
 from nucypher.blockchain.eth.constants import (
     AVERAGE_BLOCK_TIME_IN_SECONDS,
+    POA_CHAINS,
     PUBLIC_CHAINS,
 )
 from nucypher.blockchain.middleware.retry import (
@@ -79,6 +81,7 @@ class EthereumClient:
         self._add_default_middleware()
 
     def _add_default_middleware(self):
+        # retry request middleware
         endpoint_uri = getattr(self.w3.provider, "endpoint_uri", "")
         if "infura" in endpoint_uri:
             self.log.debug("Adding Infura RPC retry middleware to client")
@@ -89,6 +92,22 @@ class EthereumClient:
         else:
             self.log.debug("Adding RPC retry middleware to client")
             self.add_middleware(RetryRequestMiddleware)
+
+        # poa middleware
+        chain_id = int(self.chain_id)
+        is_poa = chain_id in POA_CHAINS
+
+        self.log.debug(
+            f"Blockchain: {self.chain_name} (chain_id={chain_id}, poa={is_poa})"
+        )
+        if is_poa:
+            # proof-of-authority blockchain
+            self.log.debug("Injecting POA middleware at layer 0")
+            self.inject_middleware(geth_poa_middleware, layer=0)
+
+        # simple cache middleware
+        self.log.debug("Adding simple_cache_middleware")
+        self.add_middleware(simple_cache_middleware)
 
     @property
     def chain_name(self) -> str:

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -310,6 +310,10 @@ class BlockchainInterface:
         # self.log.debug(f"Gas strategy currently reports a gas price of {gwei_gas_price} gwei.")
 
     def connect(self):
+        if self.is_connected:
+            # safety check - connect was already previously called
+            return
+
         endpoint = self.endpoint
         self.log.info(f"Using external Web3 Provider '{self.endpoint}'")
 
@@ -322,7 +326,6 @@ class BlockchainInterface:
         if self._provider is NO_BLOCKCHAIN_CONNECTION:
             raise self.NoProvider("There are no configured blockchain providers")
 
-        # Connect if not connected
         try:
             self.w3 = self.Web3(provider=self._provider)
             # client mutates w3 instance (configures middleware etc.)

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -17,12 +17,10 @@ from eth_utils import to_checksum_address
 from web3 import HTTPProvider, IPCProvider, Web3, WebsocketProvider
 from web3.contract.contract import Contract, ContractConstructor, ContractFunction
 from web3.exceptions import TimeExhausted
-from web3.middleware import geth_poa_middleware, simple_cache_middleware
 from web3.providers import BaseProvider
 from web3.types import TxParams, TxReceipt
 
 from nucypher.blockchain.eth.clients import EthereumClient
-from nucypher.blockchain.eth.constants import POA_CHAINS
 from nucypher.blockchain.eth.decorators import validate_checksum_address
 from nucypher.blockchain.eth.providers import (
     _get_http_provider,
@@ -241,14 +239,7 @@ class BlockchainInterface:
         self.w3 = NO_BLOCKCHAIN_CONNECTION
         self.client: EthereumClient = NO_BLOCKCHAIN_CONNECTION
         self.is_light = light
-
-        speedup_strategy = ExponentialSpeedupStrategy(
-            w3=self.w3,
-            min_time_between_speedups=120,
-        )  # speedup txs if not mined after 2 mins.
-        self.tx_machine = AutomaticTxMachine(
-            w3=self.w3, tx_exec_timeout=self.TIMEOUT, strategies=[speedup_strategy]
-        )
+        self.tx_machine = None
 
         # TODO: Not ready to give users total flexibility. Let's stick for the moment to known values. See #2447
         if gas_strategy not in (
@@ -292,24 +283,6 @@ class BlockchainInterface:
                 gas_strategy = cls.GAS_STRATEGIES[cls.DEFAULT_GAS_STRATEGY]
         return gas_strategy
 
-    def attach_middleware(self):
-        chain_id = int(self.client.chain_id)
-        self.poa = chain_id in POA_CHAINS
-
-        self.log.debug(
-            f"Blockchain: {self.client.chain_name} (chain_id={chain_id}, poa={self.poa})"
-        )
-
-        # For use with Proof-Of-Authority test-blockchains
-        if self.poa is True:
-            self.log.debug("Injecting POA middleware at layer 0")
-            self.client.inject_middleware(geth_poa_middleware, layer=0)
-
-        self.log.debug("Adding simple_cache_middleware")
-        self.client.add_middleware(simple_cache_middleware)
-
-        # TODO:  See #2770
-        # self.configure_gas_strategy()
 
     def configure_gas_strategy(self, gas_strategy: Optional[Callable] = None) -> None:
         if gas_strategy:
@@ -352,8 +325,17 @@ class BlockchainInterface:
         # Connect if not connected
         try:
             self.w3 = self.Web3(provider=self._provider)
-            self.tx_machine.w3 = self.w3  # share this web3 instance with the tracker
+            # client mutates w3 instance (configures middleware etc.)
             self.client = EthereumClient(w3=self.w3)
+
+            # web3 instance fully configured; share instance with ATxM and respective strategies
+            speedup_strategy = ExponentialSpeedupStrategy(
+                w3=self.w3,
+                min_time_between_speedups=120,
+            )  # speedup txs if not mined after 2 mins.
+            self.tx_machine = AutomaticTxMachine(
+                w3=self.w3, tx_exec_timeout=self.TIMEOUT, strategies=[speedup_strategy]
+            )
         except requests.ConnectionError:  # RPC
             raise self.ConnectionFailed(
                 f"Connection Failed - {str(self.endpoint)} - is RPC enabled?"
@@ -362,8 +344,6 @@ class BlockchainInterface:
             raise self.ConnectionFailed(
                 f"Connection Failed - {str(self.endpoint)} - is IPC enabled?"
             )
-        else:
-            self.attach_middleware()
 
         return self.is_connected
 

--- a/tests/unit/test_ethereum_client.py
+++ b/tests/unit/test_ethereum_client.py
@@ -10,10 +10,10 @@ CHAIN_ID = 23
 @pytest.mark.parametrize("chain_id_return_value", [hex(CHAIN_ID), CHAIN_ID])
 def test_cached_chain_id(mocker, chain_id_return_value):
     web3_mock = mocker.MagicMock()
-    mock_client = EthereumClient(w3=web3_mock)
-
     chain_id_property_mock = PropertyMock(return_value=chain_id_return_value)
     type(web3_mock.eth).chain_id = chain_id_property_mock
+
+    mock_client = EthereumClient(w3=web3_mock)
 
     assert mock_client.chain_id == CHAIN_ID
     chain_id_property_mock.assert_called_once()

--- a/tests/unit/test_web3_clients.py
+++ b/tests/unit/test_web3_clients.py
@@ -15,10 +15,10 @@ CHAIN_ID = 11155111  # pretend to be sepolia
 @pytest.mark.parametrize("chain_id_return_value", [hex(CHAIN_ID), CHAIN_ID])
 def test_cached_chain_id(mocker, chain_id_return_value):
     web3_mock = mocker.MagicMock()
-    mock_client = EthereumClient(w3=web3_mock)
-
     chain_id_property_mock = PropertyMock(return_value=chain_id_return_value)
     type(web3_mock.eth).chain_id = chain_id_property_mock
+
+    mock_client = EthereumClient(w3=web3_mock)
 
     assert mock_client.chain_id == CHAIN_ID
     chain_id_property_mock.assert_called_once()


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**

The web3 variable on ATxM instance was being set directly, to update it, but this update did not propagate to underlying strategies. 

The ATxM instance should only be created once the properly configured web3 instance is available in the BlockchainInterface.connect() function.

This does not solve the POA issues we've been observing, but it was discovered during investigation.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
