### PR TITLE
Update ritual ID used in Lynx examples

### DIFF
--- a/examples/testnet_compound_multichain_taco.py
+++ b/examples/testnet_compound_multichain_taco.py
@@ -39,7 +39,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 0  # got this from a side channel
+ritual_id = 27  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
 # known authorized encryptor for ritual 3

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -40,7 +40,7 @@ coordinator_agent = CoordinatorAgent(
     blockchain_endpoint=polygon_endpoint,
     registry=registry,
 )
-ritual_id = 0  # got this from a side channel
+ritual_id = 27  # got this from a side channel
 ritual = coordinator_agent.get_ritual(ritual_id)
 
 # known authorized encryptor for ritual 3


### PR DESCRIPTION
**Type of PR:**
- [X] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
This change will update the ritual ID used in the examples. Note that thess examples are used on CI. This is needed because the Lynx ritual #0 has expired, so a new ritual has been initiated (id #`27`).
