### PR TITLE
Render `ThresholdSigningResponse` carrying signed hash from `/sign`

### DIFF
--- a/examples/testnet_simple_signing.py
+++ b/examples/testnet_simple_signing.py
@@ -1,8 +1,8 @@
 import base64
+import json
 import os
 
 import requests
-from hexbytes import HexBytes
 
 from nucypher.blockchain.eth import domains
 from nucypher.blockchain.eth.agents import SigningCoordinatorAgent
@@ -53,12 +53,14 @@ bob = Bob(
 print(f"BOB: {bob}")
 bob.start_learning_loop(now=True)
 
-signatures = bob.request_threshold_signatures(
+responses = bob.request_threshold_signatures(
     signing_request=signing_request,
 )
 
-print("\nData to sign: ", data_to_sign)
-print(f"\nSignatures:\n{[HexBytes(s).hex() for s in signatures]}")
+
+print(f"Signatures: {" ".join(r.signature.hex() for r in responses)}")
+print(f"\nHashes: {" ".join(r. message_hash.hex() for r in responses)}")
+print("\nOriginal Message: ", data_to_sign)
 
 print("--------- Threshold Signing Porter ---------")
 
@@ -87,8 +89,10 @@ errors = signing_results["errors"]
 assert len(errors) == 0, f"{errors}"  # no errors
 
 assert len(signing_results["signatures"]) >= threshold
-
 print("\nData to sign: ", data_to_sign)
-print(
-    f"\nSignatures:\n{[HexBytes(base64.b64decode(s[1])).hex() for s in signing_results['signatures'].values()]}"
+
+responses = signing_results["signatures"]
+responses = list(
+    json.loads(base64.b64decode(r[1]).decode()) for r in responses.values()
 )
+print(responses)

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1028,7 +1028,7 @@ class Operator(BaseActor):
         message_hash, signature = self.transacting_power.sign_message(
             message=data, standardize=False
         )
-        return message_hash, bytes(signature)
+        return bytes(message_hash), bytes(signature)
 
     def _local_operator_address(self):
         return self.__operator_address

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -815,7 +815,9 @@ class Operator(BaseActor):
         data_hash = self.signing_coordinator_agent.get_signing_cohort_data_hash(
             cohort_id
         )
-        signature = self.transacting_power.sign_message(data_hash, standardize=False)
+        _hash, signature = self.transacting_power.sign_message(
+            data_hash, standardize=False
+        )
 
         # TODO add async tx hooks
         async_tx_hooks = BlockchainInterface.AsyncTxHooks(
@@ -1017,13 +1019,15 @@ class Operator(BaseActor):
         )
         return response
 
-    def generate_signature_share(self, data: bytes) -> bytes:
+    def generate_signature_share(self, data: bytes) -> Tuple[bytes, bytes]:
         """
         Generate a signature share for the given cohort and data.
         Uses the node's TransactingPower to create an Ethereum-compatible signature for the data.
         """
-        signature = self.transacting_power.sign_message(message=data, standardize=False)
-        return bytes(signature)
+        message_hash, signature = self.transacting_power.sign_message(
+            message=data, standardize=False
+        )
+        return message_hash, bytes(signature)
 
     def _local_operator_address(self):
         return self.__operator_address

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -983,6 +983,7 @@ class Operator(BaseActor):
     def handle_threshold_signing_request(
         self, signing_request: ThresholdSignatureRequest
     ) -> ThresholdSignatureResponse:
+
         if not self.signing_coordinator_agent.is_cohort_active(
             signing_request.cohort_id
         ):

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -4,7 +4,7 @@ import time
 import traceback
 from collections import defaultdict
 from decimal import Decimal
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import maya
 from atxm.exceptions import InsufficientFunds
@@ -76,7 +76,11 @@ from nucypher.policy.conditions.utils import (
     evaluate_condition_lingo,
 )
 from nucypher.policy.payment import ContractPayment
-from nucypher.types import PhaseId, ThresholdSignatureRequest
+from nucypher.types import (
+    PhaseId,
+    ThresholdSignatureRequest,
+    ThresholdSignatureResponse,
+)
 from nucypher.utilities.emitters import StdoutEmitter
 from nucypher.utilities.logging import Logger
 from nucypher.utilities.warnings import render_ferveo_key_mismatch_warning
@@ -976,7 +980,7 @@ class Operator(BaseActor):
 
     def handle_threshold_signing_request(
         self, signing_request: ThresholdSignatureRequest
-    ) -> bytes:
+    ) -> ThresholdSignatureResponse:
         if not self.signing_coordinator_agent.is_cohort_active(
             signing_request.cohort_id
         ):
@@ -1004,8 +1008,14 @@ class Operator(BaseActor):
             condition_lingo, self.condition_provider_manager, context
         )
 
-        signature_share = self.generate_signature_share(signing_request.data_to_sign)
-        return signature_share
+        message_hash, signature = self.generate_signature_share(
+            signing_request.data_to_sign
+        )
+        response = ThresholdSignatureResponse(
+            message_hash=message_hash,
+            signature=signature,
+        )
+        return response
 
     def generate_signature_share(self, data: bytes) -> bytes:
         """

--- a/nucypher/blockchain/eth/signers/base.py
+++ b/nucypher/blockchain/eth/signers/base.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Tuple
 from urllib.parse import urlparse
 
+from eth_account.messages import SignableMessage
 from eth_typing.evm import ChecksumAddress
 from hexbytes.main import HexBytes
 
@@ -81,5 +82,7 @@ class Signer(ABC):
         return NotImplemented
 
     @abstractmethod
-    def sign_message(self, account: str, message: bytes, **kwargs) -> HexBytes:
+    def sign_message(
+        self, account: str, message: bytes, **kwargs
+    ) -> Tuple[SignableMessage, HexBytes]:
         return NotImplemented

--- a/nucypher/blockchain/eth/signers/base.py
+++ b/nucypher/blockchain/eth/signers/base.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from typing import List, Tuple
 from urllib.parse import urlparse
 
-from eth_account.messages import SignableMessage
 from eth_typing.evm import ChecksumAddress
 from hexbytes.main import HexBytes
 
@@ -84,5 +83,5 @@ class Signer(ABC):
     @abstractmethod
     def sign_message(
         self, account: str, message: bytes, **kwargs
-    ) -> Tuple[SignableMessage, HexBytes]:
+    ) -> Tuple[HexBytes, HexBytes]:
         return NotImplemented

--- a/nucypher/blockchain/eth/signers/software.py
+++ b/nucypher/blockchain/eth/signers/software.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from cytoolz.dicttoolz import dissoc
 from eth_account.account import Account
-from eth_account.messages import SignableMessage, encode_defunct
+from eth_account.messages import encode_defunct
 from eth_account.signers.local import LocalAccount
 from eth_utils.address import is_address, to_checksum_address
 from hexbytes.main import BytesLike, HexBytes
@@ -272,13 +272,13 @@ class KeystoreSigner(Signer):
     @validate_checksum_address
     def sign_message(
         self, account: str, message: bytes, **kwargs
-    ) -> Tuple[SignableMessage, HexBytes]:
+    ) -> Tuple[HexBytes, HexBytes]:
         signer = self._get_signer(account=account)
         signable_message = encode_defunct(primitive=message)
-        signature = signer.sign_message(
+        signed_message = signer.sign_message(
             signable_message=signable_message,
-        ).signature
-        return signable_message, HexBytes(signature)
+        )
+        return signed_message.messageHash, signed_message.signature
 
 
 class InMemorySigner(Signer):
@@ -346,8 +346,8 @@ class InMemorySigner(Signer):
     @validate_checksum_address
     def sign_message(
         self, account: str, message: bytes, **kwargs
-    ) -> Tuple[SignableMessage, HexBytes]:
+    ) -> Tuple[HexBytes, HexBytes]:
         signer = self._get_signer(account=account)
         signable_message = encode_defunct(primitive=message)
-        signature = signer.sign_message(signable_message=signable_message).signature
-        return signable_message, HexBytes(signature)
+        signed_message = signer.sign_message(signable_message=signable_message)
+        return signed_message.messageHash, signed_message.signature

--- a/nucypher/blockchain/eth/signers/software.py
+++ b/nucypher/blockchain/eth/signers/software.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from cytoolz.dicttoolz import dissoc
 from eth_account.account import Account
-from eth_account.messages import encode_defunct
+from eth_account.messages import SignableMessage, encode_defunct
 from eth_account.signers.local import LocalAccount
 from eth_utils.address import is_address, to_checksum_address
 from hexbytes.main import BytesLike, HexBytes
@@ -270,12 +270,15 @@ class KeystoreSigner(Signer):
         return raw_transaction
 
     @validate_checksum_address
-    def sign_message(self, account: str, message: bytes, **kwargs) -> HexBytes:
+    def sign_message(
+        self, account: str, message: bytes, **kwargs
+    ) -> Tuple[SignableMessage, HexBytes]:
         signer = self._get_signer(account=account)
+        signable_message = encode_defunct(primitive=message)
         signature = signer.sign_message(
-            signable_message=encode_defunct(primitive=message)
+            signable_message=signable_message,
         ).signature
-        return HexBytes(signature)
+        return signable_message, HexBytes(signature)
 
 
 class InMemorySigner(Signer):
@@ -341,9 +344,10 @@ class InMemorySigner(Signer):
         return raw_transaction
 
     @validate_checksum_address
-    def sign_message(self, account: str, message: bytes, **kwargs) -> HexBytes:
+    def sign_message(
+        self, account: str, message: bytes, **kwargs
+    ) -> Tuple[SignableMessage, HexBytes]:
         signer = self._get_signer(account=account)
-        signature = signer.sign_message(
-            signable_message=encode_defunct(primitive=message)
-        ).signature
-        return HexBytes(signature)
+        signable_message = encode_defunct(primitive=message)
+        signature = signer.sign_message(signable_message=signable_message).signature
+        return signable_message, HexBytes(signature)

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -893,7 +893,9 @@ class Ursula(Teacher, Character, Operator):
 
     def _substantiate_stamp(self):
         transacting_power = self.transacting_power
-        signature = transacting_power.sign_message(message=bytes(self.stamp))
+        _message_hash, signature = transacting_power.sign_message(
+            message=bytes(self.stamp)
+        )
         self.__operator_signature = signature
         self.__operator_address = transacting_power.account
         message = f"Created decentralized identity evidence: {self.__operator_signature[:10].hex()}"
@@ -1451,15 +1453,15 @@ class Enrico:
 
         # authentication message for TACo
         header_hash = keccak_digest(bytes(ciphertext.header))
-        authorization = bytes(
-            self.signer.sign_message(
+        _message_hash, authorization = self.signer.sign_message(
                 message=header_hash, account=self.signer.accounts[0]
             )
-        )
 
         return ThresholdMessageKit(
             ciphertext=ciphertext,
-            acp=AccessControlPolicy(auth_data=auth_data, authorization=authorization),
+            acp=AccessControlPolicy(
+                auth_data=auth_data, authorization=bytes(authorization)
+            ),
         )
 
     @classmethod

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -713,11 +713,11 @@ class Bob(Character):
                 f"Threshold of Ursulas unable to sign: {failures}"
             )
 
-        # Aggregate signatures
+        # Aggregate & sort signatures
         sorted_successes = sorted(
             successes.values(), key=lambda t: to_checksum_address(t[0])
         )
-        signatures = [s[1].data for s in sorted_successes]
+        signatures = [s[1].signature for s in sorted_successes]
         return signatures
 
     def threshold_decrypt(

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -717,8 +717,8 @@ class Bob(Character):
         sorted_successes = sorted(
             successes.values(), key=lambda t: to_checksum_address(t[0])
         )
-        signatures = [s[1].signature for s in sorted_successes]
-        return signatures
+        responses = [s[1] for s in sorted_successes]
+        return responses
 
     def threshold_decrypt(
         self,

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -116,7 +116,7 @@ from nucypher.policy.conditions.types import Lingo
 from nucypher.policy.kits import PolicyMessageKit
 from nucypher.policy.payment import ContractPayment, PaymentMethod
 from nucypher.policy.policies import Policy
-from nucypher.types import ThresholdSignatureRequest
+from nucypher.types import ThresholdSignatureRequest, ThresholdSignatureResponse
 from nucypher.utilities.emitters import StdoutEmitter
 from nucypher.utilities.logging import Logger
 from nucypher.utilities.networking import validate_operator_ip
@@ -680,7 +680,7 @@ class Bob(Character):
         signing_request: ThresholdSignatureRequest,
         ursulas: List["Ursula"] = None,
         timeout: int = ThresholdSigningClient.DEFAULT_TIMEOUT,
-    ) -> List[bytes]:
+    ) -> List[ThresholdSignatureResponse]:
         """
         Request a threshold signature from a cohort of Ursulas.
         """

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -193,16 +193,23 @@ class TransactingPower(CryptoPowerUp):
         return result
 
     # TODO: this is only a workaround - what are we going to do with this? standardize vs not standardize?
-    def sign_message(self, message: bytes, standardize: bool = True) -> bytes:
-        """Signs the message with the private key of the TransactingPower."""
-        signature = self._signer.sign_message(account=self.__account, message=message)
+    def sign_message(
+        self, message: bytes, standardize: bool = True
+    ) -> Tuple[bytes, bytes]:
+        """
+        Signs the message with the private key of the TransactingPower.
+        Returns the message hash and the signature as bytes.
+        """
+        message, signature = self._signer.sign_message(
+            account=self.__account, message=message
+        )
 
         # This signature will need to be passed to Rust, so we are cleaning the chain identifier
         # from the recovery byte, bringing it to the standard choice of {0, 1}.
         if not standardize:
-            return signature
+            return message.body, signature
 
-        return to_standard_signature_bytes(signature)
+        return message.body, to_standard_signature_bytes(signature)
 
     def sign_transaction(self, transaction_dict: dict) -> bytes:
         """Signs the transaction with the private key of the TransactingPower."""

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -3,6 +3,7 @@ from typing import List, Optional, Tuple, Union
 
 from eth_account._utils.signing import to_standard_signature_bytes
 from eth_typing.evm import ChecksumAddress
+from hexbytes import HexBytes
 from nucypher_core import (
     EncryptedThresholdDecryptionRequest,
     EncryptedThresholdDecryptionResponse,
@@ -195,21 +196,21 @@ class TransactingPower(CryptoPowerUp):
     # TODO: this is only a workaround - what are we going to do with this? standardize vs not standardize?
     def sign_message(
         self, message: bytes, standardize: bool = True
-    ) -> Tuple[bytes, bytes]:
+    ) -> Tuple[HexBytes, bytes]:
         """
         Signs the message with the private key of the TransactingPower.
         Returns the message hash and the signature as bytes.
         """
-        message, signature = self._signer.sign_message(
+        _hash, signature = self._signer.sign_message(
             account=self.__account, message=message
         )
 
         # This signature will need to be passed to Rust, so we are cleaning the chain identifier
         # from the recovery byte, bringing it to the standard choice of {0, 1}.
         if not standardize:
-            return message.body, signature
+            return _hash, signature
 
-        return message.body, to_standard_signature_bytes(signature)
+        return _hash, to_standard_signature_bytes(signature)
 
     def sign_transaction(self, transaction_dict: dict) -> bytes:
         """Signs the transaction with the private key of the TransactingPower."""

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -316,14 +316,12 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
 
     @rest_app.route("/sign", methods=["POST"])
     def threshold_sign():
-        """An endpoint that handles threshold signing requests."""
+        """An endpoint that handles signing requests."""
         try:
             signing_request = ThresholdSignatureRequest.from_bytes(request.data)
-            # Handle the signing request
             signing_response = this_node.handle_threshold_signing_request(
                 signing_request=signing_request
             )
-
             return Response(
                 response=bytes(signing_response),
                 status=HTTPStatus.OK,

--- a/nucypher/types.py
+++ b/nucypher/types.py
@@ -1,4 +1,5 @@
 import json
+from enum import Enum
 from typing import NamedTuple, NewType, Optional, TypeVar
 
 from hexbytes import HexBytes
@@ -20,6 +21,11 @@ class PhaseId(NamedTuple):
     phase: PhaseNumber
 
 
+class _SignatureTypes(Enum):
+    EIP191 = "EIP191"
+    EIP712 = "EIP712"
+
+
 class ThresholdSignatureRequest:
     """TODO: Implement this in nucypher_core"""
 
@@ -28,7 +34,13 @@ class ThresholdSignatureRequest:
         data_to_sign: bytes,
         cohort_id: int,
         context: Optional[ContextDict] = None,
+        _type: str = _SignatureTypes.EIP191.value,
     ):
+        if _type not in [t.value for t in _SignatureTypes]:
+            raise ValueError(
+                f"Invalid type: {_type}. Must be one of {[t.value for t in _SignatureTypes]}"
+            )
+        self.cohort_id = cohort_id
         self.data_to_sign = data_to_sign
         self.cohort_id = cohort_id
         self.context = context or {}
@@ -39,19 +51,25 @@ class ThresholdSignatureRequest:
             "data_to_sign": self.data_to_sign.hex(),
             "cohort_id": self.cohort_id,
             "context": self.context,
+            "type": _SignatureTypes.EIP191.value,
         }
         return json.dumps(data).encode()
 
     @staticmethod
     def from_bytes(request_data: bytes):
-        result = json.loads(request_data.decode())
-        data_to_sign = bytes(HexBytes(result["data_to_sign"]))
-        cohort_id = result["cohort_id"]
-        context = result["context"]
+        try:
+            result = json.loads(request_data.decode())
+            data_to_sign = bytes(HexBytes(result["data_to_sign"]))
+            cohort_id = result["cohort_id"]
+            context = result["context"]
+            _type = result["type"]
+        except (ValueError, KeyError) as e:
+            raise ValueError("Invalid request data") from e
         return ThresholdSignatureRequest(
-            data_to_sign=data_to_sign,
             cohort_id=cohort_id,
+            data_to_sign=data_to_sign,
             context=context,
+            _type=_type,
         )
 
 

--- a/nucypher/types.py
+++ b/nucypher/types.py
@@ -51,7 +51,6 @@ class ThresholdSignatureRequest:
             "data_to_sign": self.data_to_sign.hex(),
             "cohort_id": self.cohort_id,
             "context": self.context,
-            "type": _SignatureTypes.EIP191.value,
         }
         return json.dumps(data).encode()
 
@@ -62,14 +61,12 @@ class ThresholdSignatureRequest:
             data_to_sign = bytes(HexBytes(result["data_to_sign"]))
             cohort_id = result["cohort_id"]
             context = result["context"]
-            _type = result["type"]
         except (ValueError, KeyError) as e:
             raise ValueError("Invalid request data") from e
         return ThresholdSignatureRequest(
             cohort_id=cohort_id,
             data_to_sign=data_to_sign,
             context=context,
-            _type=_type,
         )
 
 

--- a/nucypher/types.py
+++ b/nucypher/types.py
@@ -57,14 +57,25 @@ class ThresholdSignatureRequest:
 
 class ThresholdSignatureResponse:
 
-    def __init__(self, data: bytes):
-        self.data = data
+    def __init__(self, message_hash: bytes, signature: bytes):
+        self.message_hash = message_hash
+        self.signature = signature
 
     def __bytes__(self) -> bytes:
         """Serialize the response to bytes in JSON format."""
-        return self.data
+        data = {
+            "message_hash": self.message_hash.hex(),
+            "signature": self.signature.hex(),
+        }
+        return json.dumps(data).encode()
 
-    @staticmethod
-    def from_bytes(response_data: bytes):
+    @classmethod
+    def from_bytes(cls, response_data: bytes):
         """Deserialize the response from bytes in JSON format."""
-        return ThresholdSignatureResponse(data=response_data)
+        result = json.loads(response_data.decode())
+        message_hash = bytes(HexBytes(result["message_hash"]))
+        signature = bytes(HexBytes(result["signature"]))
+        return cls(
+            message_hash=message_hash,
+            signature=signature,
+        )

--- a/tests/acceptance/actors/test_signing_ritual.py
+++ b/tests/acceptance/actors/test_signing_ritual.py
@@ -182,16 +182,16 @@ def test_signing_request_fulfilment(
         cohort_id=cohort_id,
         context=None,
     )
-    signatures = yield bob.request_threshold_signatures(
+    responses = yield bob.request_threshold_signatures(
         signing_request=signing_request,
     )
 
     signing_cohort = signing_coordinator_agent.get_signing_cohort(cohort_id)
-    assert len(signatures) >= signing_cohort.threshold
+    assert len(responses) >= signing_cohort.threshold
     multisig = nucypher_dependency.ThresholdSigningMultisig.at(signing_cohort.multisig)
     result = multisig.isValidSignature(
         defunct_hash_message(data_to_sign),
-        b"".join(signatures),
+        b"".join(r.signature for r in responses),
     )
     magic_value = EIP1271Auth.MAGIC_VALUE_BYTES
     assert result == magic_value, f"Invalid signature: {result} != {magic_value}"

--- a/tests/acceptance/agents/test_signing_coordinator_agent.py
+++ b/tests/acceptance/agents/test_signing_coordinator_agent.py
@@ -129,7 +129,9 @@ def test_post_signature(
     for transacting_power in transacting_powers:
         data = encode(["uint32", "address"], [cohort_id, authority])
         digest = Web3.keccak(data)
-        signature = transacting_power.sign_message(digest, standardize=False)
+        _message_hash, signature = transacting_power.sign_message(
+            digest, standardize=False
+        )
         async_tx = agent.post_signature(
             cohort_id=cohort_id,
             signature=signature,

--- a/tests/acceptance/ape-config.yaml
+++ b/tests/acceptance/ape-config.yaml
@@ -6,7 +6,7 @@ plugins:
 dependencies:
   - name: nucypher-contracts
     github: derekpierre/nucypher-contracts
-    ref: secreto
+    ref: secreto-old
     config_override:
       solidity:
         version: 0.8.23

--- a/tests/acceptance/characters/test_transacting_power.py
+++ b/tests/acceptance/characters/test_transacting_power.py
@@ -41,7 +41,7 @@ def test_character_transacting_power_signing(testerchain, test_registry, account
 
     # Sign Message
     data_to_sign = b"Premium Select Luxury Pencil Holder"
-    message, signature = power.sign_message(message=data_to_sign)
+    _message_hash, signature = power.sign_message(message=data_to_sign)
     is_verified = verify_eip_191(
         address=eth_address, message=data_to_sign, signature=signature
     )
@@ -80,7 +80,7 @@ def test_transacting_power_sign_message(testerchain, accounts):
 
     # Sign
     data_to_sign = b"Premium Select Luxury Pencil Holder"
-    signature = power.sign_message(message=data_to_sign)
+    _message_hash, signature = power.sign_message(message=data_to_sign)
 
     # Verify
     is_verified = verify_eip_191(

--- a/tests/acceptance/characters/test_transacting_power.py
+++ b/tests/acceptance/characters/test_transacting_power.py
@@ -41,7 +41,7 @@ def test_character_transacting_power_signing(testerchain, test_registry, account
 
     # Sign Message
     data_to_sign = b"Premium Select Luxury Pencil Holder"
-    signature = power.sign_message(message=data_to_sign)
+    message, signature = power.sign_message(message=data_to_sign)
     is_verified = verify_eip_191(
         address=eth_address, message=data_to_sign, signature=signature
     )

--- a/tests/acceptance/characters/test_transacting_power.py
+++ b/tests/acceptance/characters/test_transacting_power.py
@@ -42,6 +42,7 @@ def test_character_transacting_power_signing(testerchain, test_registry, account
     # Sign Message
     data_to_sign = b"Premium Select Luxury Pencil Holder"
     _message_hash, signature = power.sign_message(message=data_to_sign)
+
     is_verified = verify_eip_191(
         address=eth_address, message=data_to_sign, signature=signature
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -714,7 +714,7 @@ def valid_eip4361_auth_message():
         "issued_at": f"{maya.now().iso8601()}",
     }
     siwe_message = SiweMessage(**siwe_message_data).prepare_message()
-    signature = signer.sign_message(
+    _message_hash, signature = signer.sign_message(
         account=signer.accounts[0], message=siwe_message.encode()
     )
     auth_message = {

--- a/tests/integration/blockchain/test_keystore_signer_filesystem_integration.py
+++ b/tests/integration/blockchain/test_keystore_signer_filesystem_integration.py
@@ -198,8 +198,10 @@ def test_keystore_sign_message(mocker, good_signer, mock_account, mock_key):
     assert successful_unlock
 
     # sign message
-    message = b'A million tiny bubbles exploding'
-    signature = good_signer.sign_message(account=mock_account.address, message=message)
+    message = b"A million tiny bubbles exploding"
+    _message_hash, signature = good_signer.sign_message(
+        account=mock_account.address, message=message
+    )
     assert len(signature) == LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY
 
 

--- a/tests/unit/conditions/test_evm_auth.py
+++ b/tests/unit/conditions/test_evm_auth.py
@@ -99,7 +99,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
         "resources": ["ceramic://*"],
     }
     valid_message = SiweMessage(**siwe_message_data).prepare_message()
-    valid_message_signature = signer.sign_message(
+    _message_hash, valid_message_signature = signer.sign_message(
         account=signer.accounts[0], message=valid_message.encode()
     )
     valid_address_for_signature = signer.accounts[0]
@@ -159,7 +159,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
     expiration_message_data = dict(siwe_message_data)
     expiration_message_data["expiration_time"] = maya.now().add(hours=1).iso8601()
     expiration_message = SiweMessage(**expiration_message_data).prepare_message()
-    expiration_message_signature = signer.sign_message(
+    _message_hash, expiration_message_signature = signer.sign_message(
         account=valid_address_for_signature, message=expiration_message.encode()
     )
     EIP4361Auth.authenticate(
@@ -179,7 +179,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
     already_expired_message = SiweMessage(
         **already_expired_message_data
     ).prepare_message()
-    already_expired_message_signature = signer.sign_message(
+    _message_hash, already_expired_message_signature = signer.sign_message(
         account=valid_address_for_signature, message=already_expired_message.encode()
     )
     with pytest.raises(
@@ -196,7 +196,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
     not_before_message_data = dict(siwe_message_data)
     not_before_message_data["not_before"] = maya.now().add(hours=1).iso8601()
     not_before_message = SiweMessage(**not_before_message_data).prepare_message()
-    not_before_signature = signer.sign_message(
+    _message_hash, not_before_signature = signer.sign_message(
         account=valid_address_for_signature, message=not_before_message.encode()
     )
     with pytest.raises(
@@ -211,7 +211,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
     not_before_message_data = dict(siwe_message_data)
     not_before_message_data["not_before"] = maya.now().subtract(hours=1).iso8601()
     not_before_message = SiweMessage(**not_before_message_data).prepare_message()
-    not_before_signature = signer.sign_message(
+    _message_hash, not_before_signature = signer.sign_message(
         account=valid_address_for_signature, message=not_before_message.encode()
     )
     EIP4361Auth.authenticate(
@@ -226,7 +226,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
     futuristic_issued_at_message = SiweMessage(
         **futuristic_issued_at_message_data
     ).prepare_message()
-    futuristic_issued_at_message_signature = signer.sign_message(
+    _message_hash, futuristic_issued_at_message_signature = signer.sign_message(
         account=valid_address_for_signature,
         message=futuristic_issued_at_message.encode(),
     )
@@ -246,7 +246,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
         f"{maya.now().subtract(hours=EIP4361Auth.FRESHNESS_IN_HOURS + 1).iso8601()}"
     )
     stale_message = SiweMessage(**stale_message_data).prepare_message()
-    stale_message_signature = signer.sign_message(
+    _message_hash, stale_message_signature = signer.sign_message(
         account=valid_address_for_signature, message=stale_message.encode()
     )
     with pytest.raises(
@@ -265,7 +265,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
     old_but_not_stale_message = SiweMessage(
         **old_but_not_stale_message_data
     ).prepare_message()
-    old_not_stale_message_signature = signer.sign_message(
+    _message_hash, old_not_stale_message_signature = signer.sign_message(
         account=valid_address_for_signature, message=old_but_not_stale_message.encode()
     )
     EIP4361Auth.authenticate(
@@ -282,7 +282,7 @@ def test_authenticate_eip4361(get_random_checksum_address):
     not_stale_but_past_expiry_message = SiweMessage(
         **not_stale_but_past_expiry
     ).prepare_message()
-    not_stale_but_past_expiry_signature = signer.sign_message(
+    _message_hash, not_stale_but_past_expiry_signature = signer.sign_message(
         account=valid_address_for_signature,
         message=not_stale_but_past_expiry_message.encode(),
     )
@@ -306,7 +306,7 @@ def test_authenticate_eip1271(mocker, get_random_checksum_address):
     # signer for wallet
     data = f"I'm the owner of the smart contract wallet address {eip1271_mock_contract.address}"
     wallet_signer = InMemorySigner()
-    valid_message_signature = wallet_signer.sign_message(
+    _message_hash, valid_message_signature = wallet_signer.sign_message(
         account=wallet_signer.accounts[0], message=data.encode()
     )
     data_hash = defunct_hash_message(text=data)
@@ -375,7 +375,7 @@ def test_authenticate_eip1271(mocker, get_random_checksum_address):
 
     # use invalid signer
     invalid_signer = InMemorySigner()
-    invalid_message_signature = invalid_signer.sign_message(
+    _message_hash, invalid_message_signature = invalid_signer.sign_message(
         account=invalid_signer.accounts[0], message=data.encode()
     )
     with pytest.raises(EvmAuth.AuthenticationFailed):

--- a/tests/unit/test_keystore_signer.py
+++ b/tests/unit/test_keystore_signer.py
@@ -55,7 +55,9 @@ def test_keystore_signer_lock_account(signer, random_account):
 
 def test_keystore_signer_message(signer, random_account):
     message = b"Our attitude toward life determines life's attitude towards us."  # - Earl Nightingale
-    signature = signer.sign_message(account=random_account.address, message=message)
+    _message_hash, signature = signer.sign_message(
+        account=random_account.address, message=message
+    )
     assert len(signature) == LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY
 
     assert (

--- a/tests/unit/test_memory_signer.py
+++ b/tests/unit/test_memory_signer.py
@@ -44,7 +44,7 @@ def test_memory_signer_lock_account(signer, account):
 
 def test_memory_signer_message(signer, account):
     message = b"An in-memory signer - because sometimes, having a short-term memory is actually a superpower!"
-    signature = signer.sign_message(account=account, message=message)
+    _message_hash, signature = signer.sign_message(account=account, message=message)
     assert len(signature) == LENGTH_ECDSA_SIGNATURE_WITH_RECOVERY
 
 


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
2

**What this does**
- Renders a ThresholdSigningResponse which carries the message hash (which was signed)

**Notes**
Based over PR #3595 
Co-Authored by @derekpierre and @theref 
