### PR TITLE
JSON API Authorized Requests (OAuth and JWT Support)

### DIFF
--- a/newsfragments/3560.feature.rst
+++ b/newsfragments/3560.feature.rst
@@ -1,0 +1,1 @@
+Enable support for Bearer authorization tokens (e.g., OAuth, JWT) within HTTP GET requests for ``JsonApiCondition``.

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -93,6 +93,13 @@ def is_context_variable(variable) -> bool:
     return isinstance(variable, str) and CONTEXT_REGEX.fullmatch(variable)
 
 
+def string_contains_context_variable(variable: str) -> bool:
+    matches = re.findall(CONTEXT_REGEX, variable)
+    if not matches:
+        return False
+    return True
+
+
 def get_context_value(context_variable: str, **context) -> Any:
     try:
         # DIRECTIVES are special context vars that will pre-processed by ursula

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -95,9 +95,7 @@ def is_context_variable(variable) -> bool:
 
 def string_contains_context_variable(variable: str) -> bool:
     matches = re.findall(CONTEXT_REGEX, variable)
-    if not matches:
-        return False
-    return True
+    return bool(matches)
 
 
 def get_context_value(context_variable: str, **context) -> Any:
@@ -124,10 +122,9 @@ def resolve_any_context_variables(
     if isinstance(param, list):
         return [resolve_any_context_variables(item, **context) for item in param]
     elif isinstance(param, dict):
-        result = {}
-        for k, v in param.items():
-            result[k] = resolve_any_context_variables(v, **context)
-        return result
+        return {
+            k: resolve_any_context_variables(v, **context) for k, v in param.items()
+        }
     elif isinstance(param, str):
         # either it is a context variable OR contains a context variable within it
         # TODO separating the two cases for now out of concern of regex searching

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -116,9 +116,9 @@ def get_context_value(context_variable: str, **context) -> Any:
     return value
 
 
-def _resolve_context_variable(param: Union[Any, List[Any]], **context):
+def resolve_context_variable(param: Union[Any, List[Any]], **context):
     if isinstance(param, list):
-        return [_resolve_context_variable(item, **context) for item in param]
+        return [resolve_context_variable(item, **context) for item in param]
     elif is_context_variable(param):
         return get_context_value(context_variable=param, **context)
     else:
@@ -130,6 +130,6 @@ def resolve_parameter_context_variables(parameters: Optional[List[Any]], **conte
         processed_parameters = []  # produce empty list
     else:
         processed_parameters = [
-            _resolve_context_variable(param, **context) for param in parameters
+            resolve_context_variable(param, **context) for param in parameters
         ]
     return processed_parameters

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -31,7 +31,7 @@ from nucypher.policy.conditions.base import (
 )
 from nucypher.policy.conditions.context import (
     is_context_variable,
-    resolve_parameter_context_variables,
+    resolve_any_context_variables,
 )
 from nucypher.policy.conditions.exceptions import (
     NoConnectionToChain,
@@ -169,9 +169,11 @@ class RPCCall(ExecutionCall):
             yield provider
 
     def execute(self, providers: Dict[int, Set[HTTPProvider]], **context) -> Any:
-        resolved_parameters = resolve_parameter_context_variables(
-            self.parameters, **context
-        )
+        resolved_parameters = []
+        if self.parameters:
+            resolved_parameters = resolve_any_context_variables(
+                self.parameters, **context
+            )
 
         endpoints = self._next_endpoint(providers=providers)
         latest_error = ""

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -29,7 +29,7 @@ from nucypher.policy.conditions.base import (
 )
 from nucypher.policy.conditions.context import (
     is_context_variable,
-    resolve_context_variable,
+    resolve_any_context_variables,
 )
 from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
@@ -611,7 +611,7 @@ class ReturnValueTest:
         return result
 
     def with_resolved_context(self, **context):
-        value = resolve_context_variable(self.value, **context)
+        value = resolve_any_context_variables(self.value, **context)
         return ReturnValueTest(self.comparator, value=value, index=self.index)
 
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -28,8 +28,8 @@ from nucypher.policy.conditions.base import (
     _Serializable,
 )
 from nucypher.policy.conditions.context import (
-    _resolve_context_variable,
     is_context_variable,
+    resolve_context_variable,
 )
 from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
@@ -611,7 +611,7 @@ class ReturnValueTest:
         return result
 
     def with_resolved_context(self, **context):
-        value = _resolve_context_variable(self.value, **context)
+        value = resolve_context_variable(self.value, **context)
         return ReturnValueTest(self.comparator, value=value, index=self.index)
 
 

--- a/nucypher/policy/conditions/offchain.py
+++ b/nucypher/policy/conditions/offchain.py
@@ -5,7 +5,6 @@ from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
 from jsonpath_ng.ext import parse
 from marshmallow import ValidationError, fields, post_load, validate, validates
 from marshmallow.fields import Field, Url
-from marshmallow.validate import OneOf
 
 from nucypher.policy.conditions.base import ExecutionCall
 from nucypher.policy.conditions.context import (
@@ -44,14 +43,10 @@ class JSONPathField(Field):
 
 class JsonApiCall(ExecutionCall):
     TIMEOUT = 5  # seconds
-    HTTP_METHOD_GET = "get"
-    HTTP_METHOD_POST = "post"
-    ALLOWED_METHODS = {HTTP_METHOD_GET, HTTP_METHOD_POST}
 
     class Schema(ExecutionCall.Schema):
         endpoint = Url(required=True, relative=False, schemes=["https"])
-        method = fields.Str(required=True, validate=OneOf(["get", "post"]))
-        inputs = fields.Dict(required=False, allow_none=True)
+        parameters = fields.Dict(required=False, allow_none=True)
         query = JSONPathField(required=False, allow_none=True)
         authorization_token = fields.Str(required=False, allow_none=True)
 
@@ -69,14 +64,12 @@ class JsonApiCall(ExecutionCall):
     def __init__(
         self,
         endpoint: str,
-        method: Optional[str] = HTTP_METHOD_GET,
-        inputs: Optional[dict] = None,
+        parameters: Optional[dict] = None,
         query: Optional[str] = None,
         authorization_token: Optional[str] = None,
     ):
         self.endpoint = endpoint
-        self.method = method
-        self.inputs = inputs or {}
+        self.parameters = parameters or {}
         self.query = query
         self.authorization_token = authorization_token
 
@@ -95,7 +88,7 @@ class JsonApiCall(ExecutionCall):
         """Fetches data from the endpoint."""
         resolved_endpoint = resolve_any_context_variables(self.endpoint, **context)
 
-        resolved_inputs = resolve_any_context_variables(self.inputs, **context)
+        resolved_parameters = resolve_any_context_variables(self.parameters, **context)
 
         headers = None
         if self.authorization_token:
@@ -105,22 +98,12 @@ class JsonApiCall(ExecutionCall):
             headers = {"Authorization": f"Bearer {resolved_authorization_token}"}
 
         try:
-
-            if self.method == self.HTTP_METHOD_GET:
-                response = requests.get(
-                    resolved_endpoint,
-                    params=resolved_inputs,
-                    timeout=self.timeout,
-                    headers=headers,
-                )
-            else:
-                response = requests.post(
-                    resolved_endpoint,
-                    data=resolved_inputs,
-                    timeout=self.timeout,
-                    headers=headers,
-                )
-
+            response = requests.get(
+                resolved_endpoint,
+                params=resolved_parameters,
+                timeout=self.timeout,
+                headers=headers,
+            )
             response.raise_for_status()
         except requests.exceptions.HTTPError as http_error:
             self.logger.error(f"HTTP error occurred: {http_error}")
@@ -204,9 +187,8 @@ class JsonApiCondition(ExecutionCallAccessControlCondition):
         self,
         endpoint: str,
         return_value_test: ReturnValueTest,
-        method: Optional[str] = JsonApiCall.HTTP_METHOD_GET,
         query: Optional[str] = None,
-        inputs: Optional[dict] = None,
+        parameters: Optional[dict] = None,
         authorization_token: Optional[str] = None,
         condition_type: str = ConditionType.JSONAPI.value,
         name: Optional[str] = None,
@@ -214,9 +196,8 @@ class JsonApiCondition(ExecutionCallAccessControlCondition):
         super().__init__(
             endpoint=endpoint,
             return_value_test=return_value_test,
-            method=method,
             query=query,
-            inputs=inputs,
+            parameters=parameters,
             authorization_token=authorization_token,
             condition_type=condition_type,
             name=name,
@@ -227,16 +208,12 @@ class JsonApiCondition(ExecutionCallAccessControlCondition):
         return self.execution_call.endpoint
 
     @property
-    def method(self):
-        return self.execution_call.method
-
-    @property
     def query(self):
         return self.execution_call.query
 
     @property
-    def inputs(self):
-        return self.execution_call.inputs
+    def parameters(self):
+        return self.execution_call.parameters
 
     @property
     def timeout(self):

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -70,11 +70,12 @@ def lingo_with_all_condition_types(get_random_checksum_address):
         # JSON API
         "conditionType": ConditionType.JSONAPI.value,
         "endpoint": "https://api.example.com/data",
-        "query": "$.store.book[0].price",
-        "parameters": {
+        "method": "get",
+        "inputs": {
             "ids": "ethereum",
             "vs_currencies": "usd",
         },
+        "query": "$.store.book[0].price",
         "returnValueTest": {
             "comparator": "==",
             "value": 2,

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -70,11 +70,11 @@ def lingo_with_all_condition_types(get_random_checksum_address):
         # JSON API
         "conditionType": ConditionType.JSONAPI.value,
         "endpoint": "https://api.example.com/data",
-        "method": "get",
-        "inputs": {
+        "parameters": {
             "ids": "ethereum",
             "vs_currencies": "usd",
         },
+        "authorizationToken": ":authToken",
         "query": "$.store.book[0].price",
         "returnValueTest": {
             "comparator": "==",

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -7,10 +7,10 @@ import pytest
 from nucypher.policy.conditions.context import (
     USER_ADDRESS_CONTEXT,
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
-    _resolve_context_variable,
     _resolve_user_address,
     get_context_value,
     is_context_variable,
+    resolve_context_variable,
     resolve_parameter_context_variables,
 )
 from nucypher.policy.conditions.exceptions import (
@@ -76,7 +76,7 @@ def test_is_context_variable():
 
 def test_resolve_context_variable():
     for value, resolution in VALUES_WITH_RESOLUTION:
-        assert resolution == _resolve_context_variable(value, **CONTEXT)
+        assert resolution == resolve_context_variable(value, **CONTEXT)
 
 
 def test_resolve_any_context_variables():

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -47,6 +47,7 @@ DEFINITELY_NOT_CONTEXT_PARAM_NAMES = ["1234", "foo", "", 123]
 CONTEXT = {":foo": 1234, ":bar": "'BAR'"}
 
 VALUES_WITH_RESOLUTION = [
+    ([], []),
     (42, 42),
     (True, True),
     ("'bar'", "'bar'"),
@@ -102,33 +103,33 @@ def test_resolve_any_context_variables():
         # graphql query
         (
             """{
-        organization(login: ":bar") {
-          teams(first: :foo, userLogins: [":bar"]) {
-            totalCount
-            edges {
-              node {
-                id
-                name
-                description
-              }
-            }
-          }
-        }
-    }""",
+                organization(login: ":bar") {
+                  teams(first: :foo, userLogins: [":bar"]) {
+                    totalCount
+                    edges {
+                      node {
+                        id
+                        name
+                        description
+                      }
+                    }
+                  }
+                }
+            }""",
             """{
-        organization(login: "BAR") {
-          teams(first: 1234, userLogins: ["BAR"]) {
-            totalCount
-            edges {
-              node {
-                id
-                name
-                description
-              }
-            }
-          }
-        }
-    }""",
+                organization(login: "BAR") {
+                  teams(first: 1234, userLogins: ["BAR"]) {
+                    totalCount
+                    edges {
+                      node {
+                        id
+                        name
+                        description
+                      }
+                    }
+                  }
+                }
+            }""",
         ),
     ],
 )

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -304,6 +304,12 @@ def test_contract_condition_schema_validation():
         del condition_dict["contractAddress"]
         ContractCondition.from_dict(condition_dict)
 
+    with pytest.raises(InvalidConditionLingo):
+        # invalid contract address
+        contract_dict = contract_condition.to_dict()
+        contract_dict["contractAddress"] = "0xABCD"
+        ContractCondition.from_dict(condition_dict)
+
     balanceOf_abi = {
         "constant": True,
         "inputs": [{"name": "_owner", "type": "address"}],

--- a/tests/unit/conditions/test_json_api_condition.py
+++ b/tests/unit/conditions/test_json_api_condition.py
@@ -266,6 +266,7 @@ def test_json_api_condition_from_lingo_expression():
     lingo_json = json.dumps(lingo_dict)
     condition = JsonApiCondition.from_json(lingo_json)
     assert isinstance(condition, JsonApiCondition)
+    assert condition.to_dict() == lingo_dict
 
 
 def test_json_api_condition_from_lingo_expression_with_authorization():
@@ -290,7 +291,7 @@ def test_json_api_condition_from_lingo_expression_with_authorization():
     lingo_json = json.dumps(lingo_dict)
     condition = JsonApiCondition.from_json(lingo_json)
     assert isinstance(condition, JsonApiCondition)
-
+    assert condition.to_dict() == lingo_dict
 
 def test_ambiguous_json_path_multiple_results(mocker):
     mock_response = mocker.Mock(status_code=200)

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 import pytest
 from hexbytes import HexBytes
 
-from nucypher.policy.conditions.context import resolve_context_variable
+from nucypher.policy.conditions.context import resolve_any_context_variables
 from nucypher.policy.conditions.exceptions import ReturnValueEvaluationError
 from nucypher.policy.conditions.lingo import ReturnValueTest
 
@@ -150,14 +150,14 @@ def test_return_value_test_with_resolved_context():
     resolved = test.with_resolved_context(**context)
     assert resolved.comparator == test.comparator
     assert resolved.index == test.index
-    assert resolved.value == resolve_context_variable(test.value, **context)
+    assert resolved.value == resolve_any_context_variables(test.value, **context)
 
     test = ReturnValueTest(comparator="==", value=[42, ":foo"])
 
     resolved = test.with_resolved_context(**context)
     assert resolved.comparator == test.comparator
     assert resolved.index == test.index
-    assert resolved.value == resolve_context_variable(test.value, **context)
+    assert resolved.value == resolve_any_context_variables(test.value, **context)
 
 
 def test_return_value_test_integer():

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -6,7 +6,7 @@ from typing import NamedTuple
 import pytest
 from hexbytes import HexBytes
 
-from nucypher.policy.conditions.context import _resolve_context_variable
+from nucypher.policy.conditions.context import resolve_context_variable
 from nucypher.policy.conditions.exceptions import ReturnValueEvaluationError
 from nucypher.policy.conditions.lingo import ReturnValueTest
 
@@ -150,14 +150,14 @@ def test_return_value_test_with_resolved_context():
     resolved = test.with_resolved_context(**context)
     assert resolved.comparator == test.comparator
     assert resolved.index == test.index
-    assert resolved.value == _resolve_context_variable(test.value, **context)
+    assert resolved.value == resolve_context_variable(test.value, **context)
 
     test = ReturnValueTest(comparator="==", value=[42, ":foo"])
 
     resolved = test.with_resolved_context(**context)
     assert resolved.comparator == test.comparator
     assert resolved.index == test.index
-    assert resolved.value == _resolve_context_variable(test.value, **context)
+    assert resolved.value == resolve_context_variable(test.value, **context)
 
 
 def test_return_value_test_integer():


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Allow "authorizationToken" to optionally be provided via the `JsonApiCondition`. The token should always be provided as a context variable since hardcoding it doesn't make much sense:
   - It would expose a token in plaintext
   - Tokens have expiry dates
   - Tokens are associated with specific users, so the use of the hardcoded token would be associated with a specific user and not the requester
   Instead, the token should be provided at decryption time. How the token is obtained (OAuth dance or JWT) is up to the application and not `taco-web`.
- The value for the "authorizationToken" context variable can either be OAuth or JWT tokens.
- Example lingo:
```json
{
  "conditionType":"json-api",
  "endpoint":"https://api.example.com/data",
  "parameters":{
    "ids":"ethereum",
    "vs_currencies":"usd"
  },
  "authorizationToken":":authToken",   <---- addition
  "query":"$.store.book[0].price",
  "returnValueTest":{
    "comparator":"==",
    "value":1.0
  }
}
```
- The context variable used for `authorizationToken` value can be anything and doesn't have to be named ":authToken". This way, adopters can use whatever context variable they want, including across multiple conditions in something like a `SequentialCondition` instead of us being prescriptive about what the name should be. Our only stipulation is that the value should be a context variable.
- The value for the context variable should be provided at decryption time by the requester. Once provided the value is used within the `Authorization` header for the HTTPS GET request i.e.
`Authorization: Bearer <authToken>`
- Expands the use of context variables since they could be included within the "endpoint", "parameters", "query" as substrings and not just an individual value.

**Issues fixed/closed:**
- Closes #3559 
- Related to https://github.com/nucypher/sprints/issues/85 - the node side of things.
- Related to #3561 

**Why it's needed:**


**Notes for reviewers:**
I performed local testing of the `JsonApiCondition` that used the GitHub API and my GitHub fine-grained access token. I did not commit those tests because my access token would be exposed.
