### PR TITLE
Support Multiple Curves for ECDSA Conditions

### DIFF
--- a/newsfragments/3602.feature.rst
+++ b/newsfragments/3602.feature.rst
@@ -1,0 +1,1 @@
+Add support for arbitrary curves in ECDSA conditions.

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -104,6 +104,10 @@ def is_context_variable(variable) -> bool:
     return isinstance(variable, str) and CONTEXT_REGEX.fullmatch(variable)
 
 
+def is_bytes_context_variable(variable) -> bool:
+    return isinstance(variable, str) and variable.startswith(":bytes")
+
+
 def string_contains_context_variable(variable: str) -> bool:
     matches = re.findall(CONTEXT_REGEX, variable)
     return bool(matches)
@@ -126,6 +130,14 @@ def get_context_value(
             raise RequiredContextVariable(
                 f'No value provided for unrecognized context variable "{context_variable}"'
             )
+        elif is_bytes_context_variable(context_variable):
+            # if it is a bytes context variable, convert the string to bytes
+            try:
+                value = bytes.fromhex(value)
+            except ValueError:
+                raise InvalidContextVariableData(
+                    f'Invalid bytes context variable "{context_variable}"; expected a hex string'
+                )
         elif isinstance(value, str):
             # possible big int value
             value = check_and_convert_big_int_string_to_int(value)
@@ -149,16 +161,14 @@ def resolve_any_context_variables(
         }
     elif isinstance(param, str):
         # either it is a context variable OR contains a context variable within it
-        # TODO separating the two cases for now out of concern of regex searching
-        #  within strings (case 2)
-        if is_context_variable(param):
+        if is_context_variable(param) or is_bytes_context_variable(param):
             return get_context_value(
                 context_variable=param, providers=providers, **context
             )
         else:
+            # Handles multiple context variables within a string (ie 'https://api.github.com/user/:foo/:bar')
             matches = re.findall(CONTEXT_REGEX, param)
             for context_var in matches:
-                # checking out of concern for faulty regex search within string
                 if context_var in context:
                     resolved_var = get_context_value(
                         context_variable=context_var, providers=providers, **context

--- a/nucypher/policy/conditions/ecdsa.py
+++ b/nucypher/policy/conditions/ecdsa.py
@@ -24,6 +24,9 @@ from nucypher.policy.conditions.exceptions import (
 )
 from nucypher.utilities.logging import Logger
 
+SUPPORTED_ECDSA_CONDITION_CURVES = {c.name: c for c in curves}
+DEFAULT_ECDSA_CONDITION_CURVE = NIST192p
+
 
 class ECDSAVerificationCall(ExecutionCall):
     # Use SHA-256 for hashing
@@ -35,7 +38,7 @@ class ECDSAVerificationCall(ExecutionCall):
         verifying_key = fields.Str(required=True)
         curve = fields.Str(
             required=False,
-            validate=validate.OneOf([curve.name for curve in curves]),
+            validate=validate.OneOf(list(SUPPORTED_ECDSA_CONDITION_CURVES)),
         )
 
         @post_load
@@ -62,15 +65,29 @@ class ECDSAVerificationCall(ExecutionCall):
         @validates_schema
         def validate_verifying_key(self, data, **kwargs):
             value = data.get("verifying_key")
-            curve = data.get("curve", NIST192p.name)
+            curve_name = data.get("curve")
+            if curve_name:
+                if curve_name not in SUPPORTED_ECDSA_CONDITION_CURVES:
+                    raise ValidationError(
+                        f"Unsupported curve: {curve_name}. Supported curves are: {SUPPORTED_ECDSA_CONDITION_CURVES.keys()}"
+                    )
+                curve = SUPPORTED_ECDSA_CONDITION_CURVES[curve_name]
+            else:
+                curve = DEFAULT_ECDSA_CONDITION_CURVE
+            try:
+                verifying_key_bytes = bytes.fromhex(value)
+            except ValueError:
+                raise ValidationError(
+                    "Invalid verifying key format, must be hex encoded"
+                )
             try:
                 VerifyingKey.from_string(
-                    string=bytes.fromhex(value),
-                    curve={c.name: c for c in curves}[curve],
+                    verifying_key_bytes,
+                    curve=curve,
                 )
             except Exception as e:
                 raise ValidationError(
-                    f"Invalid verifying key format, must be hex encoded: {str(e)}"
+                    f"Invalid verifying key for curve {curve_name}: {str(e)}"
                 )
 
     def __init__(self, message: Any, signature: str, verifying_key: str, curve: Curve):
@@ -146,7 +163,6 @@ class ECDSACondition(AccessControlCondition):
     """
 
     CONDITION_TYPE = "ecdsa"  # Add this to ConditionType enum
-    SUPPORTED_CURVES = {c.name: c for c in curves}
 
     class Schema(AccessControlCondition.Schema, ECDSAVerificationCall.Schema):
         condition_type = fields.Str(validate=validate.Equal("ecdsa"), required=True)
@@ -160,13 +176,13 @@ class ECDSACondition(AccessControlCondition):
         message: Any,
         signature: str,
         verifying_key: str,
-        curve: Optional[str] = NIST192p.name,
+        curve: Optional[str] = DEFAULT_ECDSA_CONDITION_CURVE.name,
         condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
     ):
-        if curve not in self.SUPPORTED_CURVES:
+        if curve not in SUPPORTED_ECDSA_CONDITION_CURVES:
             raise InvalidCondition(
-                f"Unsupported curve: {curve}. Supported curves are: {list(self.SUPPORTED_CURVES.keys())}"
+                f"Unsupported curve: {curve}. Supported curves are: {list(SUPPORTED_ECDSA_CONDITION_CURVES.keys())}"
             )
 
         try:
@@ -174,7 +190,7 @@ class ECDSACondition(AccessControlCondition):
                 message=message,
                 signature=signature,
                 verifying_key=verifying_key,
-                curve=self.SUPPORTED_CURVES[curve],
+                curve=SUPPORTED_ECDSA_CONDITION_CURVES[curve],
             )
         except ExecutionCall.InvalidExecutionCall as e:
             raise InvalidCondition(str(e)) from e
@@ -192,6 +208,10 @@ class ECDSACondition(AccessControlCondition):
     @property
     def verifying_key(self):
         return self.execution_call.verifying_key
+
+    @property
+    def curve(self):
+        return self.execution_call.curve
 
     def verify(self, **context) -> Tuple[bool, Any]:
         result = self.execution_call.execute(**context)

--- a/nucypher/policy/conditions/ecdsa.py
+++ b/nucypher/policy/conditions/ecdsa.py
@@ -1,9 +1,9 @@
-import base64
 import hashlib
 from typing import Any, Optional, Tuple
 
-from ecdsa import BadSignatureError, VerifyingKey
-from ecdsa.util import sigdecode_der
+from ecdsa import BadSignatureError, NIST192p, VerifyingKey
+from ecdsa.curves import Curve, curves
+from ecdsa.util import sigdecode_string
 from marshmallow import ValidationError, fields, post_load, validate, validates
 
 from nucypher.policy.conditions.base import AccessControlCondition, ExecutionCall
@@ -26,6 +26,10 @@ class ECDSAVerificationCall(ExecutionCall):
         message = fields.Raw(required=True)
         signature = fields.Str(required=True)
         verifying_key = fields.Str(required=True)
+        curve = fields.Str(
+            required=False,
+            validate=validate.OneOf([curve.name for curve in curves]),
+        )
 
         @post_load
         def make(self, data, **kwargs):
@@ -41,30 +45,27 @@ class ECDSAVerificationCall(ExecutionCall):
         @validates("signature")
         def validate_signature(self, value):
             if not is_context_variable(value):
-                # Try to decode it to ensure it's valid base64
                 try:
-                    base64.b64decode(value)
+                    bytes.fromhex(value)
                 except Exception as e:
                     raise ValidationError(
-                        f"Invalid signature format, must be base64 encoded: {str(e)}"
+                        f"Invalid signature format, must be hex encoded: {str(e)}"
                     )
 
         @validates("verifying_key")
         def validate_verifying_key(self, value):
             try:
-                VerifyingKey.from_pem(value.encode())
+                bytes.fromhex(value)
             except Exception as e:
-                raise ValidationError(f"Invalid verifying key format: {str(e)}")
+                raise ValidationError(
+                    f"Invalid verifying key format, must be hex encoded: {str(e)}"
+                )
 
-    def __init__(
-        self,
-        message: Any,
-        signature: str,
-        verifying_key: str,
-    ):
+    def __init__(self, message: Any, signature: str, verifying_key: str, curve: Curve):
         self.message = message
         self.signature = signature
         self.verifying_key = verifying_key
+        self.curve = curve
         self.logger = Logger(__name__)
         super().__init__()
 
@@ -84,22 +85,25 @@ class ECDSAVerificationCall(ExecutionCall):
                 # Normal resolution for other cases
                 message = resolve_any_context_variables(self.message, **context)
 
-            signature_b64 = resolve_any_context_variables(self.signature, **context)
+            signature_hex = resolve_any_context_variables(self.signature, **context)
 
             # Ensure message is bytes
             if isinstance(message, str):
                 message = message.encode("utf-8")
 
-            # Decode the b64 signature
+            # Decode the hex signature
             try:
-                signature = base64.b64decode(signature_b64)
+                signature = bytes.fromhex(signature_hex)
             except Exception as e:
                 self.logger.error(f"Error decoding signature: {e}")
                 return False
 
             # Load the verifying key
             try:
-                verifying_key = VerifyingKey.from_pem(self.verifying_key.encode())
+                verifying_key = VerifyingKey.from_string(
+                    string=bytes.fromhex(self.verifying_key),
+                    curve=self.curve,
+                )
             except Exception as e:
                 self.logger.error(f"Error loading verifying key: {e}")
                 return False
@@ -109,7 +113,7 @@ class ECDSAVerificationCall(ExecutionCall):
                 signature=signature,
                 data=message,
                 hashfunc=self._hash_func,
-                sigdecode=sigdecode_der,
+                sigdecode=sigdecode_string,
             )
         except BadSignatureError:
             return False
@@ -130,6 +134,7 @@ class ECDSACondition(AccessControlCondition):
     """
 
     CONDITION_TYPE = "ecdsa"  # Add this to ConditionType enum
+    SUPPORTED_CURVES = {c.name: c for c in curves}
 
     class Schema(AccessControlCondition.Schema, ECDSAVerificationCall.Schema):
         condition_type = fields.Str(validate=validate.Equal("ecdsa"), required=True)
@@ -143,14 +148,21 @@ class ECDSACondition(AccessControlCondition):
         message: Any,
         signature: str,
         verifying_key: str,
+        curve: Optional[str] = NIST192p.name,
         condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
     ):
+        if curve not in self.SUPPORTED_CURVES:
+            raise InvalidCondition(
+                f"Unsupported curve: {curve}. Supported curves are: {list(self.SUPPORTED_CURVES.keys())}"
+            )
+
         try:
             self.execution_call = ECDSAVerificationCall(
                 message=message,
                 signature=signature,
                 verifying_key=verifying_key,
+                curve=self.SUPPORTED_CURVES[curve],
             )
         except ExecutionCall.InvalidExecutionCall as e:
             raise InvalidCondition(str(e)) from e

--- a/nucypher/policy/conditions/ecdsa.py
+++ b/nucypher/policy/conditions/ecdsa.py
@@ -90,7 +90,7 @@ class ECDSAVerificationCall(ExecutionCall):
             if isinstance(message, str):
                 message = message.encode("utf-8")
 
-            # Decode the base64 signature
+            # Decode the b64 signature
             try:
                 signature = base64.b64decode(signature_b64)
             except Exception as e:

--- a/nucypher/policy/conditions/ecdsa.py
+++ b/nucypher/policy/conditions/ecdsa.py
@@ -4,7 +4,14 @@ from typing import Any, Optional, Tuple
 from ecdsa import BadSignatureError, NIST192p, VerifyingKey
 from ecdsa.curves import Curve, curves
 from ecdsa.util import sigdecode_string
-from marshmallow import ValidationError, fields, post_load, validate, validates
+from marshmallow import (
+    ValidationError,
+    fields,
+    post_load,
+    validate,
+    validates,
+    validates_schema,
+)
 
 from nucypher.policy.conditions.base import AccessControlCondition, ExecutionCall
 from nucypher.policy.conditions.context import (
@@ -52,10 +59,15 @@ class ECDSAVerificationCall(ExecutionCall):
                         f"Invalid signature format, must be hex encoded: {str(e)}"
                     )
 
-        @validates("verifying_key")
-        def validate_verifying_key(self, value):
+        @validates_schema
+        def validate_verifying_key(self, data, **kwargs):
+            value = data.get("verifying_key")
+            curve = data.get("curve", NIST192p.name)
             try:
-                bytes.fromhex(value)
+                VerifyingKey.from_string(
+                    string=bytes.fromhex(value),
+                    curve={c.name: c for c in curves}[curve],
+                )
             except Exception as e:
                 raise ValidationError(
                     f"Invalid verifying key format, must be hex encoded: {str(e)}"

--- a/tests/acceptance/conditions/test_ecdsa_condition.py
+++ b/tests/acceptance/conditions/test_ecdsa_condition.py
@@ -1,16 +1,14 @@
-import base64
-
-from ecdsa import SECP256k1, SigningKey
-from ecdsa.util import sigencode_der
+from ecdsa import NIST192p, SigningKey
+from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.context import USER_ADDRESS_CONTEXT
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
 from nucypher.policy.conditions.lingo import ConditionLingo
 
 # Create test key pair for ECDSA signing
-TEST_SIGNING_KEY = SigningKey.generate()
+TEST_SIGNING_KEY = SigningKey.generate(curve=NIST192p)
 TEST_VERIFYING_KEY = TEST_SIGNING_KEY.verifying_key
-TEST_VERIFYING_KEY_PEM = TEST_VERIFYING_KEY.to_pem().decode("utf-8")
+TEST_VERIFYING_KEY_HEX = TEST_VERIFYING_KEY.to_string().hex()
 
 # Test message
 TEST_MESSAGE = b"This is a test message that requires ECDSA verification"
@@ -22,22 +20,23 @@ def test_ecdsa_condition_verification_flow():
     """
     # Sign the test message with the private key
     signature = TEST_SIGNING_KEY.sign(
-        TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
-    )
-    signature_b64 = base64.b64encode(signature).decode("utf-8")
+        TEST_MESSAGE,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
+    ).hex()
 
     # Create an ECDSA condition
     ecdsa_condition = ECDSACondition(
         message=USER_ADDRESS_CONTEXT,
         signature=":signature",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
     )
 
     # Create a complete condition lingo
     condition_lingo = ConditionLingo(ecdsa_condition)
 
     # Set up the context for verification
-    context = {USER_ADDRESS_CONTEXT: TEST_MESSAGE, ":signature": signature_b64}
+    context = {USER_ADDRESS_CONTEXT: TEST_MESSAGE, ":signature": signature}
 
     # Evaluate the condition
     result = condition_lingo.eval(**context)
@@ -49,12 +48,11 @@ def test_ecdsa_condition_verification_flow():
     invalid_signature = TEST_SIGNING_KEY.sign(
         different_message,
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
-    )
-    invalid_signature_b64 = base64.b64encode(invalid_signature).decode("utf-8")
+        sigencode=sigencode_string,
+    ).hex()
 
     # Update context with invalid signature
-    context[":signature"] = invalid_signature_b64
+    context[":signature"] = invalid_signature
 
     # Evaluate the condition again
     result = condition_lingo.eval(**context)
@@ -72,26 +70,27 @@ def test_ecdsa_condition_in_compound_condition():
 
     # Sign the test message with the private key
     signature = TEST_SIGNING_KEY.sign(
-        TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
-    )
-    signature_b64 = base64.b64encode(signature).decode("utf-8")
+        TEST_MESSAGE,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
+    ).hex()
 
     # Create an ECDSA condition
     ecdsa_condition = ECDSACondition(
         message=USER_ADDRESS_CONTEXT,
         signature=":signature",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
     )
 
     # Create a second ECDSA condition with different requirements
-    second_signing_key = SigningKey.generate(curve=SECP256k1)
+    second_signing_key = SigningKey.generate(curve=NIST192p)
     second_verifying_key = second_signing_key.verifying_key
-    second_verifying_key_pem = second_verifying_key.to_pem().decode("utf-8")
+    second_verifying_key_hex = second_verifying_key.to_string().hex()
 
     second_ecdsa_condition = ECDSACondition(
         message=":second_message",
         signature=":second_signature",
-        verifying_key=second_verifying_key_pem,
+        verifying_key=second_verifying_key_hex,
     )
 
     # Create a compound condition with OR operator
@@ -105,7 +104,7 @@ def test_ecdsa_condition_in_compound_condition():
     # Context with only the first signature valid
     context = {
         USER_ADDRESS_CONTEXT: TEST_MESSAGE,
-        ":signature": signature_b64,
+        ":signature": signature,
         ":second_message": b"Second message",
         ":second_signature": "invalid_signature",  # Invalid signature for second condition
     }
@@ -134,12 +133,11 @@ def test_ecdsa_condition_in_compound_condition():
     second_signature = second_signing_key.sign(
         b"Second message",
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
-    )
-    second_signature_b64 = base64.b64encode(second_signature).decode("utf-8")
+        sigencode=sigencode_string,
+    ).hex()
 
     # Update context with valid second signature
-    context[":second_signature"] = second_signature_b64
+    context[":second_signature"] = second_signature
 
     # Compound AND condition should now succeed with both signatures valid
     result = condition_lingo.eval(**context)

--- a/tests/acceptance/conditions/test_ecdsa_condition.py
+++ b/tests/acceptance/conditions/test_ecdsa_condition.py
@@ -8,7 +8,7 @@ from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCa
 from nucypher.policy.conditions.lingo import ConditionLingo
 
 # Create test key pair for ECDSA signing
-TEST_SIGNING_KEY = SigningKey.generate(curve=SECP256k1)
+TEST_SIGNING_KEY = SigningKey.generate()
 TEST_VERIFYING_KEY = TEST_SIGNING_KEY.verifying_key
 TEST_VERIFYING_KEY_PEM = TEST_VERIFYING_KEY.to_pem().decode("utf-8")
 

--- a/tests/integration/conditions/test_ecdsa_condition_integration.py
+++ b/tests/integration/conditions/test_ecdsa_condition_integration.py
@@ -1,7 +1,7 @@
 import base64
 
 from ecdsa import SECP256k1, SigningKey
-from ecdsa.util import sigencode_der
+from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
 from nucypher.policy.conditions.lingo import (
@@ -22,7 +22,9 @@ def test_ecdsa_lingo_basic_verification():
     """Test a basic ECDSA verification using condition lingo"""
     # Sign the test message
     signature = TEST_SIGNING_KEY.sign(
-        TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+        TEST_MESSAGE,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
     )
     signature_b64 = base64.b64encode(signature).decode("utf-8")
 
@@ -46,7 +48,7 @@ def test_ecdsa_lingo_basic_verification():
     invalid_signature = TEST_SIGNING_KEY.sign(
         different_message,
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
+        sigencode=sigencode_string,
     )
     invalid_signature_b64 = base64.b64encode(invalid_signature).decode("utf-8")
 
@@ -59,7 +61,9 @@ def test_ecdsa_in_compound_condition():
     """Test ECDSA as part of a compound condition"""
     # Sign the message
     signature = TEST_SIGNING_KEY.sign(
-        TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+        TEST_MESSAGE,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
     )
     signature_b64 = base64.b64encode(signature).decode("utf-8")
 
@@ -100,7 +104,7 @@ def test_ecdsa_in_compound_condition():
     second_signature = second_key.sign(
         second_message,
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
+        sigencode=sigencode_string,
     )
     second_signature_b64 = base64.b64encode(second_signature).decode("utf-8")
 

--- a/tests/integration/conditions/test_ecdsa_condition_integration.py
+++ b/tests/integration/conditions/test_ecdsa_condition_integration.py
@@ -1,4 +1,3 @@
-import base64
 
 from ecdsa import Ed25519, SECP256k1, SigningKey
 from ecdsa.util import sigencode_string

--- a/tests/integration/conditions/test_ecdsa_condition_integration.py
+++ b/tests/integration/conditions/test_ecdsa_condition_integration.py
@@ -25,8 +25,7 @@ def test_ecdsa_lingo_basic_verification():
         TEST_MESSAGE,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    signature_b64 = base64.b64encode(signature).decode("utf-8")
+    ).hex()
 
     # Create condition
     ecdsa_condition = ECDSACondition(
@@ -39,7 +38,7 @@ def test_ecdsa_lingo_basic_verification():
     lingo = ConditionLingo(ecdsa_condition)
 
     # Valid context
-    context = {":message": TEST_MESSAGE, ":signature": signature_b64}
+    context = {":message": TEST_MESSAGE, ":signature": signature}
     result = lingo.eval(**context)
     assert result is True
 
@@ -49,10 +48,9 @@ def test_ecdsa_lingo_basic_verification():
         different_message,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    invalid_signature_b64 = base64.b64encode(invalid_signature).decode("utf-8")
+    ).hex()
 
-    context[":signature"] = invalid_signature_b64
+    context[":signature"] = invalid_signature
     result = lingo.eval(**context)
     assert result is False
 

--- a/tests/integration/conditions/test_ecdsa_condition_integration.py
+++ b/tests/integration/conditions/test_ecdsa_condition_integration.py
@@ -1,6 +1,6 @@
 import base64
 
-from ecdsa import SECP256k1, SigningKey
+from ecdsa import Ed25519, SECP256k1, SigningKey
 from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
@@ -12,10 +12,12 @@ from nucypher.policy.conditions.lingo import (
 # Create test key pair for ECDSA signing
 TEST_SIGNING_KEY = SigningKey.generate(curve=SECP256k1)
 TEST_VERIFYING_KEY = TEST_SIGNING_KEY.verifying_key
-TEST_VERIFYING_KEY_PEM = TEST_VERIFYING_KEY.to_pem().decode("utf-8")
+TEST_VERIFYING_KEY_HEX = TEST_VERIFYING_KEY.to_string().hex()
 
 # Test message
-TEST_MESSAGE = b"This is a test message that requires ECDSA verification"
+TEST_MESSAGE = (
+    b"There is a road, no simple highway, between the dawn and the dark of night. -JG"
+)
 
 
 def test_ecdsa_lingo_basic_verification():
@@ -31,7 +33,8 @@ def test_ecdsa_lingo_basic_verification():
     ecdsa_condition = ECDSACondition(
         message=":message",
         signature=":signature",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1.name,
     )
 
     # Create condition lingo
@@ -62,25 +65,26 @@ def test_ecdsa_in_compound_condition():
         TEST_MESSAGE,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    signature_b64 = base64.b64encode(signature).decode("utf-8")
+    ).hex()
 
     # Create two ECDSA conditions
     ecdsa_condition1 = ECDSACondition(
         message=":message1",
         signature=":signature1",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1.name,
     )
 
     # Create a second key pair
     second_key = SigningKey.generate(curve=SECP256k1)
     second_verifying_key = second_key.verifying_key
-    second_verifying_key_pem = second_verifying_key.to_pem().decode("utf-8")
+    second_verifying_key_hex = second_verifying_key.to_string().hex()
 
     ecdsa_condition2 = ECDSACondition(
         message=":message2",
         signature=":signature2",
-        verifying_key=second_verifying_key_pem,
+        verifying_key=second_verifying_key_hex,
+        curve=SECP256k1.name,
     )
 
     # Create OR compound condition
@@ -103,15 +107,14 @@ def test_ecdsa_in_compound_condition():
         second_message,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    second_signature_b64 = base64.b64encode(second_signature).decode("utf-8")
+    ).hex()
 
     # Test case: first signature valid, second invalid
     context = {
         ":message1": TEST_MESSAGE,
-        ":signature1": signature_b64,
+        ":signature1": signature,
         ":message2": b"Not the correct message",
-        ":signature2": second_signature_b64,
+        ":signature2": second_signature,
     }
 
     # OR condition should succeed if at least one is valid
@@ -125,3 +128,32 @@ def test_ecdsa_in_compound_condition():
 
     # Now both conditions are valid, so AND should pass
     assert and_lingo.eval(**context) is True
+
+
+def test_discord_ed25519_with_ecdsa_condition():
+    # Discord Ed25519 test vector
+    public_key_hex = "b853dd9f496723daf64bf2f5a886086f790df66e61d7b6f7f98a50c9e5ede8f3"
+    signature_hex = "0a12acb96843700b724f1c9dba3075a7fc482677e0c713eb6be63bfea406fb33b4715975f1062b2dff95127bd559ee23758911bd217760727dc44e7880bc6e04"
+    timestamp = "1749368683"
+    body = '{"app_permissions":"2248473465835073","application_id":"1380486651436073092","attachment_size_limit":10485760,"authorizing_integration_owners":{"0":"1380488052169769110"},"channel":{"flags":0,"guild_id":"1380488052169769110","icon_emoji":{"id":null,"name":"👋"},"id":"1380488052169769113","last_message_id":"1380528253168652328","name":"general","nsfw":false,"parent_id":"1380488052169769111","permissions":"2251799813685247","position":0,"rate_limit_per_user":0,"theme_color":null,"topic":null,"type":0},"channel_id":"1380488052169769113","context":0,"data":{"id":"1380515955146358918","name":"sign","options":[{"name":"message","type":3,"value":"llamas"}],"type":1},"entitlement_sku_ids":[],"entitlements":[],"guild":{"features":[],"id":"1380488052169769110","locale":"en-US"},"guild_id":"1380488052169769110","guild_locale":"en-US","id":"1381177107555680327","locale":"en-US","member":{"avatar":null,"banner":null,"communication_disabled_until":null,"deaf":false,"flags":0,"joined_at":"2025-06-06T10:06:39.888000+00:00","mute":false,"nick":null,"pending":false,"permissions":"2251799813685247","premium_since":null,"roles":[],"unusual_dm_activity_until":null,"user":{"avatar":"9c5483a989a10edc8b831b6c8f284724","avatar_decoration_data":null,"clan":null,"collectibles":null,"discriminator":"0","global_name":"kprasch","id":"410212090289192960","primary_guild":null,"public_flags":0,"username":"kprasch"}},"token":"aW50ZXJhY3Rpb246MTM4MTE3NzEwNzU1NTY4MDMyNzo2ZlVlTkdIQVFIdkdhNUN2bXlYZ1RCRkZ5YkpuVm9WUG5Bbjl0TTMyUkFTenZGYXNXclBCMjZWUWJlalczcllRak9sc0JZR3Q4WW9sODBRcDg2c2hrYmRkYzlWcjF3TjdlRFVDMVBVTkZ3Z2VmRUp4VkI1MkZGNmVvM3hkWXd1Qg","type":2,"version":1}'
+
+    # Construct the message to be signed
+    message = timestamp.encode("utf-8") + body.encode("utf-8")
+
+    # Create ECDSACondition using the Discord public key and signature
+    ecdsa_condition = ECDSACondition(
+        message=":message",
+        signature=":signature",
+        verifying_key=public_key_hex,
+        curve=Ed25519.name,
+    )
+
+    # Create condition lingo
+    lingo = ConditionLingo(ecdsa_condition)
+
+    # Valid context
+    context = {":message": message, ":signature": signature_hex}
+    result = lingo.eval(**context)
+    assert (
+        result is True
+    ), "Discord Ed25519 signature should be valid using ECDSACondition."

--- a/tests/integration/conditions/test_ecdsa_condition_json.py
+++ b/tests/integration/conditions/test_ecdsa_condition_json.py
@@ -1,7 +1,6 @@
-import base64
 import json
 
-from ecdsa import SECP256k1, SigningKey
+from ecdsa import SigningKey
 from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
@@ -11,9 +10,9 @@ from nucypher.policy.conditions.lingo import (
 )
 
 # Create test key pair for ECDSA signing
-TEST_SIGNING_KEY = SigningKey.generate(curve=SECP256k1)
+TEST_SIGNING_KEY = SigningKey.generate()
 TEST_VERIFYING_KEY = TEST_SIGNING_KEY.verifying_key
-TEST_VERIFYING_KEY_PEM = TEST_VERIFYING_KEY.to_pem().decode("utf-8")
+TEST_VERIFYING_KEY_HEX = TEST_VERIFYING_KEY.to_string().hex()
 
 # Test message
 TEST_MESSAGE = b"This is a test message that requires ECDSA verification"
@@ -26,14 +25,13 @@ def test_ecdsa_condition_json_serialization():
         TEST_MESSAGE,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    signature_b64 = base64.b64encode(signature).decode("utf-8")
+    ).hex()
 
     # Create condition
     ecdsa_condition = ECDSACondition(
         message=":message",
         signature=":signature",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
     )
 
     # Convert condition to JSON
@@ -44,7 +42,7 @@ def test_ecdsa_condition_json_serialization():
     assert condition_dict["conditionType"] == "ecdsa"
     assert condition_dict["message"] == ":message"
     assert condition_dict["signature"] == ":signature"
-    assert condition_dict["verifyingKey"] == TEST_VERIFYING_KEY_PEM
+    assert condition_dict["verifyingKey"] == TEST_VERIFYING_KEY_HEX
 
     # Recreate condition from JSON
     recreated_condition = ECDSACondition.from_json(condition_json)
@@ -52,10 +50,10 @@ def test_ecdsa_condition_json_serialization():
     # Verify the recreated condition
     assert recreated_condition.message == ":message"
     assert recreated_condition.signature == ":signature"
-    assert recreated_condition.verifying_key == TEST_VERIFYING_KEY_PEM
+    assert recreated_condition.verifying_key == TEST_VERIFYING_KEY_HEX
 
     # Check that the recreated condition works
-    context = {":message": TEST_MESSAGE, ":signature": signature_b64}
+    context = {":message": TEST_MESSAGE, ":signature": signature}
     success, result = recreated_condition.verify(**context)
     assert success is True
 
@@ -67,14 +65,13 @@ def test_ecdsa_condition_lingo_json_serialization():
         TEST_MESSAGE,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    signature_b64 = base64.b64encode(signature).decode("utf-8")
+    ).hex()
 
     # Create condition
     ecdsa_condition = ECDSACondition(
         message=":message",
         signature=":signature",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
     )
 
     # Create condition lingo
@@ -92,7 +89,7 @@ def test_ecdsa_condition_lingo_json_serialization():
     recreated_lingo = ConditionLingo.from_json(lingo_json)
 
     # Verify the recreated lingo works
-    context = {":message": TEST_MESSAGE, ":signature": signature_b64}
+    context = {":message": TEST_MESSAGE, ":signature": signature}
     result = recreated_lingo.eval(**context)
     assert result is True
 
@@ -101,11 +98,11 @@ def test_complex_condition_with_ecdsa_json_serialization():
     """Test a complex condition with ECDSA JSON serialization"""
     # Create two key pairs for the test
     key1 = TEST_SIGNING_KEY
-    key1_vk_pem = TEST_VERIFYING_KEY_PEM
+    key1_vk_hex = TEST_VERIFYING_KEY_HEX
 
-    key2 = SigningKey.generate(curve=SECP256k1)
+    key2 = SigningKey.generate()
     key2_vk = key2.verifying_key
-    key2_vk_pem = key2_vk.to_pem().decode("utf-8")
+    key2_vk_hex = key2_vk.to_string().hex()
 
     # Sign the messages
     message1 = b"Message for first key"
@@ -113,26 +110,24 @@ def test_complex_condition_with_ecdsa_json_serialization():
 
     sig1 = key1.sign(
         message1, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_string
-    )
-    sig1_b64 = base64.b64encode(sig1).decode("utf-8")
+    ).hex()
 
     sig2 = key2.sign(
         message2, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_string
-    )
-    sig2_b64 = base64.b64encode(sig2).decode("utf-8")
+    ).hex()
 
     # Create ECDSA conditions
     condition1 = ECDSACondition(
         message=":msg1",
         signature=":sig1",
-        verifying_key=key1_vk_pem,
+        verifying_key=key1_vk_hex,
         name="First Signer",
     )
 
     condition2 = ECDSACondition(
         message=":msg2",
         signature=":sig2",
-        verifying_key=key2_vk_pem,
+        verifying_key=key2_vk_hex,
         name="Second Signer",
     )
 
@@ -155,14 +150,14 @@ def test_complex_condition_with_ecdsa_json_serialization():
                 "conditionType": "ecdsa",
                 "message": ":msg1",
                 "signature": ":sig1",
-                "verifyingKey": key1_vk_pem,
+                "verifyingKey": key1_vk_hex,
             },
             {
                 "name": "Second Signer",
                 "conditionType": "ecdsa",
                 "message": ":msg2",
                 "signature": ":sig2",
-                "verifyingKey": key2_vk_pem,
+                "verifyingKey": key2_vk_hex,
             },
         ],
     }
@@ -180,9 +175,9 @@ def test_complex_condition_with_ecdsa_json_serialization():
     # Create a context with valid signatures
     context = {
         ":msg1": message1,
-        ":sig1": sig1_b64,
+        ":sig1": sig1,
         ":msg2": message2,
-        ":sig2": sig2_b64,
+        ":sig2": sig2,
     }
 
     # Verify the condition
@@ -194,10 +189,9 @@ def test_complex_condition_with_ecdsa_json_serialization():
         b"Wrong message",
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    invalid_sig2_b64 = base64.b64encode(invalid_sig2).decode("utf-8")
+    ).hex()
 
-    context[":sig2"] = invalid_sig2_b64
+    context[":sig2"] = invalid_sig2
     success, _ = recreated_condition.verify(**context)
     assert success is False
 
@@ -209,9 +203,9 @@ def test_real_world_example_json():
     # - In a compound condition with other potential access methods
 
     # Create a sample service key for verification
-    service_key = SigningKey.generate(curve=SECP256k1)
+    service_key = SigningKey.generate()
     service_vk = service_key.verifying_key
-    service_vk_pem = service_vk.to_pem().decode("utf-8")
+    service_vk_hex = service_vk.to_string().hex()
 
     # JSON representation of the condition - this is what would typically
     # be stored in a database or config file
@@ -228,7 +222,7 @@ def test_real_world_example_json():
                         "name": "API Key Signature",
                         "message": ":request_data",
                         "signature": ":request_signature",
-                        "verifyingKey": service_vk_pem,
+                        "verifyingKey": service_vk_hex,
                     },
                     # Option 2: Could combine with other conditions
                     # (e.g., a time-based condition as a fallback)
@@ -241,7 +235,7 @@ def test_real_world_example_json():
                                 "name": "Admin Signature",
                                 "message": ":admin_request",
                                 "signature": ":admin_signature",
-                                "verifyingKey": TEST_VERIFYING_KEY_PEM,
+                                "verifyingKey": TEST_VERIFYING_KEY_HEX,
                             },
                             # Add a second condition to satisfy the minimum requirement
                             {
@@ -249,7 +243,7 @@ def test_real_world_example_json():
                                 "name": "Extra Verification",
                                 "message": ":admin_request",
                                 "signature": ":admin_signature",
-                                "verifyingKey": TEST_VERIFYING_KEY_PEM,
+                                "verifyingKey": TEST_VERIFYING_KEY_HEX,
                             },
                         ],
                     },
@@ -267,12 +261,11 @@ def test_real_world_example_json():
         request_data,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    request_signature_b64 = base64.b64encode(request_signature).decode("utf-8")
+    ).hex()
 
     context = {
         ":request_data": request_data,
-        ":request_signature": request_signature_b64,
+        ":request_signature": request_signature,
     }
 
     # Evaluate condition
@@ -285,8 +278,7 @@ def test_real_world_example_json():
         admin_request,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
-    )
-    admin_signature_b64 = base64.b64encode(admin_signature).decode("utf-8")
+    ).hex()
 
     context = {
         # API key authentication fails
@@ -294,7 +286,7 @@ def test_real_world_example_json():
         ":request_signature": "invalid-signature",
         # But admin authentication succeeds
         ":admin_request": admin_request,
-        ":admin_signature": admin_signature_b64,
+        ":admin_signature": admin_signature,
     }
 
     result = lingo.eval(**context)

--- a/tests/integration/conditions/test_ecdsa_condition_json.py
+++ b/tests/integration/conditions/test_ecdsa_condition_json.py
@@ -2,7 +2,7 @@ import base64
 import json
 
 from ecdsa import SECP256k1, SigningKey
-from ecdsa.util import sigencode_der
+from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
 from nucypher.policy.conditions.lingo import (
@@ -23,7 +23,9 @@ def test_ecdsa_condition_json_serialization():
     """Test serializing and deserializing ECDSA conditions to/from JSON"""
     # Sign the test message
     signature = TEST_SIGNING_KEY.sign(
-        TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+        TEST_MESSAGE,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
     )
     signature_b64 = base64.b64encode(signature).decode("utf-8")
 
@@ -62,7 +64,9 @@ def test_ecdsa_condition_lingo_json_serialization():
     """Test serializing and deserializing a condition lingo with ECDSA condition"""
     # Sign the test message
     signature = TEST_SIGNING_KEY.sign(
-        TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+        TEST_MESSAGE,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
     )
     signature_b64 = base64.b64encode(signature).decode("utf-8")
 
@@ -108,12 +112,12 @@ def test_complex_condition_with_ecdsa_json_serialization():
     message2 = b"Message for second key"
 
     sig1 = key1.sign(
-        message1, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+        message1, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_string
     )
     sig1_b64 = base64.b64encode(sig1).decode("utf-8")
 
     sig2 = key2.sign(
-        message2, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+        message2, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_string
     )
     sig2_b64 = base64.b64encode(sig2).decode("utf-8")
 
@@ -189,7 +193,7 @@ def test_complex_condition_with_ecdsa_json_serialization():
     invalid_sig2 = key2.sign(
         b"Wrong message",
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
+        sigencode=sigencode_string,
     )
     invalid_sig2_b64 = base64.b64encode(invalid_sig2).decode("utf-8")
 
@@ -260,7 +264,9 @@ def test_real_world_example_json():
     # ---- Scenario 1: API user with valid signature ----
     request_data = b'{"action": "read", "resource": "secret-data-123"}'
     request_signature = service_key.sign(
-        request_data, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+        request_data,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
     )
     request_signature_b64 = base64.b64encode(request_signature).decode("utf-8")
 
@@ -278,7 +284,7 @@ def test_real_world_example_json():
     admin_signature = TEST_SIGNING_KEY.sign(
         admin_request,
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
+        sigencode=sigencode_string,
     )
     admin_signature_b64 = base64.b64encode(admin_signature).decode("utf-8")
 

--- a/tests/unit/conditions/test_ecdsa_condition.py
+++ b/tests/unit/conditions/test_ecdsa_condition.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from ecdsa.curves import SECP256k1
+from ecdsa.curves import SECP256k1, NIST192p
 from ecdsa.keys import SigningKey
 from ecdsa.util import sigencode_string
 from marshmallow import validates
@@ -155,6 +155,73 @@ def test_ecdsa_condition_verify_invalid_signature():
     assert result is False
 
 
+def test_ecdsa_condition_different_curves():
+    # Test with SECP256k1 curve
+    secp256k1_key = SigningKey.generate(curve=SECP256k1)
+    secp256k1_verifying_key = secp256k1_key.verifying_key
+    secp256k1_verifying_key_hex = secp256k1_verifying_key.to_string().hex()
+
+    secp256k1_message = b"Test message for SECP256k1"
+    secp256k1_signature = secp256k1_key.sign(
+        secp256k1_message,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
+    ).hex()
+
+    # Test with NIST192p curve
+    nist192p_key = SigningKey.generate(curve=NIST192p)
+    nist192p_verifying_key = nist192p_key.verifying_key
+    nist192p_verifying_key_hex = nist192p_verifying_key.to_string().hex()
+
+    nist192p_message = b"Test message for NIST192p"
+    nist192p_signature = nist192p_key.sign(
+        nist192p_message,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_string,
+    ).hex()
+
+    # Test SECP256k1 condition
+    secp256k1_condition = ECDSACondition(
+        message=":message_variable",
+        signature=":signature_variable",
+        verifying_key=secp256k1_verifying_key_hex,
+        curve=SECP256k1.name,
+    )
+
+    secp256k1_context = {
+        ":message_variable": secp256k1_message,
+        ":signature_variable": secp256k1_signature,
+    }
+    success, result = secp256k1_condition.verify(**secp256k1_context)
+    assert success
+    assert result is True
+
+    # Test NIST192p condition
+    nist192p_condition = ECDSACondition(
+        message=":message_variable",
+        signature=":signature_variable",
+        verifying_key=nist192p_verifying_key_hex,
+        curve=NIST192p.name,
+    )
+
+    nist192p_context = {
+        ":message_variable": nist192p_message,
+        ":signature_variable": nist192p_signature,
+    }
+    success, result = nist192p_condition.verify(**nist192p_context)
+    assert success
+    assert result is True
+
+    # Test that signatures don't work with wrong curves
+    wrong_curve_context = {
+        ":message_variable": secp256k1_message,
+        ":signature_variable": secp256k1_signature,
+    }
+    success, result = nist192p_condition.verify(**wrong_curve_context)
+    assert not success
+    assert result is False
+
+
 def test_ecdsa_condition_bytes_context():
     """Test that ECDSA conditions can handle bytes in context through serialization.
 
@@ -166,7 +233,7 @@ def test_ecdsa_condition_bytes_context():
     # Create a test message and sign it
     message_bytes = b"This is a test message that requires ECDSA verification"
     signature = TEST_SIGNING_KEY.sign(
-        data=message_bytes,
+        message_bytes,
         hashfunc=ECDSAVerificationCall._hash_func,
         sigencode=sigencode_string,
     ).hex()
@@ -223,3 +290,4 @@ def test_ecdsa_condition_bytes_context():
     success, result = ecdsa_condition.verify(**deserialized_context)
     assert success, "Verification should succeed with deserialized mixed context"
     assert result is True
+

--- a/tests/unit/conditions/test_ecdsa_condition.py
+++ b/tests/unit/conditions/test_ecdsa_condition.py
@@ -1,4 +1,5 @@
 import base64
+import json
 
 import pytest
 from ecdsa import SECP256k1, SigningKey
@@ -151,3 +152,74 @@ def test_ecdsa_condition_verify_invalid_signature():
     success, result = condition.verify(**context)
     assert not success
     assert result is False
+
+
+def test_ecdsa_condition_bytes_context():
+    """Test that ECDSA conditions can handle bytes in context through serialization.
+
+    This test verifies that:
+    1. Bytes can be passed in context and will be properly [de]serialized
+    2. The condition can handle both raw bytes and hex strings
+    3. The verification works correctly after serialization/deserialization
+    """
+    # Create a test message and sign it
+    message_bytes = b"This is a test message that requires ECDSA verification"
+    signature = TEST_SIGNING_KEY.sign(
+        data=message_bytes,
+        hashfunc=ECDSAVerificationCall._hash_func,
+        sigencode=sigencode_der,
+    )
+
+    signature_b64 = base64.b64encode(signature).decode("utf-8")
+
+    # Create an ECDSA condition
+    ecdsa_condition = ECDSACondition(
+        message=":bytes:message",
+        signature=":signature",
+        verifying_key=TEST_VERIFYING_KEY_PEM,
+    )
+
+    # Test with raw bytes in context
+    context_with_bytes = {
+        ":bytes:message": message_bytes.hex(),
+        ":signature": signature_b64,
+    }
+
+    # The context should be serializable
+    serialized_context = json.dumps(context_with_bytes)
+    deserialized_context = json.loads(serialized_context)
+
+    # Verification should work with the deserialized context
+    success, result = ecdsa_condition.verify(**deserialized_context)
+    assert success, "Verification should succeed with deserialized bytes context"
+    assert result is True
+
+    # Test with hex string in context (backwards compatibility)
+    context_with_hex = {
+        ":bytes:message": message_bytes.hex(),
+        ":signature": signature_b64,
+    }
+
+    # The context should be serializable
+    serialized_context = json.dumps(context_with_hex)
+    deserialized_context = json.loads(serialized_context)
+
+    # Verification should work with the deserialized context
+    success, result = ecdsa_condition.verify(**deserialized_context)
+    assert success, "Verification should succeed with deserialized hex context"
+    assert result is True
+
+    # Test with mixed types (some bytes, some hex)
+    context_mixed = {
+        ":bytes:message": message_bytes.hex(),
+        ":signature": signature_b64,
+    }
+
+    # The context should be serializable
+    serialized_context = json.dumps(context_mixed)
+    deserialized_context = json.loads(serialized_context)
+
+    # Verification should work with the deserialized context
+    success, result = ecdsa_condition.verify(**deserialized_context)
+    assert success, "Verification should succeed with deserialized mixed context"
+    assert result is True

--- a/tests/unit/conditions/test_ecdsa_condition.py
+++ b/tests/unit/conditions/test_ecdsa_condition.py
@@ -1,5 +1,7 @@
+import hashlib
 import json
-
+import nacl.exceptions
+import nacl.signing
 import pytest
 from ecdsa.curves import SECP256k1, NIST192p
 from ecdsa.keys import SigningKey
@@ -291,3 +293,57 @@ def test_ecdsa_condition_bytes_context():
     assert success, "Verification should succeed with deserialized mixed context"
     assert result is True
 
+def test_discord_ed25519_signature():
+    # Discord Ed25519 test vector
+    public_key_hex = "b853dd9f496723daf64bf2f5a886086f790df66e61d7b6f7f98a50c9e5ede8f3"
+    signature_hex = "0a12acb96843700b724f1c9dba3075a7fc482677e0c713eb6be63bfea406fb33b4715975f1062b2dff95127bd559ee23758911bd217760727dc44e7880bc6e04"
+    timestamp = "1749368683"
+    body = '{"app_permissions":"2248473465835073","application_id":"1380486651436073092","attachment_size_limit":10485760,"authorizing_integration_owners":{"0":"1380488052169769110"},"channel":{"flags":0,"guild_id":"1380488052169769110","icon_emoji":{"id":null,"name":"👋"},"id":"1380488052169769113","last_message_id":"1380528253168652328","name":"general","nsfw":false,"parent_id":"1380488052169769111","permissions":"2251799813685247","position":0,"rate_limit_per_user":0,"theme_color":null,"topic":null,"type":0},"channel_id":"1380488052169769113","context":0,"data":{"id":"1380515955146358918","name":"sign","options":[{"name":"message","type":3,"value":"llamas"}],"type":1},"entitlement_sku_ids":[],"entitlements":[],"guild":{"features":[],"id":"1380488052169769110","locale":"en-US"},"guild_id":"1380488052169769110","guild_locale":"en-US","id":"1381177107555680327","locale":"en-US","member":{"avatar":null,"banner":null,"communication_disabled_until":null,"deaf":false,"flags":0,"joined_at":"2025-06-06T10:06:39.888000+00:00","mute":false,"nick":null,"pending":false,"permissions":"2251799813685247","premium_since":null,"roles":[],"unusual_dm_activity_until":null,"user":{"avatar":"9c5483a989a10edc8b831b6c8f284724","avatar_decoration_data":null,"clan":null,"collectibles":null,"discriminator":"0","global_name":"kprasch","id":"410212090289192960","primary_guild":null,"public_flags":0,"username":"kprasch"}},"token":"aW50ZXJhY3Rpb246MTM4MTE3NzEwNzU1NTY4MDMyNzo2ZlVlTkdIQVFIdkdhNUN2bXlYZ1RCRkZ5YkpuVm9WUG5Bbjl0TTMyUkFTenZGYXNXclBCMjZWUWJlalczcllRak9sc0JZR3Q4WW9sODBRcDg2c2hrYmRkYzlWcjF3TjdlRFVDMVBVTkZ3Z2VmRUp4VkI1MkZGNmVvM3hkWXd1Qg","type":2,"version":1}'
+
+    public_key = bytes.fromhex(public_key_hex)
+    signature = bytes.fromhex(signature_hex)
+    message = timestamp.encode("utf-8") + body.encode("utf-8")
+
+    verify_key = nacl.signing.VerifyKey(public_key)
+    try:
+        verify_key.verify(message, signature)
+        verified = True
+    except nacl.exceptions.BadSignatureError:
+        verified = False
+
+    assert (
+        verified
+    ), "Discord Ed25519 signature should be valid for the given message and public key."
+
+
+def test_discord_ed25519_signature_with_ecdsa():
+    # Discord Ed25519 test vector
+    public_key_hex = "b853dd9f496723daf64bf2f5a886086f790df66e61d7b6f7f98a50c9e5ede8f3"
+    signature_hex = "0a12acb96843700b724f1c9dba3075a7fc482677e0c713eb6be63bfea406fb33b4715975f1062b2dff95127bd559ee23758911bd217760727dc44e7880bc6e04"
+    timestamp = "1749368683"
+    body = '{"app_permissions":"2248473465835073","application_id":"1380486651436073092","attachment_size_limit":10485760,"authorizing_integration_owners":{"0":"1380488052169769110"},"channel":{"flags":0,"guild_id":"1380488052169769110","icon_emoji":{"id":null,"name":"👋"},"id":"1380488052169769113","last_message_id":"1380528253168652328","name":"general","nsfw":false,"parent_id":"1380488052169769111","permissions":"2251799813685247","position":0,"rate_limit_per_user":0,"theme_color":null,"topic":null,"type":0},"channel_id":"1380488052169769113","context":0,"data":{"id":"1380515955146358918","name":"sign","options":[{"name":"message","type":3,"value":"llamas"}],"type":1},"entitlement_sku_ids":[],"entitlements":[],"guild":{"features":[],"id":"1380488052169769110","locale":"en-US"},"guild_id":"1380488052169769110","guild_locale":"en-US","id":"1381177107555680327","locale":"en-US","member":{"avatar":null,"banner":null,"communication_disabled_until":null,"deaf":false,"flags":0,"joined_at":"2025-06-06T10:06:39.888000+00:00","mute":false,"nick":null,"pending":false,"permissions":"2251799813685247","premium_since":null,"roles":[],"unusual_dm_activity_until":null,"user":{"avatar":"9c5483a989a10edc8b831b6c8f284724","avatar_decoration_data":null,"clan":null,"collectibles":null,"discriminator":"0","global_name":"kprasch","id":"410212090289192960","primary_guild":null,"public_flags":0,"username":"kprasch"}},"token":"aW50ZXJhY3Rpb246MTM4MTE3NzEwNzU1NTY4MDMyNzo2ZlVlTkdIQVFIdkdhNUN2bXlYZ1RCRkZ5YkpuVm9WUG5Bbjl0TTMyUkFTenZGYXNXclBCMjZWUWJlalczcllRak9sc0JZR3Q4WW9sODBRcDg2c2hrYmRkYzlWcjF3TjdlRFVDMVBVTkZ3Z2VmRUp4VkI1MkZGNmVvM3hkWXd1Qg","type":2,"version":1}'
+
+    public_key = bytes.fromhex(public_key_hex)
+    signature = bytes.fromhex(signature_hex)
+    message = timestamp.encode("utf-8") + body.encode("utf-8")
+
+    # Using nacl for Ed25519 verification
+    verify_key_nacl = nacl.signing.VerifyKey(public_key)
+    try:
+        verify_key_nacl.verify(message, signature)
+        verified_nacl = True
+    except nacl.exceptions.BadSignatureError:
+        verified_nacl = False
+
+    from ecdsa import Ed25519, VerifyingKey
+
+    try:
+        verify_key_ecdsa = VerifyingKey.from_string(public_key, curve=Ed25519)
+        verified_ecdsa = verify_key_ecdsa.verify(
+            signature, message, hashfunc=hashlib.sha256
+        )
+    except Exception:
+        verified_ecdsa = False
+
+    assert verified_nacl
+    assert verified_ecdsa

--- a/tests/unit/conditions/test_ecdsa_condition.py
+++ b/tests/unit/conditions/test_ecdsa_condition.py
@@ -1,9 +1,10 @@
 import hashlib
 import json
+
 import nacl.exceptions
 import nacl.signing
 import pytest
-from ecdsa.curves import SECP256k1, NIST192p
+from ecdsa.curves import NIST192p, SECP256k1
 from ecdsa.keys import SigningKey
 from ecdsa.util import sigencode_string
 from marshmallow import validates
@@ -95,7 +96,7 @@ def test_ecdsa_condition_missing_verifying_key():
 
 def test_ecdsa_condition_invalid_verifying_key():
     with pytest.raises(
-        InvalidCondition, match="'verifying_key' field - Invalid verifying key format"
+        InvalidCondition, match="Invalid verifying key format, must be hex encoded"
     ):
         _ = ECDSACondition(
             message=":message_variable",
@@ -109,6 +110,7 @@ def test_ecdsa_condition_initialization():
         message=":message_variable",
         signature=":signature_variable",
         verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1.name,
     )
 
     assert condition.message == ":message_variable"
@@ -146,6 +148,7 @@ def test_ecdsa_condition_verify_invalid_signature():
         message=":message_variable",
         signature=":signature_variable",
         verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1.name,
     )
 
     context = {

--- a/tests/unit/conditions/test_ecdsa_condition.py
+++ b/tests/unit/conditions/test_ecdsa_condition.py
@@ -1,9 +1,9 @@
-import base64
 import json
 
 import pytest
-from ecdsa import SECP256k1, SigningKey
-from ecdsa.util import sigencode_der
+from ecdsa.curves import SECP256k1
+from ecdsa.keys import SigningKey
+from ecdsa.util import sigencode_string
 from marshmallow import validates
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
@@ -15,15 +15,15 @@ from nucypher.policy.conditions.exceptions import (
 TEST_SIGNING_KEY = SigningKey.generate(curve=SECP256k1)
 TEST_VERIFYING_KEY = TEST_SIGNING_KEY.verifying_key
 
-# Get the PEM encoded verifying key
-TEST_VERIFYING_KEY_PEM = TEST_VERIFYING_KEY.to_pem().decode("utf-8")
+# Get the hex encoded verifying key
+TEST_VERIFYING_KEY_HEX = TEST_VERIFYING_KEY.to_string().hex()
 
 # Test message and signature
 TEST_MESSAGE = b"This is a test message for ECDSA verification"
 TEST_SIGNATURE = TEST_SIGNING_KEY.sign(
-    TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_der
+    TEST_MESSAGE, hashfunc=ECDSAVerificationCall._hash_func, sigencode=sigencode_string
 )
-TEST_SIGNATURE_B64 = base64.b64encode(TEST_SIGNATURE).decode("utf-8")
+TEST_SIGNATURE_HEX = TEST_SIGNATURE.hex()
 
 
 class TestECDSAVerificationCall(ECDSAVerificationCall):
@@ -40,8 +40,9 @@ class TestECDSAVerificationCall(ECDSAVerificationCall):
 def test_ecdsa_verification_call_valid():
     call = TestECDSAVerificationCall(
         message=TEST_MESSAGE,
-        signature=TEST_SIGNATURE_B64,
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        signature=TEST_SIGNATURE_HEX,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1,
     )
     assert call.execute()
 
@@ -51,14 +52,14 @@ def test_ecdsa_verification_call_invalid_signature():
     invalid_signature = TEST_SIGNING_KEY.sign(
         b"Different message",
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
-    )
-    invalid_signature_b64 = base64.b64encode(invalid_signature).decode("utf-8")
+        sigencode=sigencode_string,
+    ).hex()
 
     call = TestECDSAVerificationCall(
         message=TEST_MESSAGE,
-        signature=invalid_signature_b64,
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        signature=invalid_signature,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1,
     )
     assert not call.execute()
 
@@ -105,12 +106,12 @@ def test_ecdsa_condition_initialization():
     condition = ECDSACondition(
         message=":message_variable",
         signature=":signature_variable",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
     )
 
     assert condition.message == ":message_variable"
     assert condition.signature == ":signature_variable"
-    assert condition.verifying_key == TEST_VERIFYING_KEY_PEM
+    assert condition.verifying_key == TEST_VERIFYING_KEY_HEX
     assert condition.condition_type == ECDSACondition.CONDITION_TYPE
 
 
@@ -118,12 +119,13 @@ def test_ecdsa_condition_verify():
     condition = ECDSACondition(
         message=":message_variable",
         signature=":signature_variable",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1.name,
     )
 
     context = {
         ":message_variable": TEST_MESSAGE,
-        ":signature_variable": TEST_SIGNATURE_B64,
+        ":signature_variable": TEST_SIGNATURE_HEX,
     }
     success, result = condition.verify(**context)
     assert success
@@ -135,19 +137,18 @@ def test_ecdsa_condition_verify_invalid_signature():
     invalid_signature = TEST_SIGNING_KEY.sign(
         b"Different message",
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
-    )
-    invalid_signature_b64 = base64.b64encode(invalid_signature).decode("utf-8")
+        sigencode=sigencode_string,
+    ).hex()
 
     condition = ECDSACondition(
         message=":message_variable",
         signature=":signature_variable",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
     )
 
     context = {
         ":message_variable": TEST_MESSAGE,
-        ":signature_variable": invalid_signature_b64,
+        ":signature_variable": invalid_signature,
     }
     success, result = condition.verify(**context)
     assert not success
@@ -167,22 +168,21 @@ def test_ecdsa_condition_bytes_context():
     signature = TEST_SIGNING_KEY.sign(
         data=message_bytes,
         hashfunc=ECDSAVerificationCall._hash_func,
-        sigencode=sigencode_der,
-    )
-
-    signature_b64 = base64.b64encode(signature).decode("utf-8")
+        sigencode=sigencode_string,
+    ).hex()
 
     # Create an ECDSA condition
     ecdsa_condition = ECDSACondition(
         message=":bytes:message",
         signature=":signature",
-        verifying_key=TEST_VERIFYING_KEY_PEM,
+        verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=SECP256k1.name,
     )
 
     # Test with raw bytes in context
     context_with_bytes = {
         ":bytes:message": message_bytes.hex(),
-        ":signature": signature_b64,
+        ":signature": signature,
     }
 
     # The context should be serializable
@@ -197,7 +197,7 @@ def test_ecdsa_condition_bytes_context():
     # Test with hex string in context (backwards compatibility)
     context_with_hex = {
         ":bytes:message": message_bytes.hex(),
-        ":signature": signature_b64,
+        ":signature": signature,
     }
 
     # The context should be serializable
@@ -212,7 +212,7 @@ def test_ecdsa_condition_bytes_context():
     # Test with mixed types (some bytes, some hex)
     context_mixed = {
         ":bytes:message": message_bytes.hex(),
-        ":signature": signature_b64,
+        ":signature": signature,
     }
 
     # The context should be serializable

--- a/tests/unit/conditions/test_ecdsa_condition.py
+++ b/tests/unit/conditions/test_ecdsa_condition.py
@@ -296,6 +296,7 @@ def test_ecdsa_condition_bytes_context():
     assert success, "Verification should succeed with deserialized mixed context"
     assert result is True
 
+
 def test_discord_ed25519_signature():
     # Discord Ed25519 test vector
     public_key_hex = "b853dd9f496723daf64bf2f5a886086f790df66e61d7b6f7f98a50c9e5ede8f3"


### PR DESCRIPTION
**Type of PR:**
Feature

**Required reviews:** 
1

**What this does:**
- Supports All elliptic curves in `ecdsa` library for ECDSA verification
- Standardizes public keys and signatures to hex encoding for ECDSA conditions
- Expands testing of ECDSA conditions to support multicurve


**Why it's needed:**
Some applications (like discord bots) use other curves, namely, ED25519.

**Notes**
Based over #3605 

