### PR TITLE
TACoApplication contract no longer accepts commitment duration

### DIFF
--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,6 +1,5 @@
 import random
 
-import maya
 import pytest
 from web3 import Web3
 
@@ -43,11 +42,6 @@ MIN_AUTHORIZATION = Web3.to_wei(40_000, "ether")
 
 REWARD_DURATION = 7 * ONE_DAY  # one week in seconds
 DEAUTHORIZATION_DURATION = 60 * ONE_DAY  # 60 days in seconds
-
-COMMITMENT_DURATION_1 = 182 * ONE_DAY  # 182 days in seconds
-COMMITMENT_DURATION_2 = 2 * COMMITMENT_DURATION_1  # 365 days in seconds
-
-COMMITMENT_DEADLINE = 100 * ONE_DAY  # 100 days after deployment
 
 PENALTY_DEFAULT = 1000  # 10% penalty
 PENALTY_INCREMENT = 2500  # 25% penalty increment
@@ -161,8 +155,6 @@ def taco_application(
         MIN_OPERATOR_SECONDS,
         REWARD_DURATION,
         DEAUTHORIZATION_DURATION,
-        [COMMITMENT_DURATION_1, COMMITMENT_DURATION_2],
-        maya.now().epoch + COMMITMENT_DEADLINE,
         PENALTY_DEFAULT,
         PENALTY_DURATION,
         PENALTY_INCREMENT,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**

`nucypher` acceptance tests are failing due to `nucypher-contracts` changes made in https://github.com/nucypher/nucypher-contracts/pull/345. The TACoApplication contract no longer accepts commitment duration parameters.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
