### PR TITLE
Signing Object ABI Attribute Validation follow up

### DIFF
--- a/examples/testnet_simple_signing.py
+++ b/examples/testnet_simple_signing.py
@@ -52,8 +52,10 @@ ERC_1271_ABI = """[
     }
 ]"""
 
-ETH_ENDPOINT = os.environ["DEMO_L1_PROVIDER_URI"]
-POLYGON_ENDPOINT = os.environ["DEMO_L2_PROVIDER_URI"]
+ETH_ENDPOINT = os.environ.get("DEMO_L1_PROVIDER_URI", "https://sepolia.drpc.org")
+POLYGON_ENDPOINT = os.environ.get(
+    "DEMO_L2_PROVIDER_URI", "https://polygon-amoy.drpc.org"
+)
 PORTER_BASE_URL = "https://porter-lynx.nucypher.io"
 
 

--- a/examples/testnet_simple_taco.py
+++ b/examples/testnet_simple_taco.py
@@ -21,10 +21,12 @@ LOG_LEVEL = "info"
 GlobalLoggerSettings.set_log_level(log_level_name=LOG_LEVEL)
 GlobalLoggerSettings.start_console_logging()
 
-eth_endpoint = os.environ["DEMO_L1_PROVIDER_URI"]
+eth_endpoint = os.environ.get("DEMO_L1_PROVIDER_URI", "https://sepolia.drpc.org")
 domain = domains.LYNX
 
-polygon_endpoint = os.environ["DEMO_L2_PROVIDER_URI"]
+polygon_endpoint = os.environ.get(
+    "DEMO_L2_PROVIDER_URI", "https://polygon-amoy.drpc.org"
+)
 
 ###############
 # Enrico

--- a/newsfragments/3609.feature.rst
+++ b/newsfragments/3609.feature.rst
@@ -1,0 +1,1 @@
+Support for ABI call data guardrails when processing signing requests.

--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -907,7 +907,7 @@ class SigningCoordinatorAgent(EthereumContractAgent):
         signing_cohort.chains = self.get_chains(cohort_id)
 
         for chain in signing_cohort.chains:
-            signing_cohort.conditions[chain] = self.get_condition(
+            signing_cohort.conditions[chain] = self.get_signing_cohort_conditions(
                 cohort_id=cohort_id, chain_id=chain
             )
         return signing_cohort
@@ -923,8 +923,10 @@ class SigningCoordinatorAgent(EthereumContractAgent):
         return result
 
     @contract_api(CONTRACT_CALL)
-    def get_condition(self, cohort_id: int, chain_id: int) -> bytes:
-        result = self.contract.functions.getCondition(cohort_id, chain_id).call()
+    def get_signing_cohort_conditions(self, cohort_id: int, chain_id: int) -> bytes:
+        result = self.contract.functions.getSigningCohortConditions(
+            cohort_id, chain_id
+        ).call()
         return result
 
     @contract_api(CONTRACT_CALL)

--- a/nucypher/network/signing.py
+++ b/nucypher/network/signing.py
@@ -324,7 +324,7 @@ def sign_signature_request_data(
 def deserialize_signature_request(
     request_data: bytes,
 ) -> BaseSignatureRequest:
-    """Deserialize a signature request from bytes."""
+    """Deserialize a signature request from bytes, and add signing object to context"""
     try:
         result = json.loads(request_data.decode())
         signature_type_str = result["signature_type"]

--- a/nucypher/network/signing.py
+++ b/nucypher/network/signing.py
@@ -101,8 +101,7 @@ class EIP191SignatureRequest(BaseSignatureRequest):
         )
 
     def __bytes__(self) -> bytes:
-        """Serialize the UserOperation request to bytes in JSON format."""
-        # Serialize the UserOperation data
+        """Serialize the EIP191 request to bytes in JSON format."""
         data = {
             "data": HexBytes(self.data).hex(),
             "cohort_id": self.cohort_id,
@@ -114,7 +113,7 @@ class EIP191SignatureRequest(BaseSignatureRequest):
 
     @classmethod
     def from_bytes(cls, request_data: bytes):
-        """Deserialize the UserOperation request from bytes in JSON format."""
+        """Deserialize the EIP191 request from bytes in JSON format."""
         try:
             result = json.loads(request_data.decode())
             data = bytes(HexBytes(result["data"]))
@@ -209,7 +208,7 @@ class UserOperationSignatureRequest(BaseSignatureRequest):
 
 
 class PackedUserOperationSignatureRequest(BaseSignatureRequest):
-    """A specialized signature request for UserOperation."""
+    """A specialized signature request for PackedUserOperation."""
 
     def __init__(
         self,
@@ -230,12 +229,12 @@ class PackedUserOperationSignatureRequest(BaseSignatureRequest):
         )
 
     def __bytes__(self) -> bytes:
-        """Serialize the UserOperation request to bytes in JSON format."""
-        # Serialize the UserOperation data
-        user_op_data = bytes(self.packed_user_op).decode("utf-8")
+        """Serialize the PackedUserOperation request to bytes in JSON format."""
+        # Serialize the PackedUserOperation data
+        packed_user_op_data = bytes(self.packed_user_op).decode("utf-8")
 
         data = {
-            "packed_user_op": user_op_data,
+            "packed_user_op": packed_user_op_data,
             "aa_version": self.aa_version.value,
             "cohort_id": self.cohort_id,
             "chain_id": self.chain_id,
@@ -246,10 +245,10 @@ class PackedUserOperationSignatureRequest(BaseSignatureRequest):
 
     @classmethod
     def from_bytes(cls, request_data: bytes):
-        """Deserialize the UserOperation request from bytes in JSON format."""
+        """Deserialize the PackedUserOperation request from bytes in JSON format."""
         try:
             result = json.loads(request_data.decode())
-            user_op_data = result["packed_user_op"]
+            packed_user_op_data = result["packed_user_op"]
             aa_version_str = AAVersion(result["aa_version"])
             cohort_id = result["cohort_id"]
             chain_id = result["chain_id"]
@@ -269,7 +268,9 @@ class PackedUserOperationSignatureRequest(BaseSignatureRequest):
             )
 
         # Reconstruct the UserOperation
-        packed_user_op = PackedUserOperation.from_bytes(user_op_data.encode("utf-8"))
+        packed_user_op = PackedUserOperation.from_bytes(
+            packed_user_op_data.encode("utf-8")
+        )
 
         return cls(
             packed_user_op=packed_user_op,

--- a/nucypher/network/signing.py
+++ b/nucypher/network/signing.py
@@ -281,6 +281,12 @@ class PackedUserOperationSignatureRequest(BaseSignatureRequest):
         )
 
 
+class UnsupportedSignatureRequest(ValueError):
+    """
+    Raised for unrecognized signature requests.
+    """
+
+
 #
 # Logic for using SignatureRequest data classes
 # This will stay in nucypher, while the data classes will move to nucypher-core
@@ -310,7 +316,9 @@ def sign_signature_request_data(
             standardize=False,
         )
 
-    raise ValueError(f"Unsupported signature request: {request.__class__.__name__}")
+    raise UnsupportedSignatureRequest(
+        f"Unsupported signature request: {request.__class__.__name__}"
+    )
 
 
 def deserialize_signature_request(
@@ -333,7 +341,9 @@ def deserialize_signature_request(
             signature_request = EIP191SignatureRequest.from_bytes(request_data)
 
         if not signature_request:
-            raise ValueError(f"Invalid signature request type: {signature_type}")
+            raise UnsupportedSignatureRequest(
+                f"Invalid signature request type: {signature_type}"
+            )
 
         # add the signing object to the context
         signing_object = get_signature_request_object(signature_request)
@@ -342,7 +352,7 @@ def deserialize_signature_request(
         return signature_request
 
     except (json.JSONDecodeError, ValueError) as e:
-        raise ValueError("Invalid signature request data") from e
+        raise UnsupportedSignatureRequest("Invalid signature request data") from e
 
 
 def get_signature_request_object(request: BaseSignatureRequest) -> Any:
@@ -354,4 +364,6 @@ def get_signature_request_object(request: BaseSignatureRequest) -> Any:
     elif isinstance(request, EIP191SignatureRequest):
         return request.data
 
-    raise ValueError(f"Unsupported signature request: {request.__class__.__name__}")
+    raise UnsupportedSignatureRequest(
+        f"Unsupported signature request: {request.__class__.__name__}"
+    )

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -281,13 +281,17 @@ _COMPARATOR_FUNCTIONS = {
     "<": pyoperator.lt,
     "<=": pyoperator.le,
     ">=": pyoperator.ge,
-    "in": pyoperator.contains,  # currently only supports checking value in list (not sub-string/bytes comparisons)
+    # currently only supports checking value in list (not sub-string/bytes comparisons)
+    "in": pyoperator.contains,
+    "!in": lambda container, item: pyoperator.not_(
+        pyoperator.contains(container, item)
+    ),
 }
 
 
 class ConditionVariable(_Serializable):
     class Schema(CamelCaseSchema):
-        var_name = fields.Str(required=True)  # TODO: should this be required?
+        var_name = fields.Str(required=True)
         condition = _ConditionField(required=True)
 
         @post_load
@@ -585,10 +589,10 @@ class ReturnValueTest(_Serializable):
                 return
 
             comparator = data.get("comparator")
-            if comparator == "in" and not isinstance(value, list):
+            if comparator in ["in", "!in"] and not isinstance(value, list):
                 raise ValidationError(
                     field_name="value",
-                    message=f'"{type(value)}" is not a valid type for the "in" comparator; only list is allowed.',
+                    message=f'"{type(value)}" is not a valid type for the "in"/"!in" comparators; only list is allowed.',
                 )
 
         @post_load
@@ -675,9 +679,9 @@ class ReturnValueTest(_Serializable):
 
         processed_data = self._process_data(data, self.index)
         comparator_function = _COMPARATOR_FUNCTIONS.get(self.comparator)
-        if comparator_function == pyoperator.contains:
-            # for 'contains' operator, the left operand is the value and
-            # right operand is the data to check
+        if self.comparator in ["in", "!in"]:
+            # for 'contains'/`not_(contains)` operators, the left operand is
+            # the value (container) and the right operand is the data to check
 
             # first need to sanitize all values in list
             sanitized_list = [self._sanitize_value(v) for v in self.value]

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -281,9 +281,9 @@ _COMPARATOR_FUNCTIONS = {
     "<": pyoperator.lt,
     "<=": pyoperator.le,
     ">=": pyoperator.ge,
-    # currently only supports checking value in list (not sub-string/bytes comparisons)
-    "in": pyoperator.contains,
-    "!in": lambda container, item: pyoperator.not_(
+    # currently only supports checking value in list and not sub-string/bytes comparisons
+    "in": lambda item, container: pyoperator.contains(container, item),
+    "!in": lambda item, container: pyoperator.not_(
         pyoperator.contains(container, item)
     ),
 }
@@ -678,18 +678,14 @@ class ReturnValueTest(_Serializable):
             )
 
         processed_data = self._process_data(data, self.index)
+        left_operand = self._sanitize_value(processed_data)
+
         comparator_function = _COMPARATOR_FUNCTIONS.get(self.comparator)
         if self.comparator in ["in", "!in"]:
-            # for 'contains'/`not_(contains)` operators, the left operand is
-            # the value (container) and the right operand is the data to check
-
-            # first need to sanitize all values in list
+            # sanitize all values in list
             sanitized_list = [self._sanitize_value(v) for v in self.value]
-            left_operand = sanitized_list
-
-            right_operand = self._sanitize_value(processed_data)
+            right_operand = sanitized_list
         else:
-            left_operand = self._sanitize_value(processed_data)
             right_operand = self._sanitize_value(self.value)
 
         result = comparator_function(left_operand, right_operand)

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -93,7 +93,7 @@ class _ConditionField(fields.Dict):
         return instance
 
 
-# CONDITION = TIME | CONTRACT | RPC | JSON_API | JSON_RPC | JWT | COMPOUND | SEQUENTIAL | IF_THEN_ELSE_CONDITION | ECDSA | ATTRIBUTE | ABI_ATTRIBUTE
+# CONDITION = TIME | CONTRACT | RPC | JSON_API | JSON_RPC | JWT | COMPOUND | SEQUENTIAL | IF_THEN_ELSE_CONDITION | ECDSA | SIGNING_ATTRIBUTE | SIGNING_ABI_ATTRIBUTE
 class ConditionType(Enum):
     """
     Defines the types of conditions that can be evaluated.
@@ -109,8 +109,8 @@ class ConditionType(Enum):
     SEQUENTIAL = "sequential"
     IF_THEN_ELSE = "if-then-else"
     ECDSA = "ecdsa"
-    ATTRIBUTE = "attribute"
-    ABI_ATTRIBUTE = "abi-attribute"
+    SIGNING_ATTRIBUTE = "signing-attribute"
+    SIGNING_ABI_ATTRIBUTE = "signing-abi-attribute"
 
     @classmethod
     def values(cls) -> List[str]:

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -163,6 +163,10 @@ class AbiParameterValidation(_Serializable):
     class Schema(CamelCaseSchema):
         parameter_index = fields.Integer(validate=Range(min=0), required=True)
 
+        index_within_tuple = fields.Integer(
+            validate=Range(min=0), allow_none=True, required=False
+        )
+
         # Either a direct comparator...
         return_value_test = fields.Nested(
             ReturnValueTest.Schema(), allow_none=True, required=False
@@ -193,19 +197,34 @@ class AbiParameterValidation(_Serializable):
     def __init__(
         self,
         parameter_index: int,
+        index_within_tuple: Optional[int] = None,
         return_value_test: Optional[ReturnValueTest] = None,
         nested_abi_validation: Optional["AbiCallValidation"] = None,
     ):
         self.parameter_index = parameter_index
+        self.index_within_tuple = index_within_tuple
         self.return_value_test = return_value_test
         self.nested_abi_validation = nested_abi_validation
 
         self._validate()
 
+    def get_value(self, args):
+        parameter_value = args[self.parameter_index]
+
+        if self.index_within_tuple is not None:
+            if not isinstance(parameter_value, tuple):
+                raise ValueError(
+                    f"Invalid data type for checking call data; expected tuple, received {type(parameter_value)}"
+                )
+
+            return parameter_value[self.index_within_tuple]
+
+        return parameter_value
+
     def check(
         self, args: List[Any], providers: ConditionProviderManager, **context
     ) -> Tuple[bool, Any]:
-        parameter_value = args[self.parameter_index]
+        parameter_value = self.get_value(args)
 
         if self.return_value_test:
             resolved_return_value_test = self.return_value_test.with_resolved_context(
@@ -253,11 +272,20 @@ class AbiCallValidation(_Serializable):
                 total_args_num = len(arg_types)
                 parameter_value_checks = value[human_signature]
                 for parameter_value_check in parameter_value_checks:
-                    if isinstance(parameter_value_check, AbiParameterValidation):
-                        if parameter_value_check.parameter_index >= total_args_num:
+                    if parameter_value_check.parameter_index >= total_args_num:
+                        raise ValidationError(
+                            f"Parameter value index '{parameter_value_check.parameter_index}' is out of range for "
+                            f"the ABI decode string '{human_signature}'. "
+                        )
+
+                    if parameter_value_check.index_within_tuple is not None:
+                        tuple_args = arg_types[parameter_value_check.parameter_index]
+                        if parameter_value_check.index_within_tuple >= len(
+                            tuple_args.split(",")
+                        ):
                             raise ValidationError(
-                                f"Parameter value index '{parameter_value_check.parameter_index}' is out of range for "
-                                f"the ABI decode string '{human_signature}'. "
+                                f"Tuple value index '{parameter_value_check.index_within_tuple}' for parameter is out of range for "
+                                f"the ABI decoded tuple '{tuple_args}'. "
                             )
 
         @post_load

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Any, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from marshmallow import (
     ValidationError,
@@ -7,11 +7,10 @@ from marshmallow import (
     post_load,
     validate,
     validates,
-    validates_schema,
 )
 from marshmallow.validate import Range
 
-from nucypher.policy.conditions.base import Condition
+from nucypher.policy.conditions.base import Condition, _Serializable
 from nucypher.policy.conditions.context import (
     resolve_any_context_variables,
 )
@@ -19,7 +18,9 @@ from nucypher.policy.conditions.exceptions import (
     InvalidContextVariableData,
 )
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
+from nucypher.policy.conditions.signing.utils import adjust_for_attribute_value_for_eval
 from nucypher.policy.conditions.utils import (
+    CamelCaseSchema,
     ConditionProviderManager,
     camel_case_to_snake,
     is_camel_case,
@@ -44,6 +45,9 @@ class SigningObjectCondition(Condition, ABC):
             required=True, validate=validate.Equal(SIGNING_CONDITION_OBJECT_CONTEXT_VAR)
         )
 
+        class Meta:
+            ordered = True
+
     def __init__(
         self,
         signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
@@ -54,14 +58,60 @@ class SigningObjectCondition(Condition, ABC):
         super().__init__(*args, **kwargs)
 
 
-class SigningObjectAttributeCondition(SigningObjectCondition):
+class BaseSigningObjectAttributeCondition(SigningObjectCondition, ABC):
+    class Schema(SigningObjectCondition.Schema):
+        attribute_name = fields.Str(required=True)
+
+        # maintain field declaration ordering
+        class Meta:
+            ordered = True
+
+    def __init__(
+        self,
+        attribute_name: str,
+        *args,
+        **kwargs,
+    ):
+        # TODO what about camel case (from library) vs snake case (python) for
+        #  attribute names (is this sufficient?)
+        #  At the moment since there will be a python object, can we assume snake case conversion always?
+        self.attribute_name = (
+            camel_case_to_snake(attribute_name)
+            # TODO should attribute name ever be a context variable? Likely not...
+            if (attribute_name and is_camel_case(attribute_name))
+            else attribute_name
+        )
+
+        super().__init__(*args, **kwargs)
+
+    def get_attribute_value(
+        self, providers: ConditionProviderManager, **context
+    ) -> Any:
+        signing_object = resolve_any_context_variables(
+            param=self.signing_object_context_var, providers=providers, **context
+        )
+
+        try:
+            # TODO for EIP191SignatureRequest, the object is just bytes, so that would fail here
+            #  how do we handle that? Is raising the exception sufficient?
+            raw_attribute_value = getattr(signing_object, self.attribute_name)
+        except AttributeError:
+            # makes it clear that entry not present - allows possibility that
+            # attribute value could be None as a legit value
+            raise InvalidContextVariableData(
+                f"Object of type {type(signing_object)} provided does not have attribute {self.attribute_name}"
+            )
+
+        return raw_attribute_value
+
+
+class SigningObjectAttributeCondition(BaseSigningObjectAttributeCondition):
     CONDITION_TYPE = ConditionType.ATTRIBUTE.value
 
-    class Schema(SigningObjectCondition.Schema):
+    class Schema(BaseSigningObjectAttributeCondition.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.ATTRIBUTE.value), required=True
         )
-        attribute_name = fields.Str(required=True)
         return_value_test = fields.Nested(ReturnValueTest.Schema(), required=True)
 
         # maintain field declaration ordering
@@ -80,17 +130,9 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
         condition_type: str = ConditionType.ATTRIBUTE.value,
         name: Optional[str] = None,
     ):
-        # TODO what about camel case (from library) vs snake case (python) for
-        #  attribute names (is this sufficient?)
-        #  At the moment since there will be a python object, can we assume snake case conversion always?
-        self.attribute_name = (
-            camel_case_to_snake(attribute_name)
-            # TODO should attribute name ever be a context variable? Likely not...
-            if (attribute_name and is_camel_case(attribute_name))
-            else attribute_name
-        )
         self.return_value_test = return_value_test
         super().__init__(
+            attribute_name=attribute_name,
             signing_object_context_var=signing_object_context_var,
             condition_type=condition_type,
             name=name,
@@ -103,90 +145,84 @@ class SigningObjectAttributeCondition(SigningObjectCondition):
             providers=providers, **context
         )
 
-        signing_object = resolve_any_context_variables(
-            self.signing_object_context_var, providers=providers, **context
-        )
-
-        raw_attribute_value, modified_attribute_value = self.get_attribute_value(
-            signing_object
-        )
-
-        result = resolved_return_value_test.eval(modified_attribute_value)
-        return result, raw_attribute_value
-
-    def _get_raw_signing_object_attribute(self, signing_object: Any) -> Any:
-        """
-        Helper method to retrieve the attribute value from the signing object.
-        Raises InvalidContextVariableData if the attribute does not exist.
-        """
-        try:
-            # TODO for EIP191SignatureRequest, the object is just bytes, so that would fail here
-            #  how do we handle that? Is raising the exception sufficient?
-            raw_attribute_value = getattr(signing_object, self.attribute_name)
-        except AttributeError:
-            # makes it clear that entry not present - allows possibility that
-            # attribute value could be None as a legit value
-            raise InvalidContextVariableData(
-                f"Object of type {type(signing_object)} provided does not have attribute {self.attribute_name}"
-            )
-
-        return raw_attribute_value
-
-    @staticmethod
-    def _adjust_for_attribute_string_value(attribute_value: Any) -> Any:
-        """
-        Adjusts the attribute value for evaluation checking.
-        If the value is a string and does not start with '0x', it will be double-quoted.
-        """
-        if isinstance(attribute_value, str):
-            if not attribute_value.startswith("0x"):
-                # value needs to be double-quoted
-                return f'"{attribute_value}"'
-
-        return attribute_value
-
-    def get_attribute_value(self, signing_object: Any) -> Tuple[Any, Any]:
-        raw_attribute_value = self._get_raw_signing_object_attribute(signing_object)
+        raw_attribute_value = self.get_attribute_value(providers=providers, **context)
 
         # TODO: not the cleanest way to handle a string value needing to be quoted
         #  for evaluation checking
-        modified_attribute_value_to_check = self._adjust_for_attribute_string_value(
+        modified_attribute_value_to_check = adjust_for_attribute_value_for_eval(
             raw_attribute_value
         )
 
-        return raw_attribute_value, modified_attribute_value_to_check
+        result = resolved_return_value_test.eval(modified_attribute_value_to_check)
+        return result, raw_attribute_value
 
 
-class SigningObjectAbiAttributeCondition(SigningObjectAttributeCondition):
+class AbiParameterValueCheck(_Serializable):
+    class Schema(CamelCaseSchema):
+        parameter_index = fields.Int(validate=Range(min=0), required=True)
+        return_value_test = fields.Nested(ReturnValueTest.Schema(), required=True)
+
+        @post_load
+        def make(self, data, **kwargs):
+            return AbiParameterValueCheck(**data)
+
+    def __init__(self, parameter_index: int, return_value_test: ReturnValueTest):
+        self.parameter_index = parameter_index
+        self.return_value_test = return_value_test
+
+        self._validate()
+
+    def check(
+        self, args: List[Any], providers: ConditionProviderManager, **context
+    ) -> Tuple[bool, Any]:
+        resolved_return_value_test = self.return_value_test.with_resolved_context(
+            providers=providers, **context
+        )
+
+        parameter_value = args[self.parameter_index]
+        # adjust for string value
+        modified_parameter_value_to_check = adjust_for_attribute_value_for_eval(
+            parameter_value
+        )
+
+        result = resolved_return_value_test.eval(modified_parameter_value_to_check)
+        return result, parameter_value
+
+
+class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
     CONDITION_TYPE = ConditionType.ABI_ATTRIBUTE.value
 
-    class Schema(SigningObjectAttributeCondition.Schema):
+    class Schema(BaseSigningObjectAttributeCondition.Schema):
         condition_type = fields.Str(
             validate=validate.Equal(ConditionType.ABI_ATTRIBUTE.value), required=True
         )
-        abi_decode_string = fields.Str(required=True)
-        abi_decode_value_index = fields.Int(validate=Range(min=0), required=True)
+        allowed_abi_calls = fields.Dict(
+            keys=fields.Str(),
+            values=fields.List(fields.Nested(AbiParameterValueCheck.Schema())),
+            required=True,
+        )
 
-        @validates("abi_decode_string")
-        def validate_abi_decode_string(self, value: str):
-            if not is_valid_human_readable_signature(value):
-                raise ValidationError(
-                    f"Invalid ABI decode string: {value}. "
-                    "Must be a valid human-readable signature."
-                )
+        @validates("allowed_abi_calls")
+        def validate_allowed_abi_calls(
+            self, value: Dict[str, List[AbiParameterValueCheck]]
+        ):
+            human_signatures = value.keys()
+            for human_signature in human_signatures:
+                if not is_valid_human_readable_signature(human_signature):
+                    raise ValidationError(
+                        f"Invalid ABI signature: {human_signature}. "
+                        "Must be a valid human-readable signature."
+                    )
 
-        @validates_schema
-        def validate_abi_decode_value_index(self, data, **kwargs):
-            abi_decode_value_index = data.get("abi_decode_value_index")
-            abi_decode_string = data.get("abi_decode_string")
-
-            arg_types = extract_arg_types(abi_decode_string)
-            total_args_num = 1 + len(arg_types)  # method name + args
-            if abi_decode_value_index >= total_args_num:
-                raise ValidationError(
-                    f"Value index '{abi_decode_value_index}' is out of range for "
-                    f"the ABI decode string '{abi_decode_string}'. "
-                )
+                arg_types = extract_arg_types(human_signature)
+                total_args_num = len(arg_types)
+                parameter_value_checks = value[human_signature]
+                for parameter_value_check in parameter_value_checks:
+                    if parameter_value_check.parameter_index >= total_args_num:
+                        raise ValidationError(
+                            f"Parameter value index '{parameter_value_check.parameter_index}' is out of range for "
+                            f"the ABI decode string '{human_signature}'. "
+                        )
 
         # maintain field declaration ordering
         class Meta:
@@ -199,38 +235,55 @@ class SigningObjectAbiAttributeCondition(SigningObjectAttributeCondition):
     def __init__(
         self,
         attribute_name: str,
-        abi_decode_string: str,
-        abi_decode_value_index: int,
-        return_value_test: ReturnValueTest,
+        allowed_abi_calls: Dict[str, List[AbiParameterValueCheck]],
         signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
         condition_type: str = ConditionType.ABI_ATTRIBUTE.value,
         name: Optional[str] = None,
     ):
-        self.abi_decode_string = abi_decode_string
-        self.abi_decode_value_index = abi_decode_value_index
-
+        self.allowed_abi_calls = allowed_abi_calls
         super().__init__(
             attribute_name=attribute_name,
-            return_value_test=return_value_test,
             signing_object_context_var=signing_object_context_var,
             condition_type=condition_type,
             name=name,
         )
 
-    def get_attribute_value(self, signing_object: Any) -> Tuple[Any, Any]:
-        raw_attribute_value = self._get_raw_signing_object_attribute(signing_object)
-        method, args = decode_human_readable_call(
-            self.abi_decode_string, raw_attribute_value
-        )
+    def verify(
+        self, providers: ConditionProviderManager, **context
+    ) -> Tuple[bool, Any]:
+        raw_attribute_value = self.get_attribute_value(providers=providers, **context)
 
-        all_values = [method]
-        all_values.extend(args)
+        # check allowed signatures
+        args = None
+        matched_signature = None
+        for allowed_signature in self.allowed_abi_calls:
+            try:
+                _, args = decode_human_readable_call(
+                    allowed_signature, raw_attribute_value
+                )
+                matched_signature = allowed_signature
+                # found a match
+                break
+            except ValueError:
+                # signature doesn't match this call, try others in the list
+                pass
 
-        decoded_attribute_value_at_index = all_values[self.abi_decode_value_index]
+        if not matched_signature:
+            return False, []
 
-        # adjust for string value
-        modified_attribute_value_to_check = self._adjust_for_attribute_string_value(
-            decoded_attribute_value_at_index
-        )
+        parameter_values = []
+        additional_parameter_checks = self.allowed_abi_calls[matched_signature]
+        if not additional_parameter_checks:
+            # no additional checks to perform
+            return True, matched_signature
 
-        return decoded_attribute_value_at_index, modified_attribute_value_to_check
+        for parameter_check in additional_parameter_checks:
+            result, raw_value = parameter_check.check(
+                args=args, providers=providers, **context
+            )
+            parameter_values.append(raw_value)
+            if not result:
+                return False, parameter_values
+
+        # if we get here additional checks have all passed
+        return True, parameter_values

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -7,6 +7,7 @@ from marshmallow import (
     post_load,
     validate,
     validates,
+    validates_schema,
 )
 from marshmallow.validate import Range
 
@@ -15,6 +16,7 @@ from nucypher.policy.conditions.context import (
     resolve_any_context_variables,
 )
 from nucypher.policy.conditions.exceptions import (
+    InvalidCondition,
     InvalidContextVariableData,
 )
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
@@ -157,56 +159,89 @@ class SigningObjectAttributeCondition(BaseSigningObjectAttributeCondition):
         return result, raw_attribute_value
 
 
-class AbiParameterValueCheck(_Serializable):
+class AbiParameterValidation(_Serializable):
     class Schema(CamelCaseSchema):
-        parameter_index = fields.Int(validate=Range(min=0), required=True)
-        return_value_test = fields.Nested(ReturnValueTest.Schema(), required=True)
+        parameter_index = fields.Integer(validate=Range(min=0), required=True)
+
+        # Either a direct comparator...
+        return_value_test = fields.Nested(
+            ReturnValueTest.Schema(), allow_none=True, required=False
+        )
+
+        # ...or a nested ABI call to decode and evaluate
+        nested_abi_validation = fields.Nested(
+            lambda: AbiCallValidation.Schema(), allow_none=True, required=False
+        )
+
+        # maintain field declaration ordering
+        class Meta:
+            ordered = True
+
+        @validates_schema
+        def validate_rtv_or_nested_validation(self, data, **kwargs):
+            return_value_test = data.get("return_value_test")
+            nested_abi_validation = data.get("nested_abi_validation")
+            if not (bool(return_value_test) ^ bool(nested_abi_validation)):
+                raise ValidationError(
+                    "Either return value test or nested abi validation but not both."
+                )
 
         @post_load
         def make(self, data, **kwargs):
-            return AbiParameterValueCheck(**data)
+            return AbiParameterValidation(**data)
 
-    def __init__(self, parameter_index: int, return_value_test: ReturnValueTest):
+    def __init__(
+        self,
+        parameter_index: int,
+        return_value_test: Optional[ReturnValueTest] = None,
+        nested_abi_validation: Optional["AbiCallValidation"] = None,
+    ):
         self.parameter_index = parameter_index
         self.return_value_test = return_value_test
+        self.nested_abi_validation = nested_abi_validation
 
         self._validate()
 
     def check(
         self, args: List[Any], providers: ConditionProviderManager, **context
     ) -> Tuple[bool, Any]:
-        resolved_return_value_test = self.return_value_test.with_resolved_context(
-            providers=providers, **context
-        )
-
         parameter_value = args[self.parameter_index]
-        # adjust for string value
-        modified_parameter_value_to_check = adjust_for_attribute_value_for_eval(
-            parameter_value
-        )
 
-        result = resolved_return_value_test.eval(modified_parameter_value_to_check)
-        return result, parameter_value
+        if self.return_value_test:
+            resolved_return_value_test = self.return_value_test.with_resolved_context(
+                providers=providers, **context
+            )
+
+            # adjust for string value
+            modified_parameter_value_to_check = adjust_for_attribute_value_for_eval(
+                parameter_value
+            )
+
+            result = resolved_return_value_test.eval(modified_parameter_value_to_check)
+            return result, parameter_value
+        else:
+            result, value = self.nested_abi_validation.check(
+                parameter_value, providers, **context
+            )
+            return result, value
 
 
-class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
-    CONDITION_TYPE = ConditionType.ABI_ATTRIBUTE.value
-
-    class Schema(BaseSigningObjectAttributeCondition.Schema):
-        condition_type = fields.Str(
-            validate=validate.Equal(ConditionType.ABI_ATTRIBUTE.value), required=True
-        )
+class AbiCallValidation(_Serializable):
+    class Schema(CamelCaseSchema):
         allowed_abi_calls = fields.Dict(
             keys=fields.Str(),
-            values=fields.List(fields.Nested(AbiParameterValueCheck.Schema())),
+            values=fields.List(fields.Nested(AbiParameterValidation.Schema())),
             required=True,
         )
 
         @validates("allowed_abi_calls")
         def validate_allowed_abi_calls(
-            self, value: Dict[str, List[AbiParameterValueCheck]]
+            self, value: Dict[str, List[AbiParameterValidation]]
         ):
-            human_signatures = value.keys()
+            human_signatures = list(value.keys())
+            if not human_signatures:
+                raise ValidationError("At least one allowed abi call must be specified")
+
             for human_signature in human_signatures:
                 if not is_valid_human_readable_signature(human_signature):
                     raise ValidationError(
@@ -218,49 +253,36 @@ class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
                 total_args_num = len(arg_types)
                 parameter_value_checks = value[human_signature]
                 for parameter_value_check in parameter_value_checks:
-                    if parameter_value_check.parameter_index >= total_args_num:
-                        raise ValidationError(
-                            f"Parameter value index '{parameter_value_check.parameter_index}' is out of range for "
-                            f"the ABI decode string '{human_signature}'. "
-                        )
-
-        # maintain field declaration ordering
-        class Meta:
-            ordered = True
+                    if isinstance(parameter_value_check, AbiParameterValidation):
+                        if parameter_value_check.parameter_index >= total_args_num:
+                            raise ValidationError(
+                                f"Parameter value index '{parameter_value_check.parameter_index}' is out of range for "
+                                f"the ABI decode string '{human_signature}'. "
+                            )
 
         @post_load
         def make(self, data, **kwargs):
-            return SigningObjectAbiAttributeCondition(**data)
+            return AbiCallValidation(**data)
 
-    def __init__(
-        self,
-        attribute_name: str,
-        allowed_abi_calls: Dict[str, List[AbiParameterValueCheck]],
-        signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
-        condition_type: str = ConditionType.ABI_ATTRIBUTE.value,
-        name: Optional[str] = None,
-    ):
+    def __init__(self, allowed_abi_calls: Dict[str, List[AbiParameterValidation]]):
         self.allowed_abi_calls = allowed_abi_calls
-        super().__init__(
-            attribute_name=attribute_name,
-            signing_object_context_var=signing_object_context_var,
-            condition_type=condition_type,
-            name=name,
-        )
 
-    def verify(
-        self, providers: ConditionProviderManager, **context
+        self._validate()
+
+    def check(
+        self, value: Any, providers: ConditionProviderManager, **context
     ) -> Tuple[bool, Any]:
-        raw_attribute_value = self.get_attribute_value(providers=providers, **context)
+        if not isinstance(value, bytes):
+            raise ValueError(
+                f"Invalid data type for checking call data; expected bytes, received {type(value)}"
+            )
 
         # check allowed signatures
         args = None
         matched_signature = None
         for allowed_signature in self.allowed_abi_calls:
             try:
-                _, args = decode_human_readable_call(
-                    allowed_signature, raw_attribute_value
-                )
+                _, args = decode_human_readable_call(allowed_signature, value)
                 matched_signature = allowed_signature
                 # found a match
                 break
@@ -271,6 +293,8 @@ class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
         if not matched_signature:
             return False, []
 
+        # TODO: not sure what to return as "values" (currently this includes calldata bytes which
+        #  seems excessive)
         parameter_values = []
         additional_parameter_checks = self.allowed_abi_calls[matched_signature]
         if not additional_parameter_checks:
@@ -287,3 +311,50 @@ class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
 
         # if we get here additional checks have all passed
         return True, parameter_values
+
+
+class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
+    CONDITION_TYPE = ConditionType.ABI_ATTRIBUTE.value
+
+    class Schema(BaseSigningObjectAttributeCondition.Schema):
+        condition_type = fields.Str(
+            validate=validate.Equal(ConditionType.ABI_ATTRIBUTE.value), required=True
+        )
+        abi_validation = fields.Nested(AbiCallValidation.Schema(), required=True)
+
+        # maintain field declaration ordering
+        class Meta:
+            ordered = True
+
+        @post_load
+        def make(self, data, **kwargs):
+            return SigningObjectAbiAttributeCondition(**data)
+
+    def __init__(
+        self,
+        attribute_name: str,
+        abi_validation: AbiCallValidation,
+        signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+        condition_type: str = ConditionType.ABI_ATTRIBUTE.value,
+        name: Optional[str] = None,
+    ):
+        self.abi_validation = abi_validation
+        super().__init__(
+            attribute_name=attribute_name,
+            signing_object_context_var=signing_object_context_var,
+            condition_type=condition_type,
+            name=name,
+        )
+
+    def verify(
+        self, providers: ConditionProviderManager, **context
+    ) -> Tuple[bool, Any]:
+        raw_attribute_value = self.get_attribute_value(providers=providers, **context)
+
+        try:
+            result, values = self.abi_validation.check(
+                raw_attribute_value, providers, **context
+            )
+            return result, values
+        except ValueError as e:
+            raise InvalidCondition(str(e))

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -280,6 +280,14 @@ class AbiCallValidation(_Serializable):
 
                     if parameter_value_check.index_within_tuple is not None:
                         tuple_args = arg_types[parameter_value_check.parameter_index]
+                        if not (
+                            tuple_args.startswith("(") and tuple_args.endswith(")")
+                        ):
+                            raise ValidationError(
+                                f"Args value at index '{parameter_value_check.parameter_index}' is not a tuple"
+                            )
+
+                        tuple_args = tuple_args.strip("(").strip(")")
                         if parameter_value_check.index_within_tuple >= len(
                             tuple_args.split(",")
                         ):

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -296,6 +296,21 @@ class AbiCallValidation(_Serializable):
                                 f"the ABI decoded tuple '{tuple_args}'. "
                             )
 
+                    if parameter_value_check.nested_abi_validation:
+                        # ensure that corresponding arg type is bytes
+                        arg_type_to_check = arg_types[
+                            parameter_value_check.parameter_index
+                        ]
+                        if parameter_value_check.index_within_tuple is not None:
+                            tuple_args = arg_type_to_check.strip("(").strip(")")
+                            arg_type_to_check = tuple_args.split(",")[
+                                parameter_value_check.index_within_tuple
+                            ]
+                        if arg_type_to_check != "bytes":
+                            raise ValidationError(
+                                f"Nested ABI validation is only supported for bytes type, but found '{arg_type_to_check}'."
+                            )
+
         @post_load
         def make(self, data, **kwargs):
             return AbiCallValidation(**data)

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -108,11 +108,12 @@ class BaseSigningObjectAttributeCondition(SigningObjectCondition, ABC):
 
 
 class SigningObjectAttributeCondition(BaseSigningObjectAttributeCondition):
-    CONDITION_TYPE = ConditionType.ATTRIBUTE.value
+    CONDITION_TYPE = ConditionType.SIGNING_ATTRIBUTE.value
 
     class Schema(BaseSigningObjectAttributeCondition.Schema):
         condition_type = fields.Str(
-            validate=validate.Equal(ConditionType.ATTRIBUTE.value), required=True
+            validate=validate.Equal(ConditionType.SIGNING_ATTRIBUTE.value),
+            required=True,
         )
         return_value_test = fields.Nested(ReturnValueTest.Schema(), required=True)
 
@@ -129,7 +130,7 @@ class SigningObjectAttributeCondition(BaseSigningObjectAttributeCondition):
         attribute_name: str,
         return_value_test: ReturnValueTest,
         signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
-        condition_type: str = ConditionType.ATTRIBUTE.value,
+        condition_type: str = ConditionType.SIGNING_ATTRIBUTE.value,
         name: Optional[str] = None,
     ):
         self.return_value_test = return_value_test
@@ -365,11 +366,12 @@ class AbiCallValidation(_Serializable):
 
 
 class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
-    CONDITION_TYPE = ConditionType.ABI_ATTRIBUTE.value
+    CONDITION_TYPE = ConditionType.SIGNING_ABI_ATTRIBUTE.value
 
     class Schema(BaseSigningObjectAttributeCondition.Schema):
         condition_type = fields.Str(
-            validate=validate.Equal(ConditionType.ABI_ATTRIBUTE.value), required=True
+            validate=validate.Equal(ConditionType.SIGNING_ABI_ATTRIBUTE.value),
+            required=True,
         )
         abi_validation = fields.Nested(AbiCallValidation.Schema(), required=True)
 
@@ -386,7 +388,7 @@ class SigningObjectAbiAttributeCondition(BaseSigningObjectAttributeCondition):
         attribute_name: str,
         abi_validation: AbiCallValidation,
         signing_object_context_var: str = SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
-        condition_type: str = ConditionType.ABI_ATTRIBUTE.value,
+        condition_type: str = ConditionType.SIGNING_ABI_ATTRIBUTE.value,
         name: Optional[str] = None,
     ):
         self.abi_validation = abi_validation

--- a/nucypher/policy/conditions/signing/utils.py
+++ b/nucypher/policy/conditions/signing/utils.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+
+def adjust_for_attribute_value_for_eval(attribute_value: Any) -> Any:
+    """
+    Adjusts the attribute value for evaluation checking.
+    If the value is a string and does not start with '0x', it will be double-quoted.
+    """
+    if isinstance(attribute_value, str):
+        if not attribute_value.startswith("0x"):
+            # value needs to be double-quoted
+            return f'"{attribute_value}"'
+
+    return attribute_value

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -146,18 +146,35 @@ class ECDSAConditionDict(_Condition):
 #     "signingObjectContextVar": ":signingConditionObject"
 # }
 class _SigningObjectCondition(_Condition):
-    signing_object_context_var: str
+    signingObjectContextVar: str
 
 
-#
+# _BaseSigningObjectAttributeCondition abstract class represents:
+# {
+#     "signingObjectContextVar": ":signingConditionObject"
+#     "attributeName": str
+# }
+class _BaseSigningObjectAttributeCondition(_SigningObjectCondition):
+    attributeName: str
+
+
 # SigningObjectAttributeCondition represents:
 # {
 #     "attributeName": str
 #     "signingObjectContextVar": ":signingConditionObject"
 #     "returnValueTest: <>
 # }
-class SigningObjectAttributeCondition(_SigningObjectCondition):
-    attributeName: str
+class SigningObjectAttributeCondition(_BaseSigningObjectAttributeCondition):
+    returnValueTest: ReturnValueTestDict
+
+
+# AbiParameterValueCheck represents:
+# {
+#     "parameterIndex": str
+#     "returnValueTest: <>
+# }
+class AbiParameterValueCheck(TypedDict):
+    parameter_index: int
     returnValueTest: ReturnValueTestDict
 
 
@@ -165,14 +182,19 @@ class SigningObjectAttributeCondition(_SigningObjectCondition):
 # {
 #     "attributeName": str
 #     "signingObjectContextVar": ":signingConditionObject"
-#     "abiDecodeString": str
-#     "abiDecodeValueIndex: int
-#     "returnValueTest: <>
+#     "allowedAbiCalls": {
+#         "<abi_function_signature>": [
+#              <abi_parameter_value_check_1>,
+#              <abi_parameter_value_check_2>,
+#         ],
+#         "<abi_function_signature>": [
+#              <abi_parameter_value_check_1>,
+#              <abi_parameter_value_check_2>,
+#         ]
+#     }
 # }
-class SigningObjectAbiAttributeCondition(SigningObjectAttributeCondition):
-    abiDecodeString: str
-    abiDecodeValueIndex: int
-
+class SigningObjectAbiAttributeCondition(_BaseSigningObjectAttributeCondition):
+    allowedAbiCalls: Dict[str, List[AbiParameterValueCheck]]
 
 #
 # ConditionDict is a dictionary of:

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -168,33 +168,40 @@ class SigningObjectAttributeCondition(_BaseSigningObjectAttributeCondition):
     returnValueTest: ReturnValueTestDict
 
 
-# AbiParameterValueCheck represents:
+# AbiParameterValidation represents:
 # {
 #     "parameterIndex": str
+#     "indexWithinTuple": int
 #     "returnValueTest: <>
+#     "nestedAbiValidation: <>
 # }
-class AbiParameterValueCheck(TypedDict):
-    parameter_index: int
-    returnValueTest: ReturnValueTestDict
+class AbiParameterValidation(TypedDict):
+    parameterIndex: int
+    indexWithinTuple: NotRequired[int]
+    # either returnValueTest or nestedAbiValidation
+    returnValueTest: NotRequired[ReturnValueTestDict]
+    nestedAbiValidation: NotRequired["AbiCallValidation"]
 
 
-# SigningObjectAttributeCondition represents:
+# AbiCallValidation
+# {
+#    "allowedAbiCalls": {
+#        <call>: ["AbiParameterValidation"]
+#    }
+# }
+class AbiCallValidation(TypedDict):
+    allowedAbiCalls = Dict[str, List[AbiParameterValidation]]
+
+
+# SigningObjectAbiAttributeCondition represents:
 # {
 #     "attributeName": str
 #     "signingObjectContextVar": ":signingConditionObject"
-#     "allowedAbiCalls": {
-#         "<abi_function_signature>": [
-#              <abi_parameter_value_check_1>,
-#              <abi_parameter_value_check_2>,
-#         ],
-#         "<abi_function_signature>": [
-#              <abi_parameter_value_check_1>,
-#              <abi_parameter_value_check_2>,
-#         ]
-#     }
+#     "abiValidation": <abi_call_validation>
 # }
 class SigningObjectAbiAttributeCondition(_BaseSigningObjectAttributeCondition):
-    allowedAbiCalls: Dict[str, List[AbiParameterValueCheck]]
+    abiValidation: AbiCallValidation
+
 
 #
 # ConditionDict is a dictionary of:

--- a/nucypher/utilities/abi.py
+++ b/nucypher/utilities/abi.py
@@ -8,7 +8,11 @@ FUNCTION_NAME_PATTERN = r"^[a-zA-Z_][a-zA-Z0-9_]*$"
 
 
 def extract_arg_types(human_signature: str) -> List[str]:
-    # Extract argument types from signature
+    """
+    Extra list of arg types from human ABI signature.
+
+    Raises ValueError if human ABI signature is incorrectly formatted.
+    """
     start = human_signature.find("(")
     end = human_signature.rfind(")")
     if start == -1 or end == -1 or end <= start:
@@ -36,6 +40,9 @@ def extract_arg_types(human_signature: str) -> List[str]:
             current.append(char)
     if current:
         arg_types.append("".join(current).strip())
+
+    if depth != 0:
+        raise ValueError("Mismatched parentheses in function signatures")
 
     return arg_types
 

--- a/nucypher/utilities/abi.py
+++ b/nucypher/utilities/abi.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Tuple, Union
+from typing import Any, List, Tuple, Union
 
 import eth_abi
 from eth_utils import function_signature_to_4byte_selector
@@ -71,7 +71,7 @@ def encode_human_readable_call(human_signature: str, args: list) -> bytes:
 
 def decode_human_readable_call(
     human_signature: str, call_data: bytes, return_method_name: bool = True
-) -> Tuple[Union[str, bytes], List]:
+) -> Tuple[Union[str, bytes], List[Any]]:
     """
     Decode a human-readable function call signature and its arguments from the
     provided call data into method name OR method selector, and arguments

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -368,7 +368,7 @@ def test_return_value_json_serialization(test_value):
             [
                 comparator
                 for comparator in ReturnValueTest.COMPARATORS
-                if comparator != "in"
+                if comparator not in ["in", "!in"]
             ]
         )
     test = ReturnValueTest(comparator=comparator, value=test_value)
@@ -420,21 +420,41 @@ def test_return_value_non_json_serializable_adjustments():
             "0x12345678",
             "0x87654321",
         ),  # list of hex strings
+        (
+            [1, 2, 3, 4, 5],
+            3,
+            6,
+        ),  # list of integers
+        (
+            [True, True, True],
+            True,
+            False,
+        ),  # list of booleans
+        (
+            [1.1, 2.2, 3.3],
+            2.2,
+            4.4,
+        ),  # list of floats
     ],
 )
-def test_return_value_test_in_comparator(value, pass_value, fail_value):
-    test = ReturnValueTest(comparator="in", value=value)
+def test_return_value_test_in_and_not_in_comparator(value, pass_value, fail_value):
+    in_test = ReturnValueTest(comparator="in", value=value)
+    not_in_test = ReturnValueTest(comparator="!in", value=value)
 
     # ensure correct bytes/hex comparison
-    assert test.eval(pass_value), "value should pass the 'in' test"
-    assert not test.eval(fail_value), "value should not pass the 'in' test"
+    assert in_test.eval(pass_value), "value should pass the 'in' test"
+    assert not in_test.eval(fail_value), "value should not pass the 'in' test"
+
+    assert not not_in_test.eval(pass_value), "value should not pass the '!in' test"
+    assert not_in_test.eval(fail_value), "value should pass the '!in' test"
 
 
-def test_return_value_test_in_comparator_invalid_types():
+def test_return_value_test_in_and_not_in_comparator_invalid_types():
     values = [1, '"string"', b"bytes", True, {"key": "value"}]
     for value in values:
-        with pytest.raises(
-            ReturnValueTest.InvalidExpression,
-            match='not a valid type for the "in" comparator',
-        ):
-            _ = ReturnValueTest(comparator="in", value=value)
+        for comparator in ["in", "!in"]:
+            with pytest.raises(
+                ReturnValueTest.InvalidExpression,
+                match='not a valid type for the "in"/"!in" comparators',
+            ):
+                _ = ReturnValueTest(comparator="in", value=value)

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -40,7 +40,7 @@ def condition_provider_manager():
 
 def test_invalid_signing_object_attribute_condition():
     # invalid condition type
-    with pytest.raises(InvalidCondition, match=ConditionType.ATTRIBUTE.value):
+    with pytest.raises(InvalidCondition, match=ConditionType.SIGNING_ATTRIBUTE.value):
         _ = SigningObjectAttributeCondition(
             condition_type=ConditionType.TIME.value,
             attribute_name="some_attribute",
@@ -57,12 +57,12 @@ def test_invalid_signing_object_attribute_condition():
 
 def test_signing_object_attribute_condition_initialization():
     condition = SigningObjectAttributeCondition(
-        condition_type=ConditionType.ATTRIBUTE.value,
+        condition_type=ConditionType.SIGNING_ATTRIBUTE.value,
         attribute_name="call_data",
         return_value_test=ReturnValueTest("==", 0),
     )
 
-    assert condition.condition_type == ConditionType.ATTRIBUTE.value
+    assert condition.condition_type == ConditionType.SIGNING_ATTRIBUTE.value
     assert condition.signing_object_context_var == SIGNING_CONDITION_OBJECT_CONTEXT_VAR
     assert condition.attribute_name == "call_data"
     assert condition.return_value_test.eval(0)
@@ -204,7 +204,7 @@ def test_signing_object_attribute_condition_lingo_json_serialization(
 ):
     """Test serializing and deserializing a condition lingo with ECDSA condition"""
     condition = SigningObjectAttributeCondition(
-        condition_type=ConditionType.ATTRIBUTE.value,
+        condition_type=ConditionType.SIGNING_ATTRIBUTE.value,
         attribute_name="call_data",
         return_value_test=ReturnValueTest("==", "0x1234567890abcdef"),
     )
@@ -226,7 +226,10 @@ def test_signing_object_attribute_condition_lingo_json_serialization(
     # Parse JSON to dict and verify structure
     lingo_dict = json.loads(original_lingo_json)
     assert lingo_dict["version"] == ConditionLingo.VERSION
-    assert lingo_dict["condition"]["conditionType"] == ConditionType.ATTRIBUTE.value
+    assert (
+        lingo_dict["condition"]["conditionType"]
+        == ConditionType.SIGNING_ATTRIBUTE.value
+    )
 
     # Recreate lingo from JSON
     recreated_lingo = ConditionLingo.from_json(original_lingo_json)
@@ -245,7 +248,9 @@ def test_signing_object_attribute_condition_lingo_json_serialization(
 
 def test_invalid_signing_object_abi_attribute_condition():
     # invalid condition type
-    with pytest.raises(InvalidCondition, match=ConditionType.ABI_ATTRIBUTE.value):
+    with pytest.raises(
+        InvalidCondition, match=ConditionType.SIGNING_ABI_ATTRIBUTE.value
+    ):
         _ = SigningObjectAbiAttributeCondition(
             condition_type=ConditionType.TIME.value,
             attribute_name="call_data",
@@ -436,7 +441,7 @@ def test_signing_object_abi_attribute_condition_initialization():
         ),
     )
 
-    assert condition.condition_type == ConditionType.ABI_ATTRIBUTE.value
+    assert condition.condition_type == ConditionType.SIGNING_ABI_ATTRIBUTE.value
     assert condition.signing_object_context_var == SIGNING_CONDITION_OBJECT_CONTEXT_VAR
     assert condition.attribute_name == "call_data"
     assert list(condition.abi_validation.allowed_abi_calls.keys()) == [
@@ -829,7 +834,10 @@ def test_signing_object_abi_attribute_condition_lingo_json_serialization(
     # Parse JSON to dict and verify structure
     lingo_dict = json.loads(original_lingo_json)
     assert lingo_dict["version"] == ConditionLingo.VERSION
-    assert lingo_dict["condition"]["conditionType"] == ConditionType.ABI_ATTRIBUTE.value
+    assert (
+        lingo_dict["condition"]["conditionType"]
+        == ConditionType.SIGNING_ABI_ATTRIBUTE.value
+    )
 
     # Recreate lingo from JSON
     recreated_lingo = ConditionLingo.from_json(original_lingo_json)

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -312,6 +312,25 @@ def test_invalid_signing_object_abi_attribute_condition():
             ),
         )
 
+    # both return value test and nested_validation provided which isn't allowed
+    with pytest.raises(ValueError, match="return value test or nested abi validation"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_validation=AbiCallValidation(
+                {
+                    "execute(address,uint256,bytes)": [
+                        AbiParameterValidation(
+                            parameter_index=2,
+                            return_value_test=ReturnValueTest("==", 0),
+                            nested_abi_validation=AbiCallValidation(
+                                {"transfer(address,uint256)": []}
+                            ),
+                        )
+                    ]
+                }
+            ),
+        )
+
 
 def test_signing_object_abi_attribute_condition_initialization():
     condition = SigningObjectAbiAttributeCondition(
@@ -338,6 +357,36 @@ def test_signing_object_abi_attribute_condition_initialization():
     assert parameter_checks[0].parameter_index == 1
     assert parameter_checks[0].return_value_test.comparator == "=="
     assert parameter_checks[0].return_value_test.value == 0
+
+
+def test_signing_object_abi_attribute_condition_invalid_value_for_call_data_check(
+    condition_provider_manager, get_random_checksum_address
+):
+    eth_transfer_user_op = create_eth_transfer(
+        get_random_checksum_address(), 0, get_random_checksum_address(), 10_000_000
+    )
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="callData",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(address,uint256,bytes)": [
+                    AbiParameterValidation(
+                        parameter_index=0,  # incorrect index for bytes
+                        nested_abi_validation=AbiCallValidation(
+                            {
+                                "transfer(address,uint256)": [],
+                            }
+                        ),
+                    )
+                ],
+            }
+        ),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: eth_transfer_user_op}
+    with pytest.raises(
+        InvalidCondition, match="Invalid data type for checking call data"
+    ):
+        _, _ = condition.verify(providers=condition_provider_manager, **context)
 
 
 def test_signing_object_abi_attribute_condition_verify_method_call(

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -14,6 +14,7 @@ from nucypher.policy.conditions.lingo import (
 )
 from nucypher.policy.conditions.signing.base import (
     SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
+    AbiParameterValueCheck,
     SigningObjectAbiAttributeCondition,
     SigningObjectAttributeCondition,
 )
@@ -239,71 +240,79 @@ def test_invalid_signing_object_abi_attribute_condition():
         _ = SigningObjectAbiAttributeCondition(
             condition_type=ConditionType.TIME.value,
             attribute_name="call_data",
-            abi_decode_string="transfer(address,uint256)",
-            abi_decode_value_index=0,
-            return_value_test=ReturnValueTest("==", 0),
+            allowed_abi_calls={"transfer(address,uint256)": []},
         )
 
-    # no abi decode string
+    # no allowed abi calls
     with pytest.raises(InvalidCondition, match="Missing data for required field"):
         _ = SigningObjectAbiAttributeCondition(
-            attribute_name="call_data",
-            abi_decode_string=None,
-            abi_decode_value_index=0,
-            return_value_test=ReturnValueTest("==", 0),
+            attribute_name="call_data", allowed_abi_calls=None
         )
 
     # invalid abi decode string
-    with pytest.raises(InvalidCondition, match="Invalid ABI decode string"):
+    with pytest.raises(InvalidCondition, match="Invalid ABI signature"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            abi_decode_string="transfer(address,uint257)",  # invalid data type
-            abi_decode_value_index=0,
-            return_value_test=ReturnValueTest("==", 0),
+            allowed_abi_calls={
+                "transfer(address,uint257)": []  # invalid data type in signature
+            },
         )
 
     # no abi index value
-    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+    with pytest.raises(ValueError, match="Field may not be null"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            abi_decode_string="transfer(address,uint256)",
-            abi_decode_value_index=None,
-            return_value_test=ReturnValueTest("==", 0),
+            allowed_abi_calls={
+                "transfer(address,uint256)": [
+                    AbiParameterValueCheck(None, ReturnValueTest("==", 0))
+                ]
+            },
         )
 
     # negative abi index
-    with pytest.raises(InvalidCondition, match="Must be greater than or equal to 0"):
+    with pytest.raises(ValueError, match="Must be greater than or equal to 0"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            abi_decode_string="transfer(address,uint256)",
-            abi_decode_value_index=-1,
-            return_value_test=ReturnValueTest("==", 0),
+            allowed_abi_calls={
+                "transfer(address,uint256)": [
+                    AbiParameterValueCheck(-1, ReturnValueTest("==", 0))
+                ]
+            },
         )
 
     # abi index out of range
-    with pytest.raises(InvalidCondition, match="Value index '3' is out of range"):
+    with pytest.raises(
+        InvalidCondition, match="Parameter value index '2' is out of range"
+    ):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            abi_decode_string="transfer(address,uint256)",
-            abi_decode_value_index=3,  # out of range for this signature
-            return_value_test=ReturnValueTest("==", 0),
+            allowed_abi_calls={
+                "transfer(address,uint256)": [
+                    AbiParameterValueCheck(2, ReturnValueTest("==", 0))
+                ]
+            },
         )
 
 
 def test_signing_object_abi_attribute_condition_initialization():
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        abi_decode_string="transfer(address,uint256)",
-        abi_decode_value_index=2,
-        return_value_test=ReturnValueTest("==", 0),
+        allowed_abi_calls={
+            "transfer(address,uint256)": [
+                AbiParameterValueCheck(1, ReturnValueTest("==", 0))
+            ]
+        },
     )
 
     assert condition.condition_type == ConditionType.ABI_ATTRIBUTE.value
     assert condition.signing_object_context_var == SIGNING_CONDITION_OBJECT_CONTEXT_VAR
     assert condition.attribute_name == "call_data"
-    assert condition.abi_decode_string == "transfer(address,uint256)"
-    assert condition.abi_decode_value_index == 2
-    assert condition.return_value_test.eval(0)
+    assert list(condition.allowed_abi_calls.keys()) == ["transfer(address,uint256)"]
+    parameter_checks = condition.allowed_abi_calls["transfer(address,uint256)"]
+    assert len(parameter_checks) == 1
+    assert parameter_checks[0].parameter_index == 1
+    assert parameter_checks[0].return_value_test.comparator == "=="
+    assert parameter_checks[0].return_value_test.value == 0
 
 
 def test_signing_object_abi_attribute_condition_verify_method_call(
@@ -315,18 +324,19 @@ def test_signing_object_abi_attribute_condition_verify_method_call(
         call_data_human_signature, [get_random_checksum_address(), 10_000_000]
     )
 
-    allowed_method_calls = ['"transfer"', '"mint"', '"burn"']
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        abi_decode_string=call_data_human_signature,
-        abi_decode_value_index=0,  # method is at 0-index
-        return_value_test=ReturnValueTest("in", allowed_method_calls),
+        allowed_abi_calls={
+            "approve(address,uint256)": [],
+            "execute(address,uint256)": [],
+            "transfer(address,uint256)": [],
+        },
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
     success, result = condition.verify(providers=condition_provider_manager, **context)
     assert success is True
-    assert result == "transfer"
+    assert result == "transfer(address,uint256)"
 
 
 def test_signing_object_abi_attribute_condition_verify_transfer_address_call(
@@ -345,9 +355,11 @@ def test_signing_object_abi_attribute_condition_verify_transfer_address_call(
 
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        abi_decode_string=call_data_human_signature,
-        abi_decode_value_index=1,  # method is at 0-index
-        return_value_test=ReturnValueTest("in", allowed_addresses),
+        allowed_abi_calls={
+            "transfer(address,uint256)": [
+                AbiParameterValueCheck(0, ReturnValueTest("in", allowed_addresses))
+            ]
+        },
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
@@ -373,9 +385,11 @@ def test_signing_object_abi_attribute_condition_verify_transfer_amount_call(
 
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        abi_decode_string=call_data_human_signature,
-        abi_decode_value_index=2,  # method is at 0-index
-        return_value_test=ReturnValueTest("<", 20_000_000),
+        allowed_abi_calls={
+            "transfer(address,uint256)": [
+                AbiParameterValueCheck(1, ReturnValueTest("<", 20_000_000))
+            ]
+        },
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
@@ -401,9 +415,11 @@ def test_signing_object_abi_attribute_condition_lingo_json_serialization(
 
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        abi_decode_string=call_data_human_signature,
-        abi_decode_value_index=2,  # method is at 0-index
-        return_value_test=ReturnValueTest("<", 20_000_000),
+        allowed_abi_calls={
+            "transfer(address,uint256)": [
+                AbiParameterValueCheck(1, ReturnValueTest("<", 20_000_000))
+            ]
+        },
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -1,6 +1,9 @@
+import copy
 import json
+import random
 
 import pytest
+from web3 import Web3
 
 from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
@@ -14,13 +17,19 @@ from nucypher.policy.conditions.lingo import (
 )
 from nucypher.policy.conditions.signing.base import (
     SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
-    AbiParameterValueCheck,
+    AbiCallValidation,
+    AbiParameterValidation,
     SigningObjectAbiAttributeCondition,
     SigningObjectAttributeCondition,
 )
 from nucypher.policy.conditions.utils import ConditionProviderManager
 from nucypher.utilities.abi import encode_human_readable_call
-from tests.utils.erc4337 import create_eth_transfer
+from tests.utils.erc4337 import (
+    create_erc20_approve,
+    create_erc20_transfer,
+    create_eth_transfer,
+    encode_function_call,
+)
 
 
 @pytest.fixture
@@ -105,14 +114,14 @@ def test_signing_object_attribute_condition_verify_hex_string(
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
     assert result == signing_object.call_data
 
     # failure case
     signing_object.call_data = "0xdeadbeef"
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is False
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
     assert result == signing_object.call_data
 
 
@@ -120,24 +129,24 @@ def test_signing_object_attribute_condition_verify_allowed_string_list(
     mocker, condition_provider_manager
 ):
     signing_object = mocker.Mock()
-    signing_object.method_name = "burn"
+    signing_object.data = "burn"
 
-    allowed_method_calls = ['"transfer"', '"approve"', '"mint"', '"burn"']
+    allowed_data_values = ['"feel"', '"the"', '"burn"']
     condition = SigningObjectAttributeCondition(
-        attribute_name="method_name",
-        return_value_test=ReturnValueTest("in", allowed_method_calls),
+        attribute_name="data",
+        return_value_test=ReturnValueTest("in", allowed_data_values),
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
-    assert result == signing_object.method_name
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
+    assert result == signing_object.data
 
-    # failure case with disallowed method name
-    signing_object.method_name = "transferFrom"
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is False
-    assert result == signing_object.method_name
+    # failure case with disallowed value
+    signing_object.data = "fire"
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
+    assert result == signing_object.data
 
 
 def test_signing_object_attribute_condition_verify_number_value(
@@ -152,14 +161,14 @@ def test_signing_object_attribute_condition_verify_number_value(
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
     assert result == signing_object.gas_limit
 
     # failure case with disallowed method name
     signing_object.gas_limit = 5_000
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is False
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
     assert result == signing_object.gas_limit
 
 
@@ -204,8 +213,8 @@ def test_signing_object_attribute_condition_lingo_json_serialization(
     signing_object.call_data = "0x1234567890abcdef"
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
     assert result == signing_object.call_data
 
     # Create condition lingo
@@ -227,10 +236,10 @@ def test_signing_object_attribute_condition_lingo_json_serialization(
     signing_object = mocker.Mock()
     signing_object.call_data = "0x1234567890abcdef"
 
-    success, result = recreated_lingo.condition.verify(
+    allowed, result = recreated_lingo.condition.verify(
         providers=condition_provider_manager, **context
     )
-    assert success is True
+    assert allowed is True
     assert result == signing_object.call_data
 
 
@@ -240,75 +249,91 @@ def test_invalid_signing_object_abi_attribute_condition():
         _ = SigningObjectAbiAttributeCondition(
             condition_type=ConditionType.TIME.value,
             attribute_name="call_data",
-            allowed_abi_calls={"transfer(address,uint256)": []},
+            abi_validation=AbiCallValidation({"transfer(address,uint256)": []}),
         )
 
     # no allowed abi calls
     with pytest.raises(InvalidCondition, match="Missing data for required field"):
         _ = SigningObjectAbiAttributeCondition(
-            attribute_name="call_data", allowed_abi_calls=None
+            attribute_name="call_data", abi_validation=None
+        )
+
+    with pytest.raises(ValueError, match="At least one allowed abi call"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_validation=AbiCallValidation({}),
         )
 
     # invalid abi decode string
-    with pytest.raises(InvalidCondition, match="Invalid ABI signature"):
+    with pytest.raises(ValueError, match="Invalid ABI signature"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            allowed_abi_calls={
-                "transfer(address,uint257)": []  # invalid data type in signature
-            },
+            abi_validation=AbiCallValidation(
+                {"transfer(address,uint257)": []}  # invalid data type in signature
+            ),
         )
 
     # no abi index value
     with pytest.raises(ValueError, match="Field may not be null"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            allowed_abi_calls={
-                "transfer(address,uint256)": [
-                    AbiParameterValueCheck(None, ReturnValueTest("==", 0))
-                ]
-            },
+            abi_validation=AbiCallValidation(
+                {
+                    "transfer(address,uint256)": [
+                        AbiParameterValidation(None, ReturnValueTest("==", 0))
+                    ]
+                }
+            ),
         )
 
     # negative abi index
     with pytest.raises(ValueError, match="Must be greater than or equal to 0"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            allowed_abi_calls={
-                "transfer(address,uint256)": [
-                    AbiParameterValueCheck(-1, ReturnValueTest("==", 0))
-                ]
-            },
+            abi_validation=AbiCallValidation(
+                {
+                    "transfer(address,uint256)": [
+                        AbiParameterValidation(-1, ReturnValueTest("==", 0))
+                    ]
+                }
+            ),
         )
 
     # abi index out of range
-    with pytest.raises(
-        InvalidCondition, match="Parameter value index '2' is out of range"
-    ):
+    with pytest.raises(ValueError, match="Parameter value index '2' is out of range"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
-            allowed_abi_calls={
-                "transfer(address,uint256)": [
-                    AbiParameterValueCheck(2, ReturnValueTest("==", 0))
-                ]
-            },
+            abi_validation=AbiCallValidation(
+                {
+                    "transfer(address,uint256)": [
+                        AbiParameterValidation(2, ReturnValueTest("==", 0))
+                    ]
+                }
+            ),
         )
 
 
 def test_signing_object_abi_attribute_condition_initialization():
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        allowed_abi_calls={
-            "transfer(address,uint256)": [
-                AbiParameterValueCheck(1, ReturnValueTest("==", 0))
-            ]
-        },
+        abi_validation=AbiCallValidation(
+            {
+                "transfer(address,uint256)": [
+                    AbiParameterValidation(1, ReturnValueTest("==", 0))
+                ]
+            }
+        ),
     )
 
     assert condition.condition_type == ConditionType.ABI_ATTRIBUTE.value
     assert condition.signing_object_context_var == SIGNING_CONDITION_OBJECT_CONTEXT_VAR
     assert condition.attribute_name == "call_data"
-    assert list(condition.allowed_abi_calls.keys()) == ["transfer(address,uint256)"]
-    parameter_checks = condition.allowed_abi_calls["transfer(address,uint256)"]
+    assert list(condition.abi_validation.allowed_abi_calls.keys()) == [
+        "transfer(address,uint256)"
+    ]
+    parameter_checks = condition.abi_validation.allowed_abi_calls[
+        "transfer(address,uint256)"
+    ]
     assert len(parameter_checks) == 1
     assert parameter_checks[0].parameter_index == 1
     assert parameter_checks[0].return_value_test.comparator == "=="
@@ -316,91 +341,287 @@ def test_signing_object_abi_attribute_condition_initialization():
 
 
 def test_signing_object_abi_attribute_condition_verify_method_call(
-    mocker, condition_provider_manager, get_random_checksum_address
+    condition_provider_manager, get_random_checksum_address
 ):
-    call_data_human_signature = "transfer(address,uint256)"
-    signing_object = mocker.Mock()
-    signing_object.call_data = encode_human_readable_call(
-        call_data_human_signature, [get_random_checksum_address(), 10_000_000]
+    erc20_transfer_user_op = create_erc20_transfer(
+        get_random_checksum_address(),
+        0,
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+        10_000_000,
     )
-
     condition = SigningObjectAbiAttributeCondition(
-        attribute_name="call_data",
-        allowed_abi_calls={
-            "approve(address,uint256)": [],
-            "execute(address,uint256)": [],
-            "transfer(address,uint256)": [],
-        },
+        attribute_name="callData",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(address,uint256,bytes)": [
+                    AbiParameterValidation(
+                        parameter_index=2,
+                        nested_abi_validation=AbiCallValidation(
+                            {
+                                "transfer(address,uint256)": [],
+                            }
+                        ),
+                    )
+                ],
+            }
+        ),
     )
-    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+    # transfer is allowed
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: erc20_transfer_user_op}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
 
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
-    assert result == "transfer(address,uint256)"
+    # check that approve is not allowed
+    erc20_approve_user_op = create_erc20_approve(
+        get_random_checksum_address(),
+        0,
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+        1_000_000,
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: erc20_approve_user_op}
+
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
 
 
-def test_signing_object_abi_attribute_condition_verify_transfer_address_call(
-    mocker, condition_provider_manager, get_random_checksum_address
+def test_signing_object_abi_attribute_condition_verify_transfer_eth_to_address_call(
+    condition_provider_manager, get_random_checksum_address
 ):
-    call_data_human_signature = "transfer(address,uint256)"
     allowed_addresses = [
         get_random_checksum_address(),
         get_random_checksum_address(),
         get_random_checksum_address(),
     ]
-    signing_object = mocker.Mock()
-    signing_object.call_data = encode_human_readable_call(
-        call_data_human_signature, [allowed_addresses[0], 10_000_000]
-    )
+    sender = get_random_checksum_address()
+    nonce = 0
+    amount = 10_000_000
 
+    eth_transfer_user_op = create_eth_transfer(
+        sender, nonce, random.choice(allowed_addresses), amount
+    )
     condition = SigningObjectAbiAttributeCondition(
-        attribute_name="call_data",
-        allowed_abi_calls={
-            "transfer(address,uint256)": [
-                AbiParameterValueCheck(0, ReturnValueTest("in", allowed_addresses))
-            ]
-        },
+        attribute_name="callData",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(address,uint256,bytes)": [
+                    AbiParameterValidation(0, ReturnValueTest("in", allowed_addresses))
+                ]
+            }
+        ),
     )
-    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
-
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: eth_transfer_user_op}
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
 
     not_allowed_address = get_random_checksum_address()
-    signing_object.call_data = encode_human_readable_call(
-        call_data_human_signature, [not_allowed_address, 10_000_000]
+    eth_transfer_to_not_allowed_user_op = create_eth_transfer(
+        sender, nonce, not_allowed_address, amount
     )
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is False
+    context = {
+        SIGNING_CONDITION_OBJECT_CONTEXT_VAR: eth_transfer_to_not_allowed_user_op
+    }
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
 
 
-def test_signing_object_abi_attribute_condition_verify_transfer_amount_call(
+def test_signing_object_abi_attribute_condition_verify_transfer_eth_amount_call(
+    condition_provider_manager, get_random_checksum_address
+):
+    sender = get_random_checksum_address()
+    nonce = 22
+    to_address = get_random_checksum_address()
+
+    eth_transfer_user_op = create_eth_transfer(sender, nonce, to_address, 10_000_000)
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="callData",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(address,uint256,bytes)": [
+                    AbiParameterValidation(1, ReturnValueTest("<", 20_000_000))
+                ]
+            }
+        ),
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: eth_transfer_user_op}
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
+
+    eth_transfer_to_large_user_op = create_eth_transfer(
+        sender, nonce, to_address, 30_000_000
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: eth_transfer_to_large_user_op}
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
+
+
+def test_signing_object_abi_attribute_condition_nested_erc20_transfer_restriction(
+    condition_provider_manager, get_random_checksum_address
+):
+    erc20_token_address = get_random_checksum_address()
+    to_address = get_random_checksum_address()
+    amount = int(Web3.to_wei(1, "ether"))
+
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(address,uint256,bytes)": [
+                    # only allow specific token address
+                    AbiParameterValidation(
+                        0, ReturnValueTest("==", erc20_token_address)
+                    ),
+                    AbiParameterValidation(
+                        2,
+                        nested_abi_validation=AbiCallValidation(
+                            {
+                                "transfer(address,uint256)": [
+                                    # only allow transfer to specific recipient
+                                    AbiParameterValidation(
+                                        0, ReturnValueTest("==", to_address)
+                                    ),
+                                    # only allow < 2 eth to be transferred
+                                    AbiParameterValidation(
+                                        1,
+                                        ReturnValueTest(
+                                            "<", int(Web3.to_wei(2, "ether"))
+                                        ),
+                                    ),
+                                ]
+                            }
+                        ),
+                    ),
+                ]
+            }
+        ),
+    )
+
+    base_user_op_dict = dict(
+        sender=get_random_checksum_address(),
+        nonce=76,
+        token=erc20_token_address,
+        to=to_address,
+        amount=amount,
+    )
+
+    # success case
+    user_op = create_erc20_transfer(**base_user_op_dict)
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: user_op}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
+
+    # modify user op for check to fail
+    # 1) all the same except different token address
+    fail_user_op_dict = copy.deepcopy(base_user_op_dict)
+    fail_user_op_dict["token"] = get_random_checksum_address()
+    fail_user_op = create_erc20_transfer(**fail_user_op_dict)
+
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: fail_user_op}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
+
+    # 2) all the same except recipient
+    fail_user_op_dict = copy.deepcopy(base_user_op_dict)
+    fail_user_op_dict["to"] = get_random_checksum_address()
+    fail_user_op = create_erc20_transfer(**fail_user_op_dict)
+
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: fail_user_op}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
+
+    # 3) all the same except amount too high
+    fail_user_op_dict = copy.deepcopy(base_user_op_dict)
+    fail_user_op_dict["amount"] = int(Web3.to_wei(3, "ether"))
+    fail_user_op = create_erc20_transfer(**fail_user_op_dict)
+
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: fail_user_op}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
+
+    # 4) approve user op instead of a transfer (note: only transfer user op is allowed)
+    fail_user_op_dict = copy.deepcopy(base_user_op_dict)
+    del fail_user_op_dict["to"]  # approve doesn't have a "to" field
+    fail_user_op_dict["spender"] = get_random_checksum_address()
+    fail_user_op = create_erc20_approve(**fail_user_op_dict)
+
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: fail_user_op}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
+
+
+def test_signing_object_abi_attribute_condition_more_than_2_levels_nested_calldata(
     mocker, condition_provider_manager, get_random_checksum_address
 ):
-    call_data_human_signature = "transfer(address,uint256)"
-    signing_object = mocker.Mock()
-    signing_object.call_data = encode_human_readable_call(
-        call_data_human_signature, [get_random_checksum_address(), 10_000_000]
+    # Level 3: innermost transfer() call
+    transfer_data = encode_function_call(
+        "transfer(address,uint256)", [get_random_checksum_address(), 10_000_000]
+    )
+
+    # Level 2: eg. proxy.execute(token_address, 0, transfer_data)
+    proxy_execute_data = encode_function_call(
+        "execute(address,uint256,bytes)",
+        [get_random_checksum_address(), 0, transfer_data],
+    )
+
+    # Level 1: smartAccount.execute(proxy_address, 0, proxy_execute_data)
+    proxy_address = get_random_checksum_address()
+    user_op_call_data = encode_function_call(
+        "execute(address,uint256,bytes)", [proxy_address, 0, proxy_execute_data]
     )
 
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        allowed_abi_calls={
-            "transfer(address,uint256)": [
-                AbiParameterValueCheck(1, ReturnValueTest("<", 20_000_000))
-            ]
-        },
+        abi_validation=AbiCallValidation(
+            {
+                "execute(address,uint256,bytes)": [
+                    # only allow proxy address
+                    AbiParameterValidation(
+                        0, return_value_test=ReturnValueTest("==", proxy_address)
+                    ),
+                    AbiParameterValidation(
+                        2,
+                        nested_abi_validation=AbiCallValidation(
+                            {
+                                "execute(address,uint256,bytes)": [
+                                    # only allow transfer call
+                                    AbiParameterValidation(
+                                        2,
+                                        nested_abi_validation=AbiCallValidation(
+                                            {"transfer(address,uint256)": []}
+                                        ),
+                                    )
+                                ]
+                            }
+                        ),
+                    ),
+                ]
+            }
+        ),
     )
+
+    signing_object = mocker.Mock()
+    signing_object.call_data = user_op_call_data
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
 
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
-
-    signing_object.call_data = encode_human_readable_call(
-        call_data_human_signature, [get_random_checksum_address(), 30_000_000]
+    # failure case: try calling some other function from the proxy eg. call a contract function
+    contract_call = encode_function_call(
+        "execute(address,uint256,bytes)",
+        [get_random_checksum_address(), 0, encode_function_call("getValue()", [])],
     )
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is False
+    updated_proxy_execute_data = encode_function_call(
+        "execute(address,uint256,bytes)",
+        [get_random_checksum_address(), 0, contract_call],
+    )
+    updated_user_op_call_data = encode_function_call(
+        "execute(address,uint256,bytes)", [proxy_address, 0, updated_proxy_execute_data]
+    )
+    signing_object.call_data = updated_user_op_call_data
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
 
 
 def test_signing_object_abi_attribute_condition_lingo_json_serialization(
@@ -415,16 +636,18 @@ def test_signing_object_abi_attribute_condition_lingo_json_serialization(
 
     condition = SigningObjectAbiAttributeCondition(
         attribute_name="call_data",
-        allowed_abi_calls={
-            "transfer(address,uint256)": [
-                AbiParameterValueCheck(1, ReturnValueTest("<", 20_000_000))
-            ]
-        },
+        abi_validation=AbiCallValidation(
+            {
+                "transfer(address,uint256)": [
+                    AbiParameterValidation(1, ReturnValueTest("<", 20_000_000))
+                ]
+            }
+        ),
     )
     context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
 
-    success, result = condition.verify(providers=condition_provider_manager, **context)
-    assert success is True
+    allowed, result = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
 
     # Create condition lingo
     lingo = ConditionLingo(condition)
@@ -442,7 +665,7 @@ def test_signing_object_abi_attribute_condition_lingo_json_serialization(
     assert recreated_lingo.to_json() == original_lingo_json
 
     # works the same
-    success, result = recreated_lingo.condition.verify(
+    allowed, result = recreated_lingo.condition.verify(
         providers=condition_provider_manager, **context
     )
-    assert success is True
+    assert allowed is True

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -280,7 +280,10 @@ def test_invalid_signing_object_abi_attribute_condition():
             abi_validation=AbiCallValidation(
                 {
                     "transfer(address,uint256)": [
-                        AbiParameterValidation(None, ReturnValueTest("==", 0))
+                        AbiParameterValidation(
+                            parameter_index=None,
+                            return_value_test=ReturnValueTest("==", 0),
+                        )
                     ]
                 }
             ),
@@ -293,7 +296,10 @@ def test_invalid_signing_object_abi_attribute_condition():
             abi_validation=AbiCallValidation(
                 {
                     "transfer(address,uint256)": [
-                        AbiParameterValidation(-1, ReturnValueTest("==", 0))
+                        AbiParameterValidation(
+                            parameter_index=-1,
+                            return_value_test=ReturnValueTest("==", 0),
+                        )
                     ]
                 }
             ),
@@ -306,7 +312,29 @@ def test_invalid_signing_object_abi_attribute_condition():
             abi_validation=AbiCallValidation(
                 {
                     "transfer(address,uint256)": [
-                        AbiParameterValidation(2, ReturnValueTest("==", 0))
+                        AbiParameterValidation(
+                            parameter_index=2,
+                            return_value_test=ReturnValueTest("==", 0),
+                        )
+                    ]
+                }
+            ),
+        )
+
+    # tuple index out of range
+    with pytest.raises(
+        ValueError, match="Tuple value index '3' for parameter is out of range"
+    ):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_validation=AbiCallValidation(
+                {
+                    "execute((address,uint256,bytes))": [
+                        AbiParameterValidation(
+                            parameter_index=0,
+                            index_within_tuple=3,
+                            return_value_test=ReturnValueTest("==", 0),
+                        )
                     ]
                 }
             ),
@@ -338,7 +366,9 @@ def test_signing_object_abi_attribute_condition_initialization():
         abi_validation=AbiCallValidation(
             {
                 "transfer(address,uint256)": [
-                    AbiParameterValidation(1, ReturnValueTest("==", 0))
+                    AbiParameterValidation(
+                        parameter_index=1, return_value_test=ReturnValueTest("==", 0)
+                    )
                 ]
             }
         ),
@@ -455,7 +485,10 @@ def test_signing_object_abi_attribute_condition_verify_transfer_eth_to_address_c
         abi_validation=AbiCallValidation(
             {
                 "execute(address,uint256,bytes)": [
-                    AbiParameterValidation(0, ReturnValueTest("in", allowed_addresses))
+                    AbiParameterValidation(
+                        parameter_index=0,
+                        return_value_test=ReturnValueTest("in", allowed_addresses),
+                    )
                 ]
             }
         ),
@@ -488,7 +521,10 @@ def test_signing_object_abi_attribute_condition_verify_transfer_eth_amount_call(
         abi_validation=AbiCallValidation(
             {
                 "execute(address,uint256,bytes)": [
-                    AbiParameterValidation(1, ReturnValueTest("<", 20_000_000))
+                    AbiParameterValidation(
+                        parameter_index=1,
+                        return_value_test=ReturnValueTest("<", 20_000_000),
+                    )
                 ]
             }
         ),
@@ -519,7 +555,8 @@ def test_signing_object_abi_attribute_condition_nested_erc20_transfer_restrictio
                 "execute(address,uint256,bytes)": [
                     # only allow specific token address
                     AbiParameterValidation(
-                        0, ReturnValueTest("==", erc20_token_address)
+                        parameter_index=0,
+                        return_value_test=ReturnValueTest("==", erc20_token_address),
                     ),
                     AbiParameterValidation(
                         2,
@@ -528,12 +565,15 @@ def test_signing_object_abi_attribute_condition_nested_erc20_transfer_restrictio
                                 "transfer(address,uint256)": [
                                     # only allow transfer to specific recipient
                                     AbiParameterValidation(
-                                        0, ReturnValueTest("==", to_address)
+                                        parameter_index=0,
+                                        return_value_test=ReturnValueTest(
+                                            "==", to_address
+                                        ),
                                     ),
                                     # only allow < 2 eth to be transferred
                                     AbiParameterValidation(
-                                        1,
-                                        ReturnValueTest(
+                                        parameter_index=1,
+                                        return_value_test=ReturnValueTest(
                                             "<", int(Web3.to_wei(2, "ether"))
                                         ),
                                     ),
@@ -673,6 +713,51 @@ def test_signing_object_abi_attribute_condition_more_than_2_levels_nested_callda
     assert allowed is False
 
 
+def test_signing_object_abi_attribute_condition_tuple_index(
+    mocker, condition_provider_manager
+):
+    # example contract call
+    # {
+    #   to: "0xBa0c733Ab8328baD95e5708159eB55C4ec1Aae26",
+    #   value: 0n,
+    #   data: "0x42cde4e8",   <threshold() function call>
+    # }
+    expected_contract_address = "0xBa0c733Ab8328baD95e5708159eB55C4ec1Aae26"
+    call_data_from_script = encode_function_call(
+        "execute((address,uint256,bytes))",
+        [(expected_contract_address, 0, encode_function_call("threshold()", []))],
+    )
+
+    signing_object = mocker.Mock()
+    signing_object.call_data = bytes(call_data_from_script)
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: signing_object}
+
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_validation=AbiCallValidation(
+            {
+                "execute((address,uint256,bytes))": [
+                    AbiParameterValidation(
+                        parameter_index=0,
+                        index_within_tuple=0,
+                        return_value_test=ReturnValueTest(
+                            "==", expected_contract_address
+                        ),
+                    ),
+                    AbiParameterValidation(
+                        parameter_index=0,
+                        index_within_tuple=2,
+                        nested_abi_validation=AbiCallValidation({"threshold()": []}),
+                    ),
+                ]
+            }
+        ),
+    )
+
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
+
+
 def test_signing_object_abi_attribute_condition_lingo_json_serialization(
     mocker, condition_provider_manager, get_random_checksum_address
 ):
@@ -688,7 +773,10 @@ def test_signing_object_abi_attribute_condition_lingo_json_serialization(
         abi_validation=AbiCallValidation(
             {
                 "transfer(address,uint256)": [
-                    AbiParameterValidation(1, ReturnValueTest("<", 20_000_000))
+                    AbiParameterValidation(
+                        parameter_index=1,
+                        return_value_test=ReturnValueTest("<", 20_000_000),
+                    )
                 ]
             }
         ),

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -321,6 +321,23 @@ def test_invalid_signing_object_abi_attribute_condition():
             ),
         )
 
+    # invalid tuple arg
+    with pytest.raises(ValueError, match="is not a tuple"):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_validation=AbiCallValidation(
+                {
+                    "execute(address,uint256,bytes)": [
+                        AbiParameterValidation(
+                            parameter_index=0,
+                            index_within_tuple=0,
+                            return_value_test=ReturnValueTest("==", 0),
+                        )
+                    ]
+                }
+            ),
+        )
+
     # tuple index out of range
     with pytest.raises(
         ValueError, match="Tuple value index '3' for parameter is out of range"
@@ -724,6 +741,7 @@ def test_signing_object_abi_attribute_condition_tuple_index(
     # }
     expected_contract_address = "0xBa0c733Ab8328baD95e5708159eB55C4ec1Aae26"
     call_data_from_script = encode_function_call(
+        # this is how the user op is created in the MDT demo
         "execute((address,uint256,bytes))",
         [(expected_contract_address, 0, encode_function_call("threshold()", []))],
     )

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -376,6 +376,51 @@ def test_invalid_signing_object_abi_attribute_condition():
             ),
         )
 
+    # nested ABI validation for non-bytes type
+    with pytest.raises(
+        ValueError, match="Nested ABI validation is only supported for bytes type"
+    ):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="callData",
+            abi_validation=AbiCallValidation(
+                {
+                    "execute(address,uint256,bytes)": [
+                        AbiParameterValidation(
+                            parameter_index=0,  # incorrect index for bytes
+                            nested_abi_validation=AbiCallValidation(
+                                {
+                                    "transfer(address,uint256)": [],
+                                }
+                            ),
+                        )
+                    ],
+                }
+            ),
+        )
+
+    # nested ABI validation for non-bytes type within tuple
+    with pytest.raises(
+        ValueError, match="Nested ABI validation is only supported for bytes type"
+    ):
+        _ = SigningObjectAbiAttributeCondition(
+            attribute_name="callData",
+            abi_validation=AbiCallValidation(
+                {
+                    "execute((address,uint256,bytes))": [
+                        AbiParameterValidation(
+                            parameter_index=0,  # correct for tuple
+                            index_within_tuple=0,  # incorrect index within tuple
+                            nested_abi_validation=AbiCallValidation(
+                                {
+                                    "transfer(address,uint256)": [],
+                                }
+                            ),
+                        )
+                    ],
+                }
+            ),
+        )
+
 
 def test_signing_object_abi_attribute_condition_initialization():
     condition = SigningObjectAbiAttributeCondition(
@@ -404,36 +449,6 @@ def test_signing_object_abi_attribute_condition_initialization():
     assert parameter_checks[0].parameter_index == 1
     assert parameter_checks[0].return_value_test.comparator == "=="
     assert parameter_checks[0].return_value_test.value == 0
-
-
-def test_signing_object_abi_attribute_condition_invalid_value_for_call_data_check(
-    condition_provider_manager, get_random_checksum_address
-):
-    eth_transfer_user_op = create_eth_transfer(
-        get_random_checksum_address(), 0, get_random_checksum_address(), 10_000_000
-    )
-    condition = SigningObjectAbiAttributeCondition(
-        attribute_name="callData",
-        abi_validation=AbiCallValidation(
-            {
-                "execute(address,uint256,bytes)": [
-                    AbiParameterValidation(
-                        parameter_index=0,  # incorrect index for bytes
-                        nested_abi_validation=AbiCallValidation(
-                            {
-                                "transfer(address,uint256)": [],
-                            }
-                        ),
-                    )
-                ],
-            }
-        ),
-    )
-    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: eth_transfer_user_op}
-    with pytest.raises(
-        InvalidCondition, match="Invalid data type for checking call data"
-    ):
-        _, _ = condition.verify(providers=condition_provider_manager, **context)
 
 
 def test_signing_object_abi_attribute_condition_verify_method_call(
@@ -576,7 +591,7 @@ def test_signing_object_abi_attribute_condition_nested_erc20_transfer_restrictio
                         return_value_test=ReturnValueTest("==", erc20_token_address),
                     ),
                     AbiParameterValidation(
-                        2,
+                        parameter_index=2,
                         nested_abi_validation=AbiCallValidation(
                             {
                                 "transfer(address,uint256)": [
@@ -666,8 +681,8 @@ def test_signing_object_abi_attribute_condition_more_than_2_levels_nested_callda
 
     # Level 2: eg. proxy.execute(token_address, 0, transfer_data)
     proxy_execute_data = encode_function_call(
-        "execute(address,uint256,bytes)",
-        [get_random_checksum_address(), 0, transfer_data],
+        "execute((address,uint256,bytes))",
+        [(get_random_checksum_address(), 0, transfer_data)],
     )
 
     # Level 1: smartAccount.execute(proxy_address, 0, proxy_execute_data)
@@ -689,10 +704,11 @@ def test_signing_object_abi_attribute_condition_more_than_2_levels_nested_callda
                         2,
                         nested_abi_validation=AbiCallValidation(
                             {
-                                "execute(address,uint256,bytes)": [
+                                "execute((address,uint256,bytes))": [
                                     # only allow transfer call
                                     AbiParameterValidation(
-                                        2,
+                                        parameter_index=0,
+                                        index_within_tuple=2,
                                         nested_abi_validation=AbiCallValidation(
                                             {"transfer(address,uint256)": []}
                                         ),

--- a/tests/unit/test_abi_utils.py
+++ b/tests/unit/test_abi_utils.py
@@ -27,13 +27,17 @@ from nucypher.utilities.abi import (
         ("nestedTupleType(address,(string,uint256,(address,bool)))", True),
         # Failure cases
         ("invalidSignature", False),  # Invalid signature
-        ("123start(address, uint256)", False),  # Invalid function name
-        ("!start(address, uint256)", False),  # Invalid function name
+        ("123start(address,uint256)", False),  # Invalid function name
+        ("!start(address,uint256)", False),  # Invalid function name
         ("bad(!!!, address)", False),  # Invalid typ
-        ("transfer(address, uint257)", False),  # Invalid type
-        ("transfer(address, uint256", False),  # Missing closing parenthesis
+        ("transfer(address,uint257)", False),  # Invalid type
+        ("transfer(address,uint256", False),  # Missing closing parenthesis
+        (
+            "execute(address,uint256,(address,uint256,bytes)",
+            False,
+        ),  # Missing closing parenthesis
         ("transfer(,uint256)", False),  # Empty argument type
-        ("transfer(address, uint256) extra", False),  # Extra text after signature
+        ("transfer(address,uint256) extra", False),  # Extra text after signature
     ],
 )
 def test_valid_human_readable_signature(human_signature, expected):


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Follow-up to #3606 .
Based over #3606 .

The big issue being that callData can be nested within itself, so how do we structure the condition to handle that - looking at a recursive solution for now. It is very likely that this is a foundational base for which specific helpers would need to be built on top of - not sure if the helpers will be in python or typescript currently.

Structure:

```python
# AbiParameterValidation represents:
# {
#     "parameterIndex": str
#     "indexWithinTuple": int
#     "returnValueTest: <>
#     "nestedAbiValidation: <>
# }
```
(_either "returnValueTest" or "nestedAbiValidation" i.e. check the value itself or its an underlying calldata set of bytes that needs its own validation_)

```python
# AbiCallValidation
# {
#    "allowedAbiCalls": {
#        <human_abi_signature>: ["AbiParameterValidation"]
#    }
# }

# SigningObjectAbiAttributeCondition represents:
# {
#     "attributeName": str
#     "signingObjectContextVar": ":signingConditionObject"
#     "abiValidation": <abi_call_validation>
# }
```

- Also added "!in" operator for return value test to balance our "in" operator.


_`lynx` is already running this code_

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?

The other possible aspect of abi validation would be to actually simulate the transaction and then have additional checks on events, balances etc. - this was raised by @cygnusv . However, to simulate tx execution and check subsequent state is a much more involved process. It requires either local simulation eg. anvil (https://medium.com/@maria.magdalena.makeup/foundry-anvil-a-local-ethereum-node-for-development-642ca28f7892) , hardhat etc. or remote simulation eg. tenderly API (https://docs.tenderly.co/simulations/single-simulations#simulate-via-api), alchemy API (https://www.alchemy.com/docs/reference/simulation-examples) etc.

Local simulation requires:
- an additional process for running `anvil`
- additional time for launching the process then running the simulation which increases response time by the node
- existing fork in process needs to be restarted to update based on newer blocks i.e. we can't just have a background process that periodically refreshes blockchain state to latest block, but rather it would need to be restarted periodically.

Remote simulation requires:
- API keys and associated payment
- Can there be one key that all nodes use
- Centralizing force inflicted on nodes performing signing checks

In both cases, additional condition configuration options will need to be provided for any post-simulation checking of state.  Not sure where to go with this at the moment, so will look into it as part of a separate PR.
