### PR TITLE
EIP1271 Support

### DIFF
--- a/newsfragments/3576.feature.rst
+++ b/newsfragments/3576.feature.rst
@@ -1,0 +1,1 @@
+Add support for EIP1271 signature verification for smart contract wallets.

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -155,7 +155,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
         # TODO: When non-evm chains are supported, bump the version.
         #  this can return a list of chain names or other verifiable identifiers.
 
-        payload = {"version": 1.0, "evm": list(this_node.condition_providers)}
+        payload = {"version": 1.0, "evm": list(this_node.condition_providers.providers)}
         return Response(json.dumps(payload), mimetype="application/json")
 
     @rest_app.route('/decrypt', methods=["POST"])

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -154,7 +154,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
         """
         # TODO: When non-evm chains are supported, bump the version.
         #  this can return a list of chain names or other verifiable identifiers.
-        providers = this_node.condition_providers.providers
+        providers = this_node.condition_provider_manager.providers
         sorted_chain_ids = sorted(list(providers))
         payload = {"version": 1.0, "evm": sorted_chain_ids}
         return Response(json.dumps(payload), mimetype="application/json")

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -260,7 +260,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
                 try:
                     evaluate_condition_lingo(
                         condition_lingo=condition_lingo,
-                        providers=this_node.condition_providers,
+                        providers=this_node.condition_provider_manager,
                         context=context,
                     )
                 except ConditionEvalError as error:

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -154,8 +154,9 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
         """
         # TODO: When non-evm chains are supported, bump the version.
         #  this can return a list of chain names or other verifiable identifiers.
-
-        payload = {"version": 1.0, "evm": list(this_node.condition_providers.providers)}
+        providers = this_node.condition_providers.providers
+        sorted_chain_ids = sorted(list(providers))
+        payload = {"version": 1.0, "evm": sorted_chain_ids}
         return Response(json.dumps(payload), mimetype="application/json")
 
     @rest_app.route('/decrypt', methods=["POST"])

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -34,6 +34,7 @@ from nucypher.policy.conditions.context import (
     resolve_any_context_variables,
 )
 from nucypher.policy.conditions.exceptions import (
+    InvalidConnectionToChain,
     NoConnectionToChain,
     RequiredContextVariable,
     RPCExecutionFailed,
@@ -119,8 +120,9 @@ class RPCCall(ExecutionCall):
         """
         provider_chain = w3.eth.chain_id
         if provider_chain != self.chain:
-            raise NoConnectionToChain(
-                chain=self.chain,
+            raise InvalidConnectionToChain(
+                expected_chain=self.chain,
+                actual_chain=provider_chain,
                 message=f"This rpc call can only be evaluated on chain ID {self.chain} but the provider's "
                 f"connection is to chain ID {provider_chain}",
             )
@@ -154,8 +156,8 @@ class RPCCall(ExecutionCall):
         endpoints = self._next_endpoint(providers=providers)
         latest_error = ""
         for provider in endpoints:
-            w3 = self._configure_provider(provider)
             try:
+                w3 = self._configure_provider(provider)
                 result = self._execute(w3, resolved_parameters)
                 break
             except RequiredContextVariable:

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -106,7 +106,7 @@ class RPCCall(ExecutionCall):
         resolved_parameters = []
         if self.parameters:
             resolved_parameters = resolve_any_context_variables(
-                self.parameters, **context
+                param=self.parameters, providers=providers, **context
             )
 
         endpoints = providers.web3_endpoints(self.chain)
@@ -216,7 +216,7 @@ class RPCCondition(ExecutionCallAccessControlCondition):
         self, providers: ConditionProviderManager, **context
     ) -> Tuple[bool, Any]:
         resolved_return_value_test = self.return_value_test.with_resolved_context(
-            **context
+            providers=providers, **context
         )
         return_value_test = self._align_comparator_value_with_abi(
             resolved_return_value_test

--- a/nucypher/policy/conditions/exceptions.py
+++ b/nucypher/policy/conditions/exceptions.py
@@ -13,6 +13,19 @@ class NoConnectionToChain(RuntimeError):
         super().__init__(message)
 
 
+class InvalidConnectionToChain(RuntimeError):
+    """Raised when a node does not have a valid provider for a chain."""
+
+    def __init__(self, expected_chain: int, actual_chain: int, message: str = None):
+        self.expected_chain = expected_chain
+        self.actual_chain = actual_chain
+        message = (
+            message
+            or f"Invalid blockchain connection; expected chain ID {expected_chain}, but detected {actual_chain}"
+        )
+        super().__init__(message)
+
+
 class ReturnValueEvaluationError(Exception):
     """Issue with Return Value and Key"""
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -610,8 +610,10 @@ class ReturnValueTest:
         result = _COMPARATOR_FUNCTIONS[self.comparator](left_operand, right_operand)
         return result
 
-    def with_resolved_context(self, **context):
-        value = resolve_any_context_variables(self.value, **context)
+    def with_resolved_context(
+        self, providers: Optional[ConditionProviderManager] = None, **context
+    ):
+        value = resolve_any_context_variables(self.value, providers, **context)
         return ReturnValueTest(self.comparator, value=value, index=self.index)
 
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -4,7 +4,7 @@ import json
 import operator as pyoperator
 from enum import Enum
 from hashlib import md5
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, Union
+from typing import Any, List, Optional, Tuple, Type, Union
 
 from hexbytes import HexBytes
 from marshmallow import (
@@ -19,7 +19,6 @@ from marshmallow import (
 )
 from marshmallow.validate import OneOf, Range
 from packaging.version import parse as parse_version
-from web3 import HTTPProvider
 
 from nucypher.policy.conditions.base import (
     AccessControlCondition,
@@ -37,7 +36,7 @@ from nucypher.policy.conditions.exceptions import (
     ReturnValueEvaluationError,
 )
 from nucypher.policy.conditions.types import ConditionDict, Lingo
-from nucypher.policy.conditions.utils import CamelCaseSchema
+from nucypher.policy.conditions.utils import CamelCaseSchema, ConditionProviderManager
 
 
 class _ConditionField(fields.Dict):
@@ -339,7 +338,7 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
     # TODO - think about not dereferencing context but using a dict;
     #  may allows more freedom for params
     def verify(
-        self, providers: Dict[int, Set[HTTPProvider]], **context
+        self, providers: ConditionProviderManager, **context
     ) -> Tuple[bool, Any]:
         values = []
         latest_success = False

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -74,6 +74,7 @@ class JsonRpcConditionDict(BaseExecConditionDict):
     query: NotRequired[str]
     authorizationToken: NotRequired[str]
 
+
 #
 # CompoundCondition represents:
 # {

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -53,7 +53,7 @@ class ConditionProviderManager:
         if not iterator_returned_at_least_one:
             raise NoConnectionToChain(
                 chain=chain_id,
-                message=f"Problematic provider connections for chain ID {chain_id}",
+                message=f"Problematic provider endpoints for chain ID {chain_id}",
             )
 
     @staticmethod

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -45,9 +45,7 @@ class ConditionProviderManager:
             except InvalidConnectionToChain as e:
                 # don't expect to happen but must account
                 # for any misconfigurations of public endpoints
-                self.logger.warn(
-                    f"Invalid blockchain connection; expected chain ID {e.expected_chain}, but detected {e.actual_chain}"
-                )
+                self.logger.warn(str(e))
 
         # if we get here, it is because there were endpoints, but issue with configuring them
         if not iterator_returned_at_least_one:

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -198,7 +198,7 @@ def evaluate_condition_lingo(
 
 
 def extract_single_error_message_from_schema_errors(
-    errors: Dict[str, List[str]]
+    errors: Dict[str, List[str]],
 ) -> str:
     """
     Extract single error message from Schema().validate() errors result.

--- a/tests/acceptance/conditions/conftest.py
+++ b/tests/acceptance/conditions/conftest.py
@@ -57,14 +57,12 @@ def erc20_evm_condition_balanceof(testerchain, test_registry, ritual_token):
 
 
 @pytest.fixture
-def erc721_contract(accounts, project):
-    account = accounts[0]
-
+def erc721_contract(project, deployer_account):
     # deploy contract
-    deployed_contract = project.ConditionNFT.deploy(sender=account)
+    deployed_contract = project.ConditionNFT.deploy(sender=deployer_account)
 
     # mint nft with token id = 1
-    deployed_contract.mint(account.address, 1, sender=account)
+    deployed_contract.mint(deployer_account.address, 1, sender=deployer_account)
     return deployed_contract
 
 
@@ -154,3 +152,11 @@ def custom_context_variable_erc20_condition(
         parameters=[":addressToUse"],
     )
     return condition
+
+
+@pytest.fixture
+def eip1271_contract_wallet(project, deployer_account):
+    _eip1271_contract_wallet = deployer_account.deploy(
+        project.SmartContractWallet, deployer_account.address
+    )
+    return _eip1271_contract_wallet

--- a/tests/acceptance/conditions/conftest.py
+++ b/tests/acceptance/conditions/conftest.py
@@ -11,12 +11,15 @@ from nucypher.policy.conditions.lingo import (
     OrCompoundCondition,
     ReturnValueTest,
 )
+from nucypher.policy.conditions.utils import ConditionProviderManager
 from tests.constants import TEST_ETH_PROVIDER_URI, TESTERCHAIN_CHAIN_ID
 
 
 @pytest.fixture()
 def condition_providers(testerchain):
-    providers = {testerchain.client.chain_id: {testerchain.provider}}
+    providers = ConditionProviderManager(
+        {testerchain.client.chain_id: {testerchain.provider}}
+    )
     return providers
 
 @pytest.fixture()

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -92,7 +92,7 @@ def test_rpc_condition_evaluation_invalid_provider_for_chain(
     condition_providers = ConditionProviderManager({new_chain: [testerchain.provider]})
     with pytest.raises(
         NoConnectionToChain,
-        match=f"Problematic provider connections for chain ID {new_chain}",
+        match=f"Problematic provider endpoints for chain ID {new_chain}",
     ):
         _ = rpc_condition.verify(providers=condition_providers, **context)
 

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -935,7 +935,7 @@ def test_json_rpc_condition_non_evm_prototyping_example():
 
 
 def test_rpc_condition_using_eip1271(
-    testerchain, deployer_account, eip1271_contract_wallet, condition_providers
+    deployer_account, eip1271_contract_wallet, condition_providers
 ):
     # send some ETH to the smart contract wallet
     eth_amount = Web3.to_wei(2.25, "ether")

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -14,7 +14,6 @@ from nucypher.blockchain.eth.agents import (
 )
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry, RegistrySourceManager
-from nucypher.policy.conditions.evm import RPCCall
 from nucypher.utilities.logging import Logger
 from tests.constants import (
     BONUS_TOKENS_FOR_TESTS,
@@ -419,21 +418,13 @@ def taco_child_application_agent(testerchain, test_registry):
 #
 
 @pytest.fixture(scope="module")
-def mock_rpc_condition(testerchain, monkeymodule):
-    def configure_mock(*args, **kwargs):
-        return testerchain.w3
-
-    monkeymodule.setattr(RPCCall, "_configure_provider", configure_mock)
-
-
-@pytest.fixture(scope="module")
 def multichain_ids(module_mocker):
     ids = mock_permitted_multichain_connections(mocker=module_mocker)
     return ids
 
 
 @pytest.fixture(scope="module")
-def multichain_ursulas(ursulas, multichain_ids, mock_rpc_condition):
+def multichain_ursulas(ursulas, multichain_ids):
     setup_multichain_ursulas(ursulas=ursulas, chain_ids=multichain_ids)
     return ursulas
 

--- a/tests/acceptance/contracts/SmartContractWallet.sol
+++ b/tests/acceptance/contracts/SmartContractWallet.sol
@@ -1,0 +1,33 @@
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/interfaces/IERC1271.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+contract SmartContractWallet is IERC1271, Ownable {
+    using ECDSA for bytes32;
+
+    uint public balance;
+
+    bytes4 internal constant MAGICVALUE = 0x1626ba7e;
+    bytes4 constant internal INVALID_SIGNATURE = 0xffffffff;
+
+    constructor(address _owner) Ownable(_owner) public {}
+
+    function deposit() external payable {
+        balance += msg.value;
+    }
+
+    function withdraw(uint amount) external onlyOwner {
+        require(amount <= balance, "Amount exceeds balance");
+        balance -= amount;
+        payable(owner()).transfer(amount);
+    }
+
+    function isValidSignature(bytes32 _hash, bytes memory _signature) public view override returns (bytes4) {
+        address signer = _hash.recover(_signature);
+        if (signer == owner()) {
+            return MAGICVALUE;
+        } else {
+            return INVALID_SIGNATURE;
+        }
+    }
+}

--- a/tests/integration/network/test_condition_blockchain_broadcast.py
+++ b/tests/integration/network/test_condition_blockchain_broadcast.py
@@ -18,5 +18,5 @@ def test_condition_chains_endpoint_multichain(
 ):
     response = client.get("/condition_chains")
     assert response.status_code == 200
-    expected_payload = {"version": 1.0, "evm": multichain_ids}
+    expected_payload = {"version": 1.0, "evm": sorted(multichain_ids)}
     assert response.get_json() == expected_payload

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -17,6 +17,7 @@ from nucypher.policy.conditions.exceptions import (
     InvalidConditionLingo,
 )
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
+from nucypher.policy.conditions.utils import ConditionProviderManager
 from tests.constants import TESTERCHAIN_CHAIN_ID
 
 CHAIN_ID = 137
@@ -52,7 +53,7 @@ class FakeExecutionContractCondition(ContractCondition):
         def set_execution_return_value(self, value: Any):
             self.execution_return_value = value
 
-        def execute(self, providers: Dict, **context) -> Any:
+        def execute(self, providers: ConditionProviderManager, **context) -> Any:
             return self.execution_return_value
 
     EXECUTION_CALL_TYPE = FakeRPCCall
@@ -125,7 +126,7 @@ def _check_execution_logic(
             json.dumps(condition_dict)
         )
         fake_execution_contract_condition.set_execution_return_value(execution_result)
-        fake_providers = {CHAIN_ID: {Mock(BaseProvider)}}
+        fake_providers = ConditionProviderManager({CHAIN_ID: {Mock(BaseProvider)}})
         condition_result, call_result = fake_execution_contract_condition.verify(
             fake_providers, **context
         )

--- a/tests/unit/conditions/test_evm_auth.py
+++ b/tests/unit/conditions/test_evm_auth.py
@@ -341,6 +341,9 @@ def test_authenticate_eip1271(mocker, get_random_checksum_address):
     EIP1271Auth.authenticate(
         typedData, valid_message_signature, eip1271_mock_contract.address, providers
     )
+    w3.eth.contract.assert_called_once_with(
+        address=eip1271_mock_contract.address, abi=EIP1271Auth.EIP1271_ABI
+    )
 
     # invalid typed data - no chain id
     with pytest.raises(EvmAuth.InvalidData):

--- a/tests/unit/conditions/test_evm_auth.py
+++ b/tests/unit/conditions/test_evm_auth.py
@@ -3,14 +3,23 @@ import pytest
 from siwe import SiweMessage
 
 from nucypher.blockchain.eth.signers import InMemorySigner
-from nucypher.policy.conditions.auth.evm import EIP712Auth, EIP4361Auth, EvmAuth
+from nucypher.policy.conditions.auth.evm import (
+    EIP712Auth,
+    EIP1271Auth,
+    EIP4361Auth,
+    EvmAuth,
+)
 
 
 def test_auth_scheme():
+    expected_schemes = {
+        EvmAuth.AuthScheme.EIP712: EIP712Auth,
+        EvmAuth.AuthScheme.EIP4361: EIP4361Auth,
+        EvmAuth.AuthScheme.EIP1271: EIP1271Auth,
+    }
+
     for scheme in EvmAuth.AuthScheme:
-        expected_scheme = (
-            EIP712Auth if scheme == EvmAuth.AuthScheme.EIP712 else EIP4361Auth
-        )
+        expected_scheme = expected_schemes.get(scheme)
         assert EvmAuth.from_scheme(scheme=scheme.value) == expected_scheme
 
     # non-existent scheme

--- a/tests/unit/conditions/test_evm_auth.py
+++ b/tests/unit/conditions/test_evm_auth.py
@@ -1,6 +1,10 @@
 import maya
 import pytest
+from eth_account import Account
+from eth_account.messages import defunct_hash_message
+from hexbytes import HexBytes
 from siwe import SiweMessage
+from web3.contract import Contract
 
 from nucypher.blockchain.eth.signers import InMemorySigner
 from nucypher.policy.conditions.auth.evm import (
@@ -9,6 +13,9 @@ from nucypher.policy.conditions.auth.evm import (
     EIP4361Auth,
     EvmAuth,
 )
+from nucypher.policy.conditions.exceptions import NoConnectionToChain
+from nucypher.policy.conditions.utils import ConditionProviderManager
+from tests.constants import TESTERCHAIN_CHAIN_ID
 
 
 def test_auth_scheme():
@@ -287,4 +294,111 @@ def test_authenticate_eip4361(get_random_checksum_address):
             not_stale_but_past_expiry_message,
             not_stale_but_past_expiry_signature.hex(),
             valid_address_for_signature,
+        )
+
+
+def test_authenticate_eip1271(mocker, get_random_checksum_address):
+    # smart contract wallet
+    eip1271_mock_contract = mocker.Mock(spec=Contract)
+    contract_address = get_random_checksum_address()
+    eip1271_mock_contract.address = contract_address
+
+    # signer for wallet
+    data = f"I'm the owner of the smart contract wallet address {eip1271_mock_contract.address}"
+    wallet_signer = InMemorySigner()
+    valid_message_signature = wallet_signer.sign_message(
+        account=wallet_signer.accounts[0], message=data.encode()
+    )
+    data_hash = defunct_hash_message(text=data)
+    typedData = {"chain": TESTERCHAIN_CHAIN_ID, "dataHash": data_hash.hex()}
+
+    def _isValidSignature(data_hash, signature_bytes):
+        class ContractCall:
+            def __init__(self, hash, signature):
+                self.hash = hash
+                self.signature = signature
+
+            def call(self):
+                recovered_address = Account._recover_hash(
+                    message_hash=self.hash, signature=self.signature
+                )
+                if recovered_address == wallet_signer.accounts[0]:
+                    return bytes(HexBytes("0x1626ba7e"))
+
+                return bytes(HexBytes("0xffffffff"))
+
+        return ContractCall(data_hash, signature_bytes)
+
+    eip1271_mock_contract.functions.isValidSignature.side_effect = _isValidSignature
+
+    # condition provider manager
+    providers = mocker.Mock(spec=ConditionProviderManager)
+    w3 = mocker.Mock()
+    w3.eth.contract.return_value = eip1271_mock_contract
+    providers.web3_endpoints.return_value = [w3]
+
+    # valid signature
+    EIP1271Auth.authenticate(
+        typedData, valid_message_signature, eip1271_mock_contract.address, providers
+    )
+
+    # invalid typed data - no chain id
+    with pytest.raises(EvmAuth.InvalidData):
+        EIP1271Auth.authenticate(
+            {
+                "dataHash": data_hash.hex(),
+            },
+            valid_message_signature,
+            eip1271_mock_contract.address,
+            providers,
+        )
+
+    # invalid typed data - no data hash
+    with pytest.raises(EvmAuth.InvalidData):
+        EIP1271Auth.authenticate(
+            {
+                "chainId": TESTERCHAIN_CHAIN_ID,
+            },
+            valid_message_signature,
+            eip1271_mock_contract.address,
+            providers,
+        )
+
+    # use invalid signer
+    invalid_signer = InMemorySigner()
+    invalid_message_signature = invalid_signer.sign_message(
+        account=invalid_signer.accounts[0], message=data.encode()
+    )
+    with pytest.raises(EvmAuth.AuthenticationFailed):
+        EIP1271Auth.authenticate(
+            typedData,
+            invalid_message_signature,
+            eip1271_mock_contract.address,
+            providers,
+        )
+
+    # bad w3 instance failed for some reason
+    w3_bad = mocker.Mock()
+    w3_bad.eth.contract.side_effect = ValueError("something went wrong")
+    providers.web3_endpoints.return_value = [w3_bad]
+    with pytest.raises(EvmAuth.AuthenticationFailed, match="something went wrong"):
+        EIP1271Auth.authenticate(
+            typedData, valid_message_signature, eip1271_mock_contract.address, providers
+        )
+    assert w3_bad.eth.contract.call_count == 1, "one call that failed"
+
+    # fall back to good w3 instances
+    providers.web3_endpoints.return_value = [w3_bad, w3_bad, w3]
+    EIP1271Auth.authenticate(
+        typedData, valid_message_signature, eip1271_mock_contract.address, providers
+    )
+    assert w3_bad.eth.contract.call_count == 3, "two more calls that failed"
+
+    # no connection to chain
+    providers.web3_endpoints.side_effect = NoConnectionToChain(
+        chain=TESTERCHAIN_CHAIN_ID
+    )
+    with pytest.raises(EvmAuth.AuthenticationFailed, match="No connection to chain ID"):
+        EIP1271Auth.authenticate(
+            typedData, valid_message_signature, eip1271_mock_contract.address, providers
         )

--- a/tests/unit/conditions/test_evm_auth.py
+++ b/tests/unit/conditions/test_evm_auth.py
@@ -345,6 +345,12 @@ def test_authenticate_eip1271(mocker, get_random_checksum_address):
         address=eip1271_mock_contract.address, abi=EIP1271Auth.EIP1271_ABI
     )
 
+    # no providers
+    with pytest.raises(EvmAuth.AuthenticationFailed, match="no endpoints provided"):
+        EIP1271Auth.authenticate(
+            typedData, valid_message_signature, eip1271_mock_contract.address, None
+        )
+
     # invalid typed data - no chain id
     with pytest.raises(EvmAuth.InvalidData):
         EIP1271Auth.authenticate(

--- a/tests/unit/conditions/test_if_then_else_condition.py
+++ b/tests/unit/conditions/test_if_then_else_condition.py
@@ -12,6 +12,7 @@ from nucypher.policy.conditions.lingo import (
     OrCompoundCondition,
     SequentialAccessControlCondition,
 )
+from nucypher.policy.conditions.utils import ConditionProviderManager
 
 
 @pytest.fixture(scope="function")
@@ -248,7 +249,9 @@ def test_nested_multi_conditions(mock_conditions):
         else_condition=False,
     )
 
-    result, value = if_then_else_condition.verify(providers={})
+    result, value = if_then_else_condition.verify(
+        providers=ConditionProviderManager({})
+    )
     assert result is True
     assert value == [[1, 2], [2, 3]]  # [[or result], [seq result]]
 
@@ -277,7 +280,9 @@ def test_nested_multi_conditions(mock_conditions):
         ),
     )
 
-    result, value = if_then_else_condition.verify(providers={})
+    result, value = if_then_else_condition.verify(
+        providers=ConditionProviderManager({})
+    )
     assert result is False
     assert value == [[1, 2], [3, 2]]  # [[or result], [else if condition result]]
 

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -11,6 +11,7 @@ from nucypher.policy.conditions.lingo import (
     OrCompoundCondition,
     SequentialAccessControlCondition,
 )
+from nucypher.policy.conditions.utils import ConditionProviderManager
 
 
 @pytest.fixture(scope="function")
@@ -173,7 +174,9 @@ def test_sequential_condition(mock_condition_variables):
     )
 
     original_context = dict()
-    result, value = sequential_condition.verify(providers={}, **original_context)
+    result, value = sequential_condition.verify(
+        providers=ConditionProviderManager({}), **original_context
+    )
     assert result is True
     assert value == [1, 1 * 2, 1 * 2 * 3, 1 * 2 * 3 * 4]
     # only a copy of the context is modified internally
@@ -215,7 +218,9 @@ def test_sequential_condition_all_prior_vars_passed_to_subsequent_calls(
     expected_var_3_value = expected_var_1_value + expected_var_2_value + 1
 
     original_context = dict()
-    result, value = sequential_condition.verify(providers={}, **original_context)
+    result, value = sequential_condition.verify(
+        providers=ConditionProviderManager({}), **original_context
+    )
     assert result is True
     assert value == [
         expected_var_1_value,
@@ -238,4 +243,4 @@ def test_sequential_condition_a_call_fails(mock_condition_variables):
     )
 
     with pytest.raises(Web3Exception):
-        _ = sequential_condition.verify(providers={})
+        _ = sequential_condition.verify(providers=ConditionProviderManager({}))

--- a/tests/unit/conditions/test_utils.py
+++ b/tests/unit/conditions/test_utils.py
@@ -37,6 +37,7 @@ from nucypher.policy.conditions.lingo import ConditionLingo
 from nucypher.policy.conditions.utils import (
     CamelCaseSchema,
     ConditionEvalError,
+    ConditionProviderManager,
     camel_case_to_snake,
     evaluate_condition_lingo,
     to_camelcase,
@@ -102,7 +103,9 @@ def test_evaluate_condition_eval_returns_false():
         with pytest.raises(ConditionEvalError) as eval_error:
             evaluate_condition_lingo(
                 condition_lingo=condition_lingo,
-                providers={1: Mock(spec=BaseProvider)},  # fake provider
+                providers=ConditionProviderManager(
+                    {1: Mock(spec=BaseProvider)}
+                ),  # fake provider
                 context={"key": "value"},  # fake context
             )
         assert eval_error.value.status_code == HTTPStatus.FORBIDDEN
@@ -119,10 +122,12 @@ def test_evaluate_condition_eval_returns_true():
 
         evaluate_condition_lingo(
             condition_lingo=condition_lingo,
-            providers={
-                1: Mock(spec=BaseProvider),
-                2: Mock(spec=BaseProvider),
-            },  # multiple fake provider
+            providers=ConditionProviderManager(
+                {
+                    1: Mock(spec=BaseProvider),
+                    2: Mock(spec=BaseProvider),
+                }
+            ),
             context={
                 "key1": "value1",
                 "key2": "value2",

--- a/tests/utils/ursula.py
+++ b/tests/utils/ursula.py
@@ -186,7 +186,7 @@ def setup_multichain_ursulas(chain_ids: List[int], ursulas: List[Ursula]) -> Non
         }
     )
     for ursula in ursulas:
-        ursula.condition_providers = mocked_condition_providers
+        ursula.condition_provider_manager = mocked_condition_providers
 
 
 MOCK_KNOWN_URSULAS_CACHE = dict()

--- a/tests/utils/ursula.py
+++ b/tests/utils/ursula.py
@@ -11,6 +11,7 @@ from web3 import HTTPProvider
 from nucypher.blockchain.eth.signers import InMemorySigner, Signer
 from nucypher.characters.lawful import Ursula
 from nucypher.config.characters import UrsulaConfiguration
+from nucypher.policy.conditions.utils import ConditionProviderManager
 from tests.constants import TESTERCHAIN_CHAIN_ID
 from tests.utils.blockchain import ReservedTestAccountManager
 
@@ -176,12 +177,14 @@ def setup_multichain_ursulas(chain_ids: List[int], ursulas: List[Ursula]) -> Non
     fallback_blockchain_endpoints = [
         base_fallback_uri.format(i) for i in range(len(chain_ids))
     ]
-    mocked_condition_providers = {
-        cid: {HTTPProvider(uri), HTTPProvider(furi)}
-        for cid, uri, furi in zip(
-            chain_ids, blockchain_endpoints, fallback_blockchain_endpoints
-        )
-    }
+    mocked_condition_providers = ConditionProviderManager(
+        {
+            cid: [HTTPProvider(uri), HTTPProvider(furi)]
+            for cid, uri, furi in zip(
+                chain_ids, blockchain_endpoints, fallback_blockchain_endpoints
+            )
+        }
+    )
     for ursula in ursulas:
         ursula.condition_providers = mocked_condition_providers
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Support for [EIP-1271](https://ethereum.org/en/developers/tutorials/eip-1271-smart-contract-signatures/)
- Will require a corresponding `AuthProvider` implementation in `taco-web` - https://github.com/nucypher/taco-web/pull/617
- Allows EIP1271 auth signature to be used with the `:userAddress` context variable. This way either EIP4361 (for EOA wallets) or EIP1271 (for smart contract wallets) can be used with the `:userAddress` context variable. *(The initial implementation in this PR created a `:userAddressEIP1271` context variable but this was not correct, it would mean that only EIP1271 wallets could be used for condition, which doesn't really make sense - this was fixed and rebased over)*.

**Issues fixed/closed:**
> - Fixes #...

- Related to https://github.com/nucypher/sprints/issues/116

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
