### PR TITLE
Allow RPC urls to be used for RPC and Contract Conditions

### DIFF
--- a/newsfragments/3566.feature.rst
+++ b/newsfragments/3566.feature.rst
@@ -1,0 +1,1 @@
+Allow RPC urls to be specified for RPC and Contract Conditions

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -83,12 +83,8 @@ class RPCCall(ExecutionCall):
                 "null": "Undefined method name",
             },
         )
-        parameters = fields.List(
-            fields.Field, attribute="parameters", required=False, allow_none=True
-        )
-        rpc_endpoint = fields.Url(
-            attribute="rpc_endpoint", required=False, relative=False, allow_none=True
-        )
+        parameters = fields.List(fields.Field, required=False, allow_none=True)
+        rpc_endpoint = fields.Url(required=False, relative=False, allow_none=True)
 
         @validates_schema
         def validate_chain(self, data, **kwargs):

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -173,11 +173,9 @@ class RPCCall(ExecutionCall):
         self,
         provider: HTTPProvider,
         resolved_parameters: List[Any],
-        check_chain: bool = True,
     ) -> Any:
         w3 = self._configure_w3(provider)
-        if check_chain:
-            self._check_chain_id(w3)
+        self._check_chain_id(w3)
         return self._execute(w3, resolved_parameters)
 
     def execute(self, providers: Dict[int, Set[HTTPProvider]], **context) -> Any:
@@ -204,7 +202,7 @@ class RPCCall(ExecutionCall):
 
         if self.rpc_endpoint:
             result, error = self._execute_with_provider(
-                HTTPProvider(self.rpc_endpoint), resolved_parameters, check_chain=False
+                HTTPProvider(self.rpc_endpoint), resolved_parameters
             )
             if error:
                 raise RPCExecutionFailed(error)

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -112,10 +112,12 @@ class RPCCall(ExecutionCall):
         chain: int,
         method: str,
         parameters: Optional[List[Any]] = None,
+        rpc_endpoint: Optional[str] = None,
     ):
         self.chain = chain
         self.method = method
         self.parameters = parameters
+        self.rpc_endpoint = rpc_endpoint
         super().__init__()
 
     def _get_web3_py_function(self, w3: Web3, rpc_method: str):

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -425,12 +425,17 @@ class ContractCall(RPCCall):
 
     def _execute(self, w3: Web3, resolved_parameters: List[Any]) -> Any:
         """Execute onchain read and return result."""
-        self.contract_function.w3 = w3
-        bound_contract_function = self.contract_function(
-            *resolved_parameters
-        )  # bind contract function
-        contract_result = bound_contract_function.call()  # onchain read
-        return contract_result
+        try:
+            self.contract_function.w3 = w3
+            bound_contract_function = self.contract_function(
+                *resolved_parameters
+            )  # bind contract function
+            contract_result = bound_contract_function.call()  # onchain read
+            return contract_result, None
+        except Exception as e:
+            error = f"RPC call '{self.method}' failed: {e}"
+            self.LOG.warn(error)
+            return None, error
 
 
 class ContractCondition(RPCCondition):

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -87,13 +87,17 @@ class RPCCall(ExecutionCall):
         parameters = fields.List(
             fields.Field, attribute="parameters", required=False, allow_none=True
         )
-        rpc_endpoint = fields.Url(required=False, relative=False, allow_none=True)
+        rpc_endpoint = fields.Url(
+            attribute="rpc_endpoint", required=False, relative=False, allow_none=True
+        )
 
-        @validates("chain")
-        def validate_chain(self, value):
-            if value not in _CONDITION_CHAINS:
+        @validates_schema
+        def validate_chain(self, data, **kwargs):
+            chain = data.get("chain")
+            rpc_endpoint = data.get("rpc_endpoint")
+            if not rpc_endpoint and chain not in _CONDITION_CHAINS:
                 raise ValidationError(
-                    f"chain ID {value} is not a permitted blockchain for condition evaluation"
+                    f"chain ID {chain} is not a permitted blockchain for condition evaluation"
                 )
 
         @validates("method")
@@ -294,6 +298,10 @@ class RPCCondition(ExecutionCallAccessControlCondition):
     @property
     def parameters(self):
         return self.execution_call.parameters
+
+    @property
+    def rpc_endpoint(self):
+        return self.execution_call.rpc_endpoint
 
     def _align_comparator_value_with_abi(
         self, return_value_test: ReturnValueTest

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -87,7 +87,7 @@ class RPCCall(ExecutionCall):
         parameters = fields.List(
             fields.Field, attribute="parameters", required=False, allow_none=True
         )
-        rpc_endpoint = fields.Url(required=False, relative=False)
+        rpc_endpoint = fields.Url(required=False, relative=False, allow_none=True)
 
         @validates("chain")
         def validate_chain(self, value):
@@ -261,6 +261,7 @@ class RPCCondition(ExecutionCallAccessControlCondition):
         condition_type: str = ConditionType.RPC.value,
         name: Optional[str] = None,
         parameters: Optional[List[Any]] = None,
+        rpc_endpoint: Optional[str] = None,
         *args,
         **kwargs,
     ):
@@ -271,6 +272,7 @@ class RPCCondition(ExecutionCallAccessControlCondition):
             condition_type=condition_type,
             name=name,
             parameters=parameters,
+            rpc_endpoint=rpc_endpoint,
             *args,
             **kwargs,
         )

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -35,7 +35,6 @@ from nucypher.policy.conditions.context import (
 )
 from nucypher.policy.conditions.exceptions import (
     NoConnectionToChain,
-    RPCExecutionFailed,
 )
 from nucypher.policy.conditions.lingo import (
     ConditionType,
@@ -188,12 +187,8 @@ class RPCCall(ExecutionCall):
                     result = self._execute_with_provider(provider, resolved_parameters)
                     return result
                 except Exception as e:
-                    latest_error = str(e)
+                    latest_error = e
                     continue
-
-            raise RPCExecutionFailed(
-                f"RPC call '{self.method}' failed; latest error - {latest_error}"
-            )
 
         # Try custom RPC endpoint if provided
         if self.rpc_endpoint:
@@ -203,13 +198,11 @@ class RPCCall(ExecutionCall):
                 )
                 return result
             except Exception as e:
-                latest_error = str(e)
+                latest_error = e
 
         # If we get here, all attempts failed
         if latest_error:
-            raise RPCExecutionFailed(
-                f"RPC call '{self.method}' failed; latest error - {latest_error}"
-            )
+            raise latest_error
         raise NoConnectionToChain(chain=self.chain)
 
     def _execute(self, w3: Web3, resolved_parameters: List[Any]) -> Any:

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -87,7 +87,7 @@ class RPCCall(ExecutionCall):
         parameters = fields.List(
             fields.Field, attribute="parameters", required=False, allow_none=True
         )
-        endpoint = fields.Url(required=False, relative=False)
+        rpc_endpoint = fields.Url(required=False, relative=False)
 
         @validates("chain")
         def validate_chain(self, value):
@@ -181,9 +181,9 @@ class RPCCall(ExecutionCall):
                 self.parameters, **context
             )
 
-        if self.endpoint:
+        if self.rpc_endpoint:
             result, error = self._execute_with_provider(
-                HTTPProvider(self.endpoint), resolved_parameters, check_chain=False
+                HTTPProvider(self.rpc_endpoint), resolved_parameters, check_chain=False
             )
             if error:
                 raise RPCExecutionFailed(error)

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -52,11 +52,8 @@ class TimeRPCCall(RPCCall):
     def _execute(self, w3: Web3, resolved_parameters: List[Any]) -> Any:
         """Execute onchain read and return result."""
         # TODO may need to rethink as part of #3051 (multicall work).
-        try:
-            latest_block = w3.eth.get_block("latest")
-            return latest_block.timestamp, None
-        except Exception as e:
-            return None, f"RPC call '{self.method}' failed: {e}"
+        latest_block = w3.eth.get_block("latest")
+        return latest_block.timestamp
 
 
 class TimeCondition(RPCCondition):

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -43,8 +43,11 @@ class TimeRPCCall(RPCCall):
         chain: int,
         method: str = METHOD,
         parameters: Optional[List[Any]] = None,
+        rpc_endpoint: Optional[str] = None,
     ):
-        super().__init__(chain=chain, method=method, parameters=parameters)
+        super().__init__(
+            chain=chain, method=method, parameters=parameters, rpc_endpoint=rpc_endpoint
+        )
 
     def _execute(self, w3: Web3, resolved_parameters: List[Any]) -> Any:
         """Execute onchain read and return result."""

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -52,8 +52,11 @@ class TimeRPCCall(RPCCall):
     def _execute(self, w3: Web3, resolved_parameters: List[Any]) -> Any:
         """Execute onchain read and return result."""
         # TODO may need to rethink as part of #3051 (multicall work).
-        latest_block = w3.eth.get_block("latest")
-        return latest_block.timestamp
+        try:
+            latest_block = w3.eth.get_block("latest")
+            return latest_block.timestamp, None
+        except Exception as e:
+            return None, f"RPC call '{self.method}' failed: {e}"
 
 
 class TimeCondition(RPCCondition):

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -145,7 +145,7 @@ def test_rpc_condition_uses_provided_endpoint(mocker):
     # Mock eth module
     mock_w3 = mocker.Mock()
     mock_w3.eth.get_balance.return_value = 0
-    mock_w3.eth.chain_id = 8453
+    mock_w3.eth.chain_id = TESTERCHAIN_CHAIN_ID
 
     # Patch RPCCall._configure_w3 method
     mocker.patch(
@@ -206,7 +206,8 @@ def test_rpc_condition_execution_priority(mocker):
     mock_http_provider_spy.reset_mock()
 
     # Test Case 2: Unsupported chain - should use rpc_endpoint
-    unsupported_chain = 99999  # Chain not in _CONDITION_CHAINS
+    unsupported_chain = 8453
+    mock_eth.chain_id = unsupported_chain
     condition = RPCCondition(
         method="eth_getBalance",
         chain=unsupported_chain,

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -139,20 +139,15 @@ def test_rpc_condition_invalid_comparator_value_type(invalid_value, rpc_conditio
 
 
 def test_rpc_condition_uses_provided_endpoint(mocker):
-    # Mock HTTPProvider
+    # Spy HTTPProvider
     mock_http_provider_spy = mocker.spy(HTTPProvider, "__init__")
 
     # Mock eth module
-    mock_eth = mocker.Mock()
-    mock_eth.get_balance.return_value = 0
-    mock_eth.chain_id = 8453
-
-    # Create Web3 mock with required attributes
     mock_w3 = mocker.Mock()
-    mock_w3.eth = mock_eth
-    mock_w3.middleware_onion = mocker.Mock()
+    mock_w3.eth.get_balance.return_value = 0
+    mock_w3.eth.chain_id = 8453
 
-    # Patch Web3 constructor
+    # Patch RPCCall._configure_w3 method
     mocker.patch(
         "nucypher.policy.conditions.evm.RPCCall._configure_w3", return_value=mock_w3
     )
@@ -220,7 +215,7 @@ def test_rpc_condition_execution_priority(mocker):
         rpc_endpoint="https://fallback.example.com",
     )
 
-    condition.verify(providers={})
+    condition.verify(providers=providers)
     mock_http_provider_spy.assert_called_once_with(ANY, "https://fallback.example.com")
 
     # Test Case 3: Unsupported chain with no rpc_endpoint - should raise error

--- a/tests/unit/conditions/test_time_condition.py
+++ b/tests/unit/conditions/test_time_condition.py
@@ -97,7 +97,6 @@ def test_time_condition_verify(mocker):
     w3 = mocker.Mock()
     w3.eth.get_block.return_value = mock_block
     w3.eth.chain_id = TESTERCHAIN_CHAIN_ID
-    w3.middleware_onion = mocker.Mock()
 
     # Patch Web3 configuration
     mocker.patch(


### PR DESCRIPTION
**Type of PR:**
- Feature

**Required reviews:** 
- 2

**What this does:**
- update schema for RPC/Contract conditions
- if an rpc url is provided, use it. Otherwise default to current chainID based logic