### PR TITLE
Use correct transcript/aggregated transcript size during acceptance tests now that transcript size is checked

### DIFF
--- a/tests/acceptance/agents/test_coordinator_agent.py
+++ b/tests/acceptance/agents/test_coordinator_agent.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 import pytest_twisted
 from eth_utils import keccak
@@ -10,16 +8,12 @@ from twisted.internet.task import deferLater
 from nucypher.blockchain.eth.agents import CoordinatorAgent
 from nucypher.blockchain.eth.models import Coordinator
 from nucypher.crypto.powers import TransactingPower
+from tests.utils.dkg import generate_fake_ritual_transcript, threshold_from_shares
 
 
 @pytest.fixture(scope='module')
 def agent(coordinator_agent) -> CoordinatorAgent:
     return coordinator_agent
-
-
-@pytest.fixture(scope='module')
-def transcripts():
-    return [os.urandom(32), os.urandom(32)]
 
 
 @pytest.mark.usefixtures("ursulas")
@@ -116,15 +110,20 @@ def test_initiate_ritual(
 
 @pytest_twisted.inlineCallbacks
 def test_post_transcript(
-    agent, transcripts, transacting_powers, testerchain, clock, mock_async_hooks
+    agent, transacting_powers, testerchain, clock, mock_async_hooks
 ):
     ritual_id = agent.number_of_rituals() - 1
+    dkg_size = len(transacting_powers)
+    threshold = threshold_from_shares(dkg_size)
 
     txs = []
-    for i, transacting_power in enumerate(transacting_powers):
+    transcripts = []
+    for transacting_power in transacting_powers:
+        transcript = generate_fake_ritual_transcript(dkg_size, threshold)
+        transcripts.append(transcript)
         async_tx = agent.post_transcript(
             ritual_id=ritual_id,
-            transcript=transcripts[i],
+            transcript=transcript,
             transacting_power=transacting_power,
             async_tx_hooks=mock_async_hooks,
         )
@@ -171,7 +170,6 @@ def test_post_transcript(
 @pytest_twisted.inlineCallbacks
 def test_post_aggregation(
     agent,
-    aggregated_transcript,
     dkg_public_key,
     transacting_powers,
     cohort,
@@ -185,7 +183,11 @@ def test_post_aggregation(
     txs = []
     participant_public_key = SessionStaticSecret.random().public_key()
 
-    for i, transacting_power in enumerate(transacting_powers):
+    dkg_size = len(transacting_powers)
+    threshold = threshold_from_shares(dkg_size)
+    aggregated_transcript = generate_fake_ritual_transcript(dkg_size, threshold)
+
+    for transacting_power in transacting_powers:
         async_tx = agent.post_aggregation(
             ritual_id=ritual_id,
             aggregated_transcript=aggregated_transcript,

--- a/tests/utils/dkg.py
+++ b/tests/utils/dkg.py
@@ -1,0 +1,16 @@
+import os
+
+G1_SIZE = 48
+G2_SIZE = 48 * 2
+
+
+def threshold_from_shares(shares):
+    return shares // 2 + 1
+
+
+def ritual_transcript_size(shares, threshold):
+    return 40 + (1 + shares) * G2_SIZE + threshold * G1_SIZE
+
+
+def generate_fake_ritual_transcript(shares, threshold):
+    return os.urandom(ritual_transcript_size(shares, threshold))


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Upstream effect of https://github.com/nucypher/nucypher-contracts/pull/334. The transcript size is now verified by the `Coordinator` contract.

Our acceptance tests were fast and loose when creating fake transcripts. We need to ensure that the fake transcripts are of the correct size.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?