### PR TITLE
Clean up/Simplify condition validation

### DIFF
--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -4,6 +4,7 @@ from base64 import b64decode, b64encode
 from typing import Any, List, Optional, Tuple
 
 from marshmallow import Schema, ValidationError, fields
+from marshmallow.exceptions import SCHEMA
 
 from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
@@ -80,7 +81,12 @@ class AccessControlCondition(_Serializable, ABC):
         # validate using marshmallow schema
         errors = self.Schema().validate(data=self.to_dict())
         if errors:
-            raise InvalidCondition(f"Invalid {self.__class__.__name__}: {errors}")
+            error_type = list(errors.keys())[0]
+            message = errors[error_type][0]
+            message_prefix = f"'{error_type}' field - " if error_type != SCHEMA else ""
+            raise InvalidCondition(
+                f"Invalid {self.__class__.__name__}: " f"{message_prefix}{message}"
+            )
 
     @classmethod
     def from_dict(cls, data) -> "AccessControlCondition":

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -124,11 +124,13 @@ class MultiConditionAccessControl(AccessControlCondition):
     def _validate_multi_condition_nesting(
         cls,
         conditions: List[AccessControlCondition],
+        field_name: str,
         current_level: int = 1,
     ):
         if len(conditions) > cls.MAX_NUM_CONDITIONS:
-            raise InvalidCondition(
-                f"Maximum of {cls.MAX_NUM_CONDITIONS} conditions are allowed"
+            raise ValidationError(
+                field_name=field_name,
+                message=f"Maximum of {cls.MAX_NUM_CONDITIONS} conditions are allowed"
             )
 
         for condition in conditions:
@@ -137,10 +139,12 @@ class MultiConditionAccessControl(AccessControlCondition):
 
             level = current_level + 1
             if level > cls.MAX_MULTI_CONDITION_NESTED_LEVEL:
-                raise InvalidCondition(
-                    f"Only {cls.MAX_MULTI_CONDITION_NESTED_LEVEL} nested levels of multi-conditions are allowed"
+                raise ValidationError(
+                    field_name=field_name,
+                    message=f"Only {cls.MAX_MULTI_CONDITION_NESTED_LEVEL} nested levels of multi-conditions are allowed"
                 )
             cls._validate_multi_condition_nesting(
                 conditions=condition.conditions,
+                field_name=field_name,
                 current_level=level,
             )

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -87,14 +87,14 @@ class AccessControlCondition(_Serializable, ABC):
         try:
             return super().from_dict(data)
         except ValidationError as e:
-            raise InvalidConditionLingo(f"Invalid condition grammar: {e}")
+            raise InvalidConditionLingo(f"Invalid condition grammar: {e}") from e
 
     @classmethod
     def from_json(cls, data) -> "AccessControlCondition":
         try:
             return super().from_json(data)
         except ValidationError as e:
-            raise InvalidConditionLingo(f"Invalid condition grammar: {e}")
+            raise InvalidConditionLingo(f"Invalid condition grammar: {e}") from e
 
 
 class ExecutionCall(ABC):

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -11,7 +11,7 @@ from nucypher.policy.conditions.exceptions import (
 )
 from nucypher.policy.conditions.utils import (
     CamelCaseSchema,
-    extract_error_message_from_schema_errors,
+    extract_single_error_message_from_schema_errors,
 )
 
 
@@ -78,7 +78,7 @@ class AccessControlCondition(_Serializable, ABC):
     def _validate(self, **kwargs):
         errors = self.Schema().validate(data=self.to_dict())
         if errors:
-            error_message = extract_error_message_from_schema_errors(errors)
+            error_message = extract_single_error_message_from_schema_errors(errors)
             raise InvalidCondition(
                 f"Invalid {self.__class__.__name__}: {error_message}"
             )
@@ -148,7 +148,7 @@ class ExecutionCall(_Serializable, ABC):
         # validate call using marshmallow schema before creating
         errors = self.Schema().validate(data=self.to_dict())
         if errors:
-            error_message = extract_error_message_from_schema_errors(errors)
+            error_message = extract_single_error_message_from_schema_errors(errors)
             raise self.InvalidExecutionCall(f"{error_message}")
 
     @abstractmethod

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -122,7 +122,7 @@ class MultiConditionAccessControl(AccessControlCondition):
         if len(conditions) > cls.MAX_NUM_CONDITIONS:
             raise ValidationError(
                 field_name=field_name,
-                message=f"Maximum of {cls.MAX_NUM_CONDITIONS} conditions are allowed"
+                message=f"Maximum of {cls.MAX_NUM_CONDITIONS} conditions are allowed",
             )
 
         for condition in conditions:
@@ -133,7 +133,7 @@ class MultiConditionAccessControl(AccessControlCondition):
             if level > cls.MAX_MULTI_CONDITION_NESTED_LEVEL:
                 raise ValidationError(
                     field_name=field_name,
-                    message=f"Only {cls.MAX_MULTI_CONDITION_NESTED_LEVEL} nested levels of multi-conditions are allowed"
+                    message=f"Only {cls.MAX_MULTI_CONDITION_NESTED_LEVEL} nested levels of multi-conditions are allowed",
                 )
             cls._validate_multi_condition_nesting(
                 conditions=condition.conditions,

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -204,7 +204,7 @@ class RPCCall(ExecutionCall):
 
 
 class RPCCondition(ExecutionCallAccessControlCondition):
-    EXEC_CALL_TYPE = RPCCall
+    EXECUTION_CALL_TYPE = RPCCall
     CONDITION_TYPE = ConditionType.RPC.value
 
     class Schema(ExecutionCallAccessControlCondition.Schema, RPCCall.Schema):
@@ -388,7 +388,7 @@ class ContractCall(RPCCall):
 
 
 class ContractCondition(RPCCondition):
-    EXEC_CALL_TYPE = ContractCall
+    EXECUTION_CALL_TYPE = ContractCall
     CONDITION_TYPE = ConditionType.CONTRACT.value
 
     class Schema(RPCCondition.Schema, ContractCall.Schema):

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -254,7 +254,11 @@ class RPCCondition(ExecutionCallAccessControlCondition):
     ):
         super().__init__(condition_type=condition_type, *args, **kwargs)
 
+    def _validate(self):
         self._validate_expected_return_type()
+
+        # Make sure to call super
+        super()._validate()
 
     def _create_execution_call(self, *args, **kwargs) -> ExecutionCall:
         return RPCCall(*args, **kwargs)

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -143,6 +143,7 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
             CompoundAccessControlCondition._validate_operator_and_operands(
                 operator, operands, ValidationError
             )
+            CompoundAccessControlCondition._validate_multi_condition_nesting(conditions=operands, field_name="operands")
 
         @post_load
         def make(self, data, **kwargs):
@@ -305,11 +306,12 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
         class Meta:
             ordered = True
 
-        @validates_schema
-        def validate_condition_variables(self, data, **kwargs):
-            condition_variables = data["condition_variables"]
-            SequentialAccessControlCondition._validate_condition_variables(
-                condition_variables, ValidationError
+        @validates("condition_variables")
+        def validate_condition_variables(self,value):
+            SequentialAccessControlCondition._validate_condition_variables(value)
+            conditions = [cv.condition for cv in value]
+            SequentialAccessControlCondition._validate_multi_condition_nesting(
+                conditions=conditions, field_name="condition_variables"
             )
 
         @post_load

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -146,7 +146,9 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
             CompoundAccessControlCondition._validate_operator_and_operands(
                 operator, operands
             )
-            CompoundAccessControlCondition._validate_multi_condition_nesting(conditions=operands, field_name="operands")
+            CompoundAccessControlCondition._validate_multi_condition_nesting(
+                conditions=operands, field_name="operands"
+            )
 
         @post_load
         def make(self, data, **kwargs):
@@ -305,7 +307,7 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
             ordered = True
 
         @validates("condition_variables")
-        def validate_condition_variables(self,value):
+        def validate_condition_variables(self, value):
             SequentialAccessControlCondition._validate_condition_variables(value)
             conditions = [cv.condition for cv in value]
             SequentialAccessControlCondition._validate_multi_condition_nesting(
@@ -324,7 +326,6 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
     ):
         self.condition_variables = condition_variables
         super().__init__(condition_type=condition_type, name=name)
-
 
     def __repr__(self):
         r = f"{self.__class__.__name__}(num_condition_variables={len(self.condition_variables)})"

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -161,7 +161,6 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
             "operands": [CONDITION*]
         }
         """
-        self._validate_operator_and_operands(operator, operands, InvalidCondition)
 
         self.operator = operator
         self.operands = operands
@@ -170,6 +169,14 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
         self.id = md5(bytes(self)).hexdigest()[:6]
 
         super().__init__(condition_type=condition_type, name=name)
+
+    def _validate(self):
+        self._validate_operator_and_operands(
+            self.operator, self.operands, InvalidCondition
+        )
+
+        # Make sure to call super
+        super()._validate()
 
     def __repr__(self):
         return f"Operator={self.operator} (NumOperands={len(self.operands)}), id={self.id})"
@@ -306,11 +313,17 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
         condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
     ):
-        self._validate_condition_variables(
-            condition_variables=condition_variables, exception_class=InvalidCondition
-        )
         self.condition_variables = condition_variables
         super().__init__(condition_type=condition_type, name=name)
+
+    def _validate(self):
+        self._validate_condition_variables(
+            condition_variables=self.condition_variables,
+            exception_class=InvalidCondition,
+        )
+
+        # Make sure to call super
+        super()._validate()
 
     def __repr__(self):
         r = f"{self.__class__.__name__}(num_condition_variables={len(self.condition_variables)})"

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -590,7 +590,7 @@ class ExecutionCallAccessControlCondition(AccessControlCondition):
     Conditions that utilize underlying ExecutionCall objects.
     """
 
-    EXEC_CALL_TYPE = NotImplemented
+    EXECUTION_CALL_TYPE = NotImplemented
 
     class Schema(AccessControlCondition.Schema):
         return_value_test = fields.Nested(
@@ -608,7 +608,7 @@ class ExecutionCallAccessControlCondition(AccessControlCondition):
         self.return_value_test = return_value_test
 
         try:
-            self.execution_call = self.EXEC_CALL_TYPE(*args, **kwargs)
+            self.execution_call = self.EXECUTION_CALL_TYPE(*args, **kwargs)
         except ExecutionCall.InvalidExecutionCall as e:
             raise InvalidCondition(str(e)) from e
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -272,7 +272,7 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
     @classmethod
     def _validate_condition_variables(
         cls,
-        condition_variables: List[Union[Dict, ConditionVariable]],
+        condition_variables: List[ConditionVariable],
         exception_class: Union[Type[ValidationError], Type[InvalidCondition]],
     ):
         num_condition_variables = len(condition_variables)
@@ -283,6 +283,15 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
             raise exception_class(
                 f"Maximum of {cls.MAX_NUM_CONDITIONS} conditions are allowed"
             )
+
+        # check for duplicate var names
+        var_names = set()
+        for condition_variable in condition_variables:
+            if condition_variable.var_name in var_names:
+                raise exception_class(
+                    f"Duplicate variable names are not allowed - {condition_variable.var_name}"
+                )
+            var_names.add(condition_variable.var_name)
 
     class Schema(AccessControlCondition.Schema):
         condition_type = fields.Str(

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -167,14 +167,15 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
             "operands": [CONDITION*]
         }
         """
-
         self.operator = operator
         self.operands = operands
-        self.condition_type = condition_type
-        self.name = name
-        self.id = md5(bytes(self)).hexdigest()[:6]
 
-        super().__init__(condition_type=condition_type, name=name)
+        super().__init__(
+            condition_type=condition_type,
+            name=name,
+        )
+
+        self.id = md5(bytes(self)).hexdigest()[:6]
 
     def __repr__(self):
         return f"Operator={self.operator} (NumOperands={len(self.operands)}), id={self.id})"
@@ -325,7 +326,10 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
         name: Optional[str] = None,
     ):
         self.condition_variables = condition_variables
-        super().__init__(condition_type=condition_type, name=name)
+        super().__init__(
+            condition_type=condition_type,
+            name=name,
+        )
 
     def __repr__(self):
         r = f"{self.__class__.__name__}(num_condition_variables={len(self.condition_variables)})"

--- a/nucypher/policy/conditions/offchain.py
+++ b/nucypher/policy/conditions/offchain.py
@@ -14,6 +14,7 @@ from nucypher.policy.conditions.exceptions import (
 from nucypher.policy.conditions.lingo import (
     ConditionType,
     ExecutionCallAccessControlCondition,
+    ReturnValueTest,
 )
 from nucypher.utilities.logging import Logger
 
@@ -154,11 +155,21 @@ class JsonApiCondition(ExecutionCallAccessControlCondition):
 
     def __init__(
         self,
+        endpoint: str,
+        return_value_test: ReturnValueTest,
+        query: Optional[str] = None,
+        parameters: Optional[dict] = None,
         condition_type: str = ConditionType.JSONAPI.value,
-        *args,
-        **kwargs,
+        name: Optional[str] = None,
     ):
-        super().__init__(condition_type=condition_type, *args, **kwargs)
+        super().__init__(
+            endpoint=endpoint,
+            return_value_test=return_value_test,
+            query=query,
+            parameters=parameters,
+            condition_type=condition_type,
+            name=name,
+        )
 
     @property
     def endpoint(self):

--- a/nucypher/policy/conditions/offchain.py
+++ b/nucypher/policy/conditions/offchain.py
@@ -140,7 +140,7 @@ class JsonApiCondition(ExecutionCallAccessControlCondition):
     The response will be deserialized as JSON and parsed using jsonpath.
     """
 
-    EXEC_CALL_TYPE = JsonApiCall
+    EXECUTION_CALL_TYPE = JsonApiCall
     CONDITION_TYPE = ConditionType.JSONAPI.value
 
     class Schema(ExecutionCallAccessControlCondition.Schema, JsonApiCall.Schema):

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -54,7 +54,7 @@ class TimeRPCCall(RPCCall):
 
 
 class TimeCondition(RPCCondition):
-    EXEC_CALL_TYPE = TimeRPCCall
+    EXECUTION_CALL_TYPE = TimeRPCCall
     CONDITION_TYPE = ConditionType.TIME.value
 
     class Schema(RPCCondition.Schema, TimeRPCCall.Schema):

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 from web3 import Web3
 
 from nucypher.policy.conditions.evm import RPCCall, RPCCondition
-from nucypher.policy.conditions.lingo import ConditionType
+from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 
 
 class TimeRPCCall(RPCCall):
@@ -82,17 +82,19 @@ class TimeCondition(RPCCondition):
 
     def __init__(
         self,
+        return_value_test: ReturnValueTest,
+        chain: int,
         method: str = TimeRPCCall.METHOD,
-        condition_type: str = CONDITION_TYPE,
-        *args,
-        **kwargs,
+        condition_type: str = ConditionType.TIME.value,
+        name: Optional[str] = None,
     ):
         # call to super must be at the end for proper validation
         super().__init__(
-            condition_type=condition_type,
+            return_value_test=return_value_test,
+            chain=chain,
             method=method,
-            *args,
-            **kwargs,
+            condition_type=condition_type,
+            name=name,
         )
 
     @property

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -141,13 +141,15 @@ def evaluate_condition_lingo(
         raise error
 
 
-def extract_error_message_from_schema_errors(errors: Dict[str, List[str]]) -> str:
+def extract_single_error_message_from_schema_errors(
+    errors: Dict[str, List[str]]
+) -> str:
     """
-    Extract single error message from Schema().validate().
+    Extract single error message from Schema().validate() errors result.
 
-    The string is only for a single error type, and only the first message string.
-    If there are multiple error types, only one error is used; a field-specific (preferred) error is
-    prioritized over schema-specific error
+    The result is only for a single error type, and only the first message string for that type.
+    If there are multiple error types, only one error type is used; the first field-specific (@validates)
+    error type encountered is prioritized over any schema-level-specific (@validates_schema) error.
     """
     if not errors:
         raise ValueError("Validation errors must be provided")

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -1,8 +1,9 @@
 import re
 from http import HTTPStatus
-from typing import Dict, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from marshmallow import Schema, post_dump
+from marshmallow.exceptions import SCHEMA
 from web3.providers import BaseProvider
 
 from nucypher.policy.conditions.exceptions import (
@@ -138,3 +139,31 @@ def evaluate_condition_lingo(
     if error:
         log.info(error.message)  # log error message
         raise error
+
+
+def extract_error_message_from_schema_errors(errors: Dict[str, List[str]]) -> str:
+    """
+    Extract single error message from Schema().validate().
+
+    The string is only for a single error type, and only the first message string.
+    If there are multiple error types, only one error is used; a field-specific (preferred) error is
+    prioritized over schema-specific error
+    """
+    if not errors:
+        raise ValueError("Validation errors must be provided")
+
+    # extract error type - either field-specific (preferred) or schema-specific
+    error_key_to_use = None
+    for error_type in list(errors.keys()):
+        error_key_to_use = error_type
+        if error_key_to_use != SCHEMA:
+            # actual field
+            break
+
+    message = errors[error_key_to_use][0]
+    message_prefix = (
+        f"'{camel_case_to_snake(error_key_to_use)}' field - "
+        if error_key_to_use != SCHEMA
+        else ""
+    )
+    return f"{message_prefix}{message}"

--- a/nucypher/policy/conditions/validation.py
+++ b/nucypher/policy/conditions/validation.py
@@ -7,40 +7,22 @@ from typing import (
     cast,
 )
 
+from eth_typing import ChecksumAddress
+from web3 import Web3
 from web3.auto import w3
+from web3.contract.contract import ContractFunction
 from web3.types import ABIFunction
 
+from nucypher.policy.conditions import STANDARD_ABI_CONTRACT_TYPES, STANDARD_ABIS
 from nucypher.policy.conditions.context import is_context_variable
-from nucypher.policy.conditions.exceptions import (
-    InvalidCondition,
-)
 from nucypher.policy.conditions.lingo import ReturnValueTest
 
-
-def _validate_single_output_type(
-    expected_type: str,
-    comparator_value: Any,
-    comparator_index: Optional[int],
-    failure_message: str,
-) -> None:
-    if comparator_index is not None and _is_tuple_type(expected_type):
-        type_entries = _get_tuple_type_entries(expected_type)
-        expected_type = type_entries[comparator_index]
-    _validate_value_type(expected_type, comparator_value, failure_message)
-
+#
+# Schema logic
+#
 
 def _get_abi_types(abi: ABIFunction) -> List[str]:
     return [_collapse_if_tuple(cast(Dict[str, Any], arg)) for arg in abi["outputs"]]
-
-
-def _validate_value_type(
-    expected_type: str, comparator_value: Any, failure_message: str
-) -> None:
-    if is_context_variable(comparator_value):
-        # context variable types cannot be known until execution time.
-        return
-    if not w3.is_encodable(expected_type, comparator_value):
-        raise InvalidCondition(failure_message)
 
 
 def _collapse_if_tuple(abi: Dict[str, Any]) -> str:
@@ -66,6 +48,28 @@ def _get_tuple_type_entries(tuple_type: str) -> List[str]:
     return result
 
 
+def _validate_value_type(
+    expected_type: str, comparator_value: Any, failure_message: str
+) -> None:
+    if is_context_variable(comparator_value):
+        # context variable types cannot be known until execution time.
+        return
+    if not w3.is_encodable(expected_type, comparator_value):
+        raise ValueError(failure_message)
+
+
+def _validate_single_output_type(
+    expected_type: str,
+    comparator_value: Any,
+    comparator_index: Optional[int],
+    failure_message: str,
+) -> None:
+    if comparator_index is not None and _is_tuple_type(expected_type):
+        type_entries = _get_tuple_type_entries(expected_type)
+        expected_type = type_entries[comparator_index]
+    _validate_value_type(expected_type, comparator_value, failure_message)
+
+
 def _validate_multiple_output_types(
     output_abi_types: List[str],
     comparator_value: Any,
@@ -82,13 +86,44 @@ def _validate_multiple_output_types(
         return
 
     if not isinstance(comparator_value, Sequence):
-        raise InvalidCondition(failure_message)
+        raise ValueError(failure_message)
 
     if len(output_abi_types) != len(comparator_value):
-        raise InvalidCondition(failure_message)
+        raise ValueError(failure_message)
 
     for output_abi_type, component_value in zip(output_abi_types, comparator_value):
         _validate_value_type(output_abi_type, component_value, failure_message)
+
+
+def _resolve_abi(
+    w3: Web3,
+    method: str,
+    standard_contract_type: Optional[str] = None,
+    function_abi: Optional[ABIFunction] = None,
+) -> ABIFunction:
+    """Resolves the contract an/or function ABI from a standard contract name"""
+
+    if not (function_abi or standard_contract_type):
+        raise ValueError(
+            f"Ambiguous ABI - Supply either an ABI or a standard contract type ({STANDARD_ABI_CONTRACT_TYPES})."
+        )
+
+    if standard_contract_type:
+        try:
+            # Lookup the standard ABI given it's ERC standard name (standard contract type)
+            contract_abi = STANDARD_ABIS[standard_contract_type]
+        except KeyError:
+            raise ValueError(
+                f"Invalid standard contract type {standard_contract_type}; Must be one of {STANDARD_ABI_CONTRACT_TYPES}"
+            )
+
+        # Extract all function ABIs from the contract's ABI.
+        # Will raise a ValueError if there is not exactly one match.
+        function_abi = (
+            w3.eth.contract(abi=contract_abi).get_function_by_name(method).abi
+        )
+
+    return ABIFunction(function_abi)
 
 
 def _align_comparator_value_single_output(
@@ -99,7 +134,7 @@ def _align_comparator_value_single_output(
         expected_type = type_entries[comparator_index]
 
     if not w3.is_encodable(expected_type, comparator_value):
-        raise InvalidCondition(
+        raise ValueError(
             f"Mismatched comparator type ({comparator_value} as {expected_type})"
         )
     return comparator_value
@@ -112,7 +147,7 @@ def _align_comparator_value_multiple_output(
         expected_type = output_abi_types[comparator_index]
         # ensure alignment
         if not w3.is_encodable(expected_type, comparator_value):
-            raise InvalidCondition(
+            raise ValueError(
                 f"Mismatched comparator type ({comparator_value} as {expected_type})"
             )
 
@@ -122,15 +157,20 @@ def _align_comparator_value_multiple_output(
     for output_abi_type, component_value in zip(output_abi_types, comparator_value):
         # ensure alignment
         if not w3.is_encodable(output_abi_type, component_value):
-            raise InvalidCondition(
+            raise ValueError(
                 f"Mismatched comparator type ({component_value} as {output_abi_type})"
             )
         values.append(component_value)
     return values
 
 
-def _align_comparator_value_with_abi(
-    abi, return_value_test: ReturnValueTest
+#
+# Public functions.
+#
+
+
+def align_comparator_value_with_abi(
+    abi: ABIFunction, return_value_test: ReturnValueTest
 ) -> ReturnValueTest:
     output_abi_types = _get_abi_types(abi)
     comparator = return_value_test.comparator
@@ -155,13 +195,19 @@ def _align_comparator_value_with_abi(
         )
 
 
-def _validate_function_abi(function_abi: Dict, method_name: str) -> None:
-    """validates a dictionary as valid for use as a condition function ABI"""
+def validate_function_abi(
+    function_abi: Dict, method_name: Optional[str] = None
+) -> None:
+    """
+    Validates a dictionary as valid for use as a condition function ABI.
+
+    Optionally validates the method_name
+    """
     abi = ABIFunction(function_abi)
 
     if not abi.get("name"):
         raise ValueError(f"Invalid ABI, no function name found {abi}")
-    if abi.get("name") != method_name:
+    if method_name and abi.get("name") != method_name:
         raise ValueError(f"Mismatched ABI for contract function {method_name} - {abi}")
     if abi.get("type") != "function":
         raise ValueError(f"Invalid ABI type {abi}")
@@ -171,14 +217,47 @@ def _validate_function_abi(function_abi: Dict, method_name: str) -> None:
         raise ValueError(f"Invalid ABI stateMutability {abi}")
 
 
-def _validate_contract_call_abi(
-    standard_contract_type: str,
-    function_abi: Dict,
-    method_name: str,
-) -> None:
-    if not (bool(standard_contract_type) ^ bool(function_abi)):
+def get_unbound_contract_function(
+    contract_address: ChecksumAddress,
+    method: str,
+    standard_contract_type: Optional[str] = None,
+    function_abi: Optional[ABIFunction] = None,
+) -> ContractFunction:
+    """Gets an unbound contract function to evaluate"""
+    w3 = Web3()
+    function_abi = _resolve_abi(
+        w3=w3,
+        standard_contract_type=standard_contract_type,
+        method=method,
+        function_abi=function_abi,
+    )
+    try:
+        contract = w3.eth.contract(address=contract_address, abi=[function_abi])
+        contract_function = getattr(contract.functions, method)
+        return contract_function
+    except Exception as e:
         raise ValueError(
-            f"Provide 'standardContractType' or 'functionAbi'; got ({standard_contract_type}, {function_abi})."
+            f"Unable to find contract function, '{method}', for condition: {e}"
+        ) from e
+
+
+def validate_contract_function_expected_return_type(
+    contract_function: ContractFunction, return_value_test: ReturnValueTest
+) -> None:
+    output_abi_types = _get_abi_types(contract_function.contract_abi[0])
+    comparator_value = return_value_test.value
+    comparator_index = return_value_test.index
+    index_string = f"@index={comparator_index}" if comparator_index is not None else ""
+    failure_message = (
+        f"Invalid return value comparison type '{type(comparator_value)}' for "
+        f"'{contract_function.fn_name}'{index_string} based on ABI types {output_abi_types}"
+    )
+
+    if len(output_abi_types) == 1:
+        _validate_single_output_type(
+            output_abi_types[0], comparator_value, comparator_index, failure_message
         )
-    if function_abi:
-        _validate_function_abi(function_abi, method_name=method_name)
+    else:
+        _validate_multiple_output_types(
+            output_abi_types, comparator_value, comparator_index, failure_message
+        )

--- a/tests/unit/conditions/test_compound_condition.py
+++ b/tests/unit/conditions/test_compound_condition.py
@@ -156,7 +156,7 @@ def test_compound_condition_schema_validation(operator, time_condition, rpc_cond
 
 
 @pytest.mark.usefixtures("mock_skip_schema_validation")
-def test_and_condition_and_short_circuit(mocker, mock_conditions):
+def test_and_condition_and_short_circuit(mock_conditions):
     condition_1, condition_2, condition_3, condition_4 = mock_conditions
 
     and_condition = AndCompoundCondition(
@@ -289,10 +289,9 @@ def test_compound_condition(mock_conditions):
     ]  # or-condition short-circuited because condition_1 was True
 
 
-@pytest.mark.usefixtures("mock_skip_schema_validation")
-def test_nested_compound_condition_too_many_nested_levels(mock_conditions):
-    condition_1, condition_2, condition_3, condition_4 = mock_conditions
-
+def test_nested_compound_condition_too_many_nested_levels(
+    rpc_condition, time_condition
+):
     with pytest.raises(
         InvalidCondition, match="nested levels of multi-conditions are allowed"
     ):
@@ -300,24 +299,23 @@ def test_nested_compound_condition_too_many_nested_levels(mock_conditions):
             operands=[
                 OrCompoundCondition(
                     operands=[
-                        condition_1,
+                        rpc_condition,
                         AndCompoundCondition(
                             operands=[
-                                condition_2,
-                                condition_3,
+                                time_condition,
+                                rpc_condition,
                             ]
                         ),
                     ]
                 ),
-                condition_4,
+                time_condition,
             ]
         )
 
 
-@pytest.mark.usefixtures("mock_skip_schema_validation")
-def test_nested_sequential_condition_too_many_nested_levels(mock_conditions):
-    condition_1, condition_2, condition_3, condition_4 = mock_conditions
-
+def test_nested_sequential_condition_too_many_nested_levels(
+    rpc_condition, time_condition
+):
     with pytest.raises(
         InvalidCondition, match="nested levels of multi-conditions are allowed"
     ):
@@ -325,16 +323,16 @@ def test_nested_sequential_condition_too_many_nested_levels(mock_conditions):
             operands=[
                 OrCompoundCondition(
                     operands=[
-                        condition_1,
+                        rpc_condition,
                         SequentialAccessControlCondition(
                             condition_variables=[
-                                ConditionVariable("var2", condition_2),
-                                ConditionVariable("var3", condition_3),
+                                ConditionVariable("var2", time_condition),
+                                ConditionVariable("var3", rpc_condition),
                             ]
                         ),
                     ]
                 ),
-                condition_4,
+                time_condition,
             ]
         )
 

--- a/tests/unit/conditions/test_compound_condition.py
+++ b/tests/unit/conditions/test_compound_condition.py
@@ -4,7 +4,10 @@ from unittest.mock import Mock
 import pytest
 
 from nucypher.policy.conditions.base import AccessControlCondition
-from nucypher.policy.conditions.exceptions import InvalidCondition
+from nucypher.policy.conditions.exceptions import (
+    InvalidCondition,
+    InvalidConditionLingo,
+)
 from nucypher.policy.conditions.lingo import (
     AndCompoundCondition,
     CompoundAccessControlCondition,
@@ -121,35 +124,35 @@ def test_compound_condition_schema_validation(operator, time_condition, rpc_cond
     compound_condition_dict = compound_condition.to_dict()
 
     # no issues here
-    CompoundAccessControlCondition.validate(compound_condition_dict)
+    CompoundAccessControlCondition.from_dict(compound_condition_dict)
 
     # no issues with optional name
     compound_condition_dict["name"] = "my_contract_condition"
-    CompoundAccessControlCondition.validate(compound_condition_dict)
+    CompoundAccessControlCondition.from_dict(compound_condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # incorrect condition type
         compound_condition_dict = compound_condition.to_dict()
         compound_condition_dict["condition_type"] = ConditionType.RPC.value
-        CompoundAccessControlCondition.validate(compound_condition_dict)
+        CompoundAccessControlCondition.from_dict(compound_condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # invalid operator
         compound_condition_dict = compound_condition.to_dict()
         compound_condition_dict["operator"] = "5True"
-        CompoundAccessControlCondition.validate(compound_condition_dict)
+        CompoundAccessControlCondition.from_dict(compound_condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no operator
         compound_condition_dict = compound_condition.to_dict()
         del compound_condition_dict["operator"]
-        CompoundAccessControlCondition.validate(compound_condition_dict)
+        CompoundAccessControlCondition.from_dict(compound_condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no operands
         compound_condition_dict = compound_condition.to_dict()
         del compound_condition_dict["operands"]
-        CompoundAccessControlCondition.validate(compound_condition_dict)
+        CompoundAccessControlCondition.from_dict(compound_condition_dict)
 
 
 @pytest.mark.usefixtures("mock_skip_schema_validation")

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -141,7 +141,7 @@ def test_invalid_contract_condition():
     # invalid condition type
     with pytest.raises(
         InvalidCondition,
-        match=f"must be instantiated with the {ConditionType.CONTRACT.value} type",
+        match=f"'condition_type' field - Must be equal to {ConditionType.CONTRACT.value}",
     ):
         _ = ContractCondition(
             condition_type=ConditionType.RPC.value,
@@ -166,7 +166,7 @@ def test_invalid_contract_condition():
 
     # no abi or contract type
     with pytest.raises(
-        InvalidCondition, match="Provide 'standardContractType' or 'functionAbi'"
+        InvalidCondition, match="Provide a standard contract type or function ABI"
     ):
         _ = ContractCondition(
             contract_address="0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
@@ -221,7 +221,7 @@ def test_invalid_contract_condition():
 
     # standard contract type and function ABI
     with pytest.raises(
-        InvalidCondition, match="Provide 'standardContractType' or 'functionAbi'"
+        InvalidCondition, match="Provide a standard contract type or function ABI"
     ):
         _ = ContractCondition(
             contract_address="0xaDD9D957170dF6F33982001E4c22eCCdd5539118",

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -55,7 +55,7 @@ class FakeExecutionContractCondition(ContractCondition):
         def execute(self, providers: Dict, **context) -> Any:
             return self.execution_return_value
 
-    EXEC_CALL_TYPE = FakeRPCCall
+    EXECUTION_CALL_TYPE = FakeRPCCall
 
     class Schema(ContractCondition.Schema):
         @post_load

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -205,7 +205,9 @@ def test_invalid_contract_condition():
         )
 
     # method not in ABI
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(
+        InvalidCondition, match="Could not find any function with matching name"
+    ):
         _ = ContractCondition(
             contract_address="0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
             method="getPolicy",
@@ -226,7 +228,48 @@ def test_invalid_contract_condition():
             method="balanceOf",
             chain=TESTERCHAIN_CHAIN_ID,
             standard_contract_type="ERC20",
-            function_abi={"rando": "ABI"},
+            function_abi={
+                "inputs": [
+                    {"internalType": "bytes16", "name": "_policyID", "type": "bytes16"}
+                ],
+                "name": "getPolicy",
+                "outputs": [
+                    {
+                        "components": [
+                            {
+                                "internalType": "address payable",
+                                "name": "sponsor",
+                                "type": "address",
+                            },
+                            {
+                                "internalType": "uint32",
+                                "name": "startTimestamp",
+                                "type": "uint32",
+                            },
+                            {
+                                "internalType": "uint32",
+                                "name": "endTimestamp",
+                                "type": "uint32",
+                            },
+                            {
+                                "internalType": "uint16",
+                                "name": "size",
+                                "type": "uint16",
+                            },
+                            {
+                                "internalType": "address",
+                                "name": "owner",
+                                "type": "address",
+                            },
+                        ],
+                        "internalType": "struct SubscriptionManager.Policy",
+                        "name": "",
+                        "type": "tuple",
+                    }
+                ],
+                "stateMutability": "view",
+                "type": "function",
+            },
             return_value_test=ReturnValueTest("!=", 0),
             parameters=[
                 ":hrac",
@@ -388,7 +431,9 @@ def test_abi_bool_output(contract_condition_dict):
     assert isinstance(contract_condition.return_value_test.value, bool)
 
     # invalid type fails
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = 23
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
@@ -418,7 +463,8 @@ def test_abi_bool_output(contract_condition_dict):
     )
 
     # test where context var has invalid expected type(s), so only detected at decryption time
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=True,
@@ -437,7 +483,9 @@ def test_abi_uint_output(contract_condition_dict):
     assert isinstance(contract_condition.return_value_test.value, int)
 
     # invalid type fails
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = True
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
@@ -467,7 +515,8 @@ def test_abi_uint_output(contract_condition_dict):
     )
 
     # test where context var has invalid expected type(s), so only detected at decryption time
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=123456789,
@@ -486,7 +535,9 @@ def test_abi_int_output(contract_condition_dict):
     assert isinstance(contract_condition.return_value_test.value, int)
 
     # invalid type fails
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = [1, 2, 3]
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
@@ -516,7 +567,8 @@ def test_abi_int_output(contract_condition_dict):
     )
 
     # test where context var has invalid expected type(s), so only detected at decryption time
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=-123456789,
@@ -537,7 +589,9 @@ def test_abi_address_output(contract_condition_dict, get_random_checksum_address
     assert isinstance(contract_condition.return_value_test.value, str)
 
     # invalid type fails
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = 1.25
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
@@ -568,7 +622,8 @@ def test_abi_address_output(contract_condition_dict, get_random_checksum_address
     )
 
     # test where context var has invalid expected type(s), so only detected at decryption time
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=checksum_address,
@@ -606,7 +661,9 @@ def test_abi_bytes_output(bytes_test_scenario, contract_condition_dict):
     assert isinstance(contract_condition.return_value_test.value, str)
 
     # invalid type fails
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = 1.25
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
@@ -636,7 +693,8 @@ def test_abi_bytes_output(bytes_test_scenario, contract_condition_dict):
     )
 
     # test where context var has invalid expected type(s), so only detected at decryption time
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=call_result_in_bytes,
@@ -666,27 +724,37 @@ def test_abi_tuple_output(contract_condition_dict):
     assert isinstance(contract_condition.return_value_test.value, Sequence)
 
     # 1. invalid type
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = 1
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     # 2. invalid number of values
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = [1, 2]
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     # 3a. Unmatched type
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = [True, 2, 3]
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     # 3b. Unmatched type
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = [1, False, 3]
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     # 3c. Unmatched type
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["value"] = [1, 2, 3.14159]
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
@@ -724,7 +792,8 @@ def test_abi_tuple_output(contract_condition_dict):
     )
 
     # test where context var has invalid expected type(s) - boolean is unexpected in index 1
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=(1, 2, 3, random_bytes),
@@ -793,7 +862,9 @@ def test_abi_tuple_output_with_index(
     assert isinstance(contract_condition.return_value_test.value, str)
 
     # invalid type at index
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         contract_condition_dict["returnValueTest"]["index"] = 0
         contract_condition_dict["returnValueTest"][
             "value"
@@ -826,7 +897,8 @@ def test_abi_tuple_output_with_index(
         )
 
     # using index, test where context var has invalid expected type - unexpected type in index 2
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=tuple(result),
@@ -962,7 +1034,8 @@ def test_abi_multiple_output_values(
         )
 
     # test where context var has invalid expected type
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=tuple(result),
@@ -997,8 +1070,9 @@ def test_abi_multiple_output_values(
     )
 
     # test where context var has invalid expected type
+    # consequently this is not an invalid condition, but rather an incorrect context value
     comparator_value[0][0] = True  # should be address but setting to bool
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=tuple(result),
@@ -1091,7 +1165,9 @@ def test_abi_nested_tuples_output_values(
         [1],
         get_random_checksum_address(),  # missing tuple value
     ]
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     contract_condition_dict["returnValueTest"]["value"] = [
@@ -1100,7 +1176,9 @@ def test_abi_nested_tuples_output_values(
         random_bytes_hex,
         get_random_checksum_address(),  # incorrect tuple value for Timeframe
     ]
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     contract_condition_dict["returnValueTest"]["value"] = [
@@ -1108,7 +1186,9 @@ def test_abi_nested_tuples_output_values(
         [1, random_bytes_hex, 3],
         get_random_checksum_address(),  # too many values
     ]
-    with pytest.raises(InvalidCondition, match="Invalid return value comparison type"):
+    with pytest.raises(
+        InvalidConditionLingo, match="Invalid return value comparison type"
+    ):
         ContractCondition.from_json(json.dumps(contract_condition_dict))
 
     # process index 1 (bool)
@@ -1153,7 +1233,8 @@ def test_abi_nested_tuples_output_values(
         )
 
     # test where context var has invalid expected type
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    # consequently this is not an invalid condition, but rather an incorrect context value
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=tuple(result),
@@ -1187,8 +1268,9 @@ def test_abi_nested_tuples_output_values(
     )
 
     # test where context var has invalid expected type
+    # consequently this is not an invalid condition, but rather an incorrect context value
     comparator_value[0][2] = 1.25  # should be an address
-    with pytest.raises(InvalidCondition, match="Mismatched comparator type"):
+    with pytest.raises(ValueError, match="Mismatched comparator type"):
         _check_execution_logic(
             condition_dict=contract_condition_dict,
             execution_result=tuple(result),

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -55,6 +55,8 @@ class FakeExecutionContractCondition(ContractCondition):
         def execute(self, providers: Dict, **context) -> Any:
             return self.execution_return_value
 
+    EXEC_CALL_TYPE = FakeRPCCall
+
     class Schema(ContractCondition.Schema):
         @post_load
         def make(self, data, **kwargs):
@@ -62,9 +64,6 @@ class FakeExecutionContractCondition(ContractCondition):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-    def _create_execution_call(self, *args, **kwargs) -> ContractCall:
-        return self.FakeRPCCall(*args, **kwargs)
 
     def set_execution_return_value(self, value: Any):
         self.execution_call.set_execution_return_value(value)

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -250,17 +250,17 @@ def test_contract_condition_schema_validation():
     condition_dict = contract_condition.to_dict()
 
     # no issues here
-    ContractCondition.validate(condition_dict)
+    ContractCondition.from_dict(condition_dict)
 
     # no issues with optional name
     condition_dict["name"] = "my_contract_condition"
-    ContractCondition.validate(condition_dict)
+    ContractCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no contract address defined
         condition_dict = contract_condition.to_dict()
         del condition_dict["contractAddress"]
-        ContractCondition.validate(condition_dict)
+        ContractCondition.from_dict(condition_dict)
 
     balanceOf_abi = {
         "constant": True,
@@ -272,29 +272,29 @@ def test_contract_condition_schema_validation():
         "type": "function",
     }
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no function abi or standard contract type
         condition_dict = contract_condition.to_dict()
         del condition_dict["standardContractType"]
-        ContractCondition.validate(condition_dict)
+        ContractCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # provide both function abi and standard contract type
         condition_dict = contract_condition.to_dict()
         condition_dict["functionAbi"] = balanceOf_abi
-        ContractCondition.validate(condition_dict)
+        ContractCondition.from_dict(condition_dict)
 
     # remove standardContractType but specify function abi; no issues with that
     condition_dict = contract_condition.to_dict()
     del condition_dict["standardContractType"]
     condition_dict["functionAbi"] = balanceOf_abi
-    ContractCondition.validate(condition_dict)
+    ContractCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no returnValueTest defined
         condition_dict = contract_condition.to_dict()
         del condition_dict["returnValueTest"]
-        ContractCondition.validate(condition_dict)
+        ContractCondition.from_dict(condition_dict)
 
 
 def test_contract_condition_repr(contract_condition_dict):

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -48,7 +48,7 @@ def test_invalid_rpc_condition():
         )
 
     # unsupported chain id
-    with pytest.raises(InvalidCondition, match="is not a permitted blockchain"):
+    with pytest.raises(InvalidCondition, match="90210 is not a permitted blockchain"):
         _ = RPCCondition(
             method="eth_getBalance",
             chain=90210,  # Beverly Hills Chain :)
@@ -57,10 +57,10 @@ def test_invalid_rpc_condition():
         )
 
     # invalid chain type provided
-    with pytest.raises(ValueError, match="must be the integer chain ID"):
+    with pytest.raises(ValueError, match="invalid literal for int"):
         _ = RPCCondition(
             method="eth_getBalance",
-            chain=str(TESTERCHAIN_CHAIN_ID),  # should be int not str.
+            chain="chainId",  # should be int not str.
             return_value_test=ReturnValueTest("==", 0),
             parameters=["0xaDD9D957170dF6F33982001E4c22eCCdd5539118"],
         )

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -1,7 +1,10 @@
 import pytest
 
 from nucypher.policy.conditions.evm import RPCCondition
-from nucypher.policy.conditions.exceptions import InvalidCondition
+from nucypher.policy.conditions.exceptions import (
+    InvalidCondition,
+    InvalidConditionLingo,
+)
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 from tests.constants import TESTERCHAIN_CHAIN_ID
 
@@ -67,44 +70,44 @@ def test_rpc_condition_schema_validation(rpc_condition):
     condition_dict = rpc_condition.to_dict()
 
     # no issues here
-    RPCCondition.validate(condition_dict)
+    RPCCondition.from_dict(condition_dict)
 
     # no issues with optional name
     condition_dict["name"] = "my_rpc_condition"
-    RPCCondition.validate(condition_dict)
+    RPCCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no chain defined
         condition_dict = rpc_condition.to_dict()
         del condition_dict["chain"]
-        RPCCondition.validate(condition_dict)
+        RPCCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no method defined
         condition_dict = rpc_condition.to_dict()
         del condition_dict["method"]
-        RPCCondition.validate(condition_dict)
+        RPCCondition.from_dict(condition_dict)
 
     # no issue with no parameters
     condition_dict = rpc_condition.to_dict()
     del condition_dict["parameters"]
-    RPCCondition.validate(condition_dict)
+    RPCCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no returnValueTest defined
         condition_dict = rpc_condition.to_dict()
         del condition_dict["returnValueTest"]
-        RPCCondition.validate(condition_dict)
+        RPCCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # chain id not an integer
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
-        RPCCondition.validate(condition_dict)
+        RPCCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # chain id not a permitted chain
         condition_dict["chain"] = 90210  # Beverly Hills Chain :)
-        RPCCondition.validate(condition_dict)
+        RPCCondition.from_dict(condition_dict)
 
 
 def test_rpc_condition_repr(rpc_condition):

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -38,15 +38,15 @@ def mock_condition_variables(mocker):
     return var_1, var_2, var_3, var_4
 
 
-@pytest.mark.usefixtures("mock_skip_schema_validation")
-def test_invalid_sequential_condition(mock_condition_variables):
-    var_1, var_2, var_3, var_4 = mock_condition_variables
+def test_invalid_sequential_condition(rpc_condition, time_condition):
+    var_1 = ConditionVariable("var1", time_condition)
+    var_2 = ConditionVariable("var2", rpc_condition)
 
     # invalid condition type
     with pytest.raises(InvalidCondition, match=ConditionType.SEQUENTIAL.value):
         _ = SequentialAccessControlCondition(
             condition_type=ConditionType.TIME.value,
-            condition_variables=list(mock_condition_variables),
+            condition_variables=[var_1, var_2],
         )
 
     # no variables
@@ -62,8 +62,8 @@ def test_invalid_sequential_condition(mock_condition_variables):
         )
 
     # too many variables
-    too_many_variables = list(mock_condition_variables)
-    too_many_variables.extend(mock_condition_variables)  # duplicate list length
+    too_many_variables = [var_1, var_2, var_1, var_2]
+    too_many_variables.extend(too_many_variables)  # duplicate list length
     assert len(too_many_variables) > SequentialAccessControlCondition.MAX_NUM_CONDITIONS
     with pytest.raises(InvalidCondition, match="Maximum of"):
         _ = SequentialAccessControlCondition(
@@ -71,16 +71,20 @@ def test_invalid_sequential_condition(mock_condition_variables):
         )
 
     # duplicate var names
-    dupe_var = ConditionVariable(var_1.var_name, condition=var_4.condition)
+    dupe_var = ConditionVariable(var_1.var_name, condition=var_2.condition)
     with pytest.raises(InvalidCondition, match="Duplicate"):
         _ = SequentialAccessControlCondition(
-            condition_variables=[var_1, var_2, var_3, dupe_var],
+            condition_variables=[var_1, var_2, dupe_var],
         )
 
 
-@pytest.mark.usefixtures("mock_skip_schema_validation")
-def test_nested_sequential_condition_too_many_nested_levels(mock_condition_variables):
-    var_1, var_2, var_3, var_4 = mock_condition_variables
+def test_nested_sequential_condition_too_many_nested_levels(
+    rpc_condition, time_condition
+):
+    var_1 = ConditionVariable("var1", time_condition)
+    var_2 = ConditionVariable("var2", rpc_condition)
+    var_3 = ConditionVariable("var3", time_condition)
+    var_4 = ConditionVariable("var4", rpc_condition)
 
     with pytest.raises(
         InvalidCondition, match="nested levels of multi-conditions are allowed"
@@ -111,9 +115,13 @@ def test_nested_sequential_condition_too_many_nested_levels(mock_condition_varia
         )
 
 
-@pytest.mark.usefixtures("mock_skip_schema_validation")
-def test_nested_compound_condition_too_many_nested_levels(mock_condition_variables):
-    var_1, var_2, var_3, var_4 = mock_condition_variables
+def test_nested_compound_condition_too_many_nested_levels(
+    rpc_condition, time_condition
+):
+    var_1 = ConditionVariable("var1", time_condition)
+    var_2 = ConditionVariable("var2", rpc_condition)
+    var_3 = ConditionVariable("var3", time_condition)
+    var_4 = ConditionVariable("var4", rpc_condition)
 
     with pytest.raises(
         InvalidCondition, match="nested levels of multi-conditions are allowed"

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -40,7 +40,7 @@ def mock_condition_variables(mocker):
 
 @pytest.mark.usefixtures("mock_skip_schema_validation")
 def test_invalid_sequential_condition(mock_condition_variables):
-    var_1, *_ = mock_condition_variables
+    var_1, var_2, var_3, var_4 = mock_condition_variables
 
     # invalid condition type
     with pytest.raises(InvalidCondition, match=ConditionType.SEQUENTIAL.value):
@@ -68,6 +68,13 @@ def test_invalid_sequential_condition(mock_condition_variables):
     with pytest.raises(InvalidCondition, match="Maximum of"):
         _ = SequentialAccessControlCondition(
             condition_variables=too_many_variables,
+        )
+
+    # duplicate var names
+    dupe_var = ConditionVariable(var_1.var_name, condition=var_4.condition)
+    with pytest.raises(InvalidCondition, match="Duplicate"):
+        _ = SequentialAccessControlCondition(
+            condition_variables=[var_1, var_2, var_3, dupe_var],
         )
 
 

--- a/tests/unit/conditions/test_time_condition.py
+++ b/tests/unit/conditions/test_time_condition.py
@@ -1,6 +1,9 @@
 import pytest
 
-from nucypher.policy.conditions.exceptions import InvalidCondition
+from nucypher.policy.conditions.exceptions import (
+    InvalidCondition,
+    InvalidConditionLingo,
+)
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 from nucypher.policy.conditions.time import TimeCondition, TimeRPCCall
 from tests.constants import TESTERCHAIN_CHAIN_ID
@@ -37,38 +40,38 @@ def test_time_condition_schema_validation(time_condition):
     condition_dict = time_condition.to_dict()
 
     # no issues here
-    TimeCondition.validate(condition_dict)
+    TimeCondition.from_dict(condition_dict)
 
     # no issues with optional name
     condition_dict["name"] = "my_time_machine"
-    TimeCondition.validate(condition_dict)
+    TimeCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no method
         condition_dict = time_condition.to_dict()
         del condition_dict["method"]
-        TimeCondition.validate(condition_dict)
+        TimeCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # no returnValueTest defined
         condition_dict = time_condition.to_dict()
         del condition_dict["returnValueTest"]
-        TimeCondition.validate(condition_dict)
+        TimeCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # invalid method name
         condition_dict["method"] = "my_blocktime"
-        TimeCondition.validate(condition_dict)
+        TimeCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # chain id not an integer
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
-        TimeCondition.validate(condition_dict)
+        TimeCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(InvalidConditionLingo):
         # chain id not a permitted chain
         condition_dict["chain"] = 90210  # Beverly Hills Chain :)
-        TimeCondition.validate(condition_dict)
+        TimeCondition.from_dict(condition_dict)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Simplify condition validation via inheritance.

To validate initialization values provided during Condition initialization we use a combination of variable checks in the python constructor `__init__()`, and condition schema validation via marshmallow. 

These checks are typically done using separate functions/methods. The reason being that there is a Python API for conditions (i.e. condition objects instantiated directly via constructor), and a condition lingo received from web apps (i.e. objects instantiated from json strings) which go through the marshmallow schema mechanism.

Since this validation is duplicated, all checks performed by schemas needed to be done via python objects - but that wasn't fully the case. Since there are separate checks via Python API and others done via Marshmallow schema, this can be confusing and will eventually become out of sync (it is already 😬 ).

The marshmallow schema mechanism is already feature-rich, so let's have all validation be performed by the schema for us.

Therefore:
- The base `AccessControlCondition` now performs a schema validation in its constructor via `_validate()` call. 
- Because conditions are validated in the base class constructor and via their schemas, condition sub-classes should set all member variables before calling super().__init__() since the schema values used are obtained from `.to_dict()` which creates a dict based on member variables for a condition class.
- All necessary validation should be performed via Schema classes i.e. `@validates` and `@validates_schema` decorators. 
    - This created a problem where underlying ExecutionCalls were instantiated in the constructor before the condition schema was validated. Therefore, execution calls should have their own schema which can be validated before instantiation by a condition. The condition schema extends the execution call schema so that fields don't have to be duplicated for condition and execution call, but the fields for underlying execution calls are implicitly used as part of the condition schema itself. (There is no change in overall condition schema, just a reorganization between execution call and condition. This also paves the way for execution calls to possibly be top-level/higher-order objects that can be used separately from conditions.

**Issues fixed/closed:**
> - Fixes #...

- Follow-up to #3500 
- Somewhat related to #3555 - "This also paves the way for execution calls to possibly be top-level/higher-order objects that can be used separately from conditions."

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

This is a tricky code re-org but happy to walk anyone through the change. Let me know.
