### PR TITLE
Learner node latency tracking

### DIFF
--- a/newsfragments/3562.feature.rst
+++ b/newsfragments/3562.feature.rst
@@ -1,0 +1,1 @@
+Enhance threshold decryption request efficiency by prioritizing nodes in the cohort with lower communication latency.

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -387,6 +387,8 @@ class Alice(Character, actors.PolicyAuthor):
 
 
 class Bob(Character):
+    _TRACK_NODE_LATENCY_STATS = True
+
     banner = BOB_BANNER
     _default_dkg_variant = FerveoVariant.Simple
     _default_crypto_powerups = [SigningPower, DecryptingPower]

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -79,17 +79,20 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
             self.log.warn(message)
             raise self.ThresholdDecryptionRequestFailed(message)
 
-        ursulas_sorted_by_latency = (
+        ursulas_to_contact = (
             self._learner.node_latency_collector.order_addresses_by_latency(
                 list(encrypted_requests)
             )
+            if self._learner.node_latency_collector
+            else list(encrypted_requests)
         )
+
         # Discussion about WorkerPool parameters:
         # "https://github.com/nucypher/nucypher/pull/3393#discussion_r1456307991"
         worker_pool = WorkerPool(
             worker=worker,
             value_factory=self.ThresholdDecryptionRequestFactory(
-                ursulas_to_contact=ursulas_sorted_by_latency,
+                ursulas_to_contact=ursulas_to_contact,
                 batch_size=math.ceil(threshold * 1.25),
                 threshold=threshold,
             ),

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -79,7 +79,6 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
             self.log.warn(message)
             raise self.ThresholdDecryptionRequestFailed(message)
 
-        # TODO: Find a better request order, perhaps based on latency data obtained from discovery loop - #3395
         ursulas_sorted_by_latency = (
             self._learner.node_latency_collector.order_addresses_by_latency(
                 list(encrypted_requests)

--- a/nucypher/network/decryption.py
+++ b/nucypher/network/decryption.py
@@ -1,6 +1,5 @@
 import math
 from http import HTTPStatus
-from random import shuffle
 from typing import Dict, List, Tuple
 
 from eth_typing import ChecksumAddress
@@ -81,14 +80,17 @@ class ThresholdDecryptionClient(ThresholdAccessControlClient):
             raise self.ThresholdDecryptionRequestFailed(message)
 
         # TODO: Find a better request order, perhaps based on latency data obtained from discovery loop - #3395
-        requests = list(encrypted_requests)
-        shuffle(requests)
+        ursulas_sorted_by_latency = (
+            self._learner.node_latency_collector.order_addresses_by_latency(
+                list(encrypted_requests)
+            )
+        )
         # Discussion about WorkerPool parameters:
         # "https://github.com/nucypher/nucypher/pull/3393#discussion_r1456307991"
         worker_pool = WorkerPool(
             worker=worker,
             value_factory=self.ThresholdDecryptionRequestFactory(
-                ursulas_to_contact=requests,
+                ursulas_to_contact=ursulas_sorted_by_latency,
                 batch_size=math.ceil(threshold * 1.25),
                 threshold=threshold,
             ),

--- a/nucypher/network/nodes.py
+++ b/nucypher/network/nodes.py
@@ -1,9 +1,8 @@
 import time
-from collections import defaultdict, deque
+from collections import deque
 from contextlib import suppress
 from queue import Queue
-from threading import Lock
-from typing import List, Optional, Set, Tuple
+from typing import Optional, Set, Tuple
 
 import maya
 import requests
@@ -41,6 +40,7 @@ from nucypher.crypto.signing import InvalidSignature, SignatureStamp
 from nucypher.network.exceptions import NodeSeemsToBeDown
 from nucypher.network.middleware import RestMiddleware
 from nucypher.network.protocols import InterfaceInfo, SuspiciousActivity
+from nucypher.utilities.latency import NodeLatencyStatsCollector
 from nucypher.utilities.logging import Logger
 
 TEACHER_NODES = {
@@ -52,72 +52,6 @@ TEACHER_NODES = {
     domains.LYNX: ("https://lynx.nucypher.network:9151",),
     domains.TAPIR: ("https://tapir.nucypher.network:9151",),
 }
-
-
-class NodeLatencyStatsCollector:
-    TOTAL_TIME = "total_time"
-    COUNT = "count"
-    MAX_LATENCY = 2**32 - 1  # just need a large number
-
-    class NodeExecutionContextManager:
-        def __init__(
-            self,
-            stats_collector: "NodeLatencyStatsCollector",
-            staker_address: str,
-        ):
-            self._stats_collector = stats_collector
-            self.staker_address = staker_address
-
-        def __enter__(self):
-            self.start_time = time.perf_counter()
-            return self
-
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            if exc_type:
-                # exception occurred - reset stats since connectivity was compromised
-                self._stats_collector.reset_stats(self.staker_address)
-            else:
-                # no exception
-                end_time = time.perf_counter()
-                execution_time = end_time - self.start_time
-                self._stats_collector.update_stats(self.staker_address, execution_time)
-
-    def __init__(self):
-        # staker_address -> { "total_time": <float>, "count": <integer> }
-        self._node_stats = defaultdict(lambda: {self.TOTAL_TIME: 0.0, self.COUNT: 0})
-        self._lock = Lock()
-
-    def update_stats(self, staking_address: str, latest_time_taken: float):
-        with self._lock:
-            self._node_stats[staking_address][self.TOTAL_TIME] += latest_time_taken
-            self._node_stats[staking_address][self.COUNT] += 1
-
-    def reset_stats(self, staking_address: str):
-        with self._lock:
-            self._node_stats[staking_address][self.TOTAL_TIME] = 0
-            self._node_stats[staking_address][self.COUNT] = 0
-
-    def get_latency_tracker(self, staker_address: str) -> NodeExecutionContextManager:
-        return self.NodeExecutionContextManager(
-            stats_collector=self, staker_address=staker_address
-        )
-
-    def get_average_latency_time(self, staking_address: str):
-        with self._lock:
-            count = self._node_stats[staking_address][self.COUNT]
-            # just need a large number > 0
-            return (
-                self.MAX_LATENCY
-                if count == 0
-                else self._node_stats[staking_address][self.TOTAL_TIME] / count
-            )
-
-    def order_addresses_by_latency(self, staking_addresses: List[str]):
-        result = sorted(
-            staking_addresses,
-            key=lambda staking_address: self.get_average_latency_time(staking_address),
-        )
-        return result
 
 
 class NodeSprout:

--- a/nucypher/utilities/latency.py
+++ b/nucypher/utilities/latency.py
@@ -1,0 +1,80 @@
+import time
+from collections import defaultdict
+from threading import Lock
+from typing import List
+
+from eth_typing import ChecksumAddress
+
+
+class NodeLatencyStatsCollector:
+    """
+    Track latency statistics related to communication with other nodes.
+    """
+
+    TOTAL_TIME = "total_time"
+    COUNT = "count"
+    MAX_LATENCY = 2**32 - 1  # just need a large number
+
+    class NodeLatencyContextManager:
+        def __init__(
+            self,
+            stats_collector: "NodeLatencyStatsCollector",
+            staker_address: ChecksumAddress,
+        ):
+            self._stats_collector = stats_collector
+            self.staker_address = staker_address
+
+        def __enter__(self):
+            self.start_time = time.perf_counter()
+            return self
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            if exc_type:
+                # exception occurred - reset stats since connectivity was compromised
+                self._stats_collector.reset_stats(self.staker_address)
+            else:
+                # no exception
+                end_time = time.perf_counter()
+                execution_time = end_time - self.start_time
+                self._stats_collector.update_stats(self.staker_address, execution_time)
+
+    def __init__(self):
+        # staker_address -> { "total_time": <float>, "count": <integer> }
+        self._node_stats = defaultdict(lambda: {self.TOTAL_TIME: 0.0, self.COUNT: 0})
+        self._lock = Lock()
+
+    def update_stats(self, staking_address: ChecksumAddress, latest_time_taken: float):
+        with self._lock:
+            self._node_stats[staking_address][self.TOTAL_TIME] += latest_time_taken
+            self._node_stats[staking_address][self.COUNT] += 1
+
+    def reset_stats(self, staking_address: ChecksumAddress):
+        with self._lock:
+            self._node_stats[staking_address][self.TOTAL_TIME] = 0
+            self._node_stats[staking_address][self.COUNT] = 0
+
+    def get_latency_tracker(
+        self, staker_address: ChecksumAddress
+    ) -> NodeLatencyContextManager:
+        return self.NodeLatencyContextManager(
+            stats_collector=self, staker_address=staker_address
+        )
+
+    def get_average_latency_time(self, staking_address: ChecksumAddress) -> float:
+        with self._lock:
+            count = self._node_stats[staking_address][self.COUNT]
+            # just need a large number > 0
+            return (
+                self.MAX_LATENCY
+                if count == 0
+                else self._node_stats[staking_address][self.TOTAL_TIME] / count
+            )
+
+    def order_addresses_by_latency(
+        self, staking_addresses: List[ChecksumAddress]
+    ) -> List[ChecksumAddress]:
+        result = sorted(
+            staking_addresses,
+            key=lambda staking_address: self.get_average_latency_time(staking_address),
+        )
+        return result

--- a/nucypher/utilities/latency.py
+++ b/nucypher/utilities/latency.py
@@ -36,7 +36,7 @@ class NodeLatencyStatsCollector:
                 # no exception
                 end_time = time.perf_counter()
                 execution_time = end_time - self.start_time
-                self._stats_collector.update_stats(self.staker_address, execution_time)
+                self._stats_collector._update_stats(self.staker_address, execution_time)
 
     def __init__(self):
         # staker_address -> { "total_time": <float>, "count": <integer> }
@@ -45,7 +45,7 @@ class NodeLatencyStatsCollector:
         )
         self._lock = Lock()
 
-    def update_stats(self, staking_address: ChecksumAddress, latest_time_taken: float):
+    def _update_stats(self, staking_address: ChecksumAddress, latest_time_taken: float):
         with self._lock:
             old_avg = self._node_stats[staking_address][self.CURRENT_AVERAGE]
             old_count = self._node_stats[staking_address][self.COUNT]

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -305,7 +305,7 @@ def test_authorized_decryption(
         bob.node_latency_collector.reset_stats(ursula.checksum_address)
         # add a single data point for each ursula: some time between 0.1 and 4
         mock_latency = random.uniform(0.1, 4)
-        bob.node_latency_collector.update_stats(ursula.checksum_address, mock_latency)
+        bob.node_latency_collector._update_stats(ursula.checksum_address, mock_latency)
         latency_stats[ursula.checksum_address] = mock_latency
 
     expected_ursula_request_ordering = sorted(

--- a/tests/unit/test_node_latency_collector.py
+++ b/tests/unit/test_node_latency_collector.py
@@ -76,7 +76,7 @@ def test_collector_stats_obtained(execution_data):
     # update stats for all nodes
     for node, execution_times in executions.items():
         for i, exec_time in enumerate(execution_times):
-            node_latency_collector.update_stats(node, exec_time)
+            node_latency_collector._update_stats(node, exec_time)
 
             # check ongoing average
             subset_of_times = execution_times[: (i + 1)]
@@ -110,7 +110,7 @@ def test_collector_stats_reset(execution_data):
     # update stats for all nodes
     for node, execution_times in executions.items():
         for exec_time in execution_times:
-            node_latency_collector.update_stats(node, exec_time)
+            node_latency_collector._update_stats(node, exec_time)
 
         assert floats_sufficiently_equal(
             node_latency_collector.get_average_latency_time(node),
@@ -179,7 +179,7 @@ def test_collector_simple_concurrency(execution_data):
         for exec_time in execution_times:
             # add some delay for better concurrency
             time.sleep(0.1)
-            node_latency_collector.update_stats(node_address, exec_time)
+            node_latency_collector._update_stats(node_address, exec_time)
 
     # use thread pool
     n_threads = len(executions)

--- a/tests/unit/test_node_latency_collector.py
+++ b/tests/unit/test_node_latency_collector.py
@@ -1,0 +1,269 @@
+import random
+import time
+from concurrent.futures import ThreadPoolExecutor, wait
+from unittest.mock import patch
+
+import pytest
+from eth_typing import ChecksumAddress
+
+from nucypher.utilities.latency import NodeLatencyStatsCollector
+
+
+@pytest.fixture(scope="module")
+def execution_data(get_random_checksum_address):
+    executions = {}
+
+    node_1 = get_random_checksum_address()
+    node_1_exec_times = [11.23, 24.8, 31.5, 40.21]
+    executions[node_1] = node_1_exec_times
+
+    node_2 = get_random_checksum_address()
+    node_2_exec_times = [5.03, 6.78, 7.42, 8.043]
+    executions[node_2] = node_2_exec_times
+
+    node_3 = get_random_checksum_address()
+    node_3_exec_times = [0.44, 4.512, 3.3]
+    executions[node_3] = node_3_exec_times
+
+    node_4 = get_random_checksum_address()
+    node_4_exec_times = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    executions[node_4] = node_4_exec_times
+
+    sorted_order = sorted(
+        list(executions.keys()),
+        key=lambda x: sum(executions.get(x)) / len(executions.get(x)),
+    )
+    assert sorted_order == [
+        node_4,
+        node_3,
+        node_2,
+        node_1,
+    ]  # test of the test - "that's sooo meta"
+
+    return executions, sorted_order
+
+
+def floats_sufficiently_equal(a: float, b: float):
+    if abs(a - b) < 1e-9:
+        return True
+
+    return False
+
+
+def test_collector_initialization_no_data_collected(get_random_checksum_address):
+    node_latency_collector = NodeLatencyStatsCollector()
+
+    staker_addresses = [get_random_checksum_address() for _ in range(4)]
+
+    # no data collected so average equals maximum latency
+    for staker_address in staker_addresses:
+        assert (
+            node_latency_collector.get_average_latency_time(staker_address)
+            == NodeLatencyStatsCollector.MAX_LATENCY
+        )
+
+    # no data collected so no change in order
+    assert (
+        node_latency_collector.order_addresses_by_latency(staker_addresses)
+        == staker_addresses
+    )
+
+
+def test_collector_stats_obtained(execution_data):
+    executions, expected_node_sorted_order = execution_data
+    node_latency_collector = NodeLatencyStatsCollector()
+
+    # update stats for all nodes
+    for node, execution_times in executions.items():
+        for i, exec_time in enumerate(execution_times):
+            node_latency_collector.update_stats(node, exec_time)
+
+            # check ongoing average
+            subset_of_times = execution_times[: (i + 1)]
+            # floating point arithmetic makes an exact check tricky
+            assert floats_sufficiently_equal(
+                node_latency_collector.get_average_latency_time(node),
+                sum(subset_of_times) / len(subset_of_times),
+            )
+
+        # check final average
+        # floating point arithmetic makes an exact check tricky
+        assert floats_sufficiently_equal(
+            node_latency_collector.get_average_latency_time(node),
+            sum(execution_times) / len(execution_times),
+        )
+
+    node_addresses = list(executions.keys())
+    for _ in range(10):
+        # try various random permutations of order
+        random.shuffle(node_addresses)
+        assert (
+            node_latency_collector.order_addresses_by_latency(node_addresses)
+            == expected_node_sorted_order
+        )
+
+
+def test_collector_stats_reset(execution_data):
+    executions, original_expected_node_sorted_order = execution_data
+    node_latency_collector = NodeLatencyStatsCollector()
+
+    # update stats for all nodes
+    for node, execution_times in executions.items():
+        for exec_time in execution_times:
+            node_latency_collector.update_stats(node, exec_time)
+
+        assert floats_sufficiently_equal(
+            node_latency_collector.get_average_latency_time(node),
+            sum(execution_times) / len(execution_times),
+        )
+
+    # proper order
+    assert (
+        node_latency_collector.order_addresses_by_latency(list(executions.keys()))
+        == original_expected_node_sorted_order
+    )
+
+    # reset stats for fastest node, in which case it should now move to the end of the ordered list
+    node_latency_collector.reset_stats(original_expected_node_sorted_order[0])
+    assert (
+        node_latency_collector.get_average_latency_time(
+            original_expected_node_sorted_order[0]
+        )
+        == NodeLatencyStatsCollector.MAX_LATENCY
+    )
+
+    updated_order = original_expected_node_sorted_order[1:] + [
+        original_expected_node_sorted_order[0]
+    ]
+    assert updated_order != original_expected_node_sorted_order
+    assert (
+        node_latency_collector.order_addresses_by_latency(list(executions.keys()))
+        == updated_order
+    )
+
+    # reset another node's stats
+    node_latency_collector.reset_stats(updated_order[1])
+    assert (
+        node_latency_collector.get_average_latency_time(updated_order[1])
+        == NodeLatencyStatsCollector.MAX_LATENCY
+    )
+    # the order the addresses are passed in dictates the order of nodes without stats
+    expected_updated_updated_order = (
+        [updated_order[0]] + updated_order[2:-1] + [updated_order[1], updated_order[3]]
+    )
+    assert (
+        node_latency_collector.order_addresses_by_latency(updated_order)
+        == expected_updated_updated_order
+    )
+
+    # reset all stats
+    for node in executions.keys():
+        node_latency_collector.reset_stats(node)
+        assert (
+            node_latency_collector.get_average_latency_time(node)
+            == NodeLatencyStatsCollector.MAX_LATENCY
+        )
+    all_reset_order = list(executions.keys())
+    assert (
+        node_latency_collector.order_addresses_by_latency(all_reset_order)
+        == all_reset_order
+    )
+
+
+def test_collector_simple_concurrency(execution_data):
+    executions, expected_node_sorted_order = execution_data
+    node_latency_collector = NodeLatencyStatsCollector()
+
+    def populate_executions(node_address: ChecksumAddress):
+        execution_times = executions[node_address]
+        for exec_time in execution_times:
+            # add some delay for better concurrency
+            time.sleep(0.1)
+            node_latency_collector.update_stats(node_address, exec_time)
+
+    # use thread pool
+    n_threads = len(executions)
+    with ThreadPoolExecutor(n_threads) as executor:
+        # download each url and save as a local file
+        futures = []
+        for node_address in executions.keys():
+            f = executor.submit(populate_executions, node_address)
+            futures.append(f)
+
+        wait(futures, timeout=3)  # these shouldn't take long; only wait max 3s
+
+    assert (
+        node_latency_collector.order_addresses_by_latency(list(executions.keys()))
+        == expected_node_sorted_order
+    )
+
+
+def test_collector_tracker_no_exception(execution_data):
+    executions, expected_node_sorted_order = execution_data
+    node_latency_collector = NodeLatencyStatsCollector()
+    for node, execution_times in executions.items():
+        for exec_time in execution_times:
+            base_perf_counter = time.perf_counter()
+            end_time = base_perf_counter + exec_time
+            with patch("time.perf_counter", side_effect=[base_perf_counter, end_time]):
+                with node_latency_collector.get_latency_tracker(node):
+                    # fake execution; do nothing
+                    time.sleep(0)
+
+        # floating point arithmetic makes an exact check tricky
+        assert floats_sufficiently_equal(
+            node_latency_collector.get_average_latency_time(node),
+            sum(execution_times) / len(execution_times),
+        )
+
+    node_addresses = list(executions.keys())
+    for _ in range(10):
+        # try various random permutations of order
+        random.shuffle(node_addresses)
+        assert (
+            node_latency_collector.order_addresses_by_latency(node_addresses)
+            == expected_node_sorted_order
+        )
+
+
+def test_collector_tracker_exception(execution_data):
+    executions, _ = execution_data
+    node_latency_collector = NodeLatencyStatsCollector()
+
+    node_not_to_raise = random.sample(list(executions.keys()), 1)[0]
+    for node, execution_times in executions.items():
+        for exec_time in execution_times:
+            base_perf_counter = time.perf_counter()
+            end_time = base_perf_counter + exec_time
+            with patch("time.perf_counter", side_effect=[base_perf_counter, end_time]):
+                exception_propagated = False
+                try:
+                    with node_latency_collector.get_latency_tracker(node):
+                        # raise exception during whatever node execution
+                        if node != node_not_to_raise:
+                            raise ConnectionRefusedError("random execution exception")
+                except ConnectionRefusedError:
+                    exception_propagated = True
+
+                assert exception_propagated == (node != node_not_to_raise)
+
+        if node != node_not_to_raise:
+            # no stats stored so average equals MAX_LATENCY
+            assert (
+                node_latency_collector.get_average_latency_time(node)
+                == NodeLatencyStatsCollector.MAX_LATENCY
+            )
+        else:
+            # floating point arithmetic makes an exact check tricky
+            assert floats_sufficiently_equal(
+                node_latency_collector.get_average_latency_time(node_not_to_raise),
+                sum(execution_times) / len(execution_times),
+            )
+
+    node_addresses = list(executions.keys())
+    exp_sorted_addresses = [node_not_to_raise] + [
+        a for a in node_addresses if a != node_not_to_raise
+    ]
+    sorted_addresses = node_latency_collector.order_addresses_by_latency(node_addresses)
+    assert sorted_addresses[0] == node_not_to_raise
+    assert sorted_addresses == exp_sorted_addresses

--- a/tests/unit/test_node_latency_collector.py
+++ b/tests/unit/test_node_latency_collector.py
@@ -1,3 +1,4 @@
+import math
 import random
 import time
 from concurrent.futures import ThreadPoolExecutor, wait
@@ -43,13 +44,6 @@ def execution_data(get_random_checksum_address):
     return executions, sorted_order
 
 
-def floats_sufficiently_equal(a: float, b: float):
-    if abs(a - b) < 1e-9:
-        return True
-
-    return False
-
-
 def test_collector_initialization_no_data_collected(get_random_checksum_address):
     node_latency_collector = NodeLatencyStatsCollector()
 
@@ -81,14 +75,14 @@ def test_collector_stats_obtained(execution_data):
             # check ongoing average
             subset_of_times = execution_times[: (i + 1)]
             # floating point arithmetic makes an exact check tricky
-            assert floats_sufficiently_equal(
+            assert math.isclose(
                 node_latency_collector.get_average_latency_time(node),
                 sum(subset_of_times) / len(subset_of_times),
             )
 
         # check final average
         # floating point arithmetic makes an exact check tricky
-        assert floats_sufficiently_equal(
+        assert math.isclose(
             node_latency_collector.get_average_latency_time(node),
             sum(execution_times) / len(execution_times),
         )
@@ -119,7 +113,7 @@ def test_collector_moving_average_window(max_window, get_random_checksum_address
         exec_times.append(value)
         node_collector_stats._update_stats(node, value)
         # all values available used
-        assert floats_sufficiently_equal(
+        assert math.isclose(
             node_collector_stats.get_average_latency_time(node),
             sum(exec_times) / len(exec_times),
         )
@@ -131,7 +125,7 @@ def test_collector_moving_average_window(max_window, get_random_checksum_address
         node_collector_stats._update_stats(node, value)
 
     # only the latest "max_window" values are used for the average, even though additional values were collected
-    assert floats_sufficiently_equal(
+    assert math.isclose(
         node_collector_stats.get_average_latency_time(node),
         sum(exec_times[-max_window:]) / len(exec_times[-max_window:]),
     )
@@ -146,7 +140,7 @@ def test_collector_stats_reset(execution_data):
         for exec_time in execution_times:
             node_latency_collector._update_stats(node, exec_time)
 
-        assert floats_sufficiently_equal(
+        assert math.isclose(
             node_latency_collector.get_average_latency_time(node),
             sum(execution_times) / len(execution_times),
         )
@@ -245,7 +239,7 @@ def test_collector_tracker_no_exception(execution_data):
                     time.sleep(0)
 
         # floating point arithmetic makes an exact check tricky
-        assert floats_sufficiently_equal(
+        assert math.isclose(
             node_latency_collector.get_average_latency_time(node),
             sum(execution_times) / len(execution_times),
         )
@@ -289,7 +283,7 @@ def test_collector_tracker_exception(execution_data):
             )
         else:
             # floating point arithmetic makes an exact check tricky
-            assert floats_sufficiently_equal(
+            assert math.isclose(
                 node_latency_collector.get_average_latency_time(node_not_to_raise),
                 sum(execution_times) / len(execution_times),
             )


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Updates a `Learner` to track average node connection latency and then uses it to order threshold decryption requests. Only the `/node_metadata` endpoint for all nodes is used for collecting stats. This is called whenever the Learner learns about other nodes from a node (teacher).

The list of ursulas representing the ritual cohort is ordered from smallest average latency to largest, and that list is used for sending decryption requests via the `ThresholdDecryptionRequestFactory`.

Porter uses the same code and will directly benefit from this change. Porter can use this code before an official `nucypher/nucypher` by simply using a github dependency. Consequently, we can release an updated Porter as soon as we like.

**Issues fixed/closed:**
Closes https://github.com/nucypher/nucypher/issues/3395.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
