### PR TITLE
Attribute-based Signing Object Condition

### DIFF
--- a/newsfragments/3606.feature.rst
+++ b/newsfragments/3606.feature.rst
@@ -1,0 +1,2 @@
+Allow signing logic that can inspect and enforce rules on various attributes of the object
+being signed via a flexible, attribute-based condition.

--- a/nucypher/network/signing.py
+++ b/nucypher/network/signing.py
@@ -21,7 +21,6 @@ class SignatureRequestType(Enum):
     USEROP = "userop"
     PACKED_USER_OP = "packedUserOp"
     EIP_191 = "eip-191"
-    EIP_712 = "eip-712"
 
 
 # TODO I'm hesitant to have too much logic in this module because

--- a/nucypher/network/signing.py
+++ b/nucypher/network/signing.py
@@ -1,11 +1,12 @@
 import json
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from hexbytes import HexBytes
 
 from nucypher.crypto.powers import TransactingPower
+from nucypher.policy.conditions.signing.base import SIGNING_CONDITION_OBJECT_CONTEXT_VAR
 from nucypher.policy.conditions.types import ContextDict
 from nucypher.utilities.erc4337_utils import (
     AAVersion,
@@ -352,13 +353,36 @@ def deserialize_signature_request(
         signature_type_str = result["signature_type"]
         signature_type = SignatureRequestType(signature_type_str)
 
+        signature_request = None
         if signature_type == SignatureRequestType.USEROP:
-            return UserOperationSignatureRequest.from_bytes(request_data)
+            signature_request = UserOperationSignatureRequest.from_bytes(request_data)
         elif signature_type == SignatureRequestType.PACKED_USER_OP:
-            return PackedUserOperationSignatureRequest.from_bytes(request_data)
+            signature_request = PackedUserOperationSignatureRequest.from_bytes(
+                request_data
+            )
         elif signature_type == SignatureRequestType.EIP_191:
-            return EIP191SignatureRequest.from_bytes(request_data)
+            signature_request = EIP191SignatureRequest.from_bytes(request_data)
 
-        raise ValueError(f"Invalid signature request type: {signature_type}")
+        if not signature_request:
+            raise ValueError(f"Invalid signature request type: {signature_type}")
+
+        # add the signing object to the context
+        signing_object = get_signature_request_object(signature_request)
+        signature_request.context[SIGNING_CONDITION_OBJECT_CONTEXT_VAR] = signing_object
+
+        return signature_request
+
     except (json.JSONDecodeError, ValueError) as e:
         raise ValueError("Invalid signature request data") from e
+
+
+def get_signature_request_object(request: BaseSignatureRequest) -> Any:
+    """Get the signature request object based on the request type."""
+    if isinstance(request, UserOperationSignatureRequest):
+        return request.user_op
+    elif isinstance(request, PackedUserOperationSignatureRequest):
+        return request.packed_user_op
+    elif isinstance(request, EIP191SignatureRequest):
+        return request.data
+
+    raise ValueError(f"Unsupported signature request: {request.__class__.__name__}")

--- a/nucypher/network/signing.py
+++ b/nucypher/network/signing.py
@@ -35,8 +35,6 @@ class BaseSignatureRequest(ABC):
         signature_type: SignatureRequestType,
         context: Optional[ContextDict] = None,
     ):
-        if not isinstance(signature_type, SignatureRequestType):
-            raise ValueError(f"Invalid signature type: {signature_type}")
         self.cohort_id = cohort_id
         self.chain_id = chain_id
         self.context = context or {}
@@ -153,14 +151,6 @@ class UserOperationSignatureRequest(BaseSignatureRequest):
         aa_version: AAVersion,
         context: Optional[ContextDict] = None,
     ):
-
-        if not isinstance(user_op, UserOperation):
-            raise ValueError("UserOp must be an instance of UserOperation.")
-        if aa_version is None:
-            raise ValueError(
-                "AA version must be specified for UserOperation signing request."
-            )
-
         self.user_op = user_op
         self.aa_version = aa_version
         super().__init__(
@@ -200,22 +190,15 @@ class UserOperationSignatureRequest(BaseSignatureRequest):
         except (json.JSONDecodeError, KeyError) as e:
             raise ValueError("Invalid UserOperation request data") from e
 
-        try:
-            aa_version = AAVersion(aa_version_str)
+        aa_version = AAVersion(aa_version_str)
 
-            # Validate signature type
-            signature_type = SignatureRequestType(signature_type_str)
-            if signature_type != SignatureRequestType.USEROP:
-                raise ValueError(
-                    f"Expected USEROP signature type, got {signature_type}"
-                )
+        # Validate signature type
+        signature_type = SignatureRequestType(signature_type_str)
+        if signature_type != SignatureRequestType.USEROP:
+            raise ValueError(f"Expected USEROP signature type, got {signature_type}")
 
-            # Reconstruct the UserOperation
-            user_op = UserOperation.from_bytes(user_op_data.encode("utf-8"))
-
-        except ValueError:
-            # Re-raise ValueError as-is (includes our validation errors)
-            raise
+        # Reconstruct the UserOperation
+        user_op = UserOperation.from_bytes(user_op_data.encode("utf-8"))
 
         return cls(
             user_op=user_op,
@@ -237,13 +220,6 @@ class PackedUserOperationSignatureRequest(BaseSignatureRequest):
         aa_version: AAVersion,
         context: Optional[ContextDict] = None,
     ):
-
-        if not isinstance(packed_user_op, PackedUserOperation):
-            raise ValueError("UserOp must be an instance of PackedUserOperation.")
-        if aa_version is None:
-            raise ValueError(
-                "AA version must be specified for UserOperation signing request."
-            )
 
         self.packed_user_op = packed_user_op
         self.aa_version = aa_version
@@ -284,24 +260,17 @@ class PackedUserOperationSignatureRequest(BaseSignatureRequest):
         except (json.JSONDecodeError, KeyError) as e:
             raise ValueError("Invalid PackedUserOperation request data") from e
 
-        try:
-            aa_version = AAVersion(aa_version_str)
+        aa_version = AAVersion(aa_version_str)
 
-            # Validate signature type
-            signature_type = SignatureRequestType(signature_type_str)
-            if signature_type != SignatureRequestType.PACKED_USER_OP:
-                raise ValueError(
-                    f"Expected PACKED_USER_OP signature type, got {signature_type}"
-                )
-
-            # Reconstruct the UserOperation
-            packed_user_op = PackedUserOperation.from_bytes(
-                user_op_data.encode("utf-8")
+        # Validate signature type
+        signature_type = SignatureRequestType(signature_type_str)
+        if signature_type != SignatureRequestType.PACKED_USER_OP:
+            raise ValueError(
+                f"Expected PACKED_USER_OP signature type, got {signature_type}"
             )
 
-        except ValueError:
-            # Re-raise ValueError as-is (includes our validation errors)
-            raise
+        # Reconstruct the UserOperation
+        packed_user_op = PackedUserOperation.from_bytes(user_op_data.encode("utf-8"))
 
         return cls(
             packed_user_op=packed_user_op,

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -54,7 +54,7 @@ class _Serializable:
         return instance
 
 
-class AccessControlCondition(_Serializable, ABC):
+class Condition(_Serializable, ABC):
     CONDITION_TYPE = NotImplemented
 
     class Schema(CamelCaseSchema):
@@ -84,33 +84,33 @@ class AccessControlCondition(_Serializable, ABC):
             )
 
     @classmethod
-    def from_dict(cls, data) -> "AccessControlCondition":
+    def from_dict(cls, data) -> "Condition":
         try:
             return super().from_dict(data)
         except ValidationError as e:
             raise InvalidConditionLingo(f"Invalid condition grammar: {e}") from e
 
     @classmethod
-    def from_json(cls, data) -> "AccessControlCondition":
+    def from_json(cls, data) -> "Condition":
         try:
             return super().from_json(data)
         except ValidationError as e:
             raise InvalidConditionLingo(f"Invalid condition grammar: {e}") from e
 
 
-class MultiConditionAccessControl(AccessControlCondition):
+class MultiCondition(Condition):
     MAX_NUM_CONDITIONS = 5
     MAX_MULTI_CONDITION_NESTED_LEVEL = 2
 
     @property
     @abstractmethod
-    def conditions(self) -> List[AccessControlCondition]:
+    def conditions(self) -> List[Condition]:
         raise NotImplementedError
 
     @classmethod
     def _validate_multi_condition_nesting(
         cls,
-        conditions: List[AccessControlCondition],
+        conditions: List[Condition],
         field_name: str,
         current_level: int = 1,
     ):
@@ -121,7 +121,7 @@ class MultiConditionAccessControl(AccessControlCondition):
             )
 
         for condition in conditions:
-            if not isinstance(condition, MultiConditionAccessControl):
+            if not isinstance(condition, MultiCondition):
                 continue
 
             level = current_level + 1

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -53,6 +53,12 @@ class _Serializable:
         instance = cls.from_json(json_payload)
         return instance
 
+    def _validate(self, **kwargs):
+        errors = self.Schema().validate(data=self.to_dict())
+        if errors:
+            error_message = extract_single_error_message_from_schema_errors(errors)
+            raise ValueError(f"Invalid {self.__class__.__name__}: {error_message}")
+
 
 class Condition(_Serializable, ABC):
     CONDITION_TYPE = NotImplemented
@@ -68,20 +74,15 @@ class Condition(_Serializable, ABC):
         self.condition_type = condition_type
         self.name = name
 
-        self._validate()
+        try:
+            self._validate()
+        except ValueError as e:
+            raise InvalidCondition(f"{e}")
 
     @abstractmethod
     def verify(self, *args, **kwargs) -> Tuple[bool, Any]:
         """Returns the boolean result of the evaluation and the returned value in a two-tuple."""
         raise NotImplementedError
-
-    def _validate(self, **kwargs):
-        errors = self.Schema().validate(data=self.to_dict())
-        if errors:
-            error_message = extract_single_error_message_from_schema_errors(errors)
-            raise InvalidCondition(
-                f"Invalid {self.__class__.__name__}: {error_message}"
-            )
 
     @classmethod
     def from_dict(cls, data) -> "Condition":
@@ -146,10 +147,10 @@ class ExecutionCall(_Serializable, ABC):
 
     def __init__(self):
         # validate call using marshmallow schema before creating
-        errors = self.Schema().validate(data=self.to_dict())
-        if errors:
-            error_message = extract_single_error_message_from_schema_errors(errors)
-            raise self.InvalidExecutionCall(f"{error_message}")
+        try:
+            self._validate()
+        except ValueError as e:
+            raise self.InvalidExecutionCall(f"{e}")
 
     @abstractmethod
     def execute(self, *args, **kwargs) -> Any:

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -13,7 +13,7 @@ from nucypher.policy.conditions.exceptions import (
 )
 from nucypher.policy.conditions.utils import (
     ConditionProviderManager,
-    check_and_convert_big_int_string_to_int,
+    check_and_convert_any_big_ints,
 )
 
 USER_ADDRESS_CONTEXT = ":userAddress"
@@ -138,9 +138,9 @@ def get_context_value(
                 raise InvalidContextVariableData(
                     f'Invalid bytes context variable "{context_variable}"; expected a hex string'
                 )
-        elif isinstance(value, str):
-            # possible big int value
-            value = check_and_convert_big_int_string_to_int(value)
+
+        # possibly contains big int value(s)
+        value = check_and_convert_any_big_ints(value)
 
     return value
 

--- a/nucypher/policy/conditions/ecdsa.py
+++ b/nucypher/policy/conditions/ecdsa.py
@@ -13,7 +13,7 @@ from marshmallow import (
     validates_schema,
 )
 
-from nucypher.policy.conditions.base import AccessControlCondition, ExecutionCall
+from nucypher.policy.conditions.base import Condition, ExecutionCall
 from nucypher.policy.conditions.context import (
     USER_ADDRESS_CONTEXT,
     is_context_variable,
@@ -151,7 +151,7 @@ class ECDSAVerificationCall(ExecutionCall):
             return False
 
 
-class ECDSACondition(AccessControlCondition):
+class ECDSACondition(Condition):
     """
     An ECDSA condition is satisfied when a provided signature can be verified
     against a message using the provided verifying key.
@@ -164,7 +164,7 @@ class ECDSACondition(AccessControlCondition):
 
     CONDITION_TYPE = "ecdsa"  # Add this to ConditionType enum
 
-    class Schema(AccessControlCondition.Schema, ECDSAVerificationCall.Schema):
+    class Schema(Condition.Schema, ECDSAVerificationCall.Schema):
         condition_type = fields.Str(validate=validate.Equal("ecdsa"), required=True)
 
         @post_load

--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -35,7 +35,7 @@ from nucypher.policy.conditions.exceptions import (
 from nucypher.policy.conditions.lingo import (
     AnyField,
     ConditionType,
-    ExecutionCallAccessControlCondition,
+    ExecutionCallCondition,
     ReturnValueTest,
 )
 from nucypher.policy.conditions.utils import (
@@ -140,11 +140,11 @@ class RPCCall(ExecutionCall):
         return rpc_result
 
 
-class RPCCondition(ExecutionCallAccessControlCondition):
+class RPCCondition(ExecutionCallCondition):
     EXECUTION_CALL_TYPE = RPCCall
     CONDITION_TYPE = ConditionType.RPC.value
 
-    class Schema(ExecutionCallAccessControlCondition.Schema, RPCCall.Schema):
+    class Schema(ExecutionCallCondition.Schema, RPCCall.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.RPC.value), required=True
         )

--- a/nucypher/policy/conditions/json/api.py
+++ b/nucypher/policy/conditions/json/api.py
@@ -13,7 +13,7 @@ from nucypher.policy.conditions.json.base import (
 )
 from nucypher.policy.conditions.lingo import (
     ConditionType,
-    ExecutionCallAccessControlCondition,
+    ExecutionCallCondition,
     ReturnValueTest,
 )
 from nucypher.utilities.logging import Logger
@@ -71,7 +71,7 @@ class JsonApiCondition(BaseJsonRequestCondition):
     EXECUTION_CALL_TYPE = JsonApiCall
     CONDITION_TYPE = ConditionType.JSONAPI.value
 
-    class Schema(ExecutionCallAccessControlCondition.Schema, JsonApiCall.Schema):
+    class Schema(ExecutionCallCondition.Schema, JsonApiCall.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.JSONAPI.value), required=True
         )

--- a/nucypher/policy/conditions/json/base.py
+++ b/nucypher/policy/conditions/json/base.py
@@ -18,7 +18,7 @@ from nucypher.policy.conditions.exceptions import (
     JsonRequestException,
 )
 from nucypher.policy.conditions.json.utils import process_result_for_condition_eval
-from nucypher.policy.conditions.lingo import ExecutionCallAccessControlCondition
+from nucypher.policy.conditions.lingo import ExecutionCallCondition
 from nucypher.utilities.logging import Logger
 
 
@@ -144,7 +144,7 @@ class JSONPathField(Field):
         return value
 
 
-class BaseJsonRequestCondition(ExecutionCallAccessControlCondition, ABC):
+class BaseJsonRequestCondition(ExecutionCallCondition, ABC):
     def verify(self, **context) -> Tuple[bool, Any]:
         """
         Verifies the JSON condition.

--- a/nucypher/policy/conditions/json/rpc.py
+++ b/nucypher/policy/conditions/json/rpc.py
@@ -19,7 +19,7 @@ from nucypher.policy.conditions.json.base import (
 from nucypher.policy.conditions.lingo import (
     AnyField,
     ConditionType,
-    ExecutionCallAccessControlCondition,
+    ExecutionCallCondition,
     ReturnValueTest,
 )
 
@@ -121,9 +121,7 @@ class JsonRpcCondition(BaseJsonRequestCondition):
     EXECUTION_CALL_TYPE = JsonEndpointRPCCall
     CONDITION_TYPE = ConditionType.JSONRPC.value
 
-    class Schema(
-        ExecutionCallAccessControlCondition.Schema, JsonEndpointRPCCall.Schema
-    ):
+    class Schema(ExecutionCallCondition.Schema, JsonEndpointRPCCall.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.JSONRPC.value), required=True
         )

--- a/nucypher/policy/conditions/jwt.py
+++ b/nucypher/policy/conditions/jwt.py
@@ -6,7 +6,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives.serialization import load_pem_public_key
 from marshmallow import ValidationError, fields, post_load, validate, validates
 
-from nucypher.policy.conditions.base import AccessControlCondition, ExecutionCall
+from nucypher.policy.conditions.base import Condition, ExecutionCall
 from nucypher.policy.conditions.context import (
     is_context_variable,
     resolve_any_context_variables,
@@ -99,7 +99,7 @@ class JWTVerificationCall(ExecutionCall):
         return payload
 
 
-class JWTCondition(AccessControlCondition):
+class JWTCondition(Condition):
     """
     A JWT condition can be satisfied by presenting a valid JWT token, which not only is
     required to be cryptographically verifiable, but also must fulfill certain additional
@@ -108,7 +108,7 @@ class JWTCondition(AccessControlCondition):
 
     CONDITION_TYPE = ConditionType.JWT.value
 
-    class Schema(AccessControlCondition.Schema, JWTVerificationCall.Schema):
+    class Schema(Condition.Schema, JWTVerificationCall.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.JWT.value), required=True
         )

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -39,6 +39,7 @@ from nucypher.policy.conditions.types import ConditionDict, Lingo
 from nucypher.policy.conditions.utils import (
     CamelCaseSchema,
     ConditionProviderManager,
+    check_and_convert_any_big_ints,
     check_and_convert_big_int_string_to_int,
 )
 
@@ -50,23 +51,11 @@ class AnyField(fields.Field):
     numbers as integers, so those need converting to integers.
     """
 
-    def _convert_any_big_ints_from_string(self, value):
-        if isinstance(value, list):
-            return [self._convert_any_big_ints_from_string(item) for item in value]
-        elif isinstance(value, dict):
-            return {
-                k: self._convert_any_big_ints_from_string(v) for k, v in value.items()
-            }
-        elif isinstance(value, str):
-            return check_and_convert_big_int_string_to_int(value)
-
-        return value
-
     def _serialize(self, value, attr, obj, **kwargs):
         return value
 
     def _deserialize(self, value, attr, data, **kwargs):
-        return self._convert_any_big_ints_from_string(value)
+        return check_and_convert_any_big_ints(value)
 
 
 class AnyLargeIntegerField(fields.Int):

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -21,9 +21,9 @@ from marshmallow.validate import OneOf, Range
 from packaging.version import parse as parse_version
 
 from nucypher.policy.conditions.base import (
-    AccessControlCondition,
+    Condition,
     ExecutionCall,
-    MultiConditionAccessControl,
+    MultiCondition,
     _Serializable,
 )
 from nucypher.policy.conditions.context import (
@@ -140,7 +140,7 @@ class Operator(Enum):
         return [op.value for op in cls]
 
 
-class CompoundAccessControlCondition(MultiConditionAccessControl):
+class CompoundCondition(MultiCondition):
     """
     A combination of two or more conditions connected by logical operators such as AND, OR, NOT.
 
@@ -166,7 +166,7 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
     def _validate_operator_and_operands(
         cls,
         operator: str,
-        operands: List[AccessControlCondition],
+        operands: List[Condition],
     ):
         if operator not in cls.OPERATORS:
             raise ValidationError(
@@ -191,7 +191,7 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
                 message="Maximum of {cls.MAX_NUM_CONDITIONS} operands allowed for '{operator}' compound condition",
             )
 
-    class Schema(AccessControlCondition.Schema):
+    class Schema(Condition.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.COMPOUND.value), required=True
         )
@@ -206,21 +206,19 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
         def validate_operator_and_operands(self, data, **kwargs):
             operator = data["operator"]
             operands = data["operands"]
-            CompoundAccessControlCondition._validate_operator_and_operands(
-                operator, operands
-            )
-            CompoundAccessControlCondition._validate_multi_condition_nesting(
+            CompoundCondition._validate_operator_and_operands(operator, operands)
+            CompoundCondition._validate_multi_condition_nesting(
                 conditions=operands, field_name="operands"
             )
 
         @post_load
         def make(self, data, **kwargs):
-            return CompoundAccessControlCondition(**data)
+            return CompoundCondition(**data)
 
     def __init__(
         self,
         operator: str,
-        operands: List[AccessControlCondition],
+        operands: List[Condition],
         condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
     ):
@@ -270,18 +268,18 @@ class CompoundAccessControlCondition(MultiConditionAccessControl):
         return self.operands
 
 
-class OrCompoundCondition(CompoundAccessControlCondition):
-    def __init__(self, operands: List[AccessControlCondition]):
+class OrCompoundCondition(CompoundCondition):
+    def __init__(self, operands: List[Condition]):
         super().__init__(operator=self.OR_OPERATOR, operands=operands)
 
 
-class AndCompoundCondition(CompoundAccessControlCondition):
-    def __init__(self, operands: List[AccessControlCondition]):
+class AndCompoundCondition(CompoundCondition):
+    def __init__(self, operands: List[Condition]):
         super().__init__(operator=self.AND_OPERATOR, operands=operands)
 
 
-class NotCompoundCondition(CompoundAccessControlCondition):
-    def __init__(self, operand: AccessControlCondition):
+class NotCompoundCondition(CompoundCondition):
+    def __init__(self, operand: Condition):
         super().__init__(operator=self.NOT_OPERATOR, operands=[operand])
 
 
@@ -304,12 +302,12 @@ class ConditionVariable(_Serializable):
         def make(self, data, **kwargs):
             return ConditionVariable(**data)
 
-    def __init__(self, var_name: str, condition: AccessControlCondition):
+    def __init__(self, var_name: str, condition: Condition):
         self.var_name = var_name
         self.condition = condition
 
 
-class SequentialAccessControlCondition(MultiConditionAccessControl):
+class SequentialCondition(MultiCondition):
     """
     A series of conditions that are evaluated in a specific order, where the result of one
     condition can be used in subsequent conditions.
@@ -358,7 +356,7 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
                 )
             var_names.add(condition_variable.var_name)
 
-    class Schema(AccessControlCondition.Schema):
+    class Schema(Condition.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.SEQUENTIAL.value), required=True
         )
@@ -372,15 +370,15 @@ class SequentialAccessControlCondition(MultiConditionAccessControl):
 
         @validates("condition_variables")
         def validate_condition_variables(self, value):
-            SequentialAccessControlCondition._validate_condition_variables(value)
+            SequentialCondition._validate_condition_variables(value)
             conditions = [cv.condition for cv in value]
-            SequentialAccessControlCondition._validate_multi_condition_nesting(
+            SequentialCondition._validate_multi_condition_nesting(
                 conditions=conditions, field_name="condition_variables"
             )
 
         @post_load
         def make(self, data, **kwargs):
-            return SequentialAccessControlCondition(**data)
+            return SequentialCondition(**data)
 
     def __init__(
         self,
@@ -456,7 +454,7 @@ class _ElseConditionField(fields.Field):
         return instance
 
 
-class IfThenElseCondition(MultiConditionAccessControl):
+class IfThenElseCondition(MultiCondition):
     """
     A condition that represents simple if-then-else logic.
 
@@ -472,7 +470,7 @@ class IfThenElseCondition(MultiConditionAccessControl):
 
     MAX_NUM_CONDITIONS = 3  # only ever max of 3 (if, then, else)
 
-    class Schema(AccessControlCondition.Schema):
+    class Schema(Condition.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.IF_THEN_ELSE.value), required=True
         )
@@ -501,7 +499,7 @@ class IfThenElseCondition(MultiConditionAccessControl):
 
         @validates("else_condition")
         def validate_else_condition(self, value):
-            if isinstance(value, AccessControlCondition):
+            if isinstance(value, Condition):
                 self._validate_nested_conditions("else_condition", value)
 
         @post_load
@@ -510,9 +508,9 @@ class IfThenElseCondition(MultiConditionAccessControl):
 
     def __init__(
         self,
-        if_condition: AccessControlCondition,
-        then_condition: AccessControlCondition,
-        else_condition: Union[AccessControlCondition, bool],
+        if_condition: Condition,
+        then_condition: Condition,
+        else_condition: Union[Condition, bool],
         condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
     ):
@@ -534,7 +532,7 @@ class IfThenElseCondition(MultiConditionAccessControl):
     @property
     def conditions(self):
         values = [self.if_condition, self.then_condition]
-        if isinstance(self.else_condition, AccessControlCondition):
+        if isinstance(self.else_condition, Condition):
             values.append(self.else_condition)
 
         return values
@@ -553,7 +551,7 @@ class IfThenElseCondition(MultiConditionAccessControl):
             return then_result, values
 
         # else
-        if isinstance(self.else_condition, AccessControlCondition):
+        if isinstance(self.else_condition, Condition):
             # actual condition
             else_result, else_value = self.else_condition.verify(*args, **kwargs)
         else:
@@ -712,7 +710,7 @@ class ConditionLingo(_Serializable):
     the Lit Protocol (https://github.com/LIT-Protocol); credit to the authors for inspiring this work.
     """
 
-    def __init__(self, condition: AccessControlCondition, version: str = VERSION):
+    def __init__(self, condition: Condition, version: str = VERSION):
         self.condition = condition
         self.check_version_compatibility(version)
         self.version = version
@@ -756,7 +754,7 @@ class ConditionLingo(_Serializable):
     @classmethod
     def resolve_condition_class(
         cls, condition: ConditionDict, version: int = None
-    ) -> Type[AccessControlCondition]:
+    ) -> Type[Condition]:
         """
         Inspects a given block of JSON and attempts to resolve it's intended datatype within the
         conditions expression framework.
@@ -775,11 +773,11 @@ class ConditionLingo(_Serializable):
             TimeCondition,
             ContractCondition,
             RPCCondition,
-            CompoundAccessControlCondition,
+            CompoundCondition,
             JsonApiCondition,
             JsonRpcCondition,
             JWTCondition,
-            SequentialAccessControlCondition,
+            SequentialCondition,
             IfThenElseCondition,
             ECDSACondition,
         ):
@@ -798,14 +796,14 @@ class ConditionLingo(_Serializable):
             )
 
 
-class ExecutionCallAccessControlCondition(AccessControlCondition):
+class ExecutionCallCondition(Condition):
     """
     Conditions that utilize underlying ExecutionCall objects.
     """
 
     EXECUTION_CALL_TYPE = NotImplemented
 
-    class Schema(AccessControlCondition.Schema):
+    class Schema(Condition.Schema):
         return_value_test = fields.Nested(
             ReturnValueTest.ReturnValueTestSchema(), required=True
         )

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -785,7 +785,7 @@ class ConditionLingo(_Serializable):
         from nucypher.policy.conditions.json.rpc import JsonRpcCondition
         from nucypher.policy.conditions.jwt import JWTCondition
         from nucypher.policy.conditions.signing.base import (
-            AttributeSigningObjectCondition,
+            SigningObjectAttributeCondition,
         )
         from nucypher.policy.conditions.time import TimeCondition
 
@@ -803,7 +803,7 @@ class ConditionLingo(_Serializable):
             SequentialCondition,
             IfThenElseCondition,
             ECDSACondition,
-            AttributeSigningObjectCondition,
+            SigningObjectAttributeCondition,
         ):
             if condition.CONDITION_TYPE == condition_type:
                 return condition

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -110,6 +110,7 @@ class ConditionType(Enum):
     IF_THEN_ELSE = "if-then-else"
     ECDSA = "ecdsa"
     ATTRIBUTE = "attribute"
+    ABI_ATTRIBUTE = "abi-attribute"
 
     @classmethod
     def values(cls) -> List[str]:
@@ -785,6 +786,7 @@ class ConditionLingo(_Serializable):
         from nucypher.policy.conditions.json.rpc import JsonRpcCondition
         from nucypher.policy.conditions.jwt import JWTCondition
         from nucypher.policy.conditions.signing.base import (
+            SigningObjectAbiAttributeCondition,
             SigningObjectAttributeCondition,
         )
         from nucypher.policy.conditions.time import TimeCondition
@@ -804,6 +806,7 @@ class ConditionLingo(_Serializable):
             IfThenElseCondition,
             ECDSACondition,
             SigningObjectAttributeCondition,
+            SigningObjectAbiAttributeCondition,
         ):
             if condition.CONDITION_TYPE == condition_type:
                 return condition

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -93,7 +93,7 @@ class _ConditionField(fields.Dict):
         return instance
 
 
-# CONDITION = TIME | CONTRACT | RPC | JSON_API | JSON_RPC | JWT | COMPOUND | SEQUENTIAL | IF_THEN_ELSE_CONDITION | ECDSA
+# CONDITION = TIME | CONTRACT | RPC | JSON_API | JSON_RPC | JWT | COMPOUND | SEQUENTIAL | IF_THEN_ELSE_CONDITION | ECDSA | ATTRIBUTE
 class ConditionType(Enum):
     """
     Defines the types of conditions that can be evaluated.
@@ -280,6 +280,7 @@ _COMPARATOR_FUNCTIONS = {
     "<": pyoperator.lt,
     "<=": pyoperator.le,
     ">=": pyoperator.ge,
+    "in": pyoperator.contains,
 }
 
 
@@ -552,37 +553,48 @@ class IfThenElseCondition(MultiCondition):
         return else_result, values
 
 
-class ReturnValueTest:
+class ReturnValueTest(_Serializable):
     class InvalidExpression(ValueError):
         pass
 
     COMPARATORS = tuple(_COMPARATOR_FUNCTIONS)
 
-    class ReturnValueTestSchema(CamelCaseSchema):
+    class Schema(CamelCaseSchema):
         SKIP_VALUES = (None,)
-        comparator = fields.Str(required=True, validate=OneOf(_COMPARATOR_FUNCTIONS))
+        comparator = fields.Str(
+            required=True,
+            validate=OneOf(_COMPARATOR_FUNCTIONS, error="Not a permitted comparator"),
+        )
         value = AnyField(
             allow_none=False, required=True
         )  # any valid type (excludes None)
         index = fields.Int(
-            strict=True, required=False, validate=Range(min=0), allow_none=True
+            strict=True,
+            required=False,
+            validate=Range(
+                min=0, error="Not a permitted index. Must be a an non-negative integer."
+            ),
+            allow_none=True,
         )
+
+        @validates_schema
+        def validate_comparator_and_value(self, data, **kwargs):
+            value = data.get("value")
+            if is_context_variable(value):
+                return
+
+            comparator = data.get("comparator")
+            if comparator == "in" and not isinstance(value, list):
+                raise ValidationError(
+                    field_name="value",
+                    message=f'"{type(value)}" is not a valid type for the "in" comparator; only list is allowed.',
+                )
 
         @post_load
         def make(self, data, **kwargs):
             return ReturnValueTest(**data)
 
     def __init__(self, comparator: str, value: Any, index: int = None):
-        if comparator not in self.COMPARATORS:
-            raise self.InvalidExpression(
-                f'"{comparator}" is not a permitted comparator.'
-            )
-
-        if index is not None and (not isinstance(index, int) or index < 0):
-            raise self.InvalidExpression(
-                f'"{index}" is not a permitted index. Must be a an non-negative integer.'
-            )
-
         if not is_context_variable(value):
             # adjust stored value to be JSON serializable
             if isinstance(value, (tuple, set)):
@@ -605,6 +617,11 @@ class ReturnValueTest:
         self.comparator = comparator
         self.value = value
         self.index = index
+
+        try:
+            self._validate()
+        except ValueError as e:
+            raise self.InvalidExpression(f"{e}")
 
     @classmethod
     def _sanitize_value(cls, value):
@@ -656,9 +673,22 @@ class ReturnValueTest:
             )
 
         processed_data = self._process_data(data, self.index)
-        left_operand = self._sanitize_value(processed_data)
-        right_operand = self._sanitize_value(self.value)
-        result = _COMPARATOR_FUNCTIONS[self.comparator](left_operand, right_operand)
+        comparator_function = _COMPARATOR_FUNCTIONS.get(self.comparator)
+        if comparator_function == pyoperator.contains:
+            # for 'contains' operator, the left operand is the value and
+            # right operand is the data to check
+
+            # first need to sanitize all values in list
+            sanitized_list = [self._sanitize_value(v) for v in self.value]
+            left_operand = sanitized_list
+
+            right_operand = self._sanitize_value(processed_data)
+        else:
+            left_operand = self._sanitize_value(processed_data)
+            right_operand = self._sanitize_value(self.value)
+
+        result = comparator_function(left_operand, right_operand)
+
         return result
 
     def with_resolved_context(
@@ -798,9 +828,7 @@ class ExecutionCallCondition(Condition):
     EXECUTION_CALL_TYPE = NotImplemented
 
     class Schema(Condition.Schema):
-        return_value_test = fields.Nested(
-            ReturnValueTest.ReturnValueTestSchema(), required=True
-        )
+        return_value_test = fields.Nested(ReturnValueTest.Schema(), required=True)
 
     def __init__(
         self,

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -754,7 +754,9 @@ class ConditionLingo(_Serializable):
         from nucypher.policy.conditions.json.api import JsonApiCondition
         from nucypher.policy.conditions.json.rpc import JsonRpcCondition
         from nucypher.policy.conditions.jwt import JWTCondition
-        from nucypher.policy.conditions.signing.base import AttributeCondition
+        from nucypher.policy.conditions.signing.base import (
+            AttributeSigningObjectCondition,
+        )
         from nucypher.policy.conditions.time import TimeCondition
 
         # version logical adjustments can be made here as required
@@ -771,7 +773,7 @@ class ConditionLingo(_Serializable):
             SequentialCondition,
             IfThenElseCondition,
             ECDSACondition,
-            AttributeCondition,
+            AttributeSigningObjectCondition,
         ):
             if condition.CONDITION_TYPE == condition_type:
                 return condition

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -120,6 +120,7 @@ class ConditionType(Enum):
     SEQUENTIAL = "sequential"
     IF_THEN_ELSE = "if-then-else"
     ECDSA = "ecdsa"
+    ATTRIBUTE = "attribute"
 
     @classmethod
     def values(cls) -> List[str]:
@@ -764,6 +765,7 @@ class ConditionLingo(_Serializable):
         from nucypher.policy.conditions.json.api import JsonApiCondition
         from nucypher.policy.conditions.json.rpc import JsonRpcCondition
         from nucypher.policy.conditions.jwt import JWTCondition
+        from nucypher.policy.conditions.signing.base import AttributeCondition
         from nucypher.policy.conditions.time import TimeCondition
 
         # version logical adjustments can be made here as required
@@ -780,6 +782,7 @@ class ConditionLingo(_Serializable):
             SequentialCondition,
             IfThenElseCondition,
             ECDSACondition,
+            AttributeCondition,
         ):
             if condition.CONDITION_TYPE == condition_type:
                 return condition

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -93,7 +93,7 @@ class _ConditionField(fields.Dict):
         return instance
 
 
-# CONDITION = TIME | CONTRACT | RPC | JSON_API | JSON_RPC | JWT | COMPOUND | SEQUENTIAL | IF_THEN_ELSE_CONDITION | ECDSA | ATTRIBUTE
+# CONDITION = TIME | CONTRACT | RPC | JSON_API | JSON_RPC | JWT | COMPOUND | SEQUENTIAL | IF_THEN_ELSE_CONDITION | ECDSA | ATTRIBUTE | ABI_ATTRIBUTE
 class ConditionType(Enum):
     """
     Defines the types of conditions that can be evaluated.
@@ -281,7 +281,7 @@ _COMPARATOR_FUNCTIONS = {
     "<": pyoperator.lt,
     "<=": pyoperator.le,
     ">=": pyoperator.ge,
-    "in": pyoperator.contains,
+    "in": pyoperator.contains,  # currently only supports checking value in list (not sub-string/bytes comparisons)
 }
 
 

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -11,7 +11,11 @@ from nucypher.policy.conditions.exceptions import (
     InvalidContextVariableData,
 )
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
-from nucypher.policy.conditions.utils import ConditionProviderManager
+from nucypher.policy.conditions.utils import (
+    ConditionProviderManager,
+    camel_case_to_snake,
+    is_camel_case,
+)
 
 SIGNING_CONDITION_OBJECT_CONTEXT_VAR = ":signingConditionObject"
 
@@ -63,7 +67,15 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
         condition_type: str = ConditionType.ATTRIBUTE.value,
         name: Optional[str] = None,
     ):
-        self.attribute_name = attribute_name
+        # TODO what about camel case (from library) vs snake case (python) for
+        #  attribute names (is this sufficient?)
+        #  At the moment since there will be a python object, can we assume snake case conversion always?
+        self.attribute_name = (
+            camel_case_to_snake(attribute_name)
+            # TODO should attribute name ever be a context variable? Likely not...
+            if (attribute_name and is_camel_case(attribute_name))
+            else attribute_name
+        )
         self.return_value_test = return_value_test
         super().__init__(
             signing_object_context_var=signing_object_context_var,

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -3,7 +3,10 @@ from typing import Any, Optional, Tuple
 from marshmallow import ValidationError, fields, post_load, validate, validates
 
 from nucypher.policy.conditions.base import Condition
-from nucypher.policy.conditions.context import is_context_variable
+from nucypher.policy.conditions.context import (
+    is_context_variable,
+    resolve_any_context_variables,
+)
 from nucypher.policy.conditions.exceptions import (
     InvalidContextVariableData,
     RequiredContextVariable,
@@ -60,7 +63,9 @@ class AttributeCondition(Condition):
             providers=providers, **context
         )
 
-        object_dict = context.get(self.object_context_var)
+        object_dict = resolve_any_context_variables(
+            self.object_context_var, providers=providers, **context
+        )
         if not object_dict:
             raise RequiredContextVariable(
                 f"No object entry for context variable {self.object_context_var}"

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -38,7 +38,7 @@ class SigningObjectCondition(Condition, ABC):
         super().__init__(*args, **kwargs)
 
 
-class AttributeSigningObjectCondition(SigningObjectCondition):
+class SigningObjectAttributeCondition(SigningObjectCondition):
     CONDITION_TYPE = ConditionType.ATTRIBUTE.value
 
     class Schema(SigningObjectCondition.Schema):
@@ -54,7 +54,7 @@ class AttributeSigningObjectCondition(SigningObjectCondition):
 
         @post_load
         def make(self, data, **kwargs):
-            return AttributeSigningObjectCondition(**data)
+            return SigningObjectAttributeCondition(**data)
 
     def __init__(
         self,

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -9,7 +9,6 @@ from nucypher.policy.conditions.context import (
 )
 from nucypher.policy.conditions.exceptions import (
     InvalidContextVariableData,
-    RequiredContextVariable,
 )
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 from nucypher.policy.conditions.utils import ConditionProviderManager
@@ -82,10 +81,6 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
         signing_object = resolve_any_context_variables(
             self.signing_object_context_var, providers=providers, **context
         )
-        if not signing_object:
-            raise RequiredContextVariable(
-                f"No object entry for context variable {self.signing_object_context_var}"
-            )
 
         try:
             # TODO for EIP191SignatureRequest, the object is just bytes, so that would fail here
@@ -95,8 +90,18 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
             # makes it clear that entry not present - allows possibility that
             # attribute value could be None as a legit value
             raise InvalidContextVariableData(
-                f"Object provided does not have attribute {self.attribute_name}"
+                f"Object of type {type(signing_object)} provided does not have attribute {self.attribute_name}"
             )
 
-        result = resolved_return_value_test.eval(attribute_value)
+        # TODO: not the cleanest way to handle a string value needing to be quoted
+        #  for evaluation checking
+        modified_attribute_value_to_check = attribute_value
+        if isinstance(modified_attribute_value_to_check, str):
+            if not modified_attribute_value_to_check.startswith("0x"):
+                # value needs to be double-quoted
+                modified_attribute_value_to_check = (
+                    f'"{modified_attribute_value_to_check}"'
+                )
+
+        result = resolved_return_value_test.eval(modified_attribute_value_to_check)
         return result, attribute_value

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -1,10 +1,10 @@
+from abc import ABC
 from typing import Any, Optional, Tuple
 
-from marshmallow import ValidationError, fields, post_load, validate, validates
+from marshmallow import fields, post_load, validate
 
 from nucypher.policy.conditions.base import Condition
 from nucypher.policy.conditions.context import (
-    is_context_variable,
     resolve_any_context_variables,
 )
 from nucypher.policy.conditions.exceptions import (
@@ -14,16 +14,38 @@ from nucypher.policy.conditions.exceptions import (
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 from nucypher.policy.conditions.utils import ConditionProviderManager
 
+SIGNING_CONDITION_OBJECT_CONTEXT_VAR = ":signingConditionObject"
 
-class AttributeCondition(Condition):
-    CONDITION_TYPE = ConditionType.ATTRIBUTE.value
+
+class SigningObjectCondition(Condition, ABC):
+    """
+    Base class for signing conditions.
+    This class is abstract and should not be instantiated directly.
+    """
 
     class Schema(Condition.Schema):
+        signing_object_context_var = fields.Str(
+            required=True, validate=validate.Equal(SIGNING_CONDITION_OBJECT_CONTEXT_VAR)
+        )
+
+    def __init__(
+        self,
+        signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+        *args,
+        **kwargs,
+    ):
+        self.signing_object_context_var = signing_object_context_var
+        super().__init__(*args, **kwargs)
+
+
+class AttributeSigningObjectCondition(SigningObjectCondition):
+    CONDITION_TYPE = ConditionType.ATTRIBUTE.value
+
+    class Schema(SigningObjectCondition.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.ATTRIBUTE.value), required=True
         )
         attribute_name = fields.String(required=True)
-        object_context_var = fields.String(required=True)
         return_value_test = fields.Nested(
             ReturnValueTest.ReturnValueTestSchema(), required=True
         )
@@ -32,29 +54,25 @@ class AttributeCondition(Condition):
         class Meta:
             ordered = True
 
-        @validates("object_context_var")
-        def validate_object_context_var(self, value):
-            if not is_context_variable(value):
-                raise ValidationError(
-                    f"Invalid value for context variable; expected a context variable, but got '{value}'"
-                )
-
         @post_load
         def make(self, data, **kwargs):
-            return AttributeCondition(**data)
+            return AttributeSigningObjectCondition(**data)
 
     def __init__(
         self,
         attribute_name: str,
-        object_context_var: str,
         return_value_test: ReturnValueTest,
+        signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
         condition_type: str = ConditionType.ATTRIBUTE.value,
         name: Optional[str] = None,
     ):
         self.attribute_name = attribute_name
-        self.object_context_var = object_context_var
         self.return_value_test = return_value_test
-        super().__init__(condition_type=condition_type, name=name)
+        super().__init__(
+            signing_object_context_var=signing_object_context_var,
+            condition_type=condition_type,
+            name=name,
+        )
 
     def verify(
         self, providers: ConditionProviderManager, **context
@@ -63,26 +81,23 @@ class AttributeCondition(Condition):
             providers=providers, **context
         )
 
-        object_dict = resolve_any_context_variables(
-            self.object_context_var, providers=providers, **context
+        signing_object = resolve_any_context_variables(
+            self.signing_object_context_var, providers=providers, **context
         )
-        if not object_dict:
+        if not signing_object:
             raise RequiredContextVariable(
-                f"No object entry for context variable {self.object_context_var}"
-            )
-
-        if not isinstance(object_dict, dict):
-            raise InvalidContextVariableData(
-                f"Object provided for context var {self.object_context_var} is not a dictionary"
+                f"No object entry for context variable {self.signing_object_context_var}"
             )
 
         try:
-            attribute_value = object_dict[self.attribute_name]
-        except KeyError:
+            # TODO for EIP191SignatureRequest, the object is just bytes, so that would fail here
+            #  how do we handle that?
+            attribute_value = getattr(signing_object, self.attribute_name)
+        except AttributeError:
             # makes it clear that entry not present - allows possibility that
             # attribute value could be None as a legit value
             raise InvalidContextVariableData(
-                f"Object provided for context var {self.object_context_var} does not have attribute {self.attribute_name}"
+                f"Object provided does not have attribute {self.attribute_name}"
             )
 
         result = resolved_return_value_test.eval(attribute_value)

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -1,0 +1,84 @@
+from typing import Any, Optional, Tuple
+
+from marshmallow import ValidationError, fields, post_load, validate, validates
+
+from nucypher.policy.conditions.base import Condition
+from nucypher.policy.conditions.context import is_context_variable
+from nucypher.policy.conditions.exceptions import (
+    InvalidContextVariableData,
+    RequiredContextVariable,
+)
+from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
+from nucypher.policy.conditions.utils import ConditionProviderManager
+
+
+class AttributeCondition(Condition):
+    CONDITION_TYPE = ConditionType.ATTRIBUTE.value
+
+    class Schema(Condition.Schema):
+        condition_type = fields.Str(
+            validate=validate.Equal(ConditionType.ATTRIBUTE.value), required=True
+        )
+        attribute_name = fields.String(required=True)
+        object_context_var = fields.String(required=True)
+        return_value_test = fields.Nested(
+            ReturnValueTest.ReturnValueTestSchema(), required=True
+        )
+
+        # maintain field declaration ordering
+        class Meta:
+            ordered = True
+
+        @validates("object_context_var")
+        def validate_object_context_var(self, value):
+            if not is_context_variable(value):
+                raise ValidationError(
+                    f"Invalid value for context variable; expected a context variable, but got '{value}'"
+                )
+
+        @post_load
+        def make(self, data, **kwargs):
+            return AttributeCondition(**data)
+
+    def __init__(
+        self,
+        attribute_name: str,
+        object_context_var: str,
+        return_value_test: ReturnValueTest,
+        condition_type: str = ConditionType.ATTRIBUTE.value,
+        name: Optional[str] = None,
+    ):
+        self.attribute_name = attribute_name
+        self.object_context_var = object_context_var
+        self.return_value_test = return_value_test
+        super().__init__(condition_type=condition_type, name=name)
+
+    def verify(
+        self, providers: ConditionProviderManager, **context
+    ) -> Tuple[bool, Any]:
+        resolved_return_value_test = self.return_value_test.with_resolved_context(
+            providers=providers, **context
+        )
+
+        object_dict = context.get(self.object_context_var)
+        if not object_dict:
+            raise RequiredContextVariable(
+                f"No object entry for context variable {self.object_context_var}"
+            )
+
+        if not isinstance(object_dict, dict):
+            raise InvalidContextVariableData(
+                f"Object provided for context var {self.object_context_var} is not a dictionary"
+            )
+
+        try:
+            attribute_value = object_dict[self.attribute_name]
+        except KeyError:
+            # makes it clear that entry not present - allows possibility that
+            # attribute value could be None as a legit value
+            raise InvalidContextVariableData(
+                f"Object provided for context var {self.object_context_var} does not have attribute {self.attribute_name}"
+            )
+
+        result = resolved_return_value_test.eval(attribute_value)
+        return result, attribute_value

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -46,9 +46,7 @@ class AttributeSigningObjectCondition(SigningObjectCondition):
             validate=validate.Equal(ConditionType.ATTRIBUTE.value), required=True
         )
         attribute_name = fields.String(required=True)
-        return_value_test = fields.Nested(
-            ReturnValueTest.ReturnValueTestSchema(), required=True
-        )
+        return_value_test = fields.Nested(ReturnValueTest.Schema(), required=True)
 
         # maintain field declaration ordering
         class Meta:

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -121,7 +121,7 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
         """
         try:
             # TODO for EIP191SignatureRequest, the object is just bytes, so that would fail here
-            #  how do we handle that?
+            #  how do we handle that? Is raising the exception sufficient?
             raw_attribute_value = getattr(signing_object, self.attribute_name)
         except AttributeError:
             # makes it clear that entry not present - allows possibility that

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -1,7 +1,15 @@
 from abc import ABC
 from typing import Any, Optional, Tuple
 
-from marshmallow import fields, post_load, validate
+from marshmallow import (
+    ValidationError,
+    fields,
+    post_load,
+    validate,
+    validates,
+    validates_schema,
+)
+from marshmallow.validate import Range
 
 from nucypher.policy.conditions.base import Condition
 from nucypher.policy.conditions.context import (
@@ -15,6 +23,11 @@ from nucypher.policy.conditions.utils import (
     ConditionProviderManager,
     camel_case_to_snake,
     is_camel_case,
+)
+from nucypher.utilities.abi import (
+    decode_human_readable_call,
+    extract_arg_types,
+    is_valid_human_readable_signature,
 )
 
 SIGNING_CONDITION_OBJECT_CONTEXT_VAR = ":signingConditionObject"
@@ -48,7 +61,7 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.ATTRIBUTE.value), required=True
         )
-        attribute_name = fields.String(required=True)
+        attribute_name = fields.Str(required=True)
         return_value_test = fields.Nested(ReturnValueTest.Schema(), required=True)
 
         # maintain field declaration ordering
@@ -94,10 +107,22 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
             self.signing_object_context_var, providers=providers, **context
         )
 
+        raw_attribute_value, modified_attribute_value = self.get_attribute_value(
+            signing_object
+        )
+
+        result = resolved_return_value_test.eval(modified_attribute_value)
+        return result, raw_attribute_value
+
+    def _get_raw_signing_object_attribute(self, signing_object: Any) -> Any:
+        """
+        Helper method to retrieve the attribute value from the signing object.
+        Raises InvalidContextVariableData if the attribute does not exist.
+        """
         try:
             # TODO for EIP191SignatureRequest, the object is just bytes, so that would fail here
             #  how do we handle that?
-            attribute_value = getattr(signing_object, self.attribute_name)
+            raw_attribute_value = getattr(signing_object, self.attribute_name)
         except AttributeError:
             # makes it clear that entry not present - allows possibility that
             # attribute value could be None as a legit value
@@ -105,15 +130,107 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
                 f"Object of type {type(signing_object)} provided does not have attribute {self.attribute_name}"
             )
 
+        return raw_attribute_value
+
+    @staticmethod
+    def _adjust_for_attribute_string_value(attribute_value: Any) -> Any:
+        """
+        Adjusts the attribute value for evaluation checking.
+        If the value is a string and does not start with '0x', it will be double-quoted.
+        """
+        if isinstance(attribute_value, str):
+            if not attribute_value.startswith("0x"):
+                # value needs to be double-quoted
+                return f'"{attribute_value}"'
+
+        return attribute_value
+
+    def get_attribute_value(self, signing_object: Any) -> Tuple[Any, Any]:
+        raw_attribute_value = self._get_raw_signing_object_attribute(signing_object)
+
         # TODO: not the cleanest way to handle a string value needing to be quoted
         #  for evaluation checking
-        modified_attribute_value_to_check = attribute_value
-        if isinstance(modified_attribute_value_to_check, str):
-            if not modified_attribute_value_to_check.startswith("0x"):
-                # value needs to be double-quoted
-                modified_attribute_value_to_check = (
-                    f'"{modified_attribute_value_to_check}"'
+        modified_attribute_value_to_check = self._adjust_for_attribute_string_value(
+            raw_attribute_value
+        )
+
+        return raw_attribute_value, modified_attribute_value_to_check
+
+
+class SigningObjectAbiAttributeCondition(SigningObjectAttributeCondition):
+    CONDITION_TYPE = ConditionType.ABI_ATTRIBUTE.value
+
+    class Schema(SigningObjectAttributeCondition.Schema):
+        condition_type = fields.Str(
+            validate=validate.Equal(ConditionType.ABI_ATTRIBUTE.value), required=True
+        )
+        abi_decode_string = fields.Str(required=True)
+        abi_decode_value_index = fields.Int(validate=Range(min=0), required=True)
+
+        @validates("abi_decode_string")
+        def validate_abi_decode_string(self, value: str):
+            if not is_valid_human_readable_signature(value):
+                raise ValidationError(
+                    f"Invalid ABI decode string: {value}. "
+                    "Must be a valid human-readable signature."
                 )
 
-        result = resolved_return_value_test.eval(modified_attribute_value_to_check)
-        return result, attribute_value
+        @validates_schema
+        def validate_abi_decode_value_index(self, data, **kwargs):
+            abi_decode_value_index = data.get("abi_decode_value_index")
+            abi_decode_string = data.get("abi_decode_string")
+
+            arg_types = extract_arg_types(abi_decode_string)
+            total_args_num = 1 + len(arg_types)  # method name + args
+            if abi_decode_value_index >= total_args_num:
+                raise ValidationError(
+                    f"Value index '{abi_decode_value_index}' is out of range for "
+                    f"the ABI decode string '{abi_decode_string}'. "
+                )
+
+        # maintain field declaration ordering
+        class Meta:
+            ordered = True
+
+        @post_load
+        def make(self, data, **kwargs):
+            return SigningObjectAbiAttributeCondition(**data)
+
+    def __init__(
+        self,
+        attribute_name: str,
+        abi_decode_string: str,
+        abi_decode_value_index: int,
+        return_value_test: ReturnValueTest,
+        signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+        condition_type: str = ConditionType.ABI_ATTRIBUTE.value,
+        name: Optional[str] = None,
+    ):
+        self.abi_decode_string = abi_decode_string
+        self.abi_decode_value_index = abi_decode_value_index
+
+        super().__init__(
+            attribute_name=attribute_name,
+            return_value_test=return_value_test,
+            signing_object_context_var=signing_object_context_var,
+            condition_type=condition_type,
+            name=name,
+        )
+
+    def get_attribute_value(self, signing_object: Any) -> Tuple[Any, Any]:
+        raw_attribute_value = self._get_raw_signing_object_attribute(signing_object)
+        method, args = decode_human_readable_call(
+            self.abi_decode_string, raw_attribute_value
+        )
+
+        all_values = [method]
+        all_values.extend(args)
+
+        decoded_attribute_value_at_index = all_values[self.abi_decode_value_index]
+
+        # adjust for string value
+        modified_attribute_value_to_check = self._adjust_for_attribute_string_value(
+            decoded_attribute_value_at_index
+        )
+
+        return decoded_attribute_value_at_index, modified_attribute_value_to_check

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -141,16 +141,19 @@ class ECDSAConditionDict(_Condition):
     verifyingKey: str
 
 
+class _SigningObjectCondition(_Condition):
+    signing_object_context_var: str
+
+
 #
-# AttributeCondition represents:
+# AttributeSigningObjectCondition represents:
 # {
 #     "attributeName": str
 #     "objectContextVar": str
 #     "returnValueTest: <>
 # }
-class AttributeCondition(_Condition):
+class AttributeSigningObjectCondition(_SigningObjectCondition):
     attributeName: str
-    objectContextVar: str
     returnValueTest: ReturnValueTestDict
 
 
@@ -166,7 +169,7 @@ class AttributeCondition(_Condition):
 # - SequentialCondition
 # - IfThenElseCondition
 # - ECDSACondition
-# - AttributeCondition
+# - AttributeSigningObjectCondition
 ConditionDict = Union[
     TimeConditionDict,
     RPCConditionDict,
@@ -178,7 +181,7 @@ ConditionDict = Union[
     SequentialConditionDict,
     IfThenElseConditionDict,
     ECDSAConditionDict,
-    AttributeCondition,
+    AttributeSigningObjectCondition,
 ]
 
 

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -141,6 +141,10 @@ class ECDSAConditionDict(_Condition):
     verifyingKey: str
 
 
+# _SigningObjectCondition abstract class represents:
+# {
+#     "signingObjectContextVar": ":signingConditionObject"
+# }
 class _SigningObjectCondition(_Condition):
     signing_object_context_var: str
 
@@ -157,6 +161,19 @@ class SigningObjectAttributeCondition(_SigningObjectCondition):
     returnValueTest: ReturnValueTestDict
 
 
+# SigningObjectAttributeCondition represents:
+# {
+#     "attributeName": str
+#     "signingObjectContextVar": ":signingConditionObject"
+#     "abiDecodeString": str
+#     "abiDecodeValueIndex: int
+#     "returnValueTest: <>
+# }
+class SigningObjectAbiAttributeCondition(SigningObjectAttributeCondition):
+    abiDecodeString: str
+    abiDecodeValueIndex: int
+
+
 #
 # ConditionDict is a dictionary of:
 # - TimeCondition
@@ -170,6 +187,7 @@ class SigningObjectAttributeCondition(_SigningObjectCondition):
 # - IfThenElseCondition
 # - ECDSACondition
 # - SigningObjectAttributeCondition
+# - SigningObjectAbiAttributeCondition
 ConditionDict = Union[
     TimeConditionDict,
     RPCConditionDict,
@@ -182,6 +200,7 @@ ConditionDict = Union[
     IfThenElseConditionDict,
     ECDSAConditionDict,
     SigningObjectAttributeCondition,
+    SigningObjectAbiAttributeCondition,
 ]
 
 

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -35,12 +35,12 @@ class ReturnValueTestDict(TypedDict):
 
 
 # Conditions
-class _AccessControlCondition(TypedDict):
+class _Condition(TypedDict):
     name: NotRequired[str]
     conditionType: str
 
 
-class BaseExecConditionDict(_AccessControlCondition):
+class BaseExecConditionDict(_Condition):
     returnValueTest: ReturnValueTestDict
 
 
@@ -75,7 +75,7 @@ class JsonRpcConditionDict(BaseExecConditionDict):
     authorizationToken: NotRequired[str]
 
 
-class JWTConditionDict(_AccessControlCondition):
+class JWTConditionDict(_Condition):
     jwtToken: str
     publicKey: str  # TODO: See #3572 for a discussion about deprecating this in favour of the expected issuer
     expectedIssuer: NotRequired[str]
@@ -85,10 +85,10 @@ class JWTConditionDict(_AccessControlCondition):
 # CompoundCondition represents:
 # {
 #     "operator": ["and" | "or" | "not"]
-#     "operands": List[AccessControlCondition]
+#     "operands": List[Condition]
 # }
 #
-class CompoundConditionDict(_AccessControlCondition):
+class CompoundConditionDict(_Condition):
     operator: Literal["and", "or", "not"]
     operands: List["ConditionDict"]
 
@@ -97,7 +97,7 @@ class CompoundConditionDict(_AccessControlCondition):
 # ConditionVariable represents:
 # {
 #     varName: str
-#     condition: AccessControlCondition
+#     condition: Condition
 # }
 #
 class ConditionVariableDict(TypedDict):
@@ -111,18 +111,18 @@ class ConditionVariableDict(TypedDict):
 #     "conditionVariables": List[ConditionVariable]
 # }
 #
-class SequentialConditionDict(_AccessControlCondition):
+class SequentialConditionDict(_Condition):
     conditionVariables = List[ConditionVariableDict]
 
 
 #
 # IfThenElseCondition represents:
 # {
-#     "ifCondition": AccessControlCondition
-#     "thenCondition": AccessControlCondition
-#     "elseCondition": [AccessControlCondition | bool]
+#     "ifCondition": Condition
+#     "thenCondition": Condition
+#     "elseCondition": [Condition | bool]
 # }
-class IfThenElseConditionDict(_AccessControlCondition):
+class IfThenElseConditionDict(_Condition):
     ifCondition: "ConditionDict"
     thenCondition: "ConditionDict"
     elseCondition: Union["ConditionDict", bool]
@@ -135,7 +135,7 @@ class IfThenElseConditionDict(_AccessControlCondition):
 #     "signature": str
 #     "verifyingKey": str
 # }
-class ECDSAConditionDict(_AccessControlCondition):
+class ECDSAConditionDict(_Condition):
     message: Union[bytes, str]
     signature: str
     verifyingKey: str

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -142,6 +142,19 @@ class ECDSAConditionDict(_Condition):
 
 
 #
+# AttributeCondition represents:
+# {
+#     "attributeName": str
+#     "objectContextVar": str
+#     "returnValueTest: <>
+# }
+class AttributeCondition(_Condition):
+    attributeName: str
+    objectContextVar: str
+    returnValueTest: ReturnValueTestDict
+
+
+#
 # ConditionDict is a dictionary of:
 # - TimeCondition
 # - RPCCondition
@@ -153,6 +166,7 @@ class ECDSAConditionDict(_Condition):
 # - SequentialCondition
 # - IfThenElseCondition
 # - ECDSACondition
+# - AttributeCondition
 ConditionDict = Union[
     TimeConditionDict,
     RPCConditionDict,
@@ -164,6 +178,7 @@ ConditionDict = Union[
     SequentialConditionDict,
     IfThenElseConditionDict,
     ECDSAConditionDict,
+    AttributeCondition,
 ]
 
 

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -149,7 +149,7 @@ class _SigningObjectCondition(_Condition):
 # SigningObjectAttributeCondition represents:
 # {
 #     "attributeName": str
-#     "objectContextVar": str
+#     "signingObjectContextVar": ":signingConditionObject"
 #     "returnValueTest: <>
 # }
 class SigningObjectAttributeCondition(_SigningObjectCondition):

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -146,13 +146,13 @@ class _SigningObjectCondition(_Condition):
 
 
 #
-# AttributeSigningObjectCondition represents:
+# SigningObjectAttributeCondition represents:
 # {
 #     "attributeName": str
 #     "objectContextVar": str
 #     "returnValueTest: <>
 # }
-class AttributeSigningObjectCondition(_SigningObjectCondition):
+class SigningObjectAttributeCondition(_SigningObjectCondition):
     attributeName: str
     returnValueTest: ReturnValueTestDict
 
@@ -169,7 +169,7 @@ class AttributeSigningObjectCondition(_SigningObjectCondition):
 # - SequentialCondition
 # - IfThenElseCondition
 # - ECDSACondition
-# - AttributeSigningObjectCondition
+# - SigningObjectAttributeCondition
 ConditionDict = Union[
     TimeConditionDict,
     RPCConditionDict,
@@ -181,7 +181,7 @@ ConditionDict = Union[
     SequentialConditionDict,
     IfThenElseConditionDict,
     ECDSAConditionDict,
-    AttributeSigningObjectCondition,
+    SigningObjectAttributeCondition,
 ]
 
 

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -93,6 +93,11 @@ def camel_case_to_snake(data: str) -> str:
     return data
 
 
+def is_camel_case(data: str) -> bool:
+    # Must start with lowercase, contain no underscores/spaces, and have at least one uppercase after the first char
+    return bool(re.fullmatch(r"[a-z]+(?:[A-Z][a-z0-9]*)*", data))
+
+
 class CamelCaseSchema(Schema):
     """Schema that uses camel-case for its external representation
     and snake-case for its internal representation.

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -1,6 +1,6 @@
 import re
 from http import HTTPStatus
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 from marshmallow import Schema, post_dump
 from marshmallow.exceptions import SCHEMA
@@ -236,5 +236,22 @@ def check_and_convert_big_int_string_to_int(value: str) -> Union[str, int]:
         except ValueError:
             # ignore
             pass
+
+    return value
+
+
+def check_and_convert_any_big_ints(value: Any) -> Any:
+    """
+    Check if an object contains any big int strings and convert them to an integer,
+    otherwise return the object.
+
+    Expects the object to have been created from JSON so the only objects are lists or dicts.
+    """
+    if isinstance(value, list):
+        return [check_and_convert_any_big_ints(item) for item in value]
+    elif isinstance(value, dict):
+        return {k: check_and_convert_any_big_ints(v) for k, v in value.items()}
+    elif isinstance(value, str):
+        return check_and_convert_big_int_string_to_int(value)
 
     return value

--- a/nucypher/utilities/abi.py
+++ b/nucypher/utilities/abi.py
@@ -7,7 +7,7 @@ from eth_utils import function_signature_to_4byte_selector
 FUNCTION_NAME_PATTERN = r"^[a-zA-Z_][a-zA-Z0-9_]*$"
 
 
-def _extract_arg_types(human_signature: str) -> List[str]:
+def extract_arg_types(human_signature: str) -> List[str]:
     # Extract argument types from signature
     start = human_signature.find("(")
     end = human_signature.rfind(")")
@@ -49,7 +49,7 @@ def is_valid_human_readable_signature(human_signature: str) -> bool:
         if not re.fullmatch(FUNCTION_NAME_PATTERN, method_name):
             return False
 
-        arg_types = _extract_arg_types(human_signature)
+        arg_types = extract_arg_types(human_signature)
         for arg_type in arg_types:
             if not eth_abi.is_encodable_type(arg_type):
                 return False
@@ -65,7 +65,7 @@ def encode_human_readable_call(human_signature: str, args: list) -> bytes:
     a call data format suitable for Ethereum transactions.
     """
     selector = function_signature_to_4byte_selector(human_signature)
-    types = _extract_arg_types(human_signature)
+    types = extract_arg_types(human_signature)
     return selector + eth_abi.encode(types, args)
 
 
@@ -81,7 +81,7 @@ def decode_human_readable_call(
     if call_data[:4] != selector:
         raise ValueError("Call data does not match function selector")
 
-    arg_types = _extract_arg_types(human_signature)
+    arg_types = extract_arg_types(human_signature)
 
     # Decode the arguments
     args_data = call_data[4:]

--- a/nucypher/utilities/abi.py
+++ b/nucypher/utilities/abi.py
@@ -1,0 +1,94 @@
+import re
+from typing import List, Tuple, Union
+
+import eth_abi
+from eth_utils import function_signature_to_4byte_selector
+
+FUNCTION_NAME_PATTERN = r"^[a-zA-Z_][a-zA-Z0-9_]*$"
+
+
+def _extract_arg_types(human_signature: str) -> List[str]:
+    # Extract argument types from signature
+    start = human_signature.find("(")
+    end = human_signature.rfind(")")
+    if start == -1 or end == -1 or end <= start:
+        raise ValueError("Invalid function signature format")
+
+    if end != len(human_signature) - 1:
+        # case where 'fn(...) extra'
+        raise ValueError("Invalid additional data in signature")
+
+    sig_args = human_signature[start + 1 : end]
+    arg_types = []
+    depth = 0
+    current = []
+
+    for char in sig_args:
+        if char == "," and depth == 0:
+            arg_types.append("".join(current).strip())
+            current = []
+        else:
+            # account for nested structures i.e. tuples
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            current.append(char)
+    if current:
+        arg_types.append("".join(current).strip())
+
+    return arg_types
+
+
+def is_valid_human_readable_signature(human_signature: str) -> bool:
+    """
+    Check if the provided human-readable signature is valid.
+    """
+    try:
+        method_name = human_signature[: human_signature.index("(")].strip()
+        if not re.fullmatch(FUNCTION_NAME_PATTERN, method_name):
+            return False
+
+        arg_types = _extract_arg_types(human_signature)
+        for arg_type in arg_types:
+            if not eth_abi.is_encodable_type(arg_type):
+                return False
+
+        return True
+    except (ValueError, IndexError):
+        return False
+
+
+def encode_human_readable_call(human_signature: str, args: list) -> bytes:
+    """
+    Encode a human-readable function call signature and its arguments into
+    a call data format suitable for Ethereum transactions.
+    """
+    selector = function_signature_to_4byte_selector(human_signature)
+    types = _extract_arg_types(human_signature)
+    return selector + eth_abi.encode(types, args)
+
+
+def decode_human_readable_call(
+    human_signature: str, call_data: bytes, return_method_name: bool = True
+) -> Tuple[Union[str, bytes], List]:
+    """
+    Decode a human-readable function call signature and its arguments from the
+    provided call data into method name OR method selector, and arguments
+    """
+    # Get expected selector
+    selector = function_signature_to_4byte_selector(human_signature)
+    if call_data[:4] != selector:
+        raise ValueError("Call data does not match function selector")
+
+    arg_types = _extract_arg_types(human_signature)
+
+    # Decode the arguments
+    args_data = call_data[4:]
+    decoded = list(eth_abi.decode(arg_types, args_data))
+
+    if not return_method_name:
+        return selector, decoded
+    else:
+        method_name = human_signature[: human_signature.index("(")].strip()
+        return method_name, decoded

--- a/nucypher/utilities/erc4337_utils.py
+++ b/nucypher/utilities/erc4337_utils.py
@@ -4,12 +4,12 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Tuple
 
-import eth_abi
-from eth_utils import keccak, to_bytes, to_checksum_address
+from eth_utils import to_bytes, to_checksum_address
 from hexbytes import HexBytes
 
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.crypto.powers import TransactingPower
+from nucypher.utilities.abi import encode_human_readable_call
 
 
 class EntryPointContracts:
@@ -315,13 +315,7 @@ class PackedUserOperation:
 
 
 def encode_function_call(signature: str, args: list) -> HexBytes:
-    selector = HexBytes(keccak(text=signature)[:4])
-    types = [
-        t
-        for t in signature[signature.find("(") + 1 : signature.find(")")].split(",")
-        if t
-    ]
-    return selector + HexBytes(eth_abi.encode(types, args))
+    return HexBytes(encode_human_readable_call(signature, args))
 
 
 def create_eth_transfer(

--- a/nucypher/utilities/erc4337_utils.py
+++ b/nucypher/utilities/erc4337_utils.py
@@ -4,12 +4,11 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Tuple
 
-from eth_utils import to_bytes, to_checksum_address
+from eth_utils import to_bytes
 from hexbytes import HexBytes
 
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.crypto.powers import TransactingPower
-from nucypher.utilities.abi import encode_human_readable_call
 
 
 class EntryPointContracts:
@@ -312,50 +311,3 @@ class PackedUserOperation:
 
         self.signature = bytes(signature)
         return message_hash, signature
-
-
-def encode_function_call(signature: str, args: list) -> HexBytes:
-    return HexBytes(encode_human_readable_call(signature, args))
-
-
-def create_eth_transfer(
-    sender: str, nonce: int, to: str, value: int, **kwargs
-) -> "UserOperation":
-    data = encode_function_call(
-        "execute(address,uint256,bytes)",
-        [to_checksum_address(to), value, b""],
-    )
-    return UserOperation(sender, nonce, None, b"", data, **kwargs)
-
-
-def create_erc20_transfer(
-    sender: str, nonce: int, token: str, to: str, amount: int, **kwargs
-) -> "UserOperation":
-    call = encode_function_call(
-        "transfer(address,uint256)", [to_checksum_address(to), amount]
-    )
-    data = encode_function_call(
-        "execute(address,uint256,bytes)", [to_checksum_address(token), 0, call]
-    )
-    return UserOperation(sender, nonce, None, b"", data, **kwargs)
-
-
-def create_erc20_approve(
-    sender: str, nonce: int, token: str, spender: str, amount: int, **kwargs
-) -> "UserOperation":
-    call = encode_function_call(
-        "approve(address,uint256)", [to_checksum_address(spender), amount]
-    )
-    data = encode_function_call(
-        "execute(address,uint256,bytes)", [to_checksum_address(token), 0, call]
-    )
-    return UserOperation(sender, nonce, None, b"", data, **kwargs)
-
-
-def create_contract_call(
-    sender: str, nonce: int, target: str, data: HexBytes, value: int = 0, **kwargs
-) -> "UserOperation":
-    payload = encode_function_call(
-        "execute(address,uint256,bytes)", [to_checksum_address(target), value, data]
-    )
-    return UserOperation(sender, nonce, None, b"", payload, **kwargs)

--- a/nucypher/utilities/erc4337_utils.py
+++ b/nucypher/utilities/erc4337_utils.py
@@ -262,6 +262,7 @@ class PackedUserOperation:
             "paymasterAndData": self.paymaster_and_data,
         }
         if aa_version == AAVersion.MDT:
+            # TODO how extensible is this, if MDT eventually switches to v0.8.0?
             result["entryPoint"] = EntryPointContracts.ENTRYPOINT_V07
         return result
 

--- a/nucypher/utilities/erc4337_utils.py
+++ b/nucypher/utilities/erc4337_utils.py
@@ -59,7 +59,7 @@ class UserOperation:
     def __eq__(self, other) -> bool:
         if not isinstance(other, UserOperation):
             return False
-        return self.to_dict() == other.to_dict()
+        return bytes(self) == bytes(other)
 
     def __bytes__(self) -> bytes:
         return json.dumps(self.to_dict(), sort_keys=True).encode("utf-8")
@@ -221,6 +221,11 @@ class PackedUserOperation:
 
     def __bytes__(self) -> bytes:
         return json.dumps(self.to_dict(), sort_keys=True).encode("utf-8")
+
+    def __eq__(self, other) -> bool:
+        if not isinstance(other, PackedUserOperation):
+            return False
+        return bytes(self) == bytes(other)
 
     @classmethod
     def from_bytes(cls, data: bytes) -> "PackedUserOperation":

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -20,7 +20,7 @@ from nucypher.policy.conditions.lingo import (
     NotCompoundCondition,
     OrCompoundCondition,
     ReturnValueTest,
-    SequentialAccessControlCondition,
+    SequentialCondition,
 )
 from nucypher.policy.conditions.time import TimeCondition
 from tests.constants import TEST_ETH_PROVIDER_URI, TESTERCHAIN_CHAIN_ID
@@ -99,7 +99,7 @@ def condition(test_registry):
         operand=NotCompoundCondition(operand=rpc_condition)
     )
 
-    sequential_condition = SequentialAccessControlCondition(
+    sequential_condition = SequentialCondition(
         condition_variables=[
             ConditionVariable("rpc", rpc_condition),
             ConditionVariable("contract", contract_condition),

--- a/tests/acceptance/actors/test_signing_ritual.py
+++ b/tests/acceptance/actors/test_signing_ritual.py
@@ -15,9 +15,8 @@ from nucypher.policy.conditions.signing.base import SigningObjectAttributeCondit
 from nucypher.utilities.erc4337_utils import (
     AAVersion,
     PackedUserOperation,
-    create_erc20_transfer,
-    create_eth_transfer,
 )
+from tests.utils.erc4337 import create_erc20_transfer, create_eth_transfer
 
 
 @pytest.fixture(scope="module")

--- a/tests/acceptance/actors/test_signing_ritual.py
+++ b/tests/acceptance/actors/test_signing_ritual.py
@@ -1,16 +1,20 @@
 import pytest
 import pytest_twisted
+from hexbytes import HexBytes
 
 from nucypher.blockchain.eth.models import SigningCoordinator
 from nucypher.characters.lawful import Ursula
 from nucypher.network.signing import (
     EIP191SignatureRequest,
+    PackedUserOperationSignatureRequest,
     UserOperationSignatureRequest,
 )
 from nucypher.policy.conditions.auth.evm import EIP1271Auth
-from nucypher.policy.conditions.lingo import ConditionLingo
+from nucypher.policy.conditions.lingo import ConditionLingo, ReturnValueTest
+from nucypher.policy.conditions.signing.base import SigningObjectAttributeCondition
 from nucypher.utilities.erc4337_utils import (
     AAVersion,
+    PackedUserOperation,
     create_erc20_transfer,
     create_eth_transfer,
 )
@@ -246,7 +250,7 @@ def test_signing_request_fulfilment(
 
 @pytest_twisted.inlineCallbacks
 @pytest.mark.parametrize("aa_version", [AAVersion.V08, AAVersion.MDT])
-def test_user_op_signing_request_fulfilment(
+def test_user_op_signing_request_eth_transfer(
     aa_version,
     chain,
     bob,
@@ -259,9 +263,11 @@ def test_user_op_signing_request_fulfilment(
     nucypher_dependency,
     ritual_initiator,
 ):
-    signing_cohort = signing_coordinator_agent.get_signing_cohort(cohort_id)
+    print(
+        "==================== TESTING ETH TRANSFER USER OPERATION SIGNING ===================="
+    )
 
-    print("==================== TESTING USER OPERATION SIGNING ====================")
+    signing_cohort = signing_coordinator_agent.get_signing_cohort(cohort_id)
 
     # Test create_eth_transfer helper
     eth_transfer_op = create_eth_transfer(
@@ -282,6 +288,10 @@ def test_user_op_signing_request_fulfilment(
     assert eth_transfer_op.nonce == 1
     assert len(eth_transfer_op.call_data) > 0  # Should have encoded call data
 
+    expected_hash, _ = PackedUserOperation.from_user_operation(eth_transfer_op).sign(
+        ritual_initiator.transacting_power, aa_version, chain.chain_id
+    )
+
     # Test signing the ETH transfer operation
     eth_signing_request = UserOperationSignatureRequest(
         user_op=eth_transfer_op,
@@ -296,22 +306,43 @@ def test_user_op_signing_request_fulfilment(
 
     # Verify ETH transfer signatures
     assert len(responses) >= signing_cohort.threshold
-    message_hash = None
     aggregated_signature = b""
     for r in responses:
-        if message_hash is None:
-            message_hash = r.hash
-        assert message_hash == r.hash, "All hashes must be the same"
+        assert expected_hash == r.hash, "All hashes must be the same"
         aggregated_signature += r.signature
 
     multisig = get_cohort_multisig(
         cohort_id, nucypher_dependency, signing_coordinator_child
     )
-    eth_result = multisig.isValidSignature(message_hash, aggregated_signature)
+    eth_result = multisig.isValidSignature(expected_hash, aggregated_signature)
     assert (
         eth_result == EIP1271Auth.MAGIC_VALUE_BYTES
     ), f"Invalid ETH transfer signature: {eth_result} != {EIP1271Auth.MAGIC_VALUE_BYTES}"
-    print("ETH transfer signing successful")
+    print("===================== SIGNING SUCCESSFUL =====================")
+
+    yield
+
+
+@pytest_twisted.inlineCallbacks
+@pytest.mark.parametrize("aa_version", [AAVersion.V08, AAVersion.MDT])
+def test_user_op_signing_request_erc20_transfer(
+    aa_version,
+    chain,
+    bob,
+    accounts,
+    signing_coordinator_agent,
+    signing_coordinator_child,
+    initiator,
+    cohort_id,
+    cohort,
+    nucypher_dependency,
+    ritual_initiator,
+):
+    print(
+        "==================== TESTING ERC20 TRANSFER USER OPERATION SIGNING ===================="
+    )
+
+    signing_cohort = signing_coordinator_agent.get_signing_cohort(cohort_id)
 
     # Test create_erc20_transfer helper
     # Using a mock ERC20 token address
@@ -339,6 +370,10 @@ def test_user_op_signing_request_fulfilment(
     assert erc20_transfer_op.nonce == 2
     assert len(erc20_transfer_op.call_data) > 0  # Should have encoded call data
 
+    expected_hash, _ = PackedUserOperation.from_user_operation(erc20_transfer_op).sign(
+        ritual_initiator.transacting_power, aa_version, chain.chain_id
+    )
+
     # Test signing the ERC20 transfer operation
     erc20_signing_request = UserOperationSignatureRequest(
         user_op=erc20_transfer_op,
@@ -353,19 +388,242 @@ def test_user_op_signing_request_fulfilment(
 
     # Verify ERC20 transfer signatures
     assert len(responses) >= signing_cohort.threshold
-    message_hash = None
     aggregated_signature = b""
     for r in responses:
-        if message_hash is None:
-            message_hash = r.hash
-        assert message_hash == r.hash, "All hashes must be the same"
+        assert expected_hash == r.hash, "All hashes must be the same"
         aggregated_signature += r.signature
 
-    erc20_result = multisig.isValidSignature(message_hash, aggregated_signature)
+    multisig = get_cohort_multisig(
+        cohort_id, nucypher_dependency, signing_coordinator_child
+    )
+    erc20_result = multisig.isValidSignature(expected_hash, aggregated_signature)
     assert (
         erc20_result == EIP1271Auth.MAGIC_VALUE_BYTES
     ), f"Invalid ERC20 transfer signature: {erc20_result} != {EIP1271Auth.MAGIC_VALUE_BYTES}"
-    print("ERC20 transfer signing successful")
     print("===================== SIGNING SUCCESSFUL =====================")
+
+    yield
+
+
+@pytest_twisted.inlineCallbacks
+@pytest.mark.parametrize("aa_version", [AAVersion.V08, AAVersion.MDT])
+def test_packed_user_op_signing_request(
+    aa_version,
+    chain,
+    bob,
+    accounts,
+    signing_coordinator_agent,
+    signing_coordinator_child,
+    initiator,
+    cohort_id,
+    cohort,
+    nucypher_dependency,
+    ritual_initiator,
+):
+    signing_cohort = signing_coordinator_agent.get_signing_cohort(cohort_id)
+
+    print(
+        "==================== TESTING PACKED USER OPERATION SIGNING ===================="
+    )
+
+    # Test create_erc20_transfer helper
+    # Using a mock ERC20 token address
+    mock_token_address = "0x1234567890123456789012345678901234567890"
+    erc20_transfer_op = create_erc20_transfer(
+        sender=accounts[0].address,
+        nonce=2,
+        token=mock_token_address,
+        to=accounts[1].address,
+        amount=1000000000000000000,  # 1 token (assuming 18 decimals)
+        verification_gas_limit=100000,
+        call_gas_limit=100000,
+        pre_verification_gas=21000,
+        max_priority_fee_per_gas=1000000000,
+        max_fee_per_gas=2000000000,
+        # paymaster data
+        paymaster=accounts[1].address,
+        paymaster_post_op_gas_limit=100000,
+        paymaster_verification_gas_limit=200000,
+        paymaster_data=b"",
+    )
+
+    packed_user_op = PackedUserOperation.from_user_operation(erc20_transfer_op)
+    expected_hash, _ = packed_user_op.sign(
+        ritual_initiator.transacting_power, aa_version, chain.chain_id
+    )
+
+    # Test signing the ERC20 transfer operation
+    packed_erc20_signing_request = PackedUserOperationSignatureRequest(
+        packed_user_op=packed_user_op,
+        aa_version=aa_version,
+        chain_id=chain.chain_id,
+        cohort_id=cohort_id,
+        context=None,
+    )
+
+    responses = yield bob.request_threshold_signatures(
+        signing_request=packed_erc20_signing_request,
+    )
+
+    # Verify ERC20 transfer signatures
+    assert len(responses) >= signing_cohort.threshold
+    aggregated_signature = b""
+    for r in responses:
+        assert expected_hash == r.hash, "All hashes must be the same"
+        aggregated_signature += r.signature
+
+    multisig = get_cohort_multisig(
+        cohort_id, nucypher_dependency, signing_coordinator_child
+    )
+    erc20_result = multisig.isValidSignature(expected_hash, aggregated_signature)
+    assert (
+        erc20_result == EIP1271Auth.MAGIC_VALUE_BYTES
+    ), f"Invalid ERC20 transfer signature: {erc20_result} != {EIP1271Auth.MAGIC_VALUE_BYTES}"
+    print("===================== SIGNING SUCCESSFUL =====================")
+
+    yield
+
+
+#
+# This tests intentionally modifies ths condition used for the cohort; leave as last
+# test unless you intend to modify the cohort conditions.
+#
+@pytest_twisted.inlineCallbacks
+@pytest.mark.parametrize("aa_version", [AAVersion.V08, AAVersion.MDT])
+def test_signing_request_with_signing_object_attribute_condition(
+    aa_version,
+    chain,
+    bob,
+    accounts,
+    signing_coordinator_agent,
+    signing_coordinator_child,
+    initiator,
+    cohort_id,
+    cohort,
+    nucypher_dependency,
+    ritual_initiator,
+):
+
+    signing_cohort = signing_coordinator_agent.get_signing_cohort(cohort_id)
+
+    # Test create_erc20_transfer helper
+    # Using a mock ERC20 token address
+    mock_token_address = "0x1234567890123456789012345678901234567890"
+    erc20_transfer_op = create_erc20_transfer(
+        sender=accounts[0].address,
+        nonce=2,
+        token=mock_token_address,
+        to=accounts[1].address,
+        amount=1000000000000000000,  # 1 token (assuming 18 decimals)
+    )
+
+    # set condition
+    signing_object_condition = SigningObjectAttributeCondition(
+        # TODO currently this considers snake case (python) as opposed to camel
+        #  case (thinking of client-side)
+        attribute_name="call_data",
+        return_value_test=ReturnValueTest(
+            comparator="==",
+            value=HexBytes(erc20_transfer_op.call_data).hex(),
+        ),
+    )
+    on_chain_condition_lingo = ConditionLingo(signing_object_condition)
+
+    signing_coordinator_agent.set_signing_cohort_conditions(
+        cohort_id,
+        chain.chain_id,
+        on_chain_condition_lingo,
+        ritual_initiator.transacting_power,
+    )
+
+    packed_user_op = PackedUserOperation.from_user_operation(erc20_transfer_op)
+    expected_hash, _ = packed_user_op.sign(
+        ritual_initiator.transacting_power, aa_version, chain.chain_id
+    )
+
+    multisig = get_cohort_multisig(
+        cohort_id, nucypher_dependency, signing_coordinator_child
+    )
+
+    #
+    # Test signing the user op
+    #
+    print(
+        "==================== TESTING USER OP SIGNING OBJECT ATTR CONDITION ===================="
+    )
+    user_op_erc20_signing_request = UserOperationSignatureRequest(
+        user_op=erc20_transfer_op,
+        aa_version=aa_version,
+        chain_id=chain.chain_id,
+        cohort_id=cohort_id,
+        context=None,
+    )
+
+    responses = yield bob.request_threshold_signatures(
+        signing_request=user_op_erc20_signing_request,
+    )
+
+    # Verify ERC20 transfer signatures
+    assert len(responses) >= signing_cohort.threshold
+    aggregated_signature = b""
+    for r in responses:
+        assert expected_hash == r.hash, "All hashes must be the same"
+        aggregated_signature += r.signature
+
+    erc20_result = multisig.isValidSignature(expected_hash, aggregated_signature)
+    assert (
+        erc20_result == EIP1271Auth.MAGIC_VALUE_BYTES
+    ), f"Invalid user op signature: {erc20_result} != {EIP1271Auth.MAGIC_VALUE_BYTES}"
+
+    #
+    # Test signing the packed user op transfer operation
+    #
+    print(
+        "==================== TESTING PACKED USER OP SIGNING OBJECT ATTR CONDITION ===================="
+    )
+    packed_user_op_erc20_signing_request = PackedUserOperationSignatureRequest(
+        packed_user_op=PackedUserOperation.from_user_operation(erc20_transfer_op),
+        aa_version=aa_version,
+        chain_id=chain.chain_id,
+        cohort_id=cohort_id,
+        context=None,
+    )
+
+    responses = yield bob.request_threshold_signatures(
+        signing_request=packed_user_op_erc20_signing_request,
+    )
+
+    # Verify ERC20 transfer signatures
+    assert len(responses) >= signing_cohort.threshold
+    aggregated_signature = b""
+    for r in responses:
+        assert expected_hash == r.hash, "All hashes must be the same"
+        aggregated_signature += r.signature
+
+    erc20_result = multisig.isValidSignature(expected_hash, aggregated_signature)
+    assert (
+        erc20_result == EIP1271Auth.MAGIC_VALUE_BYTES
+    ), f"Invalid packed user op signature: {erc20_result} != {EIP1271Auth.MAGIC_VALUE_BYTES}"
+
+    print("===================== SIGNING SUCCESSFUL =====================")
+
+    erc20_transfer_op.call_data = (
+        b"1234"  # Modify call_data to fail attribute condition
+    )
+    failure_user_op_erc20_signing_request = UserOperationSignatureRequest(
+        user_op=erc20_transfer_op,
+        aa_version=aa_version,
+        chain_id=chain.chain_id,
+        cohort_id=cohort_id,
+        context=None,
+    )
+    with pytest.raises(
+        Ursula.NotEnoughUrsulas, match="Decryption conditions not satisfied"
+    ):
+        _ = yield bob.request_threshold_signatures(
+            signing_request=failure_user_op_erc20_signing_request,
+        )
+
+    print("===================== SIGNING FAILED =====================")
 
     yield

--- a/tests/acceptance/actors/test_signing_ritual.py
+++ b/tests/acceptance/actors/test_signing_ritual.py
@@ -519,9 +519,7 @@ def test_signing_request_with_signing_object_attribute_condition(
 
     # set condition
     signing_object_condition = SigningObjectAttributeCondition(
-        # TODO currently this considers snake case (python) as opposed to camel
-        #  case (thinking of client-side)
-        attribute_name="call_data",
+        attribute_name="callData",
         return_value_test=ReturnValueTest(
             comparator="==",
             value=HexBytes(erc20_transfer_op.call_data).hex(),

--- a/tests/acceptance/conditions/test_ecdsa_condition.py
+++ b/tests/acceptance/conditions/test_ecdsa_condition.py
@@ -64,7 +64,7 @@ def test_ecdsa_condition_in_compound_condition():
     Test using an ECDSA condition in a compound condition with another condition
     """
     from nucypher.policy.conditions.lingo import (
-        CompoundAccessControlCondition,
+        CompoundCondition,
         Operator,
     )
 
@@ -94,7 +94,7 @@ def test_ecdsa_condition_in_compound_condition():
     )
 
     # Create a compound condition with OR operator
-    compound_condition = CompoundAccessControlCondition(
+    compound_condition = CompoundCondition(
         operator=Operator.OR.value, operands=[ecdsa_condition, second_ecdsa_condition]
     )
 
@@ -116,7 +116,7 @@ def test_ecdsa_condition_in_compound_condition():
     ), "Compound OR condition should succeed if at least one ECDSA verification is true"
 
     # Create a compound condition with AND operator
-    compound_condition = CompoundAccessControlCondition(
+    compound_condition = CompoundCondition(
         operator=Operator.AND.value, operands=[ecdsa_condition, second_ecdsa_condition]
     )
 

--- a/tests/acceptance/conditions/test_multichain_evaluation.py
+++ b/tests/acceptance/conditions/test_multichain_evaluation.py
@@ -4,7 +4,7 @@ import pytest
 
 from nucypher.policy.conditions.evm import RPCCall, RPCCondition
 from nucypher.policy.conditions.lingo import (
-    CompoundAccessControlCondition,
+    CompoundCondition,
     ConditionLingo,
     ConditionType,
     ReturnValueTest,
@@ -21,7 +21,7 @@ def make_multichain_evm_conditions(bob, chain_ids):
     """This is a helper function to make a set of conditions that are valid on multiple chains."""
     operands = list()
     for chain_id in chain_ids:
-        compound_and_condition = CompoundAccessControlCondition(
+        compound_and_condition = CompoundCondition(
             operator="and",
             operands=[
                 TimeCondition(

--- a/tests/integration/conditions/test_ecdsa_condition_integration.py
+++ b/tests/integration/conditions/test_ecdsa_condition_integration.py
@@ -4,7 +4,7 @@ from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
 from nucypher.policy.conditions.lingo import (
-    CompoundAccessControlCondition,
+    CompoundCondition,
     ConditionLingo,
 )
 
@@ -87,12 +87,12 @@ def test_ecdsa_in_compound_condition():
     )
 
     # Create OR compound condition
-    or_condition = CompoundAccessControlCondition(
+    or_condition = CompoundCondition(
         operator="or", operands=[ecdsa_condition1, ecdsa_condition2]
     )
 
     # Create AND compound condition
-    and_condition = CompoundAccessControlCondition(
+    and_condition = CompoundCondition(
         operator="and", operands=[ecdsa_condition1, ecdsa_condition2]
     )
 

--- a/tests/integration/conditions/test_ecdsa_condition_json.py
+++ b/tests/integration/conditions/test_ecdsa_condition_json.py
@@ -5,7 +5,7 @@ from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
 from nucypher.policy.conditions.lingo import (
-    CompoundAccessControlCondition,
+    CompoundCondition,
     ConditionLingo,
 )
 
@@ -132,7 +132,7 @@ def test_complex_condition_with_ecdsa_json_serialization():
     )
 
     # Create compound condition (both signers must sign)
-    compound_condition = CompoundAccessControlCondition(
+    compound_condition = CompoundCondition(
         operator="and", operands=[condition1, condition2], name="Both Signers Required"
     )
 
@@ -170,7 +170,7 @@ def test_complex_condition_with_ecdsa_json_serialization():
     assert len(parsed_json["operands"]) == 2
 
     # Recreate from JSON
-    recreated_condition = CompoundAccessControlCondition.from_json(json_condition)
+    recreated_condition = CompoundCondition.from_json(json_condition)
 
     # Create a context with valid signatures
     context = {

--- a/tests/unit/conditions/conftest.py
+++ b/tests/unit/conditions/conftest.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from nucypher.policy.conditions.base import Condition
+from nucypher.policy.conditions.base import _Serializable
 from nucypher.policy.conditions.context import USER_ADDRESS_CONTEXT
 from nucypher.policy.conditions.evm import ContractCondition
 from nucypher.policy.conditions.lingo import (
@@ -99,4 +99,4 @@ def erc721_evm_condition(test_registry):
 
 @pytest.fixture(scope="function")
 def mock_skip_schema_validation(mocker):
-    mocker.patch.object(Condition.Schema, "validate", return_value=None)
+    mocker.patch.object(_Serializable, "_validate", return_value=None)

--- a/tests/unit/conditions/conftest.py
+++ b/tests/unit/conditions/conftest.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from nucypher.policy.conditions.base import AccessControlCondition
+from nucypher.policy.conditions.base import Condition
 from nucypher.policy.conditions.context import USER_ADDRESS_CONTEXT
 from nucypher.policy.conditions.evm import ContractCondition
 from nucypher.policy.conditions.lingo import (
@@ -99,4 +99,4 @@ def erc721_evm_condition(test_registry):
 
 @pytest.fixture(scope="function")
 def mock_skip_schema_validation(mocker):
-    mocker.patch.object(AccessControlCondition.Schema, "validate", return_value=None)
+    mocker.patch.object(Condition.Schema, "validate", return_value=None)

--- a/tests/unit/conditions/test_compound_condition.py
+++ b/tests/unit/conditions/test_compound_condition.py
@@ -3,39 +3,39 @@ from unittest.mock import Mock
 
 import pytest
 
-from nucypher.policy.conditions.base import AccessControlCondition
+from nucypher.policy.conditions.base import Condition
 from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
     InvalidConditionLingo,
 )
 from nucypher.policy.conditions.lingo import (
     AndCompoundCondition,
-    CompoundAccessControlCondition,
+    CompoundCondition,
     ConditionType,
     ConditionVariable,
     NotCompoundCondition,
     OrCompoundCondition,
-    SequentialAccessControlCondition,
+    SequentialCondition,
 )
 
 
 @pytest.fixture(scope="function")
 def mock_conditions():
-    condition_1 = Mock(spec=AccessControlCondition)
+    condition_1 = Mock(spec=Condition)
     condition_1.verify.return_value = (True, 1)
     condition_1.to_dict.return_value = {
         "value": 1
-    }  # needed for "id" value calc for CompoundAccessControlCondition
+    }  # needed for "id" value calc for CompoundCondition
 
-    condition_2 = Mock(spec=AccessControlCondition)
+    condition_2 = Mock(spec=Condition)
     condition_2.verify.return_value = (True, 2)
     condition_2.to_dict.return_value = {"value": 2}
 
-    condition_3 = Mock(spec=AccessControlCondition)
+    condition_3 = Mock(spec=Condition)
     condition_3.verify.return_value = (True, 3)
     condition_3.to_dict.return_value = {"value": 3}
 
-    condition_4 = Mock(spec=AccessControlCondition)
+    condition_4 = Mock(spec=Condition)
     condition_4.verify.return_value = (True, 4)
     condition_4.to_dict.return_value = {"value": 4}
 
@@ -43,15 +43,15 @@ def mock_conditions():
 
 
 def test_invalid_compound_condition(time_condition, rpc_condition):
-    for operator in CompoundAccessControlCondition.OPERATORS:
-        if operator == CompoundAccessControlCondition.NOT_OPERATOR:
+    for operator in CompoundCondition.OPERATORS:
+        if operator == CompoundCondition.NOT_OPERATOR:
             operands = [time_condition]
         else:
             operands = [time_condition, rpc_condition]
 
         # invalid condition type
         with pytest.raises(InvalidCondition, match=ConditionType.COMPOUND.value):
-            _ = CompoundAccessControlCondition(
+            _ = CompoundCondition(
                 condition_type=ConditionType.TIME.value,
                 operator=operator,
                 operands=operands,
@@ -59,100 +59,98 @@ def test_invalid_compound_condition(time_condition, rpc_condition):
 
     # invalid operator - 1 operand
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(operator="5True", operands=[time_condition])
+        _ = CompoundCondition(operator="5True", operands=[time_condition])
 
     # invalid operator - 2 operands
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(
+        _ = CompoundCondition(
             operator="5True", operands=[time_condition, rpc_condition]
         )
 
     # no operands
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(
-            operator=random.choice(CompoundAccessControlCondition.OPERATORS),
+        _ = CompoundCondition(
+            operator=random.choice(CompoundCondition.OPERATORS),
             operands=[],
         )
 
     # > 1 operand for not operator
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(
-            operator=CompoundAccessControlCondition.NOT_OPERATOR,
+        _ = CompoundCondition(
+            operator=CompoundCondition.NOT_OPERATOR,
             operands=[time_condition, rpc_condition],
         )
 
     # < 2 operands for or operator
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(
-            operator=CompoundAccessControlCondition.OR_OPERATOR,
+        _ = CompoundCondition(
+            operator=CompoundCondition.OR_OPERATOR,
             operands=[time_condition],
         )
 
     # < 2 operands for and operator
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(
-            operator=CompoundAccessControlCondition.AND_OPERATOR,
+        _ = CompoundCondition(
+            operator=CompoundCondition.AND_OPERATOR,
             operands=[rpc_condition],
         )
 
     # exceeds max operands
     operands = list()
-    for i in range(CompoundAccessControlCondition.MAX_NUM_CONDITIONS + 1):
+    for i in range(CompoundCondition.MAX_NUM_CONDITIONS + 1):
         operands.append(rpc_condition)
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(
-            operator=CompoundAccessControlCondition.OR_OPERATOR,
+        _ = CompoundCondition(
+            operator=CompoundCondition.OR_OPERATOR,
             operands=operands,
         )
     with pytest.raises(InvalidCondition):
-        _ = CompoundAccessControlCondition(
-            operator=CompoundAccessControlCondition.AND_OPERATOR,
+        _ = CompoundCondition(
+            operator=CompoundCondition.AND_OPERATOR,
             operands=operands,
         )
 
 
-@pytest.mark.parametrize("operator", CompoundAccessControlCondition.OPERATORS)
+@pytest.mark.parametrize("operator", CompoundCondition.OPERATORS)
 def test_compound_condition_schema_validation(operator, time_condition, rpc_condition):
-    if operator == CompoundAccessControlCondition.NOT_OPERATOR:
+    if operator == CompoundCondition.NOT_OPERATOR:
         operands = [time_condition]
     else:
         operands = [time_condition, rpc_condition]
 
-    compound_condition = CompoundAccessControlCondition(
-        operator=operator, operands=operands
-    )
+    compound_condition = CompoundCondition(operator=operator, operands=operands)
     compound_condition_dict = compound_condition.to_dict()
 
     # no issues here
-    CompoundAccessControlCondition.from_dict(compound_condition_dict)
+    CompoundCondition.from_dict(compound_condition_dict)
 
     # no issues with optional name
     compound_condition_dict["name"] = "my_contract_condition"
-    CompoundAccessControlCondition.from_dict(compound_condition_dict)
+    CompoundCondition.from_dict(compound_condition_dict)
 
     with pytest.raises(InvalidConditionLingo):
         # incorrect condition type
         compound_condition_dict = compound_condition.to_dict()
         compound_condition_dict["condition_type"] = ConditionType.RPC.value
-        CompoundAccessControlCondition.from_dict(compound_condition_dict)
+        CompoundCondition.from_dict(compound_condition_dict)
 
     with pytest.raises(InvalidConditionLingo):
         # invalid operator
         compound_condition_dict = compound_condition.to_dict()
         compound_condition_dict["operator"] = "5True"
-        CompoundAccessControlCondition.from_dict(compound_condition_dict)
+        CompoundCondition.from_dict(compound_condition_dict)
 
     with pytest.raises(InvalidConditionLingo):
         # no operator
         compound_condition_dict = compound_condition.to_dict()
         del compound_condition_dict["operator"]
-        CompoundAccessControlCondition.from_dict(compound_condition_dict)
+        CompoundCondition.from_dict(compound_condition_dict)
 
     with pytest.raises(InvalidConditionLingo):
         # no operands
         compound_condition_dict = compound_condition.to_dict()
         del compound_condition_dict["operands"]
-        CompoundAccessControlCondition.from_dict(compound_condition_dict)
+        CompoundCondition.from_dict(compound_condition_dict)
 
 
 @pytest.mark.usefixtures("mock_skip_schema_validation")
@@ -324,7 +322,7 @@ def test_nested_sequential_condition_too_many_nested_levels(
                 OrCompoundCondition(
                     operands=[
                         rpc_condition,
-                        SequentialAccessControlCondition(
+                        SequentialCondition(
                             condition_variables=[
                                 ConditionVariable("var2", time_condition),
                                 ConditionVariable("var3", rpc_condition),

--- a/tests/unit/conditions/test_if_then_else_condition.py
+++ b/tests/unit/conditions/test_if_then_else_condition.py
@@ -2,7 +2,7 @@ import pytest
 from web3.exceptions import Web3Exception
 
 from nucypher.policy.conditions.base import (
-    AccessControlCondition,
+    Condition,
 )
 from nucypher.policy.conditions.exceptions import InvalidCondition
 from nucypher.policy.conditions.lingo import (
@@ -10,22 +10,22 @@ from nucypher.policy.conditions.lingo import (
     ConditionVariable,
     IfThenElseCondition,
     OrCompoundCondition,
-    SequentialAccessControlCondition,
+    SequentialCondition,
 )
 from nucypher.policy.conditions.utils import ConditionProviderManager
 
 
 @pytest.fixture(scope="function")
 def mock_conditions(mocker):
-    cond_1 = mocker.Mock(spec=AccessControlCondition)
+    cond_1 = mocker.Mock(spec=Condition)
     cond_1.verify.return_value = (True, 1)
     cond_1.to_dict.return_value = {"value": 1}
 
-    cond_2 = mocker.Mock(spec=AccessControlCondition)
+    cond_2 = mocker.Mock(spec=Condition)
     cond_2.verify.return_value = (True, 2)
     cond_2.to_dict.return_value = {"value": 2}
 
-    cond_3 = mocker.Mock(spec=AccessControlCondition)
+    cond_3 = mocker.Mock(spec=Condition)
     cond_3.verify.return_value = (True, 3)
     cond_3.to_dict.return_value = {"value": 3}
 
@@ -47,7 +47,7 @@ def test_nested_sequential_condition_too_many_nested_levels(
     rpc_condition, time_condition
 ):
     # causes too many nested multi-conditions when used within a if-then-else condition
-    problematic_nested_condition = SequentialAccessControlCondition(
+    problematic_nested_condition = SequentialCondition(
         condition_variables=[
             ConditionVariable("var1", time_condition),
             ConditionVariable(
@@ -152,7 +152,7 @@ def test_nested_multi_condition_allowed_levels(rpc_condition, time_condition):
             then_condition=time_condition,
             else_condition=rpc_condition,
         ),
-        else_condition=SequentialAccessControlCondition(
+        else_condition=SequentialCondition(
             condition_variables=[
                 ConditionVariable("var1", time_condition),
                 ConditionVariable("var2", rpc_condition),
@@ -240,7 +240,7 @@ def test_nested_multi_conditions(mock_conditions):
                 cond_2,
             ]
         ),
-        then_condition=SequentialAccessControlCondition(
+        then_condition=SequentialCondition(
             condition_variables=[
                 ConditionVariable("var1", cond_2),
                 ConditionVariable("var2", cond_3),
@@ -267,7 +267,7 @@ def test_nested_multi_conditions(mock_conditions):
                 cond_2,
             ]
         ),
-        then_condition=SequentialAccessControlCondition(
+        then_condition=SequentialCondition(
             condition_variables=[
                 ConditionVariable("var1", cond_2),
                 ConditionVariable("var2", cond_3),

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -12,47 +12,46 @@ from nucypher.policy.conditions.lingo import ReturnValueTest
 
 
 def test_return_value_test_schema():
-    schema = ReturnValueTest.ReturnValueTestSchema()
+    schema = ReturnValueTest.Schema()
     return_value_test = ReturnValueTest(comparator=">", value=0, index=1)
 
-    test_dict = schema.dump(return_value_test)
-
+    test_dict = return_value_test.to_dict()
     # no issues here
     errors = schema.validate(data=test_dict)
     assert not errors, f"{errors}"
 
     # missing comparator should cause error
-    test_dict = schema.dump(return_value_test)
+    test_dict = return_value_test.to_dict()
     del test_dict["comparator"]
     errors = schema.validate(data=test_dict)
     assert errors, f"{errors}"
 
     # invalid comparator should cause error
-    test_dict = schema.dump(return_value_test)
+    test_dict = return_value_test.to_dict()
     test_dict["comparator"] = "<>"
     errors = schema.validate(data=test_dict)
     assert errors, f"{errors}"
 
     # missing value should cause error
-    test_dict = schema.dump(return_value_test)
+    test_dict = return_value_test.to_dict()
     del test_dict["value"]
     errors = schema.validate(data=test_dict)
     assert errors, f"{errors}"
 
     # missing index should NOT cause any error since optional
-    test_dict = schema.dump(return_value_test)
+    test_dict = return_value_test.to_dict()
     del test_dict["index"]
     errors = schema.validate(data=test_dict)
     assert not errors, f"{errors}"
 
     # negative index should cause error
-    test_dict = schema.dump(return_value_test)
+    test_dict = return_value_test.to_dict()
     test_dict["index"] = -3
     errors = schema.validate(data=test_dict)
     assert errors, f"{errors}"
 
     # non-integer index should cause error
-    test_dict = schema.dump(return_value_test)
+    test_dict = return_value_test.to_dict()
     test_dict["index"] = "25"
     errors = schema.validate(data=test_dict)
     assert errors, f"{errors}"
@@ -60,15 +59,7 @@ def test_return_value_test_schema():
 
 def test_return_value_index_invalid():
     with pytest.raises(ReturnValueTest.InvalidExpression):
-        _ = ReturnValueTest(comparator=">", value=0, index="james")
-
-    with pytest.raises(ReturnValueTest.InvalidExpression):
         _ = ReturnValueTest(comparator=">", value=0, index=-1)
-
-    with pytest.raises(ReturnValueTest.InvalidExpression):
-        _ = ReturnValueTest(
-            comparator=">", value=0, index="10"
-        )  # should not be a string
 
 
 def test_return_value_index():
@@ -114,7 +105,7 @@ def test_return_value_index_tuple():
 )
 def test_return_value_test_invalid_comparators(comparator):
     with pytest.raises(
-        ReturnValueTest.InvalidExpression, match="not a permitted comparator"
+        ReturnValueTest.InvalidExpression, match="Not a permitted comparator"
     ):
         _ = ReturnValueTest(comparator=comparator, value=1)
 
@@ -269,8 +260,7 @@ def test_return_value_test_bytes():
     test = ReturnValueTest(comparator="==", value=HexBytes(value).hex())
 
     # ensure serialization/deserialization
-    schema = ReturnValueTest.ReturnValueTestSchema()
-    reloaded = schema.loads(schema.dumps(test))
+    reloaded = ReturnValueTest.from_json(test.to_json())
     assert (test.comparator == reloaded.comparator) and (test.value == reloaded.value)
 
     # ensure correct bytes/hex comparison
@@ -294,8 +284,7 @@ def test_return_value_test_bytes_in_list_of_values():
     test = ReturnValueTest(comparator="==", value=json_serializable_condition_value)
 
     # ensure serialization/deserialization
-    schema = ReturnValueTest.ReturnValueTestSchema()
-    reloaded = schema.loads(schema.dumps(test))
+    reloaded = ReturnValueTest.from_json(test.to_json())
     assert (test.comparator == reloaded.comparator) and (test.value == reloaded.value)
     # ensure correct bytes/hex comparison
     assert reloaded.eval(value), "bytes compared correctly to hex"
@@ -312,8 +301,7 @@ def test_return_value_test_tuples():
     test = ReturnValueTest(comparator="==", value=value_as_list)
 
     # ensure serialization/deserialization
-    schema = ReturnValueTest.ReturnValueTestSchema()
-    reloaded = schema.loads(schema.dumps(test))
+    reloaded = ReturnValueTest.from_json(test.to_json())
     assert (test.comparator == reloaded.comparator) and (test.value == reloaded.value)
 
     # ensure correct tuple/list comparison
@@ -349,8 +337,7 @@ def test_return_value_sanitize(test_scenario):
     # sanity check comparison
     test = ReturnValueTest(comparator="==", value=value)
     # ensure serialization/deserialization
-    schema = ReturnValueTest.ReturnValueTestSchema()
-    reloaded = schema.loads(schema.dumps(test))
+    reloaded = ReturnValueTest.from_json(test.to_json())
     assert reloaded.eval(value)
 
 
@@ -372,10 +359,20 @@ def test_return_value_sanitize(test_scenario):
     ],
 )
 def test_return_value_json_serialization(test_value):
-    schema = ReturnValueTest.ReturnValueTestSchema()
-    comparator = random.choice(ReturnValueTest.COMPARATORS)
+    schema = ReturnValueTest.Schema()
+    if isinstance(test_value, list):
+        comparator = random.choice(ReturnValueTest.COMPARATORS)
+    else:
+        # can't use in without a list
+        comparator = random.choice(
+            [
+                comparator
+                for comparator in ReturnValueTest.COMPARATORS
+                if comparator != "in"
+            ]
+        )
     test = ReturnValueTest(comparator=comparator, value=test_value)
-    reloaded = schema.loads(schema.dumps(test))
+    reloaded = schema.loads(test.to_json())
     assert (test.comparator == reloaded.comparator) and (
         test.value == reloaded.value
     ), f"test for '{comparator} {test_value}'"
@@ -407,3 +404,37 @@ def test_return_value_non_json_serializable_adjustments():
         ReturnValueTest.InvalidExpression, match="No JSON serializable equivalent"
     ):
         ReturnValueTest(comparator="==", value=not_json_serializable)
+
+
+@pytest.mark.parametrize(
+    "value, pass_value, fail_value",
+    [
+        (
+            ['"Fatigue"', '"makes"', '"cowards"', '"of"', '"us"', '"all"'],
+            '"cowards"',
+            '"tired"',
+        ),  # list of string values
+        # -- Vince Lombardi
+        (
+            ["0xdeadbeef", "0x12345678"],
+            "0x12345678",
+            "0x87654321",
+        ),  # list of hex strings
+    ],
+)
+def test_return_value_test_in_comparator(value, pass_value, fail_value):
+    test = ReturnValueTest(comparator="in", value=value)
+
+    # ensure correct bytes/hex comparison
+    assert test.eval(pass_value), "value should pass the 'in' test"
+    assert not test.eval(fail_value), "value should not pass the 'in' test"
+
+
+def test_return_value_test_in_comparator_invalid_types():
+    values = [1, '"string"', b"bytes", True, {"key": "value"}]
+    for value in values:
+        with pytest.raises(
+            ReturnValueTest.InvalidExpression,
+            match='not a valid type for the "in" comparator',
+        ):
+            _ = ReturnValueTest(comparator="in", value=value)

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -2,36 +2,36 @@ import pytest
 from web3.exceptions import Web3Exception
 
 from nucypher.policy.conditions.base import (
-    AccessControlCondition,
+    Condition,
 )
 from nucypher.policy.conditions.exceptions import InvalidCondition
 from nucypher.policy.conditions.lingo import (
     ConditionType,
     ConditionVariable,
     OrCompoundCondition,
-    SequentialAccessControlCondition,
+    SequentialCondition,
 )
 from nucypher.policy.conditions.utils import ConditionProviderManager
 
 
 @pytest.fixture(scope="function")
 def mock_condition_variables(mocker):
-    cond_1 = mocker.Mock(spec=AccessControlCondition)
+    cond_1 = mocker.Mock(spec=Condition)
     cond_1.verify.return_value = (True, 1)
     cond_1.to_dict.return_value = {"value": 1}
     var_1 = ConditionVariable(var_name="var1", condition=cond_1)
 
-    cond_2 = mocker.Mock(spec=AccessControlCondition)
+    cond_2 = mocker.Mock(spec=Condition)
     cond_2.verify.return_value = (True, 2)
     cond_2.to_dict.return_value = {"value": 2}
     var_2 = ConditionVariable(var_name="var2", condition=cond_2)
 
-    cond_3 = mocker.Mock(spec=AccessControlCondition)
+    cond_3 = mocker.Mock(spec=Condition)
     cond_3.verify.return_value = (True, 3)
     cond_3.to_dict.return_value = {"value": 3}
     var_3 = ConditionVariable(var_name="var3", condition=cond_3)
 
-    cond_4 = mocker.Mock(spec=AccessControlCondition)
+    cond_4 = mocker.Mock(spec=Condition)
     cond_4.verify.return_value = (True, 4)
     cond_4.to_dict.return_value = {"value": 4}
     var_4 = ConditionVariable(var_name="var4", condition=cond_4)
@@ -45,36 +45,36 @@ def test_invalid_sequential_condition(rpc_condition, time_condition):
 
     # invalid condition type
     with pytest.raises(InvalidCondition, match=ConditionType.SEQUENTIAL.value):
-        _ = SequentialAccessControlCondition(
+        _ = SequentialCondition(
             condition_type=ConditionType.TIME.value,
             condition_variables=[var_1, var_2],
         )
 
     # no variables
     with pytest.raises(InvalidCondition, match="At least two conditions"):
-        _ = SequentialAccessControlCondition(
+        _ = SequentialCondition(
             condition_variables=[],
         )
 
     # only one variable
     with pytest.raises(InvalidCondition, match="At least two conditions"):
-        _ = SequentialAccessControlCondition(
+        _ = SequentialCondition(
             condition_variables=[var_1],
         )
 
     # too many variables
     too_many_variables = [var_1, var_2, var_1, var_2]
     too_many_variables.extend(too_many_variables)  # duplicate list length
-    assert len(too_many_variables) > SequentialAccessControlCondition.MAX_NUM_CONDITIONS
+    assert len(too_many_variables) > SequentialCondition.MAX_NUM_CONDITIONS
     with pytest.raises(InvalidCondition, match="Maximum of"):
-        _ = SequentialAccessControlCondition(
+        _ = SequentialCondition(
             condition_variables=too_many_variables,
         )
 
     # duplicate var names
     dupe_var = ConditionVariable(var_1.var_name, condition=var_2.condition)
     with pytest.raises(InvalidCondition, match="Duplicate"):
-        _ = SequentialAccessControlCondition(
+        _ = SequentialCondition(
             condition_variables=[var_1, var_2, dupe_var],
         )
 
@@ -91,17 +91,17 @@ def test_nested_sequential_condition_too_many_nested_levels(
         InvalidCondition, match="nested levels of multi-conditions are allowed"
     ):
         _ = (
-            SequentialAccessControlCondition(
+            SequentialCondition(
                 condition_variables=[
                     var_1,
                     ConditionVariable(
                         "seq_1",
-                        SequentialAccessControlCondition(
+                        SequentialCondition(
                             condition_variables=[
                                 var_2,
                                 ConditionVariable(
                                     "seq_2",
-                                    SequentialAccessControlCondition(
+                                    SequentialCondition(
                                         condition_variables=[
                                             var_3,
                                             var_4,
@@ -127,14 +127,14 @@ def test_nested_compound_condition_too_many_nested_levels(
     with pytest.raises(
         InvalidCondition, match="nested levels of multi-conditions are allowed"
     ):
-        _ = SequentialAccessControlCondition(
+        _ = SequentialCondition(
             condition_variables=[
                 ConditionVariable(
                     "var1",
                     OrCompoundCondition(
                         operands=[
                             var_1.condition,
-                            SequentialAccessControlCondition(
+                            SequentialCondition(
                                 condition_variables=[
                                     var_2,
                                     var_3,
@@ -169,7 +169,7 @@ def test_sequential_condition(mock_condition_variables):
         context[f":{var_3.var_name}"] * 4,
     )
 
-    sequential_condition = SequentialAccessControlCondition(
+    sequential_condition = SequentialCondition(
         condition_variables=[var_1, var_2, var_3, var_4],
     )
 
@@ -209,7 +209,7 @@ def test_sequential_condition_all_prior_vars_passed_to_subsequent_calls(
         + 1,
     )
 
-    sequential_condition = SequentialAccessControlCondition(
+    sequential_condition = SequentialCondition(
         condition_variables=[var_1, var_2, var_3, var_4],
     )
 
@@ -238,7 +238,7 @@ def test_sequential_condition_a_call_fails(mock_condition_variables):
 
     var_4.condition.verify.side_effect = Web3Exception
 
-    sequential_condition = SequentialAccessControlCondition(
+    sequential_condition = SequentialCondition(
         condition_variables=[var_1, var_2, var_3, var_4],
     )
 

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -14,9 +14,11 @@ from nucypher.policy.conditions.lingo import (
 )
 from nucypher.policy.conditions.signing.base import (
     SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+    SigningObjectAbiAttributeCondition,
     SigningObjectAttributeCondition,
 )
 from nucypher.policy.conditions.utils import ConditionProviderManager
+from nucypher.utilities.abi import encode_human_readable_call
 
 
 @pytest.fixture
@@ -201,3 +203,159 @@ def test_signing_object_attribute_condition_lingo_json_serialization(
     )
     assert success is True
     assert result == signing_object.call_data
+
+
+def test_invalid_signing_object_abi_attribute_condition():
+    # invalid condition type
+    with pytest.raises(InvalidCondition, match=ConditionType.ABI_ATTRIBUTE.value):
+        _ = SigningObjectAbiAttributeCondition(
+            condition_type=ConditionType.TIME.value,
+            attribute_name="call_data",
+            abi_decode_string="transfer(address,uint256)",
+            abi_decode_value_index=0,
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+    # no abi decode string
+    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_decode_string=None,
+            abi_decode_value_index=0,
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+    # invalid abi decode string
+    with pytest.raises(InvalidCondition, match="Invalid ABI decode string"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_decode_string="transfer(address,uint257)",  # invalid data type
+            abi_decode_value_index=0,
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+    # no abi index value
+    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_decode_string="transfer(address,uint256)",
+            abi_decode_value_index=None,
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+    # negative abi index
+    with pytest.raises(InvalidCondition, match="Must be greater than or equal to 0"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_decode_string="transfer(address,uint256)",
+            abi_decode_value_index=-1,
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+    # abi index out of range
+    with pytest.raises(InvalidCondition, match="Value index '3' is out of range"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_decode_string="transfer(address,uint256)",
+            abi_decode_value_index=3,  # out of range for this signature
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+
+def test_signing_object_abi_attribute_condition_initialization():
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_decode_string="transfer(address,uint256)",
+        abi_decode_value_index=2,
+        return_value_test=ReturnValueTest("==", 0),
+    )
+
+    assert condition.condition_type == ConditionType.ABI_ATTRIBUTE.value
+    assert condition.signing_object_context_var == SIGNING_CONDITION_OBJECT_CONTEXT_VAR
+    assert condition.attribute_name == "call_data"
+    assert condition.abi_decode_string == "transfer(address,uint256)"
+    assert condition.abi_decode_value_index == 2
+    assert condition.return_value_test.eval(0)
+
+
+def test_signing_object_abi_attribute_condition_verify_method_call(
+    mocker, condition_provider_manager, get_random_checksum_address
+):
+    call_data_human_signature = "transfer(address,uint256)"
+    signing_object = mocker.Mock()
+    signing_object.call_data = encode_human_readable_call(
+        call_data_human_signature, [get_random_checksum_address(), 10_000_000]
+    )
+
+    allowed_method_calls = ['"transfer"', '"mint"', '"burn"']
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_decode_string=call_data_human_signature,
+        abi_decode_value_index=0,  # method is at 0-index
+        return_value_test=ReturnValueTest("in", allowed_method_calls),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+    assert result == "transfer"
+
+
+def test_signing_object_abi_attribute_condition_verify_transfer_address_call(
+    mocker, condition_provider_manager, get_random_checksum_address
+):
+    call_data_human_signature = "transfer(address,uint256)"
+    allowed_addresses = [
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+    ]
+    signing_object = mocker.Mock()
+    signing_object.call_data = encode_human_readable_call(
+        call_data_human_signature, [allowed_addresses[0], 10_000_000]
+    )
+
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_decode_string=call_data_human_signature,
+        abi_decode_value_index=1,  # method is at 0-index
+        return_value_test=ReturnValueTest("in", allowed_addresses),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+
+    not_allowed_address = get_random_checksum_address()
+    signing_object.call_data = encode_human_readable_call(
+        call_data_human_signature, [not_allowed_address, 10_000_000]
+    )
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is False
+
+
+def test_signing_object_abi_attribute_condition_verify_transfer_amount_call(
+    mocker, condition_provider_manager, get_random_checksum_address
+):
+    call_data_human_signature = "transfer(address,uint256)"
+    signing_object = mocker.Mock()
+    signing_object.call_data = encode_human_readable_call(
+        call_data_human_signature, [get_random_checksum_address(), 10_000_000]
+    )
+
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_decode_string=call_data_human_signature,
+        abi_decode_value_index=2,  # method is at 0-index
+        return_value_test=ReturnValueTest("<", 20_000_000),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+
+    signing_object.call_data = encode_human_readable_call(
+        call_data_human_signature, [get_random_checksum_address(), 30_000_000]
+    )
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is False

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -359,3 +359,46 @@ def test_signing_object_abi_attribute_condition_verify_transfer_amount_call(
     )
     success, result = condition.verify(providers=condition_provider_manager, **context)
     assert success is False
+
+
+def test_signing_object_abi_attribute_condition_lingo_json_serialization(
+    mocker, condition_provider_manager, get_random_checksum_address
+):
+    """Test serializing and deserializing a condition lingo with ECDSA condition"""
+    call_data_human_signature = "transfer(address,uint256)"
+    signing_object = mocker.Mock()
+    signing_object.call_data = encode_human_readable_call(
+        call_data_human_signature, [get_random_checksum_address(), 10_000_000]
+    )
+
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_decode_string=call_data_human_signature,
+        abi_decode_value_index=2,  # method is at 0-index
+        return_value_test=ReturnValueTest("<", 20_000_000),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+
+    # Create condition lingo
+    lingo = ConditionLingo(condition)
+
+    # Convert lingo to JSON
+    original_lingo_json = lingo.to_json()
+
+    # Parse JSON to dict and verify structure
+    lingo_dict = json.loads(original_lingo_json)
+    assert lingo_dict["version"] == ConditionLingo.VERSION
+    assert lingo_dict["condition"]["conditionType"] == ConditionType.ABI_ATTRIBUTE.value
+
+    # Recreate lingo from JSON
+    recreated_lingo = ConditionLingo.from_json(original_lingo_json)
+    assert recreated_lingo.to_json() == original_lingo_json
+
+    # works the same
+    success, result = recreated_lingo.condition.verify(
+        providers=condition_provider_manager, **context
+    )
+    assert success is True

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -1,0 +1,203 @@
+import json
+
+import pytest
+
+from nucypher.policy.conditions.exceptions import (
+    InvalidCondition,
+    InvalidContextVariableData,
+    RequiredContextVariable,
+)
+from nucypher.policy.conditions.lingo import (
+    ConditionLingo,
+    ConditionType,
+    ReturnValueTest,
+)
+from nucypher.policy.conditions.signing.base import (
+    SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+    SigningObjectAttributeCondition,
+)
+from nucypher.policy.conditions.utils import ConditionProviderManager
+
+
+@pytest.fixture
+def condition_provider_manager():
+    """Fixture to provide a mock ConditionProviderManager."""
+    return ConditionProviderManager({})
+
+
+def test_invalid_signing_object_attribute_condition():
+    # invalid condition type
+    with pytest.raises(InvalidCondition, match=ConditionType.ATTRIBUTE.value):
+        _ = SigningObjectAttributeCondition(
+            condition_type=ConditionType.TIME.value,
+            attribute_name="some_attribute",
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+    # no attribute name
+    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+        _ = SigningObjectAttributeCondition(
+            attribute_name=None,
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+
+def test_signing_object_attribute_condition_initialization():
+    condition = SigningObjectAttributeCondition(
+        condition_type=ConditionType.ATTRIBUTE.value,
+        attribute_name="call_data",
+        return_value_test=ReturnValueTest("==", 0),
+    )
+
+    assert condition.condition_type == ConditionType.ATTRIBUTE.value
+    assert condition.signing_object_context_var == SIGNING_CONDITION_OBJECT_CONTEXT_VAR
+    assert condition.attribute_name == "call_data"
+    assert condition.return_value_test.eval(0)
+
+
+def test_signing_object_attribute_condition_verify_no_object_provided_in_context(
+    condition_provider_manager,
+):
+    condition = SigningObjectAttributeCondition(
+        attribute_name="call_data",
+        return_value_test=ReturnValueTest("==", "0x1234567890abcdef"),
+    )
+
+    context = {}
+    with pytest.raises(
+        RequiredContextVariable,
+        match="No value provided for unrecognized context variable",
+    ):
+        _ = condition.verify(providers=condition_provider_manager, **context)
+
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: None}
+    with pytest.raises(RequiredContextVariable):
+        _ = condition.verify(providers=condition_provider_manager, **context)
+
+
+def test_signing_object_attribute_condition_verify_invalid_attribute_name_for_object(
+    condition_provider_manager,
+):
+    condition = SigningObjectAttributeCondition(
+        attribute_name="call_data",
+        return_value_test=ReturnValueTest("==", "0x1234567890abcdef"),
+    )
+
+    signing_object = "object is just a string"  # string has not attribute 'call_data'
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    with pytest.raises(InvalidContextVariableData, match="does not have attribute"):
+        _ = condition.verify(providers=condition_provider_manager, **context)
+
+
+def test_signing_object_attribute_condition_verify_hex_string(
+    mocker, condition_provider_manager
+):
+    signing_object = mocker.Mock()
+    signing_object.call_data = "0x1234567890abcdef"
+    condition = SigningObjectAttributeCondition(
+        attribute_name="call_data",
+        return_value_test=ReturnValueTest("==", "0x1234567890abcdef"),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+    assert result == signing_object.call_data
+
+    # failure case
+    signing_object.call_data = "0xdeadbeef"
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is False
+    assert result == signing_object.call_data
+
+
+def test_signing_object_attribute_condition_verify_allowed_string_list(
+    mocker, condition_provider_manager
+):
+    signing_object = mocker.Mock()
+    signing_object.method_name = "burn"
+
+    allowed_method_calls = ['"transfer"', '"approve"', '"mint"', '"burn"']
+    condition = SigningObjectAttributeCondition(
+        attribute_name="method_name",
+        return_value_test=ReturnValueTest("in", allowed_method_calls),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+    assert result == signing_object.method_name
+
+    # failure case with disallowed method name
+    signing_object.method_name = "transferFrom"
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is False
+    assert result == signing_object.method_name
+
+
+def test_signing_object_attribute_condition_verify_number_value(
+    mocker, condition_provider_manager
+):
+    signing_object = mocker.Mock()
+    signing_object.gas_limit = 10_000_000
+
+    condition = SigningObjectAttributeCondition(
+        attribute_name="gas_limit",
+        return_value_test=ReturnValueTest(">", 9_000_000),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+    assert result == signing_object.gas_limit
+
+    # failure case with disallowed method name
+    signing_object.gas_limit = 5_000
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is False
+    assert result == signing_object.gas_limit
+
+
+def test_signing_object_attribute_condition_lingo_json_serialization(
+    mocker, condition_provider_manager
+):
+    """Test serializing and deserializing a condition lingo with ECDSA condition"""
+    condition = SigningObjectAttributeCondition(
+        condition_type=ConditionType.ATTRIBUTE.value,
+        attribute_name="call_data",
+        return_value_test=ReturnValueTest("==", "0x1234567890abcdef"),
+    )
+
+    signing_object = mocker.Mock()
+    signing_object.call_data = "0x1234567890abcdef"
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    success, result = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+    assert result == signing_object.call_data
+
+    # Create condition lingo
+    lingo = ConditionLingo(condition)
+
+    # Convert lingo to JSON
+    original_lingo_json = lingo.to_json()
+
+    # Parse JSON to dict and verify structure
+    lingo_dict = json.loads(original_lingo_json)
+    assert lingo_dict["version"] == ConditionLingo.VERSION
+    assert lingo_dict["condition"]["conditionType"] == ConditionType.ATTRIBUTE.value
+
+    # Recreate lingo from JSON
+    recreated_lingo = ConditionLingo.from_json(original_lingo_json)
+    assert recreated_lingo.to_json() == original_lingo_json
+
+    # works the same
+    signing_object = mocker.Mock()
+    signing_object.call_data = "0x1234567890abcdef"
+
+    success, result = recreated_lingo.condition.verify(
+        providers=condition_provider_manager, **context
+    )
+    assert success is True
+    assert result == signing_object.call_data

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -19,6 +19,7 @@ from nucypher.policy.conditions.signing.base import (
 )
 from nucypher.policy.conditions.utils import ConditionProviderManager
 from nucypher.utilities.abi import encode_human_readable_call
+from tests.utils.erc4337 import create_eth_transfer
 
 
 @pytest.fixture
@@ -159,6 +160,33 @@ def test_signing_object_attribute_condition_verify_number_value(
     success, result = condition.verify(providers=condition_provider_manager, **context)
     assert success is False
     assert result == signing_object.gas_limit
+
+
+def test_signing_object_attribute_condition_verify_userop_sender(
+    condition_provider_manager, get_random_checksum_address
+):
+    sender = get_random_checksum_address()
+    user_op = create_eth_transfer(
+        sender=sender, nonce=0, to=get_random_checksum_address(), value=10_000_000
+    )
+
+    condition = SigningObjectAttributeCondition(
+        attribute_name="sender",
+        return_value_test=ReturnValueTest("==", sender),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: user_op}
+    success, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert success is True
+
+    invalid_sender_user_op = create_eth_transfer(
+        sender=get_random_checksum_address(),
+        nonce=0,
+        to=get_random_checksum_address(),
+        value=10_000_000,
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: invalid_sender_user_op}
+    success, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert success is False
 
 
 def test_signing_object_attribute_condition_lingo_json_serialization(

--- a/tests/unit/test_abi_utils.py
+++ b/tests/unit/test_abi_utils.py
@@ -1,0 +1,133 @@
+import os
+
+import pytest
+from eth_utils import keccak
+
+from nucypher.utilities.abi import (
+    decode_human_readable_call,
+    encode_human_readable_call,
+    is_valid_human_readable_signature,
+)
+
+
+@pytest.mark.parametrize(
+    "human_signature, expected",
+    [
+        # Valid signatures
+        ("transfer(address,uint256)", True),
+        ("approve(address,uint256)", True),
+        ("transferFrom(address,address,uint256)", True),
+        ("mint(address,uint256)", True),
+        ("burn(uint256)", True),
+        ("baseTypes(uint,int,bool,address,bytes,string)", True),
+        ("otherTypes(uint256,uint128,int32,int8,bytes1,bytes32)", True),
+        ("tupleType((string,uint256,address))", True),
+        ("arrayType(uint256[],address[])", True),
+        ("tupleArrayType((string,uint256,address)[])", True),
+        # Failure cases
+        ("invalidSignature", False),  # Invalid signature
+        ("123start(address, uint256)", False),  # Invalid function name
+        ("!start(address, uint256)", False),  # Invalid function name
+        ("bad(!!!, address)", False),  # Invalid typ
+        ("transfer(address, uint257)", False),  # Invalid type
+        ("transfer(address, uint256", False),  # Missing closing parenthesis
+        ("transfer(,uint256)", False),  # Empty argument type
+        ("transfer(address, uint256) extra", False),  # Extra text after signature
+    ],
+)
+def test_valid_human_readable_signature(human_signature, expected):
+    assert is_valid_human_readable_signature(human_signature) == expected
+
+
+@pytest.mark.parametrize(
+    "human_signature, expected_method_name, args",
+    [
+        (
+            "transfer(address,uint256)",
+            "transfer",
+            ["0x1234567890abcdef1234567890abcdef12345678", 100],
+        ),
+        (
+            "approve(address,uint256)",
+            "approve",
+            ["0x1234567890abcdef1234567890abcdef12345678", 100],
+        ),
+        (
+            "transferFrom(address,address,uint256)",
+            "transferFrom",
+            [
+                "0xc83eb7e5431211ee841ccbb917f2133ec9f3ed8f",
+                "0x7dd2cd8f0ac7ec77842c40db6938cadd2a4deb36",
+                10000,
+            ],
+        ),
+        (
+            "mint(address,int256)",
+            "mint",
+            ["0x1234567890abcdef1234567890abcdef12345678", -1],
+        ),
+        ("burn(uint256,bool)", "burn", [100, True]),
+        (
+            "baseTypes(uint,int,bool,address,bytes,string)",
+            "baseTypes",
+            [
+                1,
+                2,
+                False,
+                "0x1234567890abcdef1234567890abcdef12345678",
+                os.urandom(15),
+                "test",
+            ],
+        ),
+        (
+            "otherTypes(uint256,uint128,int32,int8,bytes1,bytes32)",
+            "otherTypes",
+            [1000, 128, -32, -8, os.urandom(1), os.urandom(32)],
+        ),
+        (
+            "tupleType((string,uint256,address))",
+            "tupleType",
+            [("Alice", 30, "0x1234567890abcdef1234567890abcdef12345678")],
+        ),
+        # note array values are returned as tuples (for the following test scenario)
+        (
+            "arrayType(uint256[],address[])",
+            "arrayType",
+            [
+                (1, 2, 3),
+                (
+                    "0x1234567890abcdef1234567890abcdef12345678",
+                    "0xabcdef1234567890abcdef1234567890abcdef12",
+                ),
+            ],
+        ),
+        (
+            "tupleArrayType((string,uint256,address)[])",
+            "tupleArrayType",
+            [
+                (
+                    ("Alice", 30, "0x1234567890abcdef1234567890abcdef12345678"),
+                    ("Bob", 45, "0xabcdef1234567890abcdef1234567890abcdef12"),
+                )
+            ],
+        ),
+    ],
+)
+def test_encode_decode_human_readable_abi(human_signature, expected_method_name, args):
+    # Encode
+    encoded_call_data = encode_human_readable_call(human_signature, args)
+    assert isinstance(encoded_call_data, bytes)
+
+    # Decode (method name instead of bytes selector)
+    method, decoded_args = decode_human_readable_call(
+        human_signature, encoded_call_data, return_method_name=True
+    )
+    assert method == expected_method_name
+    assert decoded_args == args
+
+    # Decode (bytes selector instead of method name)
+    method, decoded_args = decode_human_readable_call(
+        human_signature, encoded_call_data, return_method_name=False
+    )
+    assert method == keccak(text=human_signature)[:4]
+    assert decoded_args == args

--- a/tests/unit/test_abi_utils.py
+++ b/tests/unit/test_abi_utils.py
@@ -24,6 +24,7 @@ from nucypher.utilities.abi import (
         ("tupleType((string,uint256,address))", True),
         ("arrayType(uint256[],address[])", True),
         ("tupleArrayType((string,uint256,address)[])", True),
+        ("nestedTupleType(address,(string,uint256,(address,bool)))", True),
         # Failure cases
         ("invalidSignature", False),  # Invalid signature
         ("123start(address, uint256)", False),  # Invalid function name
@@ -111,6 +112,14 @@ def test_valid_human_readable_signature(human_signature, expected):
                 )
             ],
         ),
+        (
+            "nestedTupleType(address,(string,uint256,(address,bool)))",
+            "nestedTupleType",
+            [
+                "0x1234567890abcdef1234567890abcdef12345678",
+                ("Alice", 30, ("0xabcdef1234567890abcdef1234567890abcdef12", False)),
+            ],
+        ),
     ],
 )
 def test_encode_decode_human_readable_abi(human_signature, expected_method_name, args):
@@ -131,3 +140,11 @@ def test_encode_decode_human_readable_abi(human_signature, expected_method_name,
     )
     assert method == keccak(text=human_signature)[:4]
     assert decoded_args == args
+
+    # Decoded selector does not match encoded call data
+    with pytest.raises(ValueError, match="Call data does not match function selector"):
+        decode_human_readable_call(
+            "differentHumanSignatureFromValuesInTest(address)",
+            encoded_call_data,
+            return_method_name=True,
+        )

--- a/tests/unit/test_erc4337_utils.py
+++ b/tests/unit/test_erc4337_utils.py
@@ -146,6 +146,7 @@ class TestPackedUserOperation:
             assert deserialized_op.signature == packed_user_op.signature
 
             assert packed_user_op == deserialized_op
+            assert packed_user_op != user_op
 
     def test_packed_user_op_account_gas_limits(self, sample_user_op):
         """Test _pack_account_gas_limits method"""

--- a/tests/unit/test_erc4337_utils.py
+++ b/tests/unit/test_erc4337_utils.py
@@ -14,6 +14,8 @@ from nucypher.utilities.erc4337_utils import (
     EntryPointContracts,
     PackedUserOperation,
     UserOperation,
+)
+from tests.utils.erc4337 import (
     create_contract_call,
     create_erc20_approve,
     create_erc20_transfer,

--- a/tests/unit/test_erc4337_utils.py
+++ b/tests/unit/test_erc4337_utils.py
@@ -121,6 +121,8 @@ class TestPackedUserOperation:
             assert deserialized_op.paymaster_data == user_op.paymaster_data
             assert deserialized_op.signature == user_op.signature
 
+            assert user_op == deserialized_op
+
     def test_packed_user_op_serialization(self, sample_user_op, minimal_user_op):
         for user_op in [sample_user_op, minimal_user_op]:
             packed_user_op = PackedUserOperation.from_user_operation(user_op)
@@ -140,6 +142,8 @@ class TestPackedUserOperation:
                 deserialized_op.paymaster_and_data == packed_user_op.paymaster_and_data
             )
             assert deserialized_op.signature == packed_user_op.signature
+
+            assert packed_user_op == deserialized_op
 
     def test_packed_user_op_account_gas_limits(self, sample_user_op):
         """Test _pack_account_gas_limits method"""

--- a/tests/utils/erc4337.py
+++ b/tests/utils/erc4337.py
@@ -1,0 +1,52 @@
+from eth_utils import to_checksum_address
+from hexbytes import HexBytes
+
+from nucypher.utilities.abi import encode_human_readable_call
+from nucypher.utilities.erc4337_utils import UserOperation
+
+
+def encode_function_call(signature: str, args: list) -> HexBytes:
+    return HexBytes(encode_human_readable_call(signature, args))
+
+
+def create_eth_transfer(
+    sender: str, nonce: int, to: str, value: int, **kwargs
+) -> "UserOperation":
+    data = encode_function_call(
+        "execute(address,uint256,bytes)",
+        [to_checksum_address(to), value, b""],
+    )
+    return UserOperation(sender, nonce, None, b"", data, **kwargs)
+
+
+def create_erc20_transfer(
+    sender: str, nonce: int, token: str, to: str, amount: int, **kwargs
+) -> "UserOperation":
+    call = encode_function_call(
+        "transfer(address,uint256)", [to_checksum_address(to), amount]
+    )
+    data = encode_function_call(
+        "execute(address,uint256,bytes)", [to_checksum_address(token), 0, call]
+    )
+    return UserOperation(sender, nonce, None, b"", data, **kwargs)
+
+
+def create_erc20_approve(
+    sender: str, nonce: int, token: str, spender: str, amount: int, **kwargs
+) -> "UserOperation":
+    call = encode_function_call(
+        "approve(address,uint256)", [to_checksum_address(spender), amount]
+    )
+    data = encode_function_call(
+        "execute(address,uint256,bytes)", [to_checksum_address(token), 0, call]
+    )
+    return UserOperation(sender, nonce, None, b"", data, **kwargs)
+
+
+def create_contract_call(
+    sender: str, nonce: int, target: str, data: HexBytes, value: int = 0, **kwargs
+) -> "UserOperation":
+    payload = encode_function_call(
+        "execute(address,uint256,bytes)", [to_checksum_address(target), value, data]
+    )
+    return UserOperation(sender, nonce, None, b"", payload, **kwargs)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

- A condition that can introspect various values on an object being signed.
- Add "in" operator to return value test for checking membership in a list.

**Issues fixed/closed:**

Related to https://github.com/nucypher/sprints/issues/176

**Notes for reviewers:**

Good milestone for a review/merge into the epic and then do follow-up PRs. I don't want these PRs to get too big.

**NOTE** There are some TODO comments in the PR - take a look and provide any opinions.
