### PR TITLE
Handle BigInts provided in JSON from `taco-web`

### DIFF
--- a/newsfragments/3585.feature.rst
+++ b/newsfragments/3585.feature.rst
@@ -1,0 +1,1 @@
+Allow BigInt values from ``taco-web`` typescript library to be provided as strings.

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -11,7 +11,10 @@ from nucypher.policy.conditions.exceptions import (
     InvalidContextVariableData,
     RequiredContextVariable,
 )
-from nucypher.policy.conditions.utils import ConditionProviderManager
+from nucypher.policy.conditions.utils import (
+    ConditionProviderManager,
+    check_and_convert_big_int_string_to_int,
+)
 
 USER_ADDRESS_CONTEXT = ":userAddress"
 USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT = ":userAddressExternalEIP4361"
@@ -114,6 +117,7 @@ def get_context_value(
     try:
         # DIRECTIVES are special context vars that will pre-processed by ursula
         func = _DIRECTIVES[context_variable]
+        value = func(providers=providers, **context)  # required inputs here
     except KeyError:
         # fallback for context variable without directive - assume key,value pair
         # handles the case for user customized context variables
@@ -122,8 +126,9 @@ def get_context_value(
             raise RequiredContextVariable(
                 f'No value provided for unrecognized context variable "{context_variable}"'
             )
-    else:
-        value = func(providers=providers, **context)  # required inputs here
+        elif isinstance(value, str):
+            # possible big int value
+            value = check_and_convert_big_int_string_to_int(value)
 
     return value
 

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -33,6 +33,7 @@ from nucypher.policy.conditions.exceptions import (
     RPCExecutionFailed,
 )
 from nucypher.policy.conditions.lingo import (
+    AnyField,
     ConditionType,
     ExecutionCallAccessControlCondition,
     ReturnValueTest,
@@ -71,7 +72,7 @@ class RPCCall(ExecutionCall):
                 "null": "Undefined method name",
             },
         )
-        parameters = fields.List(fields.Field, required=False, allow_none=True)
+        parameters = fields.List(AnyField, required=False, allow_none=True)
 
         @validates("method")
         def validate_method(self, value):

--- a/nucypher/policy/conditions/json/rpc.py
+++ b/nucypher/policy/conditions/json/rpc.py
@@ -17,6 +17,7 @@ from nucypher.policy.conditions.json.base import (
     JsonRequestCall,
 )
 from nucypher.policy.conditions.lingo import (
+    AnyField,
     ConditionType,
     ExecutionCallAccessControlCondition,
     ReturnValueTest,
@@ -26,7 +27,7 @@ from nucypher.policy.conditions.lingo import (
 class BaseJsonRPCCall(JsonRequestCall, ABC):
     class Schema(JsonRequestCall.Schema):
         method = fields.Str(required=True)
-        params = fields.Field(required=False, allow_none=True)
+        params = AnyField(required=False, allow_none=True)
         query = JSONPathField(required=False, allow_none=True)
         authorization_token = fields.Str(required=False, allow_none=True)
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -69,9 +69,10 @@ class AnyField(fields.Field):
         return self._convert_any_big_ints_from_string(value)
 
 
-class AnyIntegerField(fields.Int):
+class AnyLargeIntegerField(fields.Int):
     """
-    Integer field that also converts big int strings to integers.
+    Integer field that also allows for big int values for large numbers
+    to be provided from `taco-web`. BigInts will be used for integer values > MAX_SAFE_INTEGER.
     """
 
     def __init__(self, *args, **kwargs):

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -69,7 +69,7 @@ class AnyField(fields.Field):
         return self._convert_any_big_ints_from_string(value)
 
 
-class IntegerField(fields.Int):
+class AnyIntegerField(fields.Int):
     """
     Integer field that also converts big int strings to integers.
     """

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -1,6 +1,6 @@
 import re
 from http import HTTPStatus
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 from marshmallow import Schema, post_dump
 from marshmallow.exceptions import SCHEMA
@@ -223,3 +223,18 @@ def extract_single_error_message_from_schema_errors(
         else ""
     )
     return f"{message_prefix}{message}"
+
+
+def check_and_convert_big_int_string_to_int(value: str) -> Union[str, int]:
+    """
+    Check if a string is a big int string and convert it to an integer, otherwise return the string.
+    """
+    if value.endswith("n"):
+        try:
+            result = int(value[:-1])
+            return result
+        except ValueError:
+            # ignore
+            pass
+
+    return value

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -229,7 +229,7 @@ def check_and_convert_big_int_string_to_int(value: str) -> Union[str, int]:
     """
     Check if a string is a big int string and convert it to an integer, otherwise return the string.
     """
-    if value.endswith("n"):
+    if re.fullmatch("^-?\d+n$", value):
         try:
             result = int(value[:-1])
             return result

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -183,3 +183,9 @@ RPC_SUCCESSFUL_RESPONSE = {
     "id": 1,
     "result": "Geth/v1.9.20-stable-979fc968/linux-amd64/go1.15"
 }
+
+
+# Integers
+
+UINT256_MAX = 2**256 - 1
+INT256_MIN = -(2**255)

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -17,10 +17,7 @@ from nucypher.policy.conditions.lingo import (
     ConditionLingo,
     ConditionType,
 )
-from tests.constants import TESTERCHAIN_CHAIN_ID
-
-UINT256_MAX = 2**256 - 1
-INT256_MIN = -(2**255)
+from tests.constants import INT256_MIN, TESTERCHAIN_CHAIN_ID, UINT256_MAX
 
 
 @pytest.fixture(scope="module")
@@ -449,18 +446,16 @@ def test_any_field_integer_str_and_no_str_conversion(integer_value):
 def test_any_field_nested_integer():
     field = AnyField()
 
-    uint256_max = 2**256 - 1
-    int256_min = -(2**255)
     regular_number = 12341231
 
     parameters = [
-        f"{uint256_max}n",
-        {"a": [f"{int256_min}n", "my_string_value", "0xdeadbeef"], "b": regular_number},
+        f"{UINT256_MAX}n",
+        {"a": [f"{INT256_MIN}n", "my_string_value", "0xdeadbeef"], "b": regular_number},
     ]
     # quoted numbers get unquoted after deserialization
     expected_parameters = [
-        uint256_max,
-        {"a": [int256_min, "my_string_value", "0xdeadbeef"], "b": regular_number},
+        UINT256_MAX,
+        {"a": [INT256_MIN, "my_string_value", "0xdeadbeef"], "b": regular_number},
     ]
 
     deserialized_parameters = field.deserialize(value=parameters)

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -426,16 +426,16 @@ def test_any_field_integer_str_and_no_str_conversion(integer_value):
     deserialized_raw_integer = field._deserialize(
         value=integer_value, attr=None, data=None
     )
-    deserialized_string_integer = field._deserialize(
-        value=str(integer_value), attr=None, data=None
+    deserialized_big_int_string = field._deserialize(
+        value=f"{integer_value}n", attr=None, data=None
     )
-    assert deserialized_raw_integer == deserialized_string_integer
+    assert deserialized_raw_integer == deserialized_big_int_string
 
     assert (
         field._serialize(deserialized_raw_integer, attr=None, obj=None) == integer_value
     )
     assert (
-        field._serialize(deserialized_string_integer, attr=None, obj=None)
+        field._serialize(deserialized_big_int_string, attr=None, obj=None)
         == integer_value
     )
 
@@ -448,8 +448,8 @@ def test_any_field_nested_integer():
     regular_number = 12341231
 
     parameters = [
-        f"{uint256_max}",
-        {"a": [f"{int256_min}", "my_string_value", "0xdeadbeef"], "b": regular_number},
+        f"{uint256_max}n",
+        {"a": [f"{int256_min}n", "my_string_value", "0xdeadbeef"], "b": regular_number},
     ]
     # quoted numbers get unquoted after deserialization
     expected_parameters = [

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -13,7 +13,7 @@ from nucypher.policy.conditions.exceptions import (
 )
 from nucypher.policy.conditions.lingo import (
     AnyField,
-    AnyIntegerField,
+    AnyLargeIntegerField,
     ConditionLingo,
     ConditionType,
 )
@@ -477,8 +477,8 @@ def test_any_field_nested_integer():
         ("fallen", None),
     ],
 )
-def test_any_integer_field(json_value, expected_deserialized_value):
-    field = AnyIntegerField()
+def test_any_large_integer_field(json_value, expected_deserialized_value):
+    field = AnyLargeIntegerField()
 
     if expected_deserialized_value is not None:
         assert field.deserialize(json_value) == expected_deserialized_value

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -1362,7 +1362,7 @@ def test_big_int_inputs_and_outputs(
         comparator_value=return_value_test_value,  # value set in return value test
         comparator="==",
         expected_outcome=True,
-        context_var_testing=ContextVarTest.NO_CONTEXT_VAR_ONLY,
+        context_var_testing=ContextVarTest.WITH_AND_WITHOUT_CONTEXT_VAR,
     )
 
     execute_spy.assert_called_with(

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -4,11 +4,12 @@ import os
 import random
 from enum import Enum
 from typing import Any, Dict, List, Optional, Sequence, Union
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 import pytest
 from hexbytes import HexBytes
 from marshmallow import post_load
+from web3 import Web3
 from web3.providers import BaseProvider
 
 from nucypher.policy.conditions.evm import ContractCall, ContractCondition
@@ -17,8 +18,11 @@ from nucypher.policy.conditions.exceptions import (
     InvalidConditionLingo,
 )
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
-from nucypher.policy.conditions.utils import ConditionProviderManager
-from tests.constants import TESTERCHAIN_CHAIN_ID
+from nucypher.policy.conditions.utils import (
+    ConditionProviderManager,
+    check_and_convert_big_int_string_to_int,
+)
+from tests.constants import INT256_MIN, TESTERCHAIN_CHAIN_ID, UINT256_MAX
 
 CHAIN_ID = 137
 
@@ -53,7 +57,7 @@ class FakeExecutionContractCondition(ContractCondition):
         def set_execution_return_value(self, value: Any):
             self.execution_return_value = value
 
-        def execute(self, providers: ConditionProviderManager, **context) -> Any:
+        def _execute(self, w3: Web3, resolved_parameters: List[Any]) -> Any:
             return self.execution_return_value
 
     EXECUTION_CALL_TYPE = FakeRPCCall
@@ -77,11 +81,19 @@ def contract_condition_dict():
 
 def _replace_abi_outputs(condition_json: Dict, output_type: str, output_value: Any):
     # modify outputs type
-    condition_json["functionAbi"]["outputs"][0]["internalType"] = output_type
-    condition_json["functionAbi"]["outputs"][0]["type"] = output_type
+    for entry in condition_json["functionAbi"]["outputs"]:
+        entry["internalType"] = output_type
+        entry["type"] = output_type
 
     # modify return value test
     condition_json["returnValueTest"]["value"] = output_value
+
+
+def _replace_abi_inputs(condition_json: Dict, input_type: str):
+    # modify inputs type
+    for entry in condition_json["functionAbi"]["inputs"]:
+        entry["internalType"] = input_type
+        entry["type"] = input_type
 
 
 class ContextVarTest(Enum):
@@ -126,7 +138,9 @@ def _check_execution_logic(
             json.dumps(condition_dict)
         )
         fake_execution_contract_condition.set_execution_return_value(execution_result)
-        fake_providers = ConditionProviderManager({CHAIN_ID: {Mock(BaseProvider)}})
+        fake_providers = Mock(spec=ConditionProviderManager)
+        fake_providers.web3_endpoints.return_value = [Mock(BaseProvider)]
+
         condition_result, call_result = fake_execution_contract_condition.verify(
             fake_providers, **context
         )
@@ -1286,3 +1300,71 @@ def test_abi_nested_tuples_output_values(
             expected_outcome=None,
             context_var_testing=ContextVarTest.CONTEXT_VAR_ONLY,
         )
+
+
+@pytest.mark.parametrize(
+    "io_type, parameter,return_value_test_value,contract_result",
+    [
+        ("uint256", f"{UINT256_MAX}n", f"{UINT256_MAX}n", UINT256_MAX),
+        (
+            "uint256",
+            f"{int(UINT256_MAX/2)}n",
+            f"{int(UINT256_MAX/2)}n",
+            int(UINT256_MAX / 2),
+        ),
+        ("int256", f"{INT256_MIN}n", f"{INT256_MIN}n", INT256_MIN),
+        (
+            "int256",
+            f"{int(INT256_MIN/2)}n",
+            f"{int(INT256_MIN/2)}n",
+            int(INT256_MIN / 2),
+        ),
+    ],
+)
+def test_big_int_inputs_and_outputs(
+    io_type, parameter, return_value_test_value, contract_result, mocker
+):
+    # tests use of big int values in inputs and outputs (both parameters, and return value test)
+    contract_condition = {
+        "conditionType": "contract",
+        "contractAddress": "0x01B67b1194C75264d06F808A921228a95C765dd7",
+        "parameters": [parameter],
+        "method": "getValue",
+        "functionAbi": {
+            "inputs": [
+                {"internalType": "uint256", "name": "value", "type": "uint256"},
+            ],
+            "name": "getValue",
+            "outputs": [
+                {"internalType": "uint256", "name": "result", "type": "uint256"},
+            ],
+            "stateMutability": "view",
+            "type": "function",
+            "constant": True,
+        },
+        "chain": CHAIN_ID,
+        "returnValueTest": {
+            "comparator": "==",
+            "value": 0,
+        },
+    }
+
+    _replace_abi_inputs(contract_condition, input_type=io_type)
+    _replace_abi_outputs(
+        contract_condition, output_type=io_type, output_value=return_value_test_value
+    )
+
+    execute_spy = mocker.spy(FakeExecutionContractCondition.FakeRPCCall, "_execute")
+
+    _check_execution_logic(
+        condition_dict=contract_condition,
+        execution_result=contract_result,  # value returned by contract
+        comparator_value=return_value_test_value,  # value set in return value test
+        comparator="==",
+        expected_outcome=True,
+        context_var_testing=ContextVarTest.NO_CONTEXT_VAR_ONLY,
+    )
+
+    execute_spy.assert_called_with(
+        ANY, ANY, [check_and_convert_big_int_string_to_int(parameter)]
+    )  # (self, w3, [value used for parameter])


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [x] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

Based over #3586 .

Original issue - https://github.com/nucypher/taco-web/issues/634.

`taco-web` does not handle large numbers, and as such must use `BigInt`. However `BigInt` cannot be serialized to a number in JSON, so instead it is passed as a string `"12312312....1231233132n"` (format established in https://github.com/nucypher/taco-web/pull/637), and as such nodes must handle receiving a number like that. Python does not have the same issue, but must accomodate numbers received from `taco-web` in that format.

Moving forward we have to be careful about any conditions that accept integer values that can be large, since `taco-web` could pass those values as serialized BigInts. I don't think this is an issue for any existing conditions (eg. chain-id is an int, but chain ids are not that large), but something we need to keep an eye on moving forward.

**Issues fixed/closed:**
> - Fixes #...

Related to https://github.com/nucypher/taco-web/pull/637.

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!


**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
