### PR TITLE
Condition result that is a string needs to be quoted

### DIFF
--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -295,7 +295,17 @@ class ReturnValueTest:
                     f"Index '{index}' not found in returned data."
                 )
 
-        if isinstance(processed_data, (list, tuple)):
+        # string results that have whitespace but are not already quoted will
+        # cause a problem for subsequent literal_eval
+        if isinstance(processed_data, str):
+            # string that contains whitespace, check if already quoted; if not, quote it
+            if " " in processed_data and not (
+                (processed_data.startswith("'") and processed_data.endswith("'"))
+                or (processed_data.startswith('"') and processed_data.endswith('"'))
+            ):
+                # quote the string
+                processed_data = f"'{processed_data}'"
+        elif isinstance(processed_data, (list, tuple)):
             # convert any bytes in list to hex (include nested lists/tuples); no additional indexing
             processed_data = [
                 self._process_data(data=item, index=None) for item in processed_data

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -295,17 +295,7 @@ class ReturnValueTest:
                     f"Index '{index}' not found in returned data."
                 )
 
-        # string results that have whitespace but are not already quoted will
-        # cause a problem for subsequent literal_eval
-        if isinstance(processed_data, str):
-            # string that contains whitespace, check if already quoted; if not, quote it
-            if " " in processed_data and not (
-                (processed_data.startswith("'") and processed_data.endswith("'"))
-                or (processed_data.startswith('"') and processed_data.endswith('"'))
-            ):
-                # quote the string
-                processed_data = f"'{processed_data}'"
-        elif isinstance(processed_data, (list, tuple)):
+        if isinstance(processed_data, (list, tuple)):
             # convert any bytes in list to hex (include nested lists/tuples); no additional indexing
             processed_data = [
                 self._process_data(data=item, index=None) for item in processed_data

--- a/nucypher/policy/conditions/offchain.py
+++ b/nucypher/policy/conditions/offchain.py
@@ -158,7 +158,12 @@ class JsonApiCondition(AccessControlCondition):
                 or (result.startswith('"') and result.endswith('"'))
             ):
                 # quote the string
-                result = f"'{result}'"
+                if "'" in result:
+                    # use double quotes
+                    result = f'"{result}"'
+                else:
+                    # use single quotes
+                    result = f"'{result}'"
 
         return result
 

--- a/nucypher/policy/conditions/offchain.py
+++ b/nucypher/policy/conditions/offchain.py
@@ -157,4 +157,9 @@ class JsonApiCondition(AccessControlCondition):
         response = self.fetch()
         data = self.deserialize_response(response)
         result = self.query_response(data)
-        return self.return_value_test.eval(result), result
+
+        resolved_return_value_test = self.return_value_test.with_resolved_context(
+            **context
+        )
+        eval_result = resolved_return_value_test.eval(result)  # test
+        return eval_result, result

--- a/nucypher/policy/conditions/offchain.py
+++ b/nucypher/policy/conditions/offchain.py
@@ -151,19 +151,16 @@ class JsonApiCondition(AccessControlCondition):
     @staticmethod
     def _process_result_for_eval(result: Any):
         # strings that are not already quoted will cause a problem for literal_eval
-        if isinstance(result, str):
-            # check if already quoted; if not, quote it
-            if not (
-                (result.startswith("'") and result.endswith("'"))
-                or (result.startswith('"') and result.endswith('"'))
-            ):
-                # quote the string
-                if "'" in result:
-                    # use double quotes
-                    result = f'"{result}"'
-                else:
-                    # use single quotes
-                    result = f"'{result}'"
+        if not isinstance(result, str):
+            return result
+
+        # check if already quoted; if not, quote it
+        if not (
+            (result.startswith("'") and result.endswith("'"))
+            or (result.startswith('"') and result.endswith('"'))
+        ):
+            quote_type_to_use = '"' if "'" in result else "'"
+            result = f"{quote_type_to_use}{result}{quote_type_to_use}"
 
         return result
 

--- a/nucypher/policy/conditions/offchain.py
+++ b/nucypher/policy/conditions/offchain.py
@@ -148,6 +148,20 @@ class JsonApiCondition(AccessControlCondition):
 
         return result
 
+    @staticmethod
+    def _process_result_for_eval(result: Any):
+        # strings that are not already quoted will cause a problem for literal_eval
+        if isinstance(result, str):
+            # check if already quoted; if not, quote it
+            if not (
+                (result.startswith("'") and result.endswith("'"))
+                or (result.startswith('"') and result.endswith('"'))
+            ):
+                # quote the string
+                result = f"'{result}'"
+
+        return result
+
     def verify(self, **context) -> Tuple[bool, Any]:
         """
         Verifies the offchain condition is met by performing a read operation on the endpoint
@@ -161,5 +175,7 @@ class JsonApiCondition(AccessControlCondition):
         resolved_return_value_test = self.return_value_test.with_resolved_context(
             **context
         )
-        eval_result = resolved_return_value_test.eval(result)  # test
+
+        result_for_eval = self._process_result_for_eval(result)
+        eval_result = resolved_return_value_test.eval(result_for_eval)  # test
         return eval_result, result

--- a/tests/unit/conditions/test_json_api_condition.py
+++ b/tests/unit/conditions/test_json_api_condition.py
@@ -136,9 +136,9 @@ def test_json_api_condition_verify(mocker):
 )
 def test_json_api_condition_verify_strings(json_return, value_test, mocker):
     mock_response = mocker.Mock(status_code=200)
-    mock_response.json.return_value = json.loads(
-        json.dumps({"store": {"book": [{"text": f"{json_return}"}]}})
-    )
+    json_string = json.loads(json.dumps(json_return))
+    assert json_string == json_return, "valid json string used for test"
+    mock_response.json.return_value = {"store": {"book": [{"text": f"{json_return}"}]}}
     mocker.patch("requests.get", return_value=mock_response)
 
     condition = JsonApiCondition(

--- a/tests/unit/conditions/test_json_api_condition.py
+++ b/tests/unit/conditions/test_json_api_condition.py
@@ -123,7 +123,22 @@ def test_json_api_condition_verify(mocker):
     assert value == 1
 
 
-def test_json_api_condition_verify_string(mocker):
+def test_json_api_condition_verify_string_without_whitespace(mocker):
+    mock_response = mocker.Mock(status_code=200)
+    mock_response.json.return_value = {"store": {"book": [{"title": "Title"}]}}
+    mocker.patch("requests.get", return_value=mock_response)
+
+    condition = JsonApiCondition(
+        endpoint="https://api.example.com/data",
+        query="$.store.book[0].title",
+        return_value_test=ReturnValueTest("==", "'Title'"),
+    )
+    result, value = condition.verify()
+    assert result is True
+    assert value == "Title"
+
+
+def test_json_api_condition_verify_string_with_whitespace(mocker):
     mock_response = mocker.Mock(status_code=200)
     mock_response.json.return_value = {"store": {"book": [{"title": "Test Title"}]}}
     mocker.patch("requests.get", return_value=mock_response)

--- a/tests/unit/conditions/test_json_api_condition.py
+++ b/tests/unit/conditions/test_json_api_condition.py
@@ -101,7 +101,7 @@ def test_json_api_condition_fetch_failure(mocker):
     condition = JsonApiCondition(
         endpoint="https://api.example.com/data",
         query="$.store.book[0].price",
-        return_value_test=ReturnValueTest("==", "1"),
+        return_value_test=ReturnValueTest("==", 1),
     )
     with pytest.raises(InvalidCondition) as excinfo:
         condition.fetch()
@@ -110,17 +110,32 @@ def test_json_api_condition_fetch_failure(mocker):
 
 def test_json_api_condition_verify(mocker):
     mock_response = mocker.Mock(status_code=200)
-    mock_response.json.return_value = {"store": {"book": [{"price": "1"}]}}
+    mock_response.json.return_value = {"store": {"book": [{"price": 1}]}}
     mocker.patch("requests.get", return_value=mock_response)
 
     condition = JsonApiCondition(
         endpoint="https://api.example.com/data",
         query="$.store.book[0].price",
-        return_value_test=ReturnValueTest("==", "1"),
+        return_value_test=ReturnValueTest("==", 1),
     )
     result, value = condition.verify()
     assert result is True
-    assert value == "1"
+    assert value == 1
+
+
+def test_json_api_condition_verify_string(mocker):
+    mock_response = mocker.Mock(status_code=200)
+    mock_response.json.return_value = {"store": {"book": [{"title": "Test Title"}]}}
+    mocker.patch("requests.get", return_value=mock_response)
+
+    condition = JsonApiCondition(
+        endpoint="https://api.example.com/data",
+        query="$.store.book[0].title",
+        return_value_test=ReturnValueTest("==", "'Test Title'"),
+    )
+    result, value = condition.verify()
+    assert result is True
+    assert value == "Test Title"
 
 
 def test_json_api_condition_verify_invalid_json(mocker):
@@ -131,7 +146,7 @@ def test_json_api_condition_verify_invalid_json(mocker):
     condition = JsonApiCondition(
         endpoint="https://api.example.com/data",
         query="$.store.book[0].price",
-        return_value_test=ReturnValueTest("==", "2"),
+        return_value_test=ReturnValueTest("==", 2),
     )
     with pytest.raises(ConditionEvaluationFailed) as excinfo:
         condition.verify()
@@ -150,7 +165,7 @@ def test_non_json_response(mocker):
     condition = JsonApiCondition(
         endpoint="https://api.example.com/data",
         query="$.store.book[0].price",
-        return_value_test=ReturnValueTest("==", "18"),
+        return_value_test=ReturnValueTest("==", 18),
     )
 
     with pytest.raises(ConditionEvaluationFailed) as excinfo:


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

A condition execution result that is an unquoted string and will be used for return value test comparison will raise an exception. Any string that is passed to `ast.literal_eval()` must be quoted.

This affects `JsonApiCondition` in particular because JSON strings are not usually quoted. For example, see test in PR here - https://github.com/nucypher/nucypher/pull/3553/files#diff-f13d425b7bdc36d0f95ef2a4f4d356124fb4af34f11f0194302522cb881c25e3R126-R153. 

Since the book title is what is retrieved using the jsonpath query, which is "Test Title" or "Title", if you pass these to ast.literal_eval(...) it will raise an exception:
```python
In [2]: ast.literal_eval(str("Test Title"))
Traceback (most recent call last):

  File ~/.local/share/virtualenvs/nucypher-z-zdnWw9/lib/python3.10/site-packages/IPython/core/interactiveshell.py:3550 in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)

  Cell In[2], line 1
    ast.literal_eval(str("Test Title"))

  File /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py:64 in literal_eval
    node_or_string = parse(node_or_string.lstrip(" \t"), mode='eval')

  File /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py:50 in parse
    return compile(source, filename, mode, flags,

  File <unknown>:1
    Test Title
         ^
SyntaxError: invalid syntax


In [3]: ast.literal_eval(str("Title"))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[3], line 1
----> 1 ast.literal_eval(str("Title"))

File /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py:110, in literal_eval(node_or_string)
    108                 return left - right
    109     return _convert_signed_num(node)
--> 110 return _convert(node_or_string)

File /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py:109, in literal_eval.<locals>._convert(node)
    107         else:
    108             return left - right
--> 109 return _convert_signed_num(node)

File /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py:83, in literal_eval.<locals>._convert_signed_num(node)
     81     else:
     82         return - operand
---> 83 return _convert_num(node)

File /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py:74, in literal_eval.<locals>._convert_num(node)
     72 def _convert_num(node):
     73     if not isinstance(node, Constant) or type(node.value) not in (int, float, complex):
---> 74         _raise_malformed_node(node)
     75     return node.value

File /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ast.py:71, in literal_eval.<locals>._raise_malformed_node(node)
     69 if lno := getattr(node, 'lineno', None):
     70     msg += f' on line {lno}'
---> 71 raise ValueError(msg + f': {node!r}')

ValueError: malformed node or string on line 1: <ast.Name object at 0x104ea6e30>
```

It's the same reason we already force users to quote strings used for `value` in ReturnValueTest, but we have to do the same for execution results such as these.

Instead "Test Title" needs to be made into "'Test Title'".
```python
In [4]: ast.literal_eval(str("'Test Title'"))
Out[4]: 'Test Title'

In [5]: ast.literal_eval(str("'Title'"))
Out[5]: 'Title'
```

We never ran into this problem before because on-chain conditions do not return strings, but JSON endpoints can.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

Used a dev newsfragment because it fixes a bug for Json API conditions, which hasn't yet been publicly released - so not really a bug fix from a release note point of view.
