### PR TITLE
EVM Condition on "Any" (Major) EVM Chain (only `lynx` for now)

### DIFF
--- a/newsfragments/3569.feature.rst
+++ b/newsfragments/3569.feature.rst
@@ -1,0 +1,1 @@
+Added plumbing to support EVM condition evaluation on "any" (major) EVM chain outside of Ethereum and Polygon - only enabled on `lynx` testnet for now.

--- a/newsfragments/3569.feature.rst
+++ b/newsfragments/3569.feature.rst
@@ -1,1 +1,1 @@
-Added plumbing to support EVM condition evaluation on "any" (major) EVM chain outside of Ethereum and Polygon - only enabled on `lynx` testnet for now.
+Added plumbing to support EVM condition evaluation on "any" (major) EVM chain outside of Ethereum and Polygon - only enabled on ``lynx`` testnet for now.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -317,7 +317,6 @@ class Operator(BaseActor):
                 duplicated_endpoint_check[chain_id].add(uri)
 
         # Ingest default/fallback RPC providers for each chain
-        # for chain_id in self.domain.condition_chain_ids:
         default_endpoints = get_healthy_default_rpc_endpoints(self.domain)
         for chain_id, chain_endpoints in default_endpoints.items():
             # randomize list so that the same fallback RPC endpoints aren't always used by all nodes

--- a/nucypher/blockchain/eth/constants.py
+++ b/nucypher/blockchain/eth/constants.py
@@ -54,6 +54,6 @@ POA_CHAINS = {
     80002,  # "Polygon/Amoy"
 }
 
-CHAINLIST_URL = (
+CHAINLIST_URL_TEMPLATE = (
     "https://raw.githubusercontent.com/nucypher/chainlist/main/{domain}.json"
 )

--- a/nucypher/blockchain/eth/constants.py
+++ b/nucypher/blockchain/eth/constants.py
@@ -54,4 +54,6 @@ POA_CHAINS = {
     80002,  # "Polygon/Amoy"
 }
 
-CHAINLIST_URL = "https://raw.githubusercontent.com/nucypher/chainlist/main/{domain}.json"
+CHAINLIST_URL = (
+    "https://raw.githubusercontent.com/nucypher/chainlist/main/{domain}.json"
+)

--- a/nucypher/blockchain/eth/constants.py
+++ b/nucypher/blockchain/eth/constants.py
@@ -54,4 +54,4 @@ POA_CHAINS = {
     80002,  # "Polygon/Amoy"
 }
 
-CHAINLIST_URL = "https://raw.githubusercontent.com/nucypher/chainlist/main/rpc.json"
+CHAINLIST_URL = "https://raw.githubusercontent.com/nucypher/chainlist/main/{domain}.json"

--- a/nucypher/blockchain/eth/decorators.py
+++ b/nucypher/blockchain/eth/decorators.py
@@ -2,7 +2,7 @@
 
 import functools
 import inspect
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable, Optional, TypeVar, Union
 
 import eth_utils
@@ -111,7 +111,7 @@ def save_receipt(actor_method) -> Callable:  # TODO: rename to "save_result"?
     @functools.wraps(actor_method)
     def wrapped(self, *args, **kwargs) -> dict:
         receipt_or_txhash = actor_method(self, *args, **kwargs)
-        self._saved_receipts.append((datetime.utcnow(), receipt_or_txhash))
+        self._saved_receipts.append((datetime.now(timezone.utc), receipt_or_txhash))
         return receipt_or_txhash
     return wrapped
 

--- a/nucypher/blockchain/eth/domains.py
+++ b/nucypher/blockchain/eth/domains.py
@@ -1,7 +1,6 @@
 from enum import Enum
-from typing import Any, Dict, NamedTuple, Tuple
-
-from cytoolz.functoolz import memoize
+from functools import cache
+from typing import Any, Dict, NamedTuple
 
 
 class UnrecognizedTacoDomain(Exception):
@@ -29,12 +28,10 @@ class TACoDomain:
         name: str,
         eth_chain: EthChain,
         polygon_chain: PolygonChain,
-        condition_chains: Tuple[ChainInfo, ...],
     ):
         self.name = name
         self.eth_chain = eth_chain
         self.polygon_chain = polygon_chain
-        self.condition_chains = condition_chains
 
     def __repr__(self) -> str:
         return f"<TACoDomain {self.name}>"
@@ -43,9 +40,7 @@ class TACoDomain:
         return self.name
 
     def __hash__(self) -> int:
-        return hash(
-            (self.name, self.eth_chain, self.polygon_chain, self.condition_chains)
-        )
+        return hash((self.name, self.eth_chain, self.polygon_chain))
 
     def __bytes__(self) -> bytes:
         return self.name.encode()
@@ -57,7 +52,6 @@ class TACoDomain:
             self.name == other.name
             and self.eth_chain == other.eth_chain
             and self.polygon_chain == other.polygon_chain
-            and self.condition_chains == other.condition_chains
         )
 
     def __bool__(self) -> bool:
@@ -67,36 +61,24 @@ class TACoDomain:
     def is_testnet(self) -> bool:
         return self.eth_chain != EthChain.MAINNET
 
-    @property
-    def condition_chain_ids(self) -> set:
-        return set(chain.id for chain in self.condition_chains)
-
 
 
 MAINNET = TACoDomain(
     name="mainnet",
     eth_chain=EthChain.MAINNET,
     polygon_chain=PolygonChain.MAINNET,
-    condition_chains=(EthChain.MAINNET, PolygonChain.MAINNET),
 )
 
 LYNX = TACoDomain(
     name="lynx",
     eth_chain=EthChain.SEPOLIA,
     polygon_chain=PolygonChain.AMOY,
-    condition_chains=(
-        EthChain.MAINNET,
-        EthChain.SEPOLIA,
-        PolygonChain.AMOY,
-        PolygonChain.MAINNET,
-    ),
 )
 
 TAPIR = TACoDomain(
     name="tapir",
     eth_chain=EthChain.SEPOLIA,
     polygon_chain=PolygonChain.AMOY,
-    condition_chains=(EthChain.SEPOLIA, PolygonChain.AMOY),
 )
 
 
@@ -107,7 +89,7 @@ SUPPORTED_DOMAINS: Dict[str, TACoDomain] = {
 }
 
 
-@memoize
+@cache
 def get_domain(d: Any) -> TACoDomain:
     if not isinstance(d, str):
         raise TypeError(f"domain must be a string, not {type(d)}")

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -1,18 +1,17 @@
-import random
 import time
 from decimal import Decimal
+from functools import cache
 from typing import Dict, List, Union
-from urllib.parse import urlparse
 
 import requests
-from cytoolz import memoize
 from eth_typing import ChecksumAddress
 from requests import RequestException
-from web3 import HTTPProvider, Web3
+from web3 import Web3
 from web3.contract.contract import ContractConstructor, ContractFunction
 from web3.types import TxParams
 
 from nucypher.blockchain.eth.constants import CHAINLIST_URL
+from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.utilities.logging import Logger
 
 LOGGER = Logger("utility")
@@ -136,17 +135,17 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
     return True  # finally!
 
 
-def get_default_rpc_endpoints() -> Dict[int, List[str]]:
+@cache
+def get_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]]:
     """
     Fetches the default RPC endpoints for various chains
     from the nucypher/chainlist repository.
     """
-    LOGGER.debug(
-        f"Fetching default RPC endpoints from remote chainlist {CHAINLIST_URL}"
-    )
+    url = CHAINLIST_URL.format(domain=domain.name)
+    LOGGER.debug(f"Fetching default RPC endpoints from remote chainlist {url}")
 
     try:
-        response = requests.get(CHAINLIST_URL)
+        response = requests.get(url)
     except RequestException:
         LOGGER.warn("Failed to fetch default RPC endpoints: network error")
         return {}
@@ -162,78 +161,22 @@ def get_default_rpc_endpoints() -> Dict[int, List[str]]:
         return {}
 
 
-def get_healthy_default_rpc_endpoints(chain_id: int) -> List[str]:
-    """Returns a list of healthy RPC endpoints for a given chain ID."""
+def get_healthy_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]]:
+    """Returns a mapping of chain id to healthy RPC endpoints for a given domain."""
 
-    endpoints = get_default_rpc_endpoints()
-    chain_endpoints = endpoints.get(chain_id)
+    endpoints = get_default_rpc_endpoints(domain)
 
-    if not chain_endpoints:
-        LOGGER.error(f"No default RPC endpoints found for chain ID {chain_id}")
-        return list()
-
-    healthy = [
-        endpoint for endpoint in chain_endpoints if rpc_endpoint_health_check(endpoint)
-    ]
-    LOGGER.info(f"Healthy default RPC endpoints for chain ID {chain_id}: {healthy}")
-    if not healthy:
-        LOGGER.warn(
-            f"No healthy default RPC endpoints available for chain ID {chain_id}"
-        )
+    if not domain.is_testnet:
+        # iterate over all chains and filter out unhealthy endpoints
+        healthy = {
+            chain_id: [
+                endpoint
+                for endpoint in endpoints[chain_id]
+                if rpc_endpoint_health_check(endpoint)
+            ]
+            for chain_id in endpoints
+        }
+    else:
+        healthy = endpoints
 
     return healthy
-
-
-@memoize
-def _fetch_public_rpc_endpoints_from_chainlist():
-    chainid_network = "https://chainid.network/chains.json"
-
-    LOGGER.debug(f"Fetching public RPC endpoints from {chainid_network}")
-
-    try:
-        response = requests.get(chainid_network)
-    except RequestException:
-        LOGGER.warn("Failed to fetch public RPC endpoints: network error")
-        return {}
-
-    if response.status_code != 200:
-        LOGGER.error(
-            f"Failed to fetch default RPC endpoints: {response.status_code} | {response.text}"
-        )
-        return {}
-
-    result = response.json()
-    return result
-
-
-def fetch_public_rpc_endpoints_for_chain(chain_id: int) -> List[HTTPProvider]:
-    result = _fetch_public_rpc_endpoints_from_chainlist()
-    if not result:
-        return result
-
-    rpc_endpoints = []
-    for entry in result:
-        if entry["chainId"] != chain_id:
-            continue
-
-        if entry.get("status", None) == "deprecated":
-            break
-
-        endpoints = entry.get("rpc", [])
-        for endpoint in endpoints:
-            # ensure no infura key
-            if "${" in endpoint:
-                # filter out urls like:
-                # - https://mainnet.infura.io/v3/${INFURA_API_KEY},
-                # - https://mainnet.infura.io/v3/${ALCHEMY_API_KEY}
-                continue
-
-            # only use https endpoints
-            url_components = urlparse(endpoint)
-            if url_components.scheme != "https":
-                continue
-
-            rpc_endpoints.append(HTTPProvider(endpoint))
-
-    random.shuffle(rpc_endpoints)
-    return rpc_endpoints

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -138,7 +138,7 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
 @cache
 def get_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]]:
     """
-    Fetches the default RPC endpoints for various chains
+    For a given domain, fetches the default RPC endpoints for various chains
     from the nucypher/chainlist repository.
     """
     url = CHAINLIST_URL_TEMPLATE.format(domain=domain.name)
@@ -163,7 +163,6 @@ def get_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]]:
 
 def get_healthy_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]]:
     """Returns a mapping of chain id to healthy RPC endpoints for a given domain."""
-
     endpoints = get_default_rpc_endpoints(domain)
 
     if not domain.is_testnet:

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -10,7 +10,7 @@ from web3 import Web3
 from web3.contract.contract import ContractConstructor, ContractFunction
 from web3.types import TxParams
 
-from nucypher.blockchain.eth.constants import CHAINLIST_URL
+from nucypher.blockchain.eth.constants import CHAINLIST_URL_TEMPLATE
 from nucypher.blockchain.eth.domains import TACoDomain
 from nucypher.utilities.logging import Logger
 
@@ -141,7 +141,7 @@ def get_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]]:
     Fetches the default RPC endpoints for various chains
     from the nucypher/chainlist repository.
     """
-    url = CHAINLIST_URL.format(domain=domain.name)
+    url = CHAINLIST_URL_TEMPLATE.format(domain=domain.name)
     LOGGER.debug(f"Fetching default RPC endpoints from remote chainlist {url}")
 
     try:

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -1,3 +1,4 @@
+import random
 import time
 from decimal import Decimal
 from typing import Dict, List, Union
@@ -234,4 +235,5 @@ def fetch_public_rpc_endpoints_for_chain(chain_id: int) -> List[HTTPProvider]:
 
             rpc_endpoints.append(HTTPProvider(endpoint))
 
+    random.shuffle(rpc_endpoints)
     return rpc_endpoints

--- a/nucypher/crypto/tls.py
+++ b/nucypher/crypto/tls.py
@@ -42,7 +42,7 @@ def generate_self_signed_certificate(
         private_key = ec.generate_private_key(curve(), default_backend())
     public_key = private_key.public_key()
 
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     fields = [x509.NameAttribute(NameOID.COMMON_NAME, host)]
 
     subject = issuer = x509.Name(fields)

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -89,12 +89,12 @@ class RPCCall(ExecutionCall):
             fields.Field, attribute="parameters", required=False, allow_none=True
         )
 
-        @validates("chain")
-        def validate_chain(self, value):
-            if value not in _CONDITION_CHAINS:
-                raise ValidationError(
-                    f"chain ID {value} is not a permitted blockchain for condition evaluation"
-                )
+        # @validates("chain")
+        # def validate_chain(self, value):
+        #    if value not in _CONDITION_CHAINS:
+        #        raise ValidationError(
+        #            f"chain ID {value} is not a permitted blockchain for condition evaluation"
+        #        )
 
         @validates("method")
         def validate_method(self, value):

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -188,7 +188,7 @@ class EventScanner:
             # minor chain reorganisation?
             return None
         last_time = block_info["timestamp"]
-        return datetime.datetime.utcfromtimestamp(last_time)
+        return datetime.datetime.fromtimestamp(last_time, tz=datetime.timezone.utc)
 
     def get_suggested_scan_start_block(self):
         """Get where we should start to scan for new token events.

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -21,7 +21,6 @@ from tests.constants import (
     MIN_OPERATOR_SECONDS,
     TEMPORARY_DOMAIN,
     TEST_ETH_PROVIDER_URI,
-    TESTERCHAIN_CHAIN_ID,
 )
 from tests.utils.blockchain import ReservedTestAccountManager, TesterBlockchain
 from tests.utils.registry import ApeRegistrySource
@@ -452,10 +451,6 @@ def multichain_ursulas(ursulas, multichain_ids, mock_rpc_condition):
 @pytest.fixture(scope="module", autouse=True)
 def mock_condition_blockchains(module_mocker):
     """adds testerchain's chain ID to permitted conditional chains"""
-    module_mocker.patch.dict(
-        "nucypher.policy.conditions.evm._CONDITION_CHAINS",
-        {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
-    )
 
     module_mocker.patch(
         "nucypher.blockchain.eth.domains.get_domain", return_value=TEMPORARY_DOMAIN

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from nucypher.network.nodes import Learner
 from nucypher.utilities.logging import GlobalLoggerSettings
 from tests.constants import (
     MOCK_IP_ADDRESS,
-    TESTERCHAIN_CHAIN_ID,
 )
 
 # Don't re-lock accounts in the background while making commitments
@@ -135,14 +134,6 @@ def disable_check_grant_requirements(session_mocker):
     target = 'nucypher.characters.lawful.Alice._check_grant_requirements'
     session_mocker.patch(target, return_value=MOCK_IP_ADDRESS)
 
-
-@pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker):
-    """adds testerchain's chain ID to permitted conditional chains"""
-    module_mocker.patch.dict(
-        "nucypher.policy.conditions.evm._CONDITION_CHAINS",
-        {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
-    )
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -73,7 +73,6 @@ TEMPORARY_DOMAIN = TACoDomain(
     name=TEMPORARY_DOMAIN_NAME,
     eth_chain=TESTERCHAIN_CHAIN_INFO,
     polygon_chain=TESTERCHAIN_CHAIN_INFO,
-    condition_chains=(TESTERCHAIN_CHAIN_INFO,),
 )
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -272,14 +272,6 @@ def monkeypatch_get_staking_provider_from_operator(monkeymodule):
     )
 
 
-@pytest.fixture(scope="module", autouse=True)
-def mock_condition_blockchains(module_mocker):
-    """adds testerchain's chain ID to permitted conditional chains"""
-    module_mocker.patch.dict(
-        "nucypher.policy.conditions.evm._CONDITION_CHAINS",
-        {TESTERCHAIN_CHAIN_ID: "eth-tester/pyevm"},
-    )
-
 
 @pytest.fixture(scope="module")
 def multichain_ids(module_mocker):
@@ -291,6 +283,20 @@ def multichain_ids(module_mocker):
 def multichain_ursulas(ursulas, multichain_ids):
     setup_multichain_ursulas(ursulas=ursulas, chain_ids=multichain_ids)
     return ursulas
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_rpc_endpoints(module_mocker):
+    """Mock RPC endpoints for integration tests"""
+
+    def mock_get_default_endpoints(domain):
+        # Return test endpoints for the testerchain
+        return {TESTERCHAIN_CHAIN_ID: ["http://localhost:8545"]}
+
+    module_mocker.patch(
+        "nucypher.blockchain.eth.utils.get_default_rpc_endpoints",
+        side_effect=mock_get_default_endpoints,
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/learning/test_domains.py
+++ b/tests/integration/learning/test_domains.py
@@ -13,7 +13,6 @@ def domain_1():
         name="domain_uno",
         eth_chain=TESTERCHAIN_CHAIN_INFO,
         polygon_chain=TESTERCHAIN_CHAIN_INFO,
-        condition_chains=(TESTERCHAIN_CHAIN_INFO,),
     )
 
 
@@ -23,7 +22,6 @@ def domain_2():
         name="domain_dos",
         eth_chain=TESTERCHAIN_CHAIN_INFO,
         polygon_chain=TESTERCHAIN_CHAIN_INFO,
-        condition_chains=(TESTERCHAIN_CHAIN_INFO,),
     )
 
 

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -101,11 +101,13 @@ def test_rpc_condition_schema_validation(rpc_condition):
 
     with pytest.raises(InvalidConditionLingo):
         # chain id not an integer
+        condition_dict = rpc_condition.to_dict()
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
         RPCCondition.from_dict(condition_dict)
 
     with pytest.raises(InvalidConditionLingo):
         # chain id not a permitted chain
+        condition_dict = rpc_condition.to_dict()
         condition_dict["chain"] = 90210  # Beverly Hills Chain :)
         RPCCondition.from_dict(condition_dict)
 

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -47,15 +47,6 @@ def test_invalid_rpc_condition():
             parameters=["0xaDD9D957170dF6F33982001E4c22eCCdd5539118"],
         )
 
-    # # unsupported chain id
-    # with pytest.raises(InvalidCondition, match="90210 is not a permitted blockchain"):
-    #     _ = RPCCondition(
-    #         method="eth_getBalance",
-    #         chain=90210,  # Beverly Hills Chain :)
-    #         return_value_test=ReturnValueTest("==", 0),
-    #         parameters=["0xaDD9D957170dF6F33982001E4c22eCCdd5539118"],
-    #     )
-
     # invalid chain type provided
     with pytest.raises(ValueError, match="invalid literal for int"):
         _ = RPCCondition(
@@ -104,12 +95,6 @@ def test_rpc_condition_schema_validation(rpc_condition):
         condition_dict = rpc_condition.to_dict()
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
         RPCCondition.from_dict(condition_dict)
-
-    # with pytest.raises(InvalidConditionLingo):
-    #     # chain id not a permitted chain
-    #     condition_dict = rpc_condition.to_dict()
-    #     condition_dict["chain"] = 90210  # Beverly Hills Chain :)
-    #     RPCCondition.from_dict(condition_dict)
 
 
 def test_rpc_condition_repr(rpc_condition):

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -47,14 +47,14 @@ def test_invalid_rpc_condition():
             parameters=["0xaDD9D957170dF6F33982001E4c22eCCdd5539118"],
         )
 
-    # unsupported chain id
-    with pytest.raises(InvalidCondition, match="90210 is not a permitted blockchain"):
-        _ = RPCCondition(
-            method="eth_getBalance",
-            chain=90210,  # Beverly Hills Chain :)
-            return_value_test=ReturnValueTest("==", 0),
-            parameters=["0xaDD9D957170dF6F33982001E4c22eCCdd5539118"],
-        )
+    # # unsupported chain id
+    # with pytest.raises(InvalidCondition, match="90210 is not a permitted blockchain"):
+    #     _ = RPCCondition(
+    #         method="eth_getBalance",
+    #         chain=90210,  # Beverly Hills Chain :)
+    #         return_value_test=ReturnValueTest("==", 0),
+    #         parameters=["0xaDD9D957170dF6F33982001E4c22eCCdd5539118"],
+    #     )
 
     # invalid chain type provided
     with pytest.raises(ValueError, match="invalid literal for int"):
@@ -105,11 +105,11 @@ def test_rpc_condition_schema_validation(rpc_condition):
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
         RPCCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidConditionLingo):
-        # chain id not a permitted chain
-        condition_dict = rpc_condition.to_dict()
-        condition_dict["chain"] = 90210  # Beverly Hills Chain :)
-        RPCCondition.from_dict(condition_dict)
+    # with pytest.raises(InvalidConditionLingo):
+    #     # chain id not a permitted chain
+    #     condition_dict = rpc_condition.to_dict()
+    #     condition_dict["chain"] = 90210  # Beverly Hills Chain :)
+    #     RPCCondition.from_dict(condition_dict)
 
 
 def test_rpc_condition_repr(rpc_condition):

--- a/tests/unit/conditions/test_time_condition.py
+++ b/tests/unit/conditions/test_time_condition.py
@@ -60,16 +60,19 @@ def test_time_condition_schema_validation(time_condition):
 
     with pytest.raises(InvalidConditionLingo):
         # invalid method name
+        condition_dict = time_condition.to_dict()
         condition_dict["method"] = "my_blocktime"
         TimeCondition.from_dict(condition_dict)
 
     with pytest.raises(InvalidConditionLingo):
         # chain id not an integer
+        condition_dict = time_condition.to_dict()
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
         TimeCondition.from_dict(condition_dict)
 
     with pytest.raises(InvalidConditionLingo):
         # chain id not a permitted chain
+        condition_dict = time_condition.to_dict()
         condition_dict["chain"] = 90210  # Beverly Hills Chain :)
         TimeCondition.from_dict(condition_dict)
 

--- a/tests/unit/conditions/test_time_condition.py
+++ b/tests/unit/conditions/test_time_condition.py
@@ -27,14 +27,6 @@ def test_invalid_time_condition():
             method="time_after_time",
         )
 
-    # chain id not permitted
-    # with pytest.raises(InvalidCondition):
-    #     _ = TimeCondition(
-    #         return_value_test=ReturnValueTest(">", 0),
-    #         chain=90210,  # Beverly Hills Chain :)
-    #         method=TimeRPCCall.METHOD,
-    #     )
-
 
 def test_time_condition_schema_validation(time_condition):
     condition_dict = time_condition.to_dict()
@@ -69,12 +61,6 @@ def test_time_condition_schema_validation(time_condition):
         condition_dict = time_condition.to_dict()
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
         TimeCondition.from_dict(condition_dict)
-
-    # with pytest.raises(InvalidConditionLingo):
-    #     # chain id not a permitted chain
-    #     condition_dict = time_condition.to_dict()
-    #     condition_dict["chain"] = 90210  # Beverly Hills Chain :)
-    #     TimeCondition.from_dict(condition_dict)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/conditions/test_time_condition.py
+++ b/tests/unit/conditions/test_time_condition.py
@@ -28,12 +28,12 @@ def test_invalid_time_condition():
         )
 
     # chain id not permitted
-    with pytest.raises(InvalidCondition):
-        _ = TimeCondition(
-            return_value_test=ReturnValueTest(">", 0),
-            chain=90210,  # Beverly Hills Chain :)
-            method=TimeRPCCall.METHOD,
-        )
+    # with pytest.raises(InvalidCondition):
+    #     _ = TimeCondition(
+    #         return_value_test=ReturnValueTest(">", 0),
+    #         chain=90210,  # Beverly Hills Chain :)
+    #         method=TimeRPCCall.METHOD,
+    #     )
 
 
 def test_time_condition_schema_validation(time_condition):
@@ -70,11 +70,11 @@ def test_time_condition_schema_validation(time_condition):
         condition_dict["chain"] = str(TESTERCHAIN_CHAIN_ID)
         TimeCondition.from_dict(condition_dict)
 
-    with pytest.raises(InvalidConditionLingo):
-        # chain id not a permitted chain
-        condition_dict = time_condition.to_dict()
-        condition_dict["chain"] = 90210  # Beverly Hills Chain :)
-        TimeCondition.from_dict(condition_dict)
+    # with pytest.raises(InvalidConditionLingo):
+    #     # chain id not a permitted chain
+    #     condition_dict = time_condition.to_dict()
+    #     condition_dict["chain"] = 90210  # Beverly Hills Chain :)
+    #     TimeCondition.from_dict(condition_dict)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_condition_chains.py
+++ b/tests/unit/test_condition_chains.py
@@ -1,8 +1,0 @@
-from nucypher.blockchain.eth.domains import EthChain, PolygonChain
-from nucypher.policy.conditions.evm import _CONDITION_CHAINS
-
-
-def test_default_condition_chains():
-    all_chains = list(EthChain) + list(PolygonChain)
-    for chain in all_chains:
-        assert chain.id in _CONDITION_CHAINS

--- a/tests/unit/test_event_scanner.py
+++ b/tests/unit/test_event_scanner.py
@@ -1,6 +1,6 @@
 import math
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Tuple
 from unittest.mock import MagicMock, Mock
 
@@ -112,12 +112,14 @@ def test_get_block_timestamp():
 
     now = time.time()
     web3.eth.get_block.return_value = {"timestamp": now}
-    assert scanner.get_block_timestamp(block_num=0) == datetime.utcfromtimestamp(now)
+    assert scanner.get_block_timestamp(block_num=0) == datetime.fromtimestamp(
+        now, tz=timezone.utc
+    )
 
     other_time = time.time() - 1231231
     web3.eth.get_block.return_value = {"timestamp": other_time}
-    assert scanner.get_block_timestamp(block_num=21) == datetime.utcfromtimestamp(
-        other_time
+    assert scanner.get_block_timestamp(block_num=21) == datetime.fromtimestamp(
+        other_time, tz=timezone.utc
     )
 
 

--- a/tests/unit/test_taco_domains.py
+++ b/tests/unit/test_taco_domains.py
@@ -53,26 +53,18 @@ def test_polygon_chains(poly_chain_test):
             "mainnet",
             EthChain.MAINNET,
             PolygonChain.MAINNET,
-            (EthChain.MAINNET, PolygonChain.MAINNET),
         ),
         (
             domains.LYNX,
             "lynx",
             EthChain.SEPOLIA,
             PolygonChain.AMOY,
-            (
-                EthChain.MAINNET,
-                EthChain.SEPOLIA,
-                PolygonChain.AMOY,
-                PolygonChain.MAINNET,
-            ),
         ),
         (
             domains.TAPIR,
             "tapir",
             EthChain.SEPOLIA,
             PolygonChain.AMOY,
-            (EthChain.SEPOLIA, PolygonChain.AMOY),
         ),
     ),
 )
@@ -82,12 +74,10 @@ def test_taco_domain_info(taco_domain_test):
         expected_name,
         expected_eth_chain,
         expected_polygon_chain,
-        expected_condition_chains,
     ) = taco_domain_test
     assert domain_info.name == expected_name
     assert domain_info.eth_chain == expected_eth_chain
     assert domain_info.polygon_chain == expected_polygon_chain
-    assert domain_info.condition_chains == expected_condition_chains
 
     assert domain_info.is_testnet == (expected_name != "mainnet")
 

--- a/tests/utils/ursula.py
+++ b/tests/utils/ursula.py
@@ -11,7 +11,6 @@ from web3 import HTTPProvider
 from nucypher.blockchain.eth.signers import InMemorySigner, Signer
 from nucypher.characters.lawful import Ursula
 from nucypher.config.characters import UrsulaConfiguration
-from nucypher.policy.conditions.evm import _CONDITION_CHAINS
 from tests.constants import TESTERCHAIN_CHAIN_ID
 from tests.utils.blockchain import ReservedTestAccountManager
 
@@ -167,7 +166,6 @@ def mock_permitted_multichain_connections(mocker) -> List[int]:
         TESTERCHAIN_CHAIN_ID + 2,
         123456789,
     ]
-    mocker.patch.dict(_CONDITION_CHAINS, {cid: "fakechain/mainnet" for cid in ids})
     return ids
 
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
Very rough initial work as a POC for `lynx` to support any EVM chain for EVM (RPC, Contract, Time) conditions.

A barebones version as of [d414553](https://github.com/nucypher/nucypher/pull/3569/commits/d414553e5306f4de6b4789a7c734a75caa98c52c) is actually running on `lynx` currently via the `nucypher/nucypher:experimental` docker image.

Some outstanding questions/discussion points:
- [x] How do we limit use to `lynx`. Conditions don't have a concept of domain so even using the mapping, the condition needs to have a way to determine what domain the node is running in

**A: We obtain default rpc endpoints for supported chains based on domain. Each domain has their own rpc endpoint mapping in https://github.com/nucypher/chainlist**

- [x] Should we continue to use `https://chainid.network` URL or use our own more robust storage (eg. github + local, IPFS etc.). Centralization concerns using chainid.network - that being said, if this is only for lynx maybe we dont' care

**A: We will use https://github.com/nucypher/chainlist (github solution) for now.**

- [x] Fetching RPC endpoints is currently `memoize` i.e. only one call is made and then cached. While caching is a good thing perhaps we should use a timed cache, i.e. fetch a fresh list every hour / or some other timeframe? However, do we expect the list to change or not; if not, then time-based cache doesn't achieve anything, and perhaps we can just proactively make the request on startup.

**A: public RPC endpoints are obtained on startup from https://github.com/nucypher/chainlist. Health checks are performed to `mainnet` but not testnets (for now). `lynx` (not `tapir`) will now support many chains with many rpc endpoints and performing health checks will cause start up to be very slow. Since this is just for testnet we will skip this for now. In any case, the fallback nature of the using the RPC endpoints allow for redundancy if any RPC endpoint is down.**

- [x] Do we need health checks for public rpc URLs. Currently the public RPC URLs are obtained at decrytion time, so any health check slows this down - can we be more proactive about health checks in some way

**A: Health checks are only performed for `mainnet` domain, and done on startup and not at decryption time**

- [x] Does this functionality also allow for replacement of the data used for default RPC endpoints done in https://github.com/nucypher/nucypher/pull/3496 for officially supported chains.

**A: Not a replacement, but we ended up utilizing it since we continue to obtain default public rpc endpoints on startup. The only thing that really changed is that https://github.com/nucypher/chainlist now contains separate endpoint mapping files for each domain.**


^ All of these don't need to be addressed in this PR but they are for facilitating thoughts around whether a) should they be done or not, and b) should they be done sooner rather than later. The `lynx` restriction is necessary, however.

**Issues fixed/closed:**
> - Fixes #...

- Subsumes #3566 .
- Related work done in `nucypher/chainlist`:
    - https://github.com/nucypher/chainlist/pull/2
    - https://github.com/nucypher/chainlist/pull/3

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!


**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
