### PR TITLE
UserOperation objects don't have an `initCode` field but instead have `factory` and `factoryData` fields

### DIFF
--- a/nucypher/utilities/erc4337_utils.py
+++ b/nucypher/utilities/erc4337_utils.py
@@ -8,6 +8,7 @@ import eth_abi
 from eth_utils import keccak, to_bytes, to_checksum_address
 from hexbytes import HexBytes
 
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.crypto.powers import TransactingPower
 
 
@@ -33,7 +34,8 @@ class UserOperation:
     # Base
     sender: str
     nonce: int
-    init_code: bytes = b""
+    factory: str = None
+    factory_data: bytes = b""
     call_data: bytes = b""
 
     # Gas limits
@@ -68,7 +70,8 @@ class UserOperation:
         return cls(
             sender=d["sender"],
             nonce=d["nonce"],
-            init_code=bytes(HexBytes(d.get("init_code") or b"")),
+            factory=d.get("factory"),
+            factory_data=bytes(HexBytes(d.get("factory_data") or b"")),
             call_data=bytes(HexBytes(d.get("call_data") or b"")),
             call_gas_limit=d.get("call_gas_limit", 0),
             verification_gas_limit=d.get("verification_gas_limit", 0),
@@ -88,7 +91,8 @@ class UserOperation:
         return {
             "sender": self.sender,
             "nonce": self.nonce,
-            "init_code": HexBytes(self.init_code).hex(),
+            "factory": self.factory,
+            "factory_data": HexBytes(self.factory_data).hex(),
             "call_data": HexBytes(self.call_data).hex(),
             "call_gas_limit": self.call_gas_limit,
             "verification_gas_limit": self.verification_gas_limit,
@@ -181,12 +185,23 @@ class PackedUserOperation:
         return paymaster_bytes + verification_bytes + post_op_bytes + paymaster_data
 
     @classmethod
+    def _pack_init_code(cls, factory: str, factory_data: bytes) -> bytes:
+        if not factory:
+            return b""
+
+        factory_bytes = to_bytes(hexstr=factory)
+        if not factory_bytes or factory_bytes == bytes(HexBytes(NULL_ADDRESS)):
+            return b""
+
+        return factory_bytes + factory_data
+
+    @classmethod
     def from_user_operation(cls, user_op: UserOperation) -> "PackedUserOperation":
         """Convert a UserOperation to a PackedUserOperation."""
         return cls(
             sender=user_op.sender,
             nonce=user_op.nonce,
-            init_code=user_op.init_code,
+            init_code=cls._pack_init_code(user_op.factory, user_op.factory_data),
             call_data=user_op.call_data,
             account_gas_limits=cls._pack_account_gas_limits(
                 user_op.call_gas_limit, user_op.verification_gas_limit
@@ -310,7 +325,7 @@ def create_eth_transfer(
         "execute(address,uint256,bytes)",
         [to_checksum_address(to), value, b""],
     )
-    return UserOperation(sender, nonce, b"", data, **kwargs)
+    return UserOperation(sender, nonce, None, b"", data, **kwargs)
 
 
 def create_erc20_transfer(
@@ -322,7 +337,7 @@ def create_erc20_transfer(
     data = encode_function_call(
         "execute(address,uint256,bytes)", [to_checksum_address(token), 0, call]
     )
-    return UserOperation(sender, nonce, b"", data, **kwargs)
+    return UserOperation(sender, nonce, None, b"", data, **kwargs)
 
 
 def create_erc20_approve(
@@ -334,7 +349,7 @@ def create_erc20_approve(
     data = encode_function_call(
         "execute(address,uint256,bytes)", [to_checksum_address(token), 0, call]
     )
-    return UserOperation(sender, nonce, b"", data, **kwargs)
+    return UserOperation(sender, nonce, None, b"", data, **kwargs)
 
 
 def create_contract_call(
@@ -343,4 +358,4 @@ def create_contract_call(
     payload = encode_function_call(
         "execute(address,uint256,bytes)", [to_checksum_address(target), value, data]
     )
-    return UserOperation(sender, nonce, b"", payload, **kwargs)
+    return UserOperation(sender, nonce, None, b"", payload, **kwargs)

--- a/tests/acceptance/actors/test_user_op_processing.py
+++ b/tests/acceptance/actors/test_user_op_processing.py
@@ -1,6 +1,9 @@
+import os
+
 import pytest
 from eth_account import Account
 
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.utilities.erc4337_utils import (
     AAVersion,
     PackedUserOperation,
@@ -14,11 +17,13 @@ def transactor(initiator):
 
 
 @pytest.fixture(scope="module")
-def user_op(accounts):
+def user_op(accounts, get_random_checksum_address):
     user_op = UserOperation(
         sender=accounts[0].address,
         nonce=0,
-        call_data=b"deadbeef",
+        factory=get_random_checksum_address(),
+        factory_data=os.urandom(23),
+        call_data=os.urandom(32),
         verification_gas_limit=100000,
         # these should all be unique values (for proper testing)
         call_gas_limit=100000,
@@ -133,3 +138,37 @@ def test_packed_user_operation_paymaster_and_data_packing(
         == user_op.paymaster_post_op_gas_limit
     )
     assert aa_entry_point.paymasterData(packed_user_op_dict) == user_op.paymaster_data
+
+
+def test_packed_user_operation_init_code_packing(
+    accounts, chain, user_op, aa_entry_point
+):
+    # retrieved individual factory values packed into factory should match
+    packed_user_op = PackedUserOperation.from_user_operation(user_op)
+    packed_user_op_dict = packed_user_op.to_eip712_struct(
+        AAVersion.V08, chain.chain_id
+    )["message"]
+    packed_user_op_dict["signature"] = b""
+    assert aa_entry_point.factory(packed_user_op_dict) == user_op.factory
+    assert aa_entry_point.factoryData(packed_user_op_dict) == user_op.factory_data
+
+    # factory with no data
+    user_op.factory_data = b""
+    packed_user_op = PackedUserOperation.from_user_operation(user_op)
+    packed_user_op_dict = packed_user_op.to_eip712_struct(
+        AAVersion.V08, chain.chain_id
+    )["message"]
+    packed_user_op_dict["signature"] = b""
+    assert aa_entry_point.factory(packed_user_op_dict) == user_op.factory
+    assert aa_entry_point.factoryData(packed_user_op_dict) == b""
+
+    # retry with empty values
+    user_op.factory = None
+    user_op.factory_data = b""
+    packed_user_op = PackedUserOperation.from_user_operation(user_op)
+    packed_user_op_dict = packed_user_op.to_eip712_struct(
+        AAVersion.V08, chain.chain_id
+    )["message"]
+    packed_user_op_dict["signature"] = b""
+    assert aa_entry_point.factory(packed_user_op_dict) == NULL_ADDRESS
+    assert aa_entry_point.factoryData(packed_user_op_dict) == b""

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,7 +1,6 @@
 import random
 
 import pytest
-from eth.constants import ZERO_ADDRESS
 from web3 import Web3
 
 import tests
@@ -13,6 +12,7 @@ from nucypher.blockchain.eth.agents import (
     TACoApplicationAgent,
     TACoChildApplicationAgent,
 )
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry, RegistrySourceManager
 from nucypher.utilities.logging import Logger
@@ -335,7 +335,7 @@ def signing_coordinator_child(
     # current chain
     signing_coordinator_dispatcher.register(
         chain.chain_id,
-        ZERO_ADDRESS,
+        NULL_ADDRESS,
         _signing_coordinator_child.address,
         sender=deployer_account,
     )

--- a/tests/acceptance/contracts/EntryPoint.sol
+++ b/tests/acceptance/contracts/EntryPoint.sol
@@ -136,4 +136,14 @@ contract EntryPoint is EIP712 {
     function paymasterData(PackedUserOperation calldata userOp) public pure returns (bytes calldata) {
         return ERC4337Utils.paymasterData(userOp);
     }
+
+    /// @dev Returns `factory` from the {PackedUserOperation}, or address(0) if the initCode is empty or not properly formatted.
+    function factory(PackedUserOperation calldata userOp) public pure returns (address) {
+        return ERC4337Utils.factory(userOp);
+    }
+
+    /// @dev Returns `factoryData` from the {PackedUserOperation}, or empty bytes if the initCode is empty or not properly formatted.
+    function factoryData(PackedUserOperation calldata userOp) public pure returns (bytes calldata) {
+        return ERC4337Utils.factoryData(userOp);
+    }
 }

--- a/tests/unit/test_erc4337_utils.py
+++ b/tests/unit/test_erc4337_utils.py
@@ -1,10 +1,13 @@
+import os
 from unittest.mock import Mock
 
 import pytest
 from eth_account import Account
 from eth_account.messages import _hash_eip191_message, encode_typed_data
 from eth_utils import keccak
+from hexbytes import HexBytes
 
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.policy.conditions.utils import camel_case_to_snake
 from nucypher.utilities.erc4337_utils import (
     AAVersion,
@@ -23,12 +26,13 @@ class TestPackedUserOperation:
     """Test suite for PackedUserOperation class"""
 
     @pytest.fixture
-    def sample_user_op(self):
+    def sample_user_op(self, get_random_checksum_address):
         """Create a sample PackedUserOperation for testing"""
         return UserOperation(
             sender="0x1234567890123456789012345678901234567890",
             nonce=1,
-            init_code=b"\x12\x34",
+            factory="0x27BbA3872e3e00632A200C08F7CD9E999a36BA85",
+            factory_data=b"\x12\x34",
             call_data=b"\x56\x78",
             verification_gas_limit=100000,
             call_gas_limit=200000,
@@ -53,7 +57,8 @@ class TestPackedUserOperation:
         """Test PackedUserOperation initialization with all fields"""
         assert sample_user_op.sender == "0x1234567890123456789012345678901234567890"
         assert sample_user_op.nonce == 1
-        assert sample_user_op.init_code == b"\x12\x34"
+        assert sample_user_op.factory == "0x27BbA3872e3e00632A200C08F7CD9E999a36BA85"
+        assert sample_user_op.factory_data == b"\x12\x34"
         assert sample_user_op.call_data == b"\x56\x78"
         assert sample_user_op.verification_gas_limit == 100000
         assert sample_user_op.call_gas_limit == 200000
@@ -70,7 +75,8 @@ class TestPackedUserOperation:
         """Test PackedUserOperation initialization with minimal fields"""
         assert minimal_user_op.sender == "0x1234567890123456789012345678901234567890"
         assert minimal_user_op.nonce == 0
-        assert minimal_user_op.init_code == b""
+        assert minimal_user_op.factory is None
+        assert minimal_user_op.factory_data == b""
         assert minimal_user_op.call_data == b""
         assert minimal_user_op.verification_gas_limit == 0
         assert minimal_user_op.call_gas_limit == 0
@@ -90,7 +96,8 @@ class TestPackedUserOperation:
 
             assert deserialized_op.sender == user_op.sender
             assert deserialized_op.nonce == user_op.nonce
-            assert deserialized_op.init_code == user_op.init_code
+            assert deserialized_op.factory == user_op.factory
+            assert deserialized_op.factory_data == user_op.factory_data
             assert deserialized_op.call_data == user_op.call_data
             assert (
                 deserialized_op.verification_gas_limit == user_op.verification_gas_limit
@@ -162,6 +169,53 @@ class TestPackedUserOperation:
         ) | sample_user_op.max_fee_per_gas
         assert packed_user_op.gas_fees == expected.to_bytes(32, byteorder="big")
 
+    def test_get_init_code(
+        self, get_random_checksum_address, sample_user_op, minimal_user_op
+    ):
+        # no factory or factory data
+        init_code = PackedUserOperation._pack_init_code(None, b"")
+        assert init_code == b""
+
+        # factory as zero address, no factory data
+        init_code = PackedUserOperation._pack_init_code(NULL_ADDRESS, b"")
+        assert init_code == b""
+
+        # factory as zero address, w/ factory data (should never happen but we still handle this case)
+        init_code = PackedUserOperation._pack_init_code(NULL_ADDRESS, os.urandom(15))
+        assert init_code == b""
+
+        # factory as 0x str, no factory data (should never happen but we still handle this case)
+        factory = "0x"
+        init_code = PackedUserOperation._pack_init_code(factory, b"")
+        assert init_code == b""
+
+        # factory as 0x str, w/ factory data (should never happen but we still handle this case)
+        factory = "0x"
+        init_code = PackedUserOperation._pack_init_code(factory, os.urandom(15))
+        assert init_code == b""
+
+        # factory, no factory data
+        factory = get_random_checksum_address()
+        init_code = PackedUserOperation._pack_init_code(factory, b"")
+        assert init_code == bytes(HexBytes(factory))
+
+        # factory, factory data
+        factory = get_random_checksum_address()
+        factory_data = os.urandom(23)
+        init_code = PackedUserOperation._pack_init_code(factory, factory_data)
+        assert init_code == bytes(HexBytes(factory)) + factory_data
+
+        # when generating from user operations
+        packed_user_op = PackedUserOperation.from_user_operation(sample_user_op)
+        assert packed_user_op.init_code == (
+            bytes(HexBytes(sample_user_op.factory)) + sample_user_op.factory_data
+        )
+
+        packed_user_op_minimal = PackedUserOperation.from_user_operation(
+            minimal_user_op
+        )
+        assert packed_user_op_minimal.init_code == b""
+
     def test_packed_user_op_methods(self, sample_user_op):
         """Test the pack method returns correct dictionary structure"""
         packed_user_op = PackedUserOperation.from_user_operation(sample_user_op)
@@ -169,7 +223,9 @@ class TestPackedUserOperation:
         # Verify types and values
         assert packed_user_op.sender == sample_user_op.sender
         assert packed_user_op.nonce == sample_user_op.nonce
-        assert packed_user_op.init_code == sample_user_op.init_code
+        assert packed_user_op.init_code == (
+            bytes(HexBytes(sample_user_op.factory)) + sample_user_op.factory_data
+        )
         assert packed_user_op.call_data == sample_user_op.call_data
         assert (
             packed_user_op.pre_verification_gas == sample_user_op.pre_verification_gas
@@ -442,7 +498,8 @@ class TestHelperFunctions:
         assert isinstance(user_op, UserOperation)
         assert user_op.sender == common_params["sender"]
         assert user_op.nonce == common_params["nonce"]
-        assert user_op.init_code == b""
+        assert user_op.factory is None
+        assert user_op.factory_data == b""
         assert len(user_op.call_data) > 0
 
         # Verify the call data contains the execute function call
@@ -547,7 +604,8 @@ class TestERC4337Compatibility:
         required_fields = [
             "sender",
             "nonce",
-            "init_code",
+            "factory",
+            "factory_data",
             "call_data",
             "verification_gas_limit",
             "call_gas_limit",
@@ -660,7 +718,8 @@ class TestERC4337Compatibility:
         return UserOperation(
             sender="0x1234567890123456789012345678901234567890",
             nonce=1,
-            init_code=b"\x12\x34",
+            factory="0x27BbA3872e3e00632A200C08F7CD9E999a36BA85",
+            factory_data=b"\x12\x34",
             call_data=b"\x56\x78",
             verification_gas_limit=100000,
             call_gas_limit=200000,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Stick to the latest spec for `UserOperation` - https://github.com/ethereum/ercs/blob/master/ERCS/erc-4337.md#useroperation

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
