### PR TITLE
Key Recovery and Auditing Tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
 
       - id: tests
         name: Run Nucypher Unit Tests
-        entry: scripts/hooks/run_unit_tests.sh
+        entry: scripts/run_unit_tests.sh
         language: system
         types: [python]
         stages: [push]  # required additional setup: pre-commit install && pre-commit install -t pre-push

--- a/newsfragments/3538.feature.rst
+++ b/newsfragments/3538.feature.rst
@@ -1,0 +1,1 @@
+Expands recovery CLI to include audit and keystore identification features

--- a/nucypher/cli/actions/auth.py
+++ b/nucypher/cli/actions/auth.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import click
 from constant_sorrow.constants import NO_PASSWORD
@@ -80,7 +81,7 @@ def unlock_nucypher_keystore(emitter: StdoutEmitter, password: str, character_co
     return True
 
 
-def recover_keystore(emitter) -> None:
+def recover_keystore(emitter) -> Path:
     emitter.message('This procedure will recover your nucypher keystore from mnemonic seed words. '
                     'You will need to provide the entire mnemonic (space seperated) in the correct '
                     'order and choose a new password.', color='cyan')
@@ -92,3 +93,5 @@ def recover_keystore(emitter) -> None:
     __password = get_nucypher_password(emitter=emitter, confirm=True)
     keystore = Keystore.restore(words=__words, password=__password)
     emitter.message(f'Recovered nucypher keystore {keystore.id} to \n {keystore.keystore_path}', color='green')
+
+    return keystore.keystore_path

--- a/nucypher/cli/actions/auth.py
+++ b/nucypher/cli/actions/auth.py
@@ -11,7 +11,6 @@ from nucypher.cli.literature import (
     GENERIC_PASSWORD_PROMPT,
     PASSWORD_COLLECTION_NOTICE,
 )
-from nucypher.config.base import CharacterConfiguration
 from nucypher.config.constants import NUCYPHER_ENVVAR_KEYSTORE_PASSWORD
 from nucypher.crypto.keystore import _WORD_COUNT, Keystore
 from nucypher.utilities.emitters import StdoutEmitter
@@ -36,7 +35,7 @@ def get_client_password(checksum_address: str, envvar: str = None, confirm: bool
     return client_password
 
 
-def unlock_signer_account(config: CharacterConfiguration, json_ipc: bool) -> None:
+def unlock_signer_account(config, json_ipc: bool) -> None:
 
     # TODO: Remove this block after deprecating 'operator_address'
     from nucypher.config.characters import UrsulaConfiguration
@@ -67,7 +66,11 @@ def get_nucypher_password(emitter, confirm: bool = False, envvar=NUCYPHER_ENVVAR
     return keystore_password
 
 
-def unlock_nucypher_keystore(emitter: StdoutEmitter, password: str, character_configuration: CharacterConfiguration) -> bool:
+def unlock_nucypher_keystore(
+    emitter: StdoutEmitter,
+    password: str,
+    character_configuration,
+) -> bool:
     """Unlocks a nucypher keystore and attaches it to the supplied configuration if successful."""
     emitter.message(DECRYPTING_CHARACTER_KEYSTORE.format(name=character_configuration.NAME.capitalize()), color='yellow')
 

--- a/nucypher/cli/actions/auth.py
+++ b/nucypher/cli/actions/auth.py
@@ -81,17 +81,27 @@ def unlock_nucypher_keystore(emitter: StdoutEmitter, password: str, character_co
     return True
 
 
+def collect_mnemonic(emitter: StdoutEmitter) -> str:
+    """Collect nucypher mnemonic seed words interactively."""
+    while True:
+        __words = click.prompt("Enter nucypher keystore seed words")
+        word_count = len(__words.split())
+        if word_count != _WORD_COUNT:
+            emitter.message(
+                f"Invalid mnemonic - Number of words must be {str(_WORD_COUNT)}, but only got {word_count}"
+            )
+            continue
+        break
+    return __words
+
+
 def recover_keystore(emitter) -> Path:
     emitter.message('This procedure will recover your nucypher keystore from mnemonic seed words. '
                     'You will need to provide the entire mnemonic (space seperated) in the correct '
                     'order and choose a new password.', color='cyan')
     click.confirm('Do you want to continue', abort=True)
-    __words = click.prompt("Enter nucypher keystore seed words")
-    word_count = len(__words.split())
-    if word_count != _WORD_COUNT:
-        emitter.message(f'Invalid mnemonic - Number of words must be {str(_WORD_COUNT)}, but only got {word_count}')
+    __words = collect_mnemonic(emitter)
     __password = get_nucypher_password(emitter=emitter, confirm=True)
     keystore = Keystore.restore(words=__words, password=__password)
     emitter.message(f'Recovered nucypher keystore {keystore.id} to \n {keystore.keystore_path}', color='green')
-
     return keystore.keystore_path

--- a/nucypher/cli/actions/auth.py
+++ b/nucypher/cli/actions/auth.py
@@ -1,5 +1,4 @@
 import os
-from pathlib import Path
 
 import click
 from constant_sorrow.constants import NO_PASSWORD
@@ -95,7 +94,7 @@ def collect_mnemonic(emitter: StdoutEmitter) -> str:
     return __words
 
 
-def recover_keystore(emitter) -> Path:
+def recover_keystore(emitter) -> Keystore:
     emitter.message('This procedure will recover your nucypher keystore from mnemonic seed words. '
                     'You will need to provide the entire mnemonic (space seperated) in the correct '
                     'order and choose a new password.', color='cyan')
@@ -104,4 +103,4 @@ def recover_keystore(emitter) -> Path:
     __password = get_nucypher_password(emitter=emitter, confirm=True)
     keystore = Keystore.restore(words=__words, password=__password)
     emitter.message(f'Recovered nucypher keystore {keystore.id} to \n {keystore.keystore_path}', color='green')
-    return keystore.keystore_path
+    return keystore

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -196,4 +196,5 @@ def update_config_keystore_path(keystore_path: Path, config_file: Path = None) -
         ursula_config = json.load(f)
         ursula_config["keystore_path"] = keystore_path
         f.seek(0)
-        json.dump(ursula_config, f, indent=4)
+        json.dump(ursula_config, f, indent=2)
+        f.truncate()  # rest of the file truncated

--- a/nucypher/cli/actions/configure.py
+++ b/nucypher/cli/actions/configure.py
@@ -187,3 +187,13 @@ def perform_startup_ip_check(emitter: StdoutEmitter, ursula: Ursula, force: bool
         raise click.Abort()
     else:
         emitter.message('✓ External IP matches configuration', 'green')
+
+
+def update_config_keystore_path(keystore_path: Path, config_file: Path = None) -> None:
+    """Update the ursula.json configuration file to use the provided keystore path."""
+    keystore_path = str(keystore_path.resolve())
+    with open(config_file, "r+") as f:
+        ursula_config = json.load(f)
+        ursula_config["keystore_path"] = keystore_path
+        f.seek(0)
+        json.dump(ursula_config, f, indent=4)

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -446,14 +446,16 @@ def audit(config_file, keystore_filepath, view_mnemonic):
             ),
         )
 
-    config_file = config_file or DEFAULT_CONFIG_FILEPATH
-    if not config_file.exists():
-        emitter.error(f"Ursula configuration file not found - {config_file.resolve()}")
-        raise click.Abort()
-
     if keystore_filepath:
         keystore = Keystore(keystore_filepath)
     else:
+        config_file = config_file or DEFAULT_CONFIG_FILEPATH
+        if not config_file.exists():
+            emitter.error(
+                f"Ursula configuration file not found - {config_file.resolve()}"
+            )
+            raise click.Abort()
+
         ursula_config = UrsulaConfiguration.from_configuration_file(
             filepath=config_file
         )

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -465,12 +465,13 @@ def audit(config_file, keystore_filepath, view_mnemonic):
     try:
         correct = keystore.audit(words=collect_mnemonic(emitter), password=password)
     except Keystore.InvalidMnemonic:
+        correct = False
+
+    if not correct:
         emitter.message("Mnemonic is incorrect.", color="red")
-        return
-    emitter.message(
-        f"Mnemonic is {'' if correct else 'in'}correct.",
-        color="green" if correct else "red",
-    )
+        raise click.Abort()
+
+    emitter.message("Mnemonic is correct.", color="green")
 
 
 @ursula.command()

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -560,11 +560,15 @@ def public_keys(config_file, keystore_filepath, from_mnemonic):
     if from_mnemonic:
         keystore = Keystore.from_mnemonic(collect_mnemonic(emitter))
     else:
-        config_file = config_file or DEFAULT_CONFIG_FILEPATH
-        ursula_config = UrsulaConfiguration.from_configuration_file(
-            filepath=config_file
-        )
-        keystore = Keystore(keystore_filepath or ursula_config.keystore.keystore_path)
+        keystore_path_to_use = keystore_filepath
+        if not keystore_path_to_use:
+            config_file = config_file or DEFAULT_CONFIG_FILEPATH
+            ursula_config = UrsulaConfiguration.from_configuration_file(
+                filepath=config_file
+            )
+            keystore_path_to_use = ursula_config.keystore.keystore_path
+
+        keystore = Keystore(keystore_path_to_use)
         keystore.unlock(get_nucypher_password(emitter=emitter, confirm=False))
 
     ritualistic_power = keystore.derive_crypto_power(RitualisticPower)

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -444,6 +444,7 @@ def audit(config_file, keystore_filepath, view_mnemonic):
         correct = keystore.audit(words=collect_mnemonic(emitter), password=password)
     except Keystore.InvalidMnemonic:
         emitter.message("Mnemonic is incorrect.", color="red")
+        return
     emitter.message(
         f"Mnemonic is {'' if correct else 'in'}correct.",
         color="green" if correct else "red",

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -357,24 +357,13 @@ def init(
         )
         return click.get_current_context().exit(1)
 
-    click.clear()
-    if with_mnemonic:
-        emitter.echo(
-            "Hello Operator, welcome back :-) \n\n"
-            "You are about to initialize a new Ursula node configuration using an existing mnemonic phrase.\n"
-            "Have your mnemonic phrase ready and ensure you are in a secure environment.\n"
-            "Please follow the prompts.",
-            color="cyan",
-        )
-    else:
-        emitter.echo(
-            "Hello Operator, welcome on board :-) \n\n"
-            "NOTE: Initializing a new Ursula node configuration is a one-time operation\n"
-            "for the lifetime of your node.  This is a two-step process:\n\n"
-            "1. Creating a password to encrypt your operator keys\n"
-            "2. Securing a taco node seed phase\n\n"
-            "Please follow the prompts.",
-            color="cyan",
+    if key_material and with_mnemonic:
+        raise click.BadOptionUsage(
+            "--key-material",
+            message=click.style(
+                "--key-material is incompatible with --with-mnemonic",
+                fg="red",
+            ),
         )
 
     if not config_options.eth_endpoint:
@@ -392,11 +381,33 @@ def init(
                 fg="red",
             ),
         )
+
+    click.clear()
+    if with_mnemonic:
+        emitter.echo(
+            "Hello Operator, welcome :-) \n\n"
+            "You are about to initialize a new Ursula node configuration using an existing mnemonic phrase.\n"
+            "Have your mnemonic phrase ready and ensure you are in a secure environment.\n"
+            "Please follow the prompts.",
+            color="cyan",
+        )
+    else:
+        emitter.echo(
+            "Hello Operator, welcome on board :-) \n\n"
+            "NOTE: Initializing a new Ursula node configuration is a one-time operation\n"
+            "for the lifetime of your node.  This is a two-step process:\n\n"
+            "1. Creating a password to encrypt your operator keys\n"
+            "2. Securing a taco node seed phase\n\n"
+            "Please follow the prompts.",
+            color="cyan",
+        )
+
     if not config_options.domain:
         config_options.domain = select_domain(
             emitter,
             message="Select TACo Domain",
         )
+
     ursula_config = config_options.generate_config(
         emitter=emitter,
         config_root=config_root,

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -483,14 +483,6 @@ def audit(config_file, keystore_filepath, view_mnemonic):
 )
 def recover(config_file, keystore_filepath):
     emitter = StdoutEmitter()
-    if keystore_filepath and config_file:
-        raise click.BadOptionUsage(
-            "--keystore-filepath",
-            message=click.style(
-                "--keystore-filepath is incompatible with --config-file",
-                fg="red",
-            ),
-        )
     config_file = config_file or DEFAULT_CONFIG_FILEPATH
     if not config_file.exists():
         emitter.error(f"Ursula configuration file not found - {config_file.resolve()}")

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -438,7 +438,7 @@ def audit(config_file, keystore_filepath, view_mnemonic):
     config_file = config_file or DEFAULT_CONFIG_FILEPATH
     if not config_file.exists():
         emitter.error(f"Ursula configuration file not found - {config_file.absolute()}")
-        click.Abort()
+        raise click.Abort()
 
     if keystore_filepath:
         keystore = Keystore(keystore_filepath)
@@ -452,8 +452,9 @@ def audit(config_file, keystore_filepath, view_mnemonic):
     try:
         keystore.unlock(password=password)
     except Keystore.AuthenticationFailed:
-        emitter.message("Password is incorrect.", color="red")
-        return
+        emitter.error("Password is incorrect.")
+        raise click.Abort()
+
     emitter.message("Password is correct.", color="green")
 
     if view_mnemonic:
@@ -663,7 +664,7 @@ def config(general_config, config_options, config_file, force, action):
             emitter.error(
                 "--config-file <FILEPATH> is required to run a configuration file migration."
             )
-            return click.Abort()
+            raise click.Abort()
         config_file = select_config_file(
             emitter=emitter,
             checksum_address=config_options.operator_address,

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -437,7 +437,7 @@ def audit(config_file, keystore_filepath, view_mnemonic):
 
     config_file = config_file or DEFAULT_CONFIG_FILEPATH
     if not config_file.exists():
-        emitter.error(f"Ursula configuration file not found - {config_file.absolute()}")
+        emitter.error(f"Ursula configuration file not found - {config_file.resolve()}")
         raise click.Abort()
 
     if keystore_filepath:
@@ -493,7 +493,7 @@ def recover(config_file, keystore_filepath):
         )
     config_file = config_file or DEFAULT_CONFIG_FILEPATH
     if not config_file.exists():
-        emitter.error(f"Ursula configuration file not found - {config_file.absolute()}")
+        emitter.error(f"Ursula configuration file not found - {config_file.resolve()}")
         raise click.Abort()
 
     if keystore_filepath:
@@ -514,7 +514,7 @@ def recover(config_file, keystore_filepath):
         keystore_path=keystore.keystore_path, config_file=config_file
     )
     emitter.message(
-        f"Updated {config_file} to use keystore filepath: {keystore.keystore_path}",
+        f"Updated {config_file} to use keystore filepath: {keystore.keystore_path.resolve()}",
         color="green",
     )
 

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -389,12 +389,10 @@ def init(general_config, config_options, force, config_root, key_material):
 
 
 @ursula.command()
-@group_config_options
-@group_general_config
 @option_config_file
-def recover(general_config, config_options, config_file):
+def recover(config_file):
     # TODO: Combine with work in PR #2682
-    emitter = setup_emitter(general_config, config_options.operator_address)
+    emitter = StdoutEmitter()
 
     new_keystore_path = recover_keystore(emitter=emitter)
 

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -404,14 +404,16 @@ def recover(config_file):
         )
         click.Abort()
 
-    with open(ursula_config_file, "r+") as f:
+    with open(ursula_config_file, "r") as f:
         ursula_config = json.load(f)
-        ursula_config["keystore_path"] = str(new_keystore_path.absolute())
-        f.seek(0)
+
+    ursula_config["keystore_path"] = str(new_keystore_path.absolute())
+
+    with open(ursula_config_file, "w") as f:
         json.dump(ursula_config, f, indent=2)
 
     emitter.echo(
-        f"Updated ursula.json to use keystore filepath: {new_keystore_path.absolute()}"
+        f"Updated Ursula configuration, {ursula_config_file.absolute()}, to use keystore filepath: {new_keystore_path.absolute()}"
     )
 
 

--- a/nucypher/cli/painting/help.py
+++ b/nucypher/cli/painting/help.py
@@ -48,9 +48,7 @@ Path to Logs:     {USER_LOG_DIR}
 
 - Never share secret keys with anyone! 
 - Backup your keystore! Character keys are required to interact with the protocol!
-- Remember your password! Without the password, it's impossible to decrypt the key!
-
-"""
+- Remember your password! Without the password, it's impossible to decrypt the key!"""
     )
 
     if character_name == 'ursula':

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -598,8 +598,14 @@ class CharacterConfiguration(BaseConfiguration):
     ):
         """Generates local directories, private keys, and initial configuration for a new node."""
         node_config = cls(dev_mode=False, *args, **kwargs)
+        if key_material and with_mnemonic:
+            raise ValueError(
+                "Cannot provide key_material and with_mnemonic simultaneously"
+            )
         node_config.initialize(
-            key_material=key_material, with_mnemonic=with_mnemonic, password=password
+            key_material=key_material,
+            with_mnemonic=with_mnemonic,
+            password=password,
         )
         node_config.keystore.unlock(password)
         return node_config
@@ -803,6 +809,11 @@ class CharacterConfiguration(BaseConfiguration):
     ) -> Path:
         """Initialize a new configuration and write installation files to disk."""
 
+        if key_material and with_mnemonic:
+            raise ValueError(
+                "Cannot provide key_material and with_mnemonic simultaneously"
+            )
+
         # Development
         if self.dev_mode:
             self.__temp_dir = TemporaryDirectory(
@@ -838,6 +849,12 @@ class CharacterConfiguration(BaseConfiguration):
         interactive: bool = True,
         with_mnemonic: bool = False,
     ) -> Keystore:
+
+        if key_material and with_mnemonic:
+            raise ValueError(
+                "Cannot provide key_material and with_mnemonic simultaneously"
+            )
+
         if key_material:
             self.__keystore = Keystore.import_secure(
                 key_material=key_material,

--- a/nucypher/config/base.py
+++ b/nucypher/config/base.py
@@ -24,6 +24,7 @@ from nucypher.blockchain.eth.registry import (
 )
 from nucypher.blockchain.eth.signers import Signer
 from nucypher.characters.lawful import Ursula
+from nucypher.cli.actions.auth import collect_mnemonic
 from nucypher.config import constants
 from nucypher.config.util import cast_paths_from
 from nucypher.crypto.keystore import Keystore
@@ -583,18 +584,23 @@ class CharacterConfiguration(BaseConfiguration):
 
         Warning: This method allows mutation and may result in an inconsistent configuration.
         """
-        # config file should exist and we we override -> no need for modifier
+        # config file should exist and we override -> no need for modifier
         return super().update(filepath=self.config_file_location, **kwargs)
 
     @classmethod
     def generate(
-        cls, password: str, key_material: Optional[bytes] = None, *args, **kwargs
+        cls,
+        password: str,
+        key_material: Optional[bytes] = None,
+        with_mnemonic: bool = False,
+        *args,
+        **kwargs,
     ):
-        """
-        Generates local directories, private keys, and initial configuration for a new node.
-        """
+        """Generates local directories, private keys, and initial configuration for a new node."""
         node_config = cls(dev_mode=False, *args, **kwargs)
-        node_config.initialize(key_material=key_material, password=password)
+        node_config.initialize(
+            key_material=key_material, with_mnemonic=with_mnemonic, password=password
+        )
         node_config.keystore.unlock(password)
         return node_config
 
@@ -789,7 +795,12 @@ class CharacterConfiguration(BaseConfiguration):
                 power_ups.append(power_up)
         return power_ups
 
-    def initialize(self, password: str, key_material: Optional[bytes] = None) -> Path:
+    def initialize(
+        self,
+        password: str,
+        key_material: Optional[bytes] = None,
+        with_mnemonic: bool = False,
+    ) -> Path:
         """Initialize a new configuration and write installation files to disk."""
 
         # Development
@@ -806,6 +817,7 @@ class CharacterConfiguration(BaseConfiguration):
                 key_material=key_material,
                 password=password,
                 interactive=self.MNEMONIC_KEYSTORE,
+                with_mnemonic=with_mnemonic,
             )
 
         self._cache_runtime_filepaths()
@@ -824,12 +836,19 @@ class CharacterConfiguration(BaseConfiguration):
         password: str,
         key_material: Optional[bytes] = None,
         interactive: bool = True,
+        with_mnemonic: bool = False,
     ) -> Keystore:
         if key_material:
             self.__keystore = Keystore.import_secure(
                 key_material=key_material,
                 password=password,
                 keystore_dir=self.keystore_dir,
+            )
+        elif with_mnemonic:
+            self.__keystore = Keystore.restore(
+                password=password,
+                keystore_dir=self.keystore_dir,
+                words=collect_mnemonic(self.emitter),
             )
         else:
             if interactive:

--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -24,6 +24,7 @@ BASE_DIR = NUCYPHER_PACKAGE.parent.resolve()
 # User Application Filepaths
 APP_DIR = AppDirs(nucypher.__title__, nucypher.__author__)
 DEFAULT_CONFIG_ROOT = Path(os.getenv('NUCYPHER_CONFIG_ROOT', default=APP_DIR.user_data_dir))
+DEFAULT_CONFIG_FILEPATH = DEFAULT_CONFIG_ROOT / "ursula.json"
 USER_LOG_DIR = Path(os.getenv('NUCYPHER_USER_LOG_DIR', default=APP_DIR.user_log_dir))
 DEFAULT_LOG_FILENAME = "nucypher.log"
 DEFAULT_JSON_LOG_FILENAME = "nucypher.json"

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -7,7 +7,7 @@ from json import JSONDecodeError
 from os.path import abspath
 from pathlib import Path
 from secrets import token_bytes
-from typing import Callable, ClassVar, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Type, Union
 
 import click
 from constant_sorrow.constants import KEYSTORE_LOCKED
@@ -439,10 +439,9 @@ class Keystore:
     def unlock(self, password: str) -> None:
         self.__decrypt_keystore(path=self.keystore_path, password=password)
 
-    def derive_crypto_power(self,
-                            power_class: ClassVar[CryptoPowerUp],
-                            *power_args, **power_kwargs
-                            ) -> Union[KeyPairBasedPower, DerivedKeyBasedPower]:
+    def derive_crypto_power(
+        self, power_class: Type[CryptoPowerUp], *power_args, **power_kwargs
+    ) -> Union[KeyPairBasedPower, DerivedKeyBasedPower]:
 
         if not self.is_unlocked:
             raise Keystore.Locked(f"{self.id} is locked and must be unlocked before use.")

--- a/nucypher/crypto/keystore.py
+++ b/nucypher/crypto/keystore.py
@@ -352,6 +352,13 @@ class Keystore:
         keystore = cls(keystore_path=path)
         return keystore
 
+    def check(self, words: str, password: str) -> bool:
+        """Check if a mnemonic phrase can derive the secret key"""
+        __mnemonic = Mnemonic(_MNEMONIC_LANGUAGE)
+        __expected_secret = bytes(__mnemonic.to_entropy(words))
+        self.__decrypt_keystore(path=self.keystore_path, password=password)
+        return self.__secret == __expected_secret
+
     @classmethod
     def generate(
             cls, password: str,

--- a/tests/integration/cli/test_ursula_audit_cli.py
+++ b/tests/integration/cli/test_ursula_audit_cli.py
@@ -23,14 +23,13 @@ def setup_ursula_config_file(custom_filepath, ursula_test_config, config_filenam
     return keystore, ursula_config_file
 
 
-def test_ursula_audit_invalid_password(
+def test_ursula_audit_config_file_incorrect_password(
     click_runner, ursula_test_config, custom_filepath
 ):
     keystore, ursula_config_file = setup_ursula_config_file(
-        custom_filepath, ursula_test_config, "ursula-audit-invalid-password.json"
+        custom_filepath, ursula_test_config, "ursula-audit-incorrect-password.json"
     )
 
-    # view mnemonic
     audit_args = (
         "ursula",
         "audit",
@@ -48,7 +47,7 @@ def test_ursula_audit_invalid_password(
     assert "Mnemonic" not in result.output
 
 
-def test_ursula_audit_incorrect_mnemonic(
+def test_ursula_audit_config_file_incorrect_mnemonic(
     click_runner, ursula_test_config, custom_filepath
 ):
     keystore, ursula_config_file = setup_ursula_config_file(
@@ -56,7 +55,6 @@ def test_ursula_audit_incorrect_mnemonic(
     )
     mnemonic = keystore.get_mnemonic()
 
-    # view mnemonic
     audit_args = (
         "ursula",
         "audit",
@@ -134,7 +132,9 @@ def test_ursula_audit_default_config_file(
     assert "Mnemonic is correct" in result.output
 
 
-def test_ursula_audit_view_mnemonic(click_runner, ursula_test_config, custom_filepath):
+def test_ursula_audit_view_mnemonic_config_file(
+    click_runner, ursula_test_config, custom_filepath
+):
     keystore, ursula_config_file = setup_ursula_config_file(
         custom_filepath, ursula_test_config, "ursula-audit-view-mnemonic.json"
     )
@@ -146,6 +146,106 @@ def test_ursula_audit_view_mnemonic(click_runner, ursula_test_config, custom_fil
         "audit",
         "--config-file",
         str(ursula_config_file.resolve()),
+        "--view-mnemonic",
+    )
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert "Password is correct" in result.output
+    assert mnemonic in result.output
+
+
+def test_ursula_audit_keystore_file_incorrect_password(click_runner, custom_filepath):
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+
+    audit_args = (
+        "ursula",
+        "audit",
+        "--keystore-filepath",
+        str(keystore.keystore_path.resolve()),
+    )
+
+    user_input = "yadda,yadda,yadda\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code != 0, result.output
+    assert "Password is incorrect" in result.output
+    assert "Mnemonic" not in result.output
+
+
+def test_ursula_audit_keystore_file_incorrect_mnemonic(click_runner, custom_filepath):
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+    mnemonic = keystore.get_mnemonic()
+
+    audit_args = (
+        "ursula",
+        "audit",
+        "--keystore-filepath",
+        str(keystore.keystore_path.resolve()),
+    )
+
+    incorrect_mnemonic = Mnemonic("english").generate(256)
+    assert incorrect_mnemonic != mnemonic
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n" + f"{incorrect_mnemonic}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code != 0, result.output
+    assert "Password is correct" in result.output
+    assert "Mnemonic is incorrect" in result.output
+
+
+def test_ursula_audit_keystore_file(click_runner, custom_filepath):
+
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+    mnemonic = keystore.get_mnemonic()
+
+    audit_args = (
+        "ursula",
+        "audit",
+        "--keystore-filepath",
+        str(keystore.keystore_path.resolve()),
+    )
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n" + f"{mnemonic}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert "Password is correct" in result.output
+    assert "Mnemonic is correct" in result.output
+
+
+def test_ursula_audit_view_mnemonic_keystore_file(click_runner, custom_filepath):
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+    mnemonic = keystore.get_mnemonic()
+
+    audit_args = (
+        "ursula",
+        "audit",
+        "--keystore-filepath",
+        str(keystore.keystore_path.resolve()),
         "--view-mnemonic",
     )
 

--- a/tests/integration/cli/test_ursula_audit_cli.py
+++ b/tests/integration/cli/test_ursula_audit_cli.py
@@ -1,0 +1,159 @@
+import json
+
+from mnemonic import Mnemonic
+
+from nucypher.cli.main import nucypher_cli
+from nucypher.crypto.keystore import Keystore
+from tests.constants import INSECURE_DEVELOPMENT_PASSWORD
+
+
+def setup_ursula_config_file(custom_filepath, ursula_test_config, config_filename):
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+
+    # update keystore path in config file
+    ursula_config_file = custom_filepath / config_filename
+    config_values = json.loads(ursula_test_config.serialize())
+    config_values["keystore_path"] = str(keystore.keystore_path.resolve())
+    with open(ursula_config_file, "w") as f:
+        json.dump(config_values, f)
+
+    return keystore, ursula_config_file
+
+
+def test_ursula_audit_invalid_password(
+    click_runner, ursula_test_config, custom_filepath
+):
+    keystore, ursula_config_file = setup_ursula_config_file(
+        custom_filepath, ursula_test_config, "ursula-audit-invalid-password.json"
+    )
+
+    # view mnemonic
+    audit_args = (
+        "ursula",
+        "audit",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+    )
+
+    user_input = "yadda,yadda,yadda\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code != 0, result.output
+    assert "Password is incorrect" in result.output
+    assert "Mnemonic" not in result.output
+
+
+def test_ursula_audit_incorrect_mnemonic(
+    click_runner, ursula_test_config, custom_filepath
+):
+    keystore, ursula_config_file = setup_ursula_config_file(
+        custom_filepath, ursula_test_config, "ursula-audit-incorrect-mnemonic.json"
+    )
+    mnemonic = keystore.get_mnemonic()
+
+    # view mnemonic
+    audit_args = (
+        "ursula",
+        "audit",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+    )
+
+    incorrect_mnemonic = Mnemonic("english").generate(256)
+    assert incorrect_mnemonic != mnemonic
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n" + f"{incorrect_mnemonic}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code != 0, result.output
+    assert "Password is correct" in result.output
+    assert "Mnemonic is incorrect" in result.output
+
+
+def test_ursula_audit_specific_config_file(
+    click_runner,
+    custom_filepath,
+    ursula_test_config,
+):
+    keystore, ursula_config_file = setup_ursula_config_file(
+        custom_filepath, ursula_test_config, "ursula-audit.json"
+    )
+    mnemonic = keystore.get_mnemonic()
+
+    # specific config file
+    audit_args = (
+        "ursula",
+        "audit",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+    )
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n" + f"{mnemonic}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert "Password is correct" in result.output
+    assert "Mnemonic is correct" in result.output
+
+
+def test_ursula_audit_default_config_file(
+    click_runner, mocker, ursula_test_config, custom_filepath
+):
+
+    keystore, ursula_config_file = setup_ursula_config_file(
+        custom_filepath, ursula_test_config, "ursula-audit-default.json"
+    )
+    mocker.patch(
+        "nucypher.cli.commands.ursula.DEFAULT_CONFIG_FILEPATH", ursula_config_file
+    )
+
+    mnemonic = keystore.get_mnemonic()
+
+    # default config file
+    audit_args = (
+        "ursula",
+        "audit",
+    )
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n" + f"{mnemonic}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert "Password is correct" in result.output
+    assert "Mnemonic is correct" in result.output
+
+
+def test_ursula_audit_view_mnemonic(click_runner, ursula_test_config, custom_filepath):
+    keystore, ursula_config_file = setup_ursula_config_file(
+        custom_filepath, ursula_test_config, "ursula-audit-view-mnemonic.json"
+    )
+    mnemonic = keystore.get_mnemonic()
+
+    # view mnemonic
+    audit_args = (
+        "ursula",
+        "audit",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+        "--view-mnemonic",
+    )
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, audit_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert "Password is correct" in result.output
+    assert mnemonic in result.output

--- a/tests/integration/cli/test_ursula_public_keys_cli.py
+++ b/tests/integration/cli/test_ursula_public_keys_cli.py
@@ -1,0 +1,152 @@
+import json
+
+from nucypher.cli.main import nucypher_cli
+from nucypher.crypto.keystore import Keystore
+from nucypher.crypto.powers import RitualisticPower
+from tests.constants import INSECURE_DEVELOPMENT_PASSWORD
+
+
+def test_ursula_public_keys_invalid(click_runner, ursula_test_config, custom_filepath):
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+
+    ursula_config_file = custom_filepath / "ursula-test.json"
+    ursula_test_config._write_configuration_file(filepath=ursula_config_file)
+
+    expected_error = "Exactly one of --keystore-filepath, --config-file, or --from-mnemonic must be specified"
+
+    # config-file and keystore-filepath
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+        "--config-file",
+        str(ursula_config_file.absolute()),
+        "--keystore-filepath",
+        str(keystore.keystore_path.absolute()),
+    )
+
+    result = click_runner.invoke(nucypher_cli, public_keys_args, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert expected_error in result.output
+
+    # config-file and from-mnemonic
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+        "--config-file",
+        str(ursula_config_file.absolute()),
+        "--from-mnemonic",
+    )
+
+    result = click_runner.invoke(nucypher_cli, public_keys_args, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert expected_error in result.output
+
+    # keystore-filepath and from-mnemonic
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+        "--keystore-filepath",
+        str(keystore.keystore_path.absolute()),
+        "--from-mnemonic",
+    )
+
+    result = click_runner.invoke(nucypher_cli, public_keys_args, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert expected_error in result.output
+
+    # all 3 values - config-file, keystore-filepath, from-mnemonic
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+        "--config-file",
+        str(ursula_config_file.absolute()),
+        "--keystore-filepath",
+        str(keystore.keystore_path.absolute()),
+        "--from-mnemonic",
+    )
+
+    result = click_runner.invoke(nucypher_cli, public_keys_args, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert expected_error in result.output
+
+
+def test_ursula_public_keys_derived_ferveo_key(
+    click_runner, mocker, ursula_test_config, custom_filepath
+):
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+
+    power = keystore.derive_crypto_power(RitualisticPower)
+    expected_public_key = power.public_key()
+    expected_public_key_hex = bytes(expected_public_key).hex()
+
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+        "--keystore-filepath",
+        str(keystore.keystore_path.absolute()),
+    )
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, public_keys_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert expected_public_key_hex in result.output
+
+    # using config file produces same key
+    config_values = json.loads(ursula_test_config.serialize())
+    config_values["keystore_path"] = str(keystore.keystore_path.absolute())
+    updated_config_file = custom_filepath / "updated-ursula.json"
+    with open(updated_config_file, "w") as f:
+        json.dump(config_values, f)
+
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+        "--config-file",
+        str(updated_config_file.absolute()),
+    )
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, public_keys_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert expected_public_key_hex in result.output
+
+    # using default config filepath - no values provided
+    mocker.patch(
+        "nucypher.cli.commands.ursula.DEFAULT_CONFIG_FILEPATH", updated_config_file
+    )
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+    )
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, public_keys_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert expected_public_key_hex in result.output
+
+    # using mnemonic produces same key
+    words = keystore.get_mnemonic()
+
+    public_keys_args = (
+        "ursula",
+        "public-keys",
+        "--from-mnemonic",
+    )
+    user_input = f"{words}\n"
+    result = click_runner.invoke(
+        nucypher_cli, public_keys_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert expected_public_key_hex in result.output

--- a/tests/integration/cli/test_ursula_public_keys_cli.py
+++ b/tests/integration/cli/test_ursula_public_keys_cli.py
@@ -21,9 +21,9 @@ def test_ursula_public_keys_invalid(click_runner, ursula_test_config, custom_fil
         "ursula",
         "public-keys",
         "--config-file",
-        str(ursula_config_file.absolute()),
+        str(ursula_config_file.resolve()),
         "--keystore-filepath",
-        str(keystore.keystore_path.absolute()),
+        str(keystore.keystore_path.resolve()),
     )
 
     result = click_runner.invoke(nucypher_cli, public_keys_args, catch_exceptions=False)
@@ -35,7 +35,7 @@ def test_ursula_public_keys_invalid(click_runner, ursula_test_config, custom_fil
         "ursula",
         "public-keys",
         "--config-file",
-        str(ursula_config_file.absolute()),
+        str(ursula_config_file.resolve()),
         "--from-mnemonic",
     )
 
@@ -48,7 +48,7 @@ def test_ursula_public_keys_invalid(click_runner, ursula_test_config, custom_fil
         "ursula",
         "public-keys",
         "--keystore-filepath",
-        str(keystore.keystore_path.absolute()),
+        str(keystore.keystore_path.resolve()),
         "--from-mnemonic",
     )
 
@@ -61,9 +61,9 @@ def test_ursula_public_keys_invalid(click_runner, ursula_test_config, custom_fil
         "ursula",
         "public-keys",
         "--config-file",
-        str(ursula_config_file.absolute()),
+        str(ursula_config_file.resolve()),
         "--keystore-filepath",
-        str(keystore.keystore_path.absolute()),
+        str(keystore.keystore_path.resolve()),
         "--from-mnemonic",
     )
 
@@ -88,7 +88,7 @@ def test_ursula_public_keys_derived_ferveo_key(
         "ursula",
         "public-keys",
         "--keystore-filepath",
-        str(keystore.keystore_path.absolute()),
+        str(keystore.keystore_path.resolve()),
     )
 
     user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
@@ -101,7 +101,7 @@ def test_ursula_public_keys_derived_ferveo_key(
 
     # using config file produces same key
     config_values = json.loads(ursula_test_config.serialize())
-    config_values["keystore_path"] = str(keystore.keystore_path.absolute())
+    config_values["keystore_path"] = str(keystore.keystore_path.resolve())
     updated_config_file = custom_filepath / "updated-ursula.json"
     with open(updated_config_file, "w") as f:
         json.dump(config_values, f)
@@ -110,7 +110,7 @@ def test_ursula_public_keys_derived_ferveo_key(
         "ursula",
         "public-keys",
         "--config-file",
-        str(updated_config_file.absolute()),
+        str(updated_config_file.resolve()),
     )
     user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
 

--- a/tests/integration/cli/test_ursula_recover_cli.py
+++ b/tests/integration/cli/test_ursula_recover_cli.py
@@ -1,0 +1,232 @@
+from pathlib import Path
+
+from nucypher.cli.main import nucypher_cli
+from nucypher.config.characters import UrsulaConfiguration
+from nucypher.crypto.keystore import Keystore
+from tests.constants import INSECURE_DEVELOPMENT_PASSWORD, YES_ENTER
+
+
+def test_ursula_recover_invalid(click_runner, ursula_test_config, custom_filepath):
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+
+    ursula_config_file = custom_filepath / "ursula-invalid-test.json"
+
+    # no config-file - so default attempted
+    recover_args = (
+        "ursula",
+        "recover",
+        "--keystore-filepath",
+        str(keystore.keystore_path.resolve()),
+    )
+
+    result = click_runner.invoke(nucypher_cli, recover_args, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert "Ursula configuration file not found" in result.output
+
+    # config-file does not exist
+    recover_args = (
+        "ursula",
+        "recover",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+    )
+
+    result = click_runner.invoke(nucypher_cli, recover_args, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert f"'{ursula_config_file.resolve()}' does not exist" in result.output
+
+    # create config file
+    ursula_test_config._write_configuration_file(filepath=ursula_config_file)
+
+    # keystore-filepath does not exist
+    non_existent_keystore_filepath = custom_filepath / "non_existent.priv"
+    recover_args = (
+        "ursula",
+        "recover",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+        "--keystore-filepath",
+        str(non_existent_keystore_filepath.resolve()),
+    )
+
+    result = click_runner.invoke(nucypher_cli, recover_args, catch_exceptions=False)
+    assert result.exit_code != 0
+    assert (
+        f"'{non_existent_keystore_filepath.resolve()}' does not exist" in result.output
+    )
+
+
+def test_ursula_recover_keystore_file(
+    click_runner, mocker, ursula_test_config, custom_filepath
+):
+    #
+    # use specific config file
+    #
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+
+    ursula_config_file = custom_filepath / "ursula-keystore-test.json"
+    ursula_test_config._write_configuration_file(filepath=ursula_config_file)
+
+    recover_args = (
+        "ursula",
+        "recover",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+        "--keystore-filepath",
+        str(keystore.keystore_path.resolve()),
+    )
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, recover_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert str(keystore.keystore_path.resolve()) in result.output
+    updated_ursula_config = UrsulaConfiguration._read_configuration_file(
+        ursula_config_file
+    )
+    assert str(updated_ursula_config["keystore_path"].resolve()) == str(
+        keystore.keystore_path.resolve()
+    )
+    assert str(updated_ursula_config["keystore_path"].resolve()) in result.output
+
+    #
+    # use default config file
+    #
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+
+    ursula_default_file = custom_filepath / "ursula-keystore-default.json"
+    ursula_test_config._write_configuration_file(filepath=ursula_default_file)
+    mocker.patch(
+        "nucypher.cli.commands.ursula.DEFAULT_CONFIG_FILEPATH", ursula_default_file
+    )
+    recover_args = (
+        "ursula",
+        "recover",
+        "--keystore-filepath",
+        str(keystore.keystore_path.resolve()),
+    )
+
+    user_input = f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+
+    result = click_runner.invoke(
+        nucypher_cli, recover_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0
+
+    updated_default_ursula_config = UrsulaConfiguration._read_configuration_file(
+        ursula_default_file
+    )
+    assert (
+        str(updated_default_ursula_config["keystore_path"].resolve()) in result.output
+    )
+    assert str(updated_default_ursula_config["keystore_path"].resolve()) == str(
+        keystore.keystore_path.resolve()
+    )
+
+
+def test_ursula_recover_mnemonic(
+    click_runner, mocker, ursula_test_config, custom_filepath
+):
+    mocker.patch(
+        "nucypher.crypto.keystore.Keystore._DEFAULT_DIR", custom_filepath / "keystore"
+    )
+
+    #
+    # use specific config file
+    #
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+    mnemonic = keystore.get_mnemonic()
+
+    ursula_config_file = custom_filepath / "ursula-mnemonic-test.json"
+    ursula_test_config._write_configuration_file(filepath=ursula_config_file)
+    # could be None
+    old_keystore_path = (
+        UrsulaConfiguration._read_configuration_file(ursula_config_file)[
+            "keystore_path"
+        ]
+        or Path()
+    )
+
+    recover_args = (
+        "ursula",
+        "recover",
+        "--config-file",
+        str(ursula_config_file.resolve()),
+    )
+    user_input = (
+        YES_ENTER
+        + f"{mnemonic}\n"
+        + f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+        + f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+    )
+
+    result = click_runner.invoke(
+        nucypher_cli, recover_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    updated_ursula_config = UrsulaConfiguration._read_configuration_file(
+        ursula_config_file
+    )
+    assert str(updated_ursula_config["keystore_path"].resolve()) in result.output
+    assert str(updated_ursula_config["keystore_path"].resolve()) != str(
+        old_keystore_path.resolve()
+    )
+
+    #
+    # use default config file
+    #
+    keystore = Keystore.generate(
+        INSECURE_DEVELOPMENT_PASSWORD, keystore_dir=custom_filepath
+    )
+    keystore.unlock(INSECURE_DEVELOPMENT_PASSWORD)
+    mnemonic = keystore.get_mnemonic()
+
+    ursula_default_file = custom_filepath / "ursula-mnemonic-default.json"
+    mocker.patch(
+        "nucypher.cli.commands.ursula.DEFAULT_CONFIG_FILEPATH", ursula_default_file
+    )
+
+    ursula_test_config._write_configuration_file(filepath=ursula_default_file)
+    # could be None
+    old_default_keystore_path = (
+        UrsulaConfiguration._read_configuration_file(ursula_default_file)[
+            "keystore_path"
+        ]
+        or Path()
+    )
+
+    recover_args = (
+        "ursula",
+        "recover",
+    )
+
+    user_input = (
+        YES_ENTER
+        + f"{mnemonic}\n"
+        + f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+        + f"{INSECURE_DEVELOPMENT_PASSWORD}\n"
+    )
+
+    result = click_runner.invoke(
+        nucypher_cli, recover_args, input=user_input, catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    updated_default_ursula_config = UrsulaConfiguration._read_configuration_file(
+        ursula_default_file
+    )
+    assert (
+        str(updated_default_ursula_config["keystore_path"].resolve()) in result.output
+    )
+    assert str(updated_default_ursula_config["keystore_path"].resolve()) != str(
+        old_default_keystore_path.resolve()
+    )


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
2

**What this does:**
- Introduces new CLI commands:
  - `nucypher ursula public-keys [--from-mnemonic|--keystore-fiepath <path>]`
    - View local public keys from keystores or mnemonic phrases
  - `nucypher ursula audit [--view-mnemonic]`
    - Verify that a keystore password can decrypt local keys
    - Verify that a mnemonic phrase matches a local keystore file
    - View mnemonic phrase
- Expands `nucypher ursula recover [--keystore-filepath]`
  - automatically updates pre-existing ursula configuration file with recovered key filepath from mnemonic or keystore
- Expands `nucypher ursula init ... --with-mnemonic`
  - for node host relocation: creates a new configuration importing keys from the mnemonic

**Issues fixed/closed:**
- Fixes #3536 
- Closes https://github.com/nucypher/sprints/issues/47

**Why it's needed:**
- Assist in mitigation of key loss or recovery scenarios.

**Notes for reviewers:**

This branch has been published to a pre-release on docker (`nucypher/nucypher:recovery`)

##### CLI Usage Examples:

Recover using a mnemonic (with existing config):
```
nucypher ursula recover
```

Recover/Relocate by creating a new configuration and mnemonic:
```
nucypher ursula init ... --with-mnemonic
```

View public keys for a given mnemonic:     
```
nucypher ursula public-keys --from-mnemonic
```

Audit password and mnemonic:
```
nucypher ursula audit
```
(uses default configuration file to obtain keystore path)

```
nucypher ursula audit --config-file <>
```
(uses specified configuration file to obtain keystore path)

```
nucypher ursula audit --keystore-filepath <>
```
(uses specified keystore file to)

View mnemonic:
```
nucypher ursula audit ... --view-mnemonic
```

##### Docker Usage Examples:

Recover using a mnemonic (with existing config):
```
docker run -it -v ~/.local/share/nucypher:/root/.local/share/nucypher:rw -v ~/.ethereum/:/root/.ethereum:ro nucypher/nucypher:recovery nucypher ursula recover
```

Recover/Relocate by creating a new configuration and mnemonic:
```
docker run -it -v ~/.local/share/nucypher:/root/.local/share/nucypher:rw -v ~/.ethereum/:/root/.ethereum:ro nucypher/nucypher:recovery nucypher ursula init ... --with-mnemonic
```

View public keys for a given mnemonic:     
```
docker run -it nucypher/nucypher:recovery nucypher ursula public-keys --from-mnemonic
```

Audit password and mnemonic:
```
docker run -it -v ~/.local/share/nucypher:/root/.local/share/nucypher:rw -v ~/.ethereum/:/root/.ethereum:ro nucypher/nucypher:recovery nucypher ursula audit
```

View mnemonic:
```
docker run -it -v ~/.local/share/nucypher:/root/.local/share/nucypher:rw -v ~/.ethereum/:/root/.ethereum:ro nucypher/nucypher:recovery nucypher ursula audit --view-mnemonic
```