### PR TITLE
Improves comms and key mismatch prevention while using the `init` CLI

### DIFF
--- a/newsfragments/3533.feature.rst
+++ b/newsfragments/3533.feature.rst
@@ -1,0 +1,2 @@
+Prevent new nodes from initialization if the operator already has published a ferveo public key onchain.
+Improves information density and communication of keystore security obligations while using the init CLI.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1018,7 +1018,7 @@ class Operator(BaseActor):
                 color="green",
             )
 
-    def check_ferveo_public_key_match(self):
+    def check_ferveo_public_key_match(self) -> None:
         latest_ritual_id = self.coordinator_agent.number_of_rituals()
         local_ferveo_key = self.ritual_power.public_key()
         onchain_ferveo_key = self.coordinator_agent.get_provider_public_key(

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -317,8 +317,40 @@ def init(general_config, config_options, force, config_root, key_material):
     """Create a new Ursula node configuration."""
     emitter = setup_emitter(general_config, config_options.operator_address)
     _pre_launch_warnings(emitter, dev=None, force=force)
+
     if not config_root:
         config_root = general_config.config_root
+
+    config_path = Path(config_root)
+    keystore_path = config_path / Keystore._DEFAULT_DIR
+    if config_path.exists() and keystore_path.exists():
+        click.clear()
+        emitter.echo(
+            f"There are existing secret keys in '{keystore_path}'.\n"
+            "The 'init' command is a one-time operation, do not run it again.\n\n",
+            color="red",
+        )
+
+        emitter.echo(
+            "To review your existing configuration, run:\n\n"
+            "nucypher ursula config\n\n"
+            "To run your node with the existing configuration, run:\n\n"
+            "nucypher ursula run\n",
+            color="cyan",
+        )
+        return click.get_current_context().exit(1)
+
+    click.clear()
+    emitter.echo(
+        "Hello Operator, welcome on board :-) \n\n"
+        "NOTE: Initializing a new Ursula node configuration is a one-time operation\n"
+        "for the lifetime of your node.  This is a two-step process:\n\n"
+        "1. Creating a password to encrypt your operator keys\n"
+        "2. Securing a taco node seed phase\n\n"
+        "Please follow the prompts.",
+        color="cyan",
+    )
+
     if not config_options.eth_endpoint:
         raise click.BadOptionUsage(
             "--eth-endpoint",

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -321,13 +321,12 @@ def init(general_config, config_options, force, config_root, key_material):
     if not config_root:
         config_root = general_config.config_root
 
-    config_path = Path(config_root)
-    keystore_path = config_path / Keystore._DEFAULT_DIR
-    if config_path.exists() and keystore_path.exists():
+    keystore_path = Path(config_root) / Keystore._DIR_NAME
+    if keystore_path.exists() and any(keystore_path.iterdir()):
         click.clear()
         emitter.echo(
             f"There are existing secret keys in '{keystore_path}'.\n"
-            "The 'init' command is a one-time operation, do not run it again.\n\n",
+            "The 'init' command is a one-time operation, do not run it again.\n",
             color="red",
         )
 

--- a/nucypher/cli/config.py
+++ b/nucypher/cli/config.py
@@ -1,7 +1,5 @@
 # noinspection Mypy
 
-
-
 import os
 
 import click

--- a/nucypher/cli/literature.py
+++ b/nucypher/cli/literature.py
@@ -53,8 +53,8 @@ DEFAULT_TO_LONE_CONFIG_FILE = "Defaulting to {config_class} configuration file: 
 
 #  Authentication
 PASSWORD_COLLECTION_NOTICE = """
-Please provide a password to lock Operator keys.
-Do not forget this password, and ideally store it using a password manager.
+Please provide a password to encrypt your node's private keys.
+Do not forget this password. Ideally generate and store this password using a password manager.
 """
 
 COLLECT_ETH_PASSWORD = "Enter ethereum account password ({checksum_address})"

--- a/nucypher/cli/painting/help.py
+++ b/nucypher/cli/painting/help.py
@@ -3,6 +3,7 @@ from constant_sorrow.constants import NO_KEYSTORE_ATTACHED
 
 from nucypher.characters.banners import NUCYPHER_BANNER
 from nucypher.config.constants import DEFAULT_CONFIG_ROOT, USER_LOG_DIR
+from nucypher.crypto.powers import RitualisticPower
 
 
 def echo_version(ctx, param, value):
@@ -30,17 +31,21 @@ def paint_new_installation_help(emitter, new_configuration, filepath):
     character_config_class = new_configuration.__class__
     character_name = character_config_class.NAME.lower()
     if new_configuration.keystore != NO_KEYSTORE_ATTACHED:
-        maybe_public_key = new_configuration.keystore.id
+        ritual_power = new_configuration.keystore.derive_crypto_power(RitualisticPower)
+        ferveo_public_key = bytes(ritual_power.public_key()).hex()
+        maybe_public_key = f"{ferveo_public_key[:8]}...{ferveo_public_key[-8:]}"
     else:
         maybe_public_key = "(no keystore attached)"
+
     emitter.message("Generated keystore", color="green")
     emitter.message(
         f"""
     
-Public Key:   {maybe_public_key}
+DKG Public Key:   {maybe_public_key}
 Path to Keystore: {new_configuration.keystore_dir}
+Path to Config:   {filepath}
+Path to Logs:     {USER_LOG_DIR}
 
-- You can share your public key with anyone. Others need it to interact with you.
 - Never share secret keys with anyone! 
 - Backup your keystore! Character keys are required to interact with the protocol!
 - Remember your password! Without the password, it's impossible to decrypt the key!
@@ -48,18 +53,6 @@ Path to Keystore: {new_configuration.keystore_dir}
 """
     )
 
-    default_config_filepath = True
-    if new_configuration.default_filepath() != filepath:
-        default_config_filepath = False
-    emitter.message(f'Generated configuration file at {"default" if default_config_filepath else "non-default"} '
-                    f'filepath {filepath}', color='green')
-
-    # add hint about --config-file
-    if not default_config_filepath:
-        emitter.message(f'* NOTE: for a non-default configuration filepath use `--config-file "{filepath}"` '
-                        f'with subsequent `{character_name}` CLI commands', color='yellow')
-
-    # Ursula
     if character_name == 'ursula':
         hint = '''
 * Review configuration  -> nucypher ursula config

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -593,6 +593,7 @@ class CharacterConfiguration(BaseConfiguration):
         """Shortcut: Hook-up a new initial installation and configuration."""
         node_config = cls(dev_mode=False, *args, **kwargs)
         node_config.initialize(key_material=key_material, password=password)
+        node_config.keystore.unlock(password)
         return node_config
 
     def cleanup(self) -> None:

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -590,7 +590,9 @@ class CharacterConfiguration(BaseConfiguration):
     def generate(
         cls, password: str, key_material: Optional[bytes] = None, *args, **kwargs
     ):
-        """Shortcut: Hook-up a new initial installation and configuration."""
+        """
+        Generates local directories, private keys, and initial configuration for a new node.
+        """
         node_config = cls(dev_mode=False, *args, **kwargs)
         node_config.initialize(key_material=key_material, password=password)
         node_config.keystore.unlock(password)
@@ -787,7 +789,7 @@ class CharacterConfiguration(BaseConfiguration):
                 power_ups.append(power_up)
         return power_ups
 
-    def initialize(self, password: str, key_material: Optional[bytes] = None) -> str:
+    def initialize(self, password: str, key_material: Optional[bytes] = None) -> Path:
         """Initialize a new configuration and write installation files to disk."""
 
         # Development

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -102,7 +102,7 @@ class UrsulaConfiguration(CharacterConfiguration):
             self.operator_address
         )
 
-        if staking_provider_address != NULL_ADDRESS:
+        if staking_provider_address and staking_provider_address != NULL_ADDRESS:
             if coordinator_agent.is_provider_public_key_set(staking_provider_address):
                 message = (
                     f"Operator {self.operator_address} has already published a public key.\n"

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -5,13 +5,22 @@ from typing import Dict, List, Optional
 from cryptography.x509 import Certificate
 from eth_utils import is_checksum_address
 
+from nucypher.blockchain.eth.agents import (
+    ContractAgency,
+    CoordinatorAgent,
+    TACoChildApplicationAgent,
+)
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.config.base import CharacterConfiguration
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_ALICE_ETH_PASSWORD,
     NUCYPHER_ENVVAR_BOB_ETH_PASSWORD,
     NUCYPHER_ENVVAR_OPERATOR_ETH_PASSWORD,
 )
+from nucypher.utilities.emitters import StdoutEmitter
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
+from nucypher.utilities.warnings import render_lost_seed_phrase_message
 
 
 class UrsulaConfiguration(CharacterConfiguration):
@@ -66,6 +75,50 @@ class UrsulaConfiguration(CharacterConfiguration):
                 # convert chain from string key (for json) to integer
                 self.condition_blockchain_endpoints[int(chain)] = blockchain_endpoint
         self.configure_condition_blockchain_endpoints()
+
+    def initialize(self, *args, **kwargs) -> Path:
+        """
+        Check if the coordinator public key is set and prevent the creation of a new node if it is.
+        """
+        emitter = StdoutEmitter()
+        emitter.echo("Checking operator account status...")
+
+        BlockchainInterfaceFactory.get_or_create_interface(
+            endpoint=self.polygon_endpoint
+        )
+        coordinator_agent = ContractAgency.get_agent(
+            CoordinatorAgent,
+            blockchain_endpoint=self.polygon_endpoint,
+            registry=self.registry,
+        )
+
+        application_agent = ContractAgency.get_agent(
+            TACoChildApplicationAgent,
+            blockchain_endpoint=self.polygon_endpoint,
+            registry=self.registry,
+        )
+
+        staking_provider_address = application_agent.staking_provider_from_operator(
+            self.operator_address
+        )
+
+        if staking_provider_address != NULL_ADDRESS:
+            if coordinator_agent.is_provider_public_key_set(staking_provider_address):
+                message = (
+                    f"Operator {self.operator_address} has already published a public key.\n"
+                    f"It is not permitted to create a new node with this operator address."
+                    f"{render_lost_seed_phrase_message()}"
+                )
+                self.log.critical(message)
+                raise self.ConfigurationError(message)
+        else:
+            emitter.echo(
+                "NOTE: Your operator is not bonded to a staking provider. \n"
+                "Bond the operator to a staking provider on the threshold dashboard.",
+                color="cyan",
+            )
+
+        return super().initialize(*args, **kwargs)
 
     def configure_condition_blockchain_endpoints(self) -> None:
         """Configure default condition provider URIs for eth and polygon network."""

--- a/nucypher/config/characters.py
+++ b/nucypher/config/characters.py
@@ -98,25 +98,28 @@ class UrsulaConfiguration(CharacterConfiguration):
             registry=self.registry,
         )
 
-        staking_provider_address = application_agent.staking_provider_from_operator(
-            self.operator_address
-        )
-
-        if staking_provider_address and staking_provider_address != NULL_ADDRESS:
-            if coordinator_agent.is_provider_public_key_set(staking_provider_address):
-                message = (
-                    f"Operator {self.operator_address} has already published a public key.\n"
-                    f"It is not permitted to create a new node with this operator address."
-                    f"{render_lost_seed_phrase_message()}"
-                )
-                self.log.critical(message)
-                raise self.ConfigurationError(message)
-        else:
-            emitter.echo(
-                "NOTE: Your operator is not bonded to a staking provider. \n"
-                "Bond the operator to a staking provider on the threshold dashboard.",
-                color="cyan",
+        if self.operator_address:
+            staking_provider_address = application_agent.staking_provider_from_operator(
+                self.operator_address
             )
+
+            if staking_provider_address and staking_provider_address != NULL_ADDRESS:
+                if coordinator_agent.is_provider_public_key_set(
+                    staking_provider_address
+                ):
+                    message = (
+                        f"Operator {self.operator_address} has already published a public key.\n"
+                        f"It is not permitted to create a new node with this operator address."
+                        f"{render_lost_seed_phrase_message()}"
+                    )
+                    self.log.critical(message)
+                    raise self.ConfigurationError(message)
+            else:
+                emitter.echo(
+                    "NOTE: Your operator is not bonded to a staking provider. \n"
+                    "Bond the operator to a staking provider on the threshold dashboard.",
+                    color="cyan",
+                )
 
         return super().initialize(*args, **kwargs)
 

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -380,20 +380,49 @@ class Keystore:
 
         # notification
         emitter = StdoutEmitter()
-        emitter.message(
-            "Backup your seed words, you will not be able to view them again.\n"
+
+        emitter.echo(
+            "\nNOTE: Next, you will be assigned a taco node seed phase. This seed phase is used to\n"
+            "generate your keystore. You will need this seed phase to recover your keystore\n"
+            "in the future. Please write down the seed phase and keep it in a safe place.\n",
+            color="cyan",
         )
-        emitter.message(f"{__words}\n", color="cyan")
+
+        emitter.message(
+            "IMPORTANT: Backup your seed phrase, you will not be able to view them again.\n"
+            "You can use these words to restore your keystore in the future in case of loss of\n"
+            "your keystore files or password. Do not share these words with anyone.\n",
+            color="yellow",
+        )
+
+        emitter.message(
+            "WARNING: If you lose your seed phase and also lose access to your keystore/password "
+            "your stake will be slashed.\n",
+            color="red",
+        )
+        click.confirm("Reveal seed phase?", default=False, abort=True)
+        click.clear()
+
+        formatted_words = "\n".join(
+            f"{i} {w}" for i, w in enumerate(__words.split(), start=1)
+        )
+        emitter.message(f"{formatted_words}\n", color="green")
         if not click.confirm("Have you backed up your seed phrase?"):
             emitter.message('Keystore generation aborted.', color='red')
             raise click.Abort()
         click.clear()
 
         # confirmation
-        __response = click.prompt("Confirm seed words")
-        if __response != __words:
-            raise ValueError('Incorrect seed word confirmation. No keystore has been created, try again.')
+        while True:
+            __response = click.prompt("Confirm seed words (space separated)")
+            if __response != __words:
+                emitter.message(
+                    "Seed words do not match. Please try again.", color="red"
+                )
+                continue
+            break
         click.clear()
+        emitter.echo("Seed phrase confirmed. Generating keystore...", color="green")
 
     @property
     def id(self) -> str:

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -223,7 +223,8 @@ class Keystore:
     _ID_SIZE = 32
 
     # Filepath
-    _DEFAULT_DIR: Path = DEFAULT_CONFIG_ROOT / 'keystore'
+    _DIR_NAME = "keystore"
+    _DEFAULT_DIR: Path = DEFAULT_CONFIG_ROOT / _DIR_NAME
     _DELIMITER = '-'
     _SUFFIX = 'priv'
 

--- a/nucypher/utilities/warnings.py
+++ b/nucypher/utilities/warnings.py
@@ -1,3 +1,22 @@
+from nucypher.config.constants import DEFAULT_CONFIG_ROOT
+
+
+def render_lost_seed_phrase_message():
+    message = f"""
+    
+To relocate your node to a new host copy the configuration directory ({DEFAULT_CONFIG_ROOT}) to the new host.
+If you do not have a backup of the original keystore or have lost your password, you will need to recover your 
+node using the recovery phrase assigned during the initial setup by running:
+
+nucypher ursula recover
+
+If you have lost your recovery phrase: Open a support ticket in the Threshold Discord server (#taco).
+Disclose the loss immediately to minimize penalties. Your stake may be slashed, but the punishment will be significantly
+reduced if a key material handover is completed quickly, ensuring the node's service is not disrupted.
+"""
+    return message
+
+
 def render_ferveo_key_mismatch_warning(local_key, onchain_key):
     message = f"""
 
@@ -8,15 +27,7 @@ This is a critical error. Without the original private keys, your node cannot se
 IMPORTANT: Running `nucypher ursula init` will generate new private keys, which is not the correct procedure
 for relocating or restoring a TACo node.
 
-To relocate your node to a new host copy the keystore directory (~/.local/share/nucypher) to the new host.
-If you do not have a backup of the original keystore or have lost your password, you will need to recover your 
-node using the recovery phrase assigned during the initial setup by running:
-
-nucypher ursula recover
-
-If you have lost your recovery phrase: Open a support ticket in the Threshold Discord server (#taco).
-Disclose the loss immediately to minimize penalties. Your stake may be slashed, but the punishment will be significantly
-reduced if a key material handover is completed quickly, ensuring the node's service is not disrupted.
+{render_lost_seed_phrase_message()}
 
 """
     return message

--- a/tests/acceptance/cli/test_ursula_run.py
+++ b/tests/acceptance/cli/test_ursula_run.py
@@ -6,7 +6,11 @@ import pytest_twisted as pt
 from eth_account import Account
 from twisted.internet import threads
 
-from nucypher.blockchain.eth.actors import Operator
+from nucypher.blockchain.eth.agents import (
+    CoordinatorAgent,
+    TACoApplicationAgent,
+    TACoChildApplicationAgent,
+)
 from nucypher.characters.base import Learner
 from nucypher.cli.literature import NO_CONFIGURATIONS_ON_DISK
 from nucypher.cli.main import nucypher_cli
@@ -14,6 +18,8 @@ from nucypher.config.characters import UrsulaConfiguration
 from nucypher.config.constants import (
     TEMPORARY_DOMAIN_NAME,
 )
+from nucypher.crypto.ferveo.exceptions import FerveoKeyMismatch
+from nucypher.crypto.powers import RitualisticPower
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
 from tests.constants import (
     INSECURE_DEVELOPMENT_PASSWORD,
@@ -33,12 +39,24 @@ def test_missing_configuration_file(_default_filepath_mock, click_runner):
 
 
 @pt.inlineCallbacks
-def test_run_lone_default_development_ursula(click_runner, mocker, ursulas, accounts):
+def test_ursula_startup(click_runner, mocker, accounts, testerchain):
     deploy_port = select_test_port()
-    operator_address = ursulas[0].operator_address
+    operator_address = accounts[-1].address
 
-    # mock key mismatch detection
-    mocker.patch.object(Operator, "check_ferveo_public_key_match", return_value=None)
+    mocker.patch.object(
+        TACoApplicationAgent,
+        "get_staking_provider_from_operator",
+        return_value=accounts[-2].address,
+    )
+    mocker.patch.object(
+        TACoChildApplicationAgent,
+        "staking_provider_from_operator",
+        return_value=accounts[-2].address,
+    )
+    mocker.patch.object(CoordinatorAgent, "set_provider_public_key", return_value=None)
+
+    account = Account.from_key(private_key=accounts[operator_address].private_key)
+    mocker.patch.object(Account, "create", return_value=account)
 
     args = (
         "ursula",
@@ -59,9 +77,19 @@ def test_run_lone_default_development_ursula(click_runner, mocker, ursulas, acco
         "memory://",
     )
 
-    account = Account.from_key(private_key=accounts[operator_address].private_key)
-    mocker.patch.object(Account, "create", return_value=account)
+    # Trigger a ferveo key mismatch
+    mocker.patch.object(CoordinatorAgent, "get_provider_public_key", return_value=42)
+    with pytest.raises(FerveoKeyMismatch):
+        result = yield threads.deferToThread(
+            click_runner.invoke,
+            nucypher_cli,
+            args,
+            catch_exceptions=False,
+            input=INSECURE_DEVELOPMENT_PASSWORD + "\n",
+        )
 
+    # Normal startup
+    mocker.patch.object(RitualisticPower, "public_key", return_value=42)
     result = yield threads.deferToThread(
         click_runner.invoke,
         nucypher_cli,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -870,6 +870,11 @@ def clear_config_root(temp_config_root):
     if temp_config_root.exists():
         print(f"Removing {temp_config_root}")
         shutil.rmtree(Path("/tmp/nucypher-test"))
+    yield
+    if DEFAULT_CONFIG_ROOT.exists():
+        raise RuntimeError(
+            f"{DEFAULT_CONFIG_ROOT} was used by a test.  This is not permitted, please mock."
+        )
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -34,7 +34,10 @@ from nucypher.config.characters import (
     BobConfiguration,
     UrsulaConfiguration,
 )
-from nucypher.config.constants import DEFAULT_CONFIG_ROOT, TEMPORARY_DOMAIN_NAME
+from nucypher.config.constants import (
+    APP_DIR,
+    TEMPORARY_DOMAIN_NAME,
+)
 from nucypher.crypto.ferveo import dkg
 from nucypher.crypto.keystore import Keystore
 from nucypher.network.nodes import TEACHER_NODES
@@ -851,12 +854,13 @@ def temp_config_root():
 
 @pytest.fixture(scope="session", autouse=True)
 def mock_default_config_root(session_mocker, temp_config_root):
-    if DEFAULT_CONFIG_ROOT.exists():
+    real_default_config_root = Path(APP_DIR.user_data_dir)
+    if real_default_config_root.exists():
         if os.getenv("GITHUB_ACTIONS") == "true":
-            shutil.rmtree(DEFAULT_CONFIG_ROOT)
+            shutil.rmtree(real_default_config_root)
         else:
             raise RuntimeError(
-                f"{DEFAULT_CONFIG_ROOT} already exists.  It is not permitted to run tests in an (production) "
+                f"{real_default_config_root} already exists.  It is not permitted to run tests in an (production) "
                 f"environment where this directory exists.  Please remove it before running tests."
             )
     session_mocker.patch(
@@ -871,9 +875,9 @@ def clear_config_root(temp_config_root):
         print(f"Removing {temp_config_root}")
         shutil.rmtree(Path("/tmp/nucypher-test"))
     yield
-    if DEFAULT_CONFIG_ROOT.exists():
+    if Path(APP_DIR.user_data_dir).exists():
         raise RuntimeError(
-            f"{DEFAULT_CONFIG_ROOT} was used by a test.  This is not permitted, please mock."
+            f"{APP_DIR.user_data_dir} was used by a test.  This is not permitted, please mock."
         )
 
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -852,10 +852,13 @@ def temp_config_root():
 @pytest.fixture(scope="session", autouse=True)
 def mock_default_config_root(session_mocker, temp_config_root):
     if DEFAULT_CONFIG_ROOT.exists():
-        raise RuntimeError(
-            f"{DEFAULT_CONFIG_ROOT} already exists.  It is not permitted to run tests in an (production) "
-            f"environment where this directory exists.  Please remove it before running tests."
-        )
+        if os.getenv("GITHUB_ACTIONS") == "true":
+            shutil.rmtree(DEFAULT_CONFIG_ROOT)
+        else:
+            raise RuntimeError(
+                f"{DEFAULT_CONFIG_ROOT} already exists.  It is not permitted to run tests in an (production) "
+                f"environment where this directory exists.  Please remove it before running tests."
+            )
     session_mocker.patch(
         "nucypher.config.constants.DEFAULT_CONFIG_ROOT", temp_config_root
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -870,3 +870,11 @@ def clear_config_root(temp_config_root):
     if temp_config_root.exists():
         print(f"Removing {temp_config_root}")
         shutil.rmtree(Path("/tmp/nucypher-test"))
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_default_rpc_endpoint_fetch(session_mocker):
+    session_mocker.patch(
+        "nucypher.blockchain.eth.utils.get_default_rpc_endpoints",
+        return_value={TESTERCHAIN_CHAIN_ID: [TEST_ETH_PROVIDER_URI]},
+    )

--- a/tests/integration/characters/test_bob_handles_frags.py
+++ b/tests/integration/characters/test_bob_handles_frags.py
@@ -1,5 +1,6 @@
 import json
 
+import pytest
 from nucypher_core import Address, Conditions, RetrievalKit
 from nucypher_core._nucypher_core import MessageKit
 
@@ -15,6 +16,7 @@ def _policy_info_kwargs(enacted_policy):
         )
 
 
+@pytest.mark.usefixtures("mock_payment_method")
 def test_retrieval_kit(enacted_policy, ursulas):
     messages, message_kits = make_message_kits(enacted_policy.public_key)
 
@@ -29,7 +31,9 @@ def test_retrieval_kit(enacted_policy, ursulas):
     assert retrieval_kit.queried_addresses == retrieval_kit_back.queried_addresses
 
 
-def test_single_retrieve(enacted_policy, bob, ursulas):
+@pytest.mark.usefixtures("mock_payment_method")
+def test_single_retrieve(enacted_policy, bob, ursulas, mocker):
+
     bob.remember_node(ursulas[0])
     bob.start_learning_loop()
     messages, message_kits = make_message_kits(enacted_policy.public_key)
@@ -42,6 +46,7 @@ def test_single_retrieve(enacted_policy, bob, ursulas):
     assert cleartexts == messages
 
 
+@pytest.mark.usefixtures("mock_payment_method")
 def test_single_retrieve_conditions_set_directly_to_none(enacted_policy, bob, ursulas):
     bob.start_learning_loop()
     message = b"plaintext1"
@@ -59,6 +64,7 @@ def test_single_retrieve_conditions_set_directly_to_none(enacted_policy, bob, ur
     assert cleartexts == [message]
 
 
+@pytest.mark.usefixtures("mock_payment_method")
 def test_single_retrieve_conditions_empty_list(enacted_policy, bob, ursulas):
     bob.start_learning_loop()
     message = b"plaintext1"
@@ -76,6 +82,7 @@ def test_single_retrieve_conditions_empty_list(enacted_policy, bob, ursulas):
     assert cleartexts == [message]
 
 
+@pytest.mark.usefixtures("mock_payment_method")
 def test_use_external_cache(enacted_policy, bob, ursulas):
 
     bob.start_learning_loop()

--- a/tests/integration/characters/test_bob_joins_policy_and_retrieves.py
+++ b/tests/integration/characters/test_bob_joins_policy_and_retrieves.py
@@ -12,6 +12,7 @@ from tests.constants import MOCK_ETH_PROVIDER_URI
 from tests.utils.middleware import MockRestMiddleware
 
 
+@pytest.mark.usefixtures("mock_payment_method")
 def test_bob_full_retrieve_flow(
     ursulas, bob, alice, capsule_side_channel, treasure_map, enacted_policy
 ):
@@ -35,6 +36,7 @@ def test_bob_full_retrieve_flow(
     assert b"Welcome to flippering number 0." == delivered_cleartexts[0]
 
 
+@pytest.mark.usefixtures("mock_payment_method")
 def test_bob_retrieves(accounts, alice, ursulas):
     """A test to show that Bob can retrieve data from Ursula"""
 
@@ -96,6 +98,7 @@ def test_bob_retrieves(accounts, alice, ursulas):
     bob.disenchant()
 
 
+@pytest.mark.usefixtures("mock_payment_method")
 def test_bob_retrieves_with_treasure_map(
     bob, ursulas, enacted_policy, capsule_side_channel
 ):
@@ -118,6 +121,7 @@ def test_bob_retrieves_with_treasure_map(
 
 # TODO: #2813 Without kfrag and arrangement storage by nodes,
 @pytest.mark.skip()
+@pytest.mark.usefixtures("mock_payment_method")
 def test_bob_retrieves_too_late(bob, ursulas, enacted_policy, capsule_side_channel):
     clock = Clock()
     clock.advance(time.time())

--- a/tests/integration/characters/test_conditional_reencryption.py
+++ b/tests/integration/characters/test_conditional_reencryption.py
@@ -26,7 +26,10 @@ def _policy_info_kwargs(enacted_policy):
     )
 
 
-def test_single_retrieve_with_truthy_conditions(enacted_policy, bob, ursulas, mocker):
+@pytest.mark.usefixtures("mock_payment_method")
+def test_single_retrieve_with_truthy_conditions(
+    enacted_policy, bob, ursulas, mocker, mock_payment_method
+):
     from nucypher_core import MessageKit
 
     reencrypt_spy = mocker.spy(Ursula, '_reencrypt')
@@ -68,7 +71,10 @@ def test_single_retrieve_with_truthy_conditions(enacted_policy, bob, ursulas, mo
     assert reencrypt_spy.call_count == enacted_policy.threshold
 
 
-def test_single_retrieve_with_falsy_conditions(enacted_policy, bob, ursulas, mocker):
+@pytest.mark.usefixtures("mock_payment_method")
+def test_single_retrieve_with_falsy_conditions(
+    enacted_policy, bob, ursulas, mocker, mock_payment_method
+):
     from nucypher_core import MessageKit
 
     reencrypt_spy = mocker.spy(Ursula, '_reencrypt')
@@ -124,6 +130,7 @@ FAILURE_CASE_EXCEPTION_CODE_MATCHING = [
     "eval_failure_exception_class, middleware_exception_class",
     FAILURE_CASE_EXCEPTION_CODE_MATCHING,
 )
+@pytest.mark.usefixtures("mock_payment_method")
 def test_middleware_handling_of_failed_condition_responses(
     eval_failure_exception_class,
     middleware_exception_class,
@@ -131,6 +138,7 @@ def test_middleware_handling_of_failed_condition_responses(
     enacted_policy,
     bob,
     mock_rest_middleware,
+    mock_payment_method,
 ):
     # we use a failed condition for reencryption to test conversion of response codes to middleware exceptions
     from nucypher_core import MessageKit

--- a/tests/integration/cli/actions/test_select_config_file.py
+++ b/tests/integration/cli/actions/test_select_config_file.py
@@ -62,49 +62,6 @@ def test_auto_select_config_file(
                                               config_file=str(config_path)) in captured.out
 
 
-@pytest.mark.skip(reason="planned for removal")
-def test_interactive_select_config_file(
-    test_emitter,
-    capsys,
-    alice_test_config,
-    temp_dir_path,
-    mock_stdin,
-    mock_accounts,
-    patch_keystore,
-):
-
-    """Multiple configurations found - Prompt the user for a selection"""
-
-    user_input = 0
-    config = alice_test_config
-    config_class = config.__class__
-
-    # Make one configuration...
-    config_path = temp_dir_path / config_class.generate_filename()
-    config.to_configuration_file(filepath=config_path)
-    assert config_path.exists()
-    select_config_file(emitter=test_emitter,
-                       config_class=config_class,
-                       config_root=temp_dir_path)
-
-    # ... and then a bunch more
-    accounts = list(mock_accounts.items())
-    filenames = dict()
-    for filename, account in accounts:
-        config.checksum_address = account.address
-        config_path = temp_dir_path / config.generate_filename(modifier=account.address)
-        path = config.to_configuration_file(filepath=config_path, modifier=account.address)
-        filenames[path] = account.address
-        assert config_path.exists()
-
-    mock_stdin.line(str(user_input))
-
-    captured = capsys.readouterr()
-    for filename, account in accounts:
-        assert account.address in captured.out
-    assert mock_stdin.empty()
-
-
 def test_confirm_prompt_to_migrate_select_config_file(
     test_emitter, capsys, alice_test_config, temp_dir_path, mock_stdin
 ):

--- a/tests/integration/cli/test_ursula_cli_ip_detection.py
+++ b/tests/integration/cli/test_ursula_cli_ip_detection.py
@@ -1,3 +1,5 @@
+import shutil
+
 import pytest
 
 from nucypher.blockchain.eth.actors import Operator
@@ -18,7 +20,7 @@ from tests.constants import (
 
 
 @pytest.mark.usefixtures("mock_registry_sources")
-def test_ursula_startup_ip_checkup(click_runner, mocker):
+def test_ursula_startup_ip_checkup(click_runner, mocker, temp_config_root):
     target = "nucypher.cli.actions.configure.determine_external_ip_address"
 
     # Patch the get_external_ip call
@@ -48,6 +50,7 @@ def test_ursula_startup_ip_checkup(click_runner, mocker):
     )
     assert result.exit_code == 0, result.output
     assert MOCK_IP_ADDRESS in result.output
+    shutil.rmtree(str(temp_config_root.absolute()))
 
     args = (
         "ursula",
@@ -64,6 +67,7 @@ def test_ursula_startup_ip_checkup(click_runner, mocker):
         nucypher_cli, args, catch_exceptions=False, input=FAKE_PASSWORD_CONFIRMED
     )
     assert result.exit_code == 0, result.output
+    shutil.rmtree(str(temp_config_root.absolute()))
 
     # Patch get_external_ip call to error output
     mocker.patch(target, side_effect=UnknownIPAddress)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -26,6 +26,7 @@ from nucypher.cli.types import ChecksumAddress
 from nucypher.config.characters import UrsulaConfiguration
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Teacher
+from nucypher.policy.payment import SubscriptionManagerPayment
 from tests.constants import (
     KEYFILE_NAME_TEMPLATE,
     MOCK_KEYSTORE_PATH,
@@ -33,6 +34,7 @@ from tests.constants import (
     TEMPORARY_DOMAIN,
     TESTERCHAIN_CHAIN_ID,
 )
+from tests.mock.agents import MockContractAgency
 from tests.mock.interfaces import MockBlockchain
 from tests.mock.io import MockStdinWrapper
 from tests.utils.registry import MockRegistrySource, mock_registry_sources
@@ -133,7 +135,6 @@ def test_registry(module_mocker):
 @pytest.fixture(scope='module', autouse=True)
 def mock_contract_agency():
     # Patch
-    from tests.mock.agents import MockContractAgency
 
     # Monkeypatch # TODO: Use better tooling for this monkeypatch?
     get_agent = ContractAgency.get_agent
@@ -295,3 +296,8 @@ def multichain_ursulas(ursulas, multichain_ids):
 @pytest.fixture(scope="module")
 def mock_prometheus(module_mocker):
     return module_mocker.patch("nucypher.characters.lawful.start_prometheus_exporter")
+
+
+@pytest.fixture(scope="module")
+def mock_payment_method(module_mocker):
+    module_mocker.patch.object(SubscriptionManagerPayment, "verify", return_value=True)

--- a/tests/mock/agents.py
+++ b/tests/mock/agents.py
@@ -19,7 +19,7 @@ BlockchainInterfaceFactory._interfaces[MOCK_ETH_PROVIDER_URI] = CACHED_MOCK_TEST
 
 class MockContractAgent:
 
-    FAKE_CALL_RESULT = 1
+    FAKE_CALL_RESULT = 0
 
     # Internal
     __COLLECTION_MARKER = "contract_api"  # decorator attribute
@@ -53,7 +53,8 @@ class MockContractAgent:
     def __setup_mock(self, agent_class: Type[Agent]) -> None:
 
         api_methods: Iterable[Callable] = list(self.__collect_contract_api(agent_class=agent_class))
-        mock_methods, mock_properties = list(), dict()
+        mock_methods = list()
+        # mock_properties = dict()
 
         for agent_interface in api_methods:
 
@@ -88,7 +89,8 @@ class MockContractAgent:
         self._REAL_METHODS = api_methods
 
     def __get_interface_calls(self, interface: Enum) -> List[Callable]:
-        predicate = lambda method: bool(method.contract_api == interface)
+        def predicate(method):
+            return bool(method.contract_api == interface)
         interface_calls = list(filter(predicate, self._MOCK_METHODS))
         return interface_calls
 
@@ -127,9 +129,13 @@ class MockContractAgent:
 
     def get_unexpected_transactions(self, allowed: Union[Iterable[Callable], None]) -> List[Callable]:
         if allowed:
-            predicate = lambda tx: tx not in allowed and tx.called
+
+            def predicate(tx):
+                return tx not in allowed and tx.called
         else:
-            predicate = lambda tx: tx.called
+
+            def predicate(tx):
+                return tx.called
         unexpected_transactions = list(filter(predicate, self.all_transactions))
         return unexpected_transactions
 

--- a/tests/unit/crypto/test_keystore.py
+++ b/tests/unit/crypto/test_keystore.py
@@ -226,8 +226,8 @@ def test_restore_keystore_from_mnemonic(tmpdir, mocker):
         _keystore = Keystore(keystore_path=keystore_path)
 
     # Restore with user-supplied words and a new password
-    keystore = Keystore.restore(words=words, password='ANewHope')
-    keystore.unlock(password='ANewHope')
+    keystore = Keystore.restore(words=words, password="ANewHope", keystore_dir=tmpdir)
+    keystore.unlock(password="ANewHope")
     assert keystore._Keystore__secret == secret
 
 


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
2

**What this does:**
- Refines the operator experience for creating new nodes
- Blocks new node initialization on hosts with pre-existing local private keys or configurations
- Blocks new node initialization if operator account has already published a ferveo public key
- Expands communications regarding seed phrase security and responsibility while using the `init` CLI
- Alters console presentation of seed phrase to discourage copy/paste confirmation
- Begin to deprecate support for multiple configurations on a single host
- Handle testing and mocking side-effects of these changes
- Prevent tests from writing to production filepaths

**Issues fixed/closed:**
Assists #3527 
Closes #3528 
Closes https://github.com/nucypher/sprints/issues/37

**Why it's needed:**
Assists in accidental/intentional violation of operator protocols with regard to ferveo key commitment.

**Notes for reviewers:**

[![asciicast](https://asciinema.org/a/5fhYGdBxOAbiEkE4GV3L3LPxn.svg)](https://asciinema.org/a/5fhYGdBxOAbiEkE4GV3L3LPxn)
