### PR TITLE
Update constants.py

### DIFF
--- a/nucypher/config/constants.py
+++ b/nucypher/config/constants.py
@@ -39,7 +39,7 @@ NUCYPHER_SENTRY_ENDPOINT = f"https://{NUCYPHER_SENTRY_PUBLIC_KEY}@sentry.io/{NUC
 
 # Web
 CLI_ROOT = NUCYPHER_PACKAGE / "network" / "templates"
-MAX_UPLOAD_CONTENT_LENGTH = 1024 * 250  # 250kb
+MAX_UPLOAD_CONTENT_LENGTH = 1024 * 1024
 
 # Dev Mode
 TEMPORARY_DOMAIN_NAME = ":temporary-domain:"  # for use with `--dev` node runtimes


### PR DESCRIPTION

**Type of PR:**
- other 

**Required reviews:** 
- 1

**What this does:**
> Allow up to 1 megabyte of POST data to ursula endpoints.

**Why it's needed:**
Accommodates larger payload sizes for signing requests.
