### PR TITLE
Fix BigInt Regex Warning

### DIFF
--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -229,7 +229,7 @@ def check_and_convert_big_int_string_to_int(value: str) -> Union[str, int]:
     """
     Check if a string is a big int string and convert it to an integer, otherwise return the string.
     """
-    if re.fullmatch("^-?\d+n$", value):
+    if re.fullmatch(r"^-?\d+n$", value):
         try:
             result = int(value[:-1])
             return result

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -247,9 +247,13 @@ def fee_model(nucypher_dependency, deployer_account, coordinator, ritual_token):
         ritual_token.address,
         FEE_RATE,
     )
-    treasury_role = coordinator.TREASURY_ROLE()
     coordinator.grantRole(
-        treasury_role, deployer_account.address, sender=deployer_account
+        coordinator.TREASURY_ROLE(), deployer_account.address, sender=deployer_account
+    )
+    coordinator.grantRole(
+        coordinator.FEE_MODEL_MANAGER_ROLE(),
+        deployer_account.address,
+        sender=deployer_account,
     )
     coordinator.approveFeeModel(contract.address, sender=deployer_account)
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Fix BigInt string regex warning - the code worked but Python was providing a warning I didn't notice:

```
conditions/utils.py:232: SyntaxWarning: invalid escape sequence '\d'
  if re.fullmatch("^-?\d+n$", value):
```

Initial code change in #3585 .

Also fixes acceptance tests to utilize latest fee model role in Coordinator.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
