### PR TITLE
🐛 Fix critical typos in core exception and type names

### DIFF
--- a/nucypher/blockchain/eth/token.py
+++ b/nucypher/blockchain/eth/token.py
@@ -3,7 +3,7 @@ from typing import Union
 
 from eth_utils import currency
 
-from nucypher.types import ERC20UNits, NuNits, TuNits
+from nucypher.types import ERC20Units, NuNits, TuNits
 
 
 class ERC20:
@@ -71,7 +71,7 @@ class ERC20:
         """Returns a decimal value of NU"""
         return currency.from_wei(self.__value, unit='ether')
 
-    def to_units(self) -> ERC20UNits:
+    def to_units(self) -> ERC20Units:
         """Returns an int value in the Unit class for this token"""
         return self.__class__._unit(self.__value)
 

--- a/nucypher/crypto/powers.py
+++ b/nucypher/crypto/powers.py
@@ -55,7 +55,7 @@ class NoRitualisticPower(PowerUpError):
     pass
 
 
-class NotImplmplemented(PowerUpError):
+class NotImplemented(PowerUpError):
     pass
 
 class NoThresholdRequestDecryptingPower(PowerUpError):

--- a/nucypher/types.py
+++ b/nucypher/types.py
@@ -1,8 +1,8 @@
 from typing import NamedTuple, NewType, TypeVar
 
-ERC20UNits = NewType("ERC20UNits", int)
-NuNits = NewType("NuNits", ERC20UNits)
-TuNits = NewType("TuNits", ERC20UNits)
+ERC20Units = NewType("ERC20Units", int)
+NuNits = NewType("NuNits", ERC20Units)
+TuNits = NewType("TuNits", ERC20Units)
 
 Agent = TypeVar("Agent", bound="agents.EthereumContractAgent")  # noqa: F821
 


### PR DESCRIPTION
## Description

### Background

I've struggled to make meaningful contributions to the nucypher project on several occasions due to the complexity and scale of the codebase. This time I thought I might try a different approach...

I put together a definition of good practice and then used AI tools to conduct a review of the entire codebase against that definition. That work is documented in the [Empiria/nucypher](https://github.com/Empiria/nucypher) fork under the `review` branch, specifically in:

- [`review/prompt.md`](https://github.com/Empiria/nucypher/blob/review/review/prompt.md) - The prompt given to the AI agent
- [`review/review.md`](https://github.com/Empiria/nucypher/blob/review/review/review.md) - The resulting findings

I then asked the AI agent to generate github issues to tackle the findings in that review and those are also available to view in the [Empiria/nucypher](https://github.com/Empiria/nucypher/issues) fork.

### This PR - First Quick Win

This PR represents the first and simplest fix from the review findings, addressing [**Issue #11: Critical Typos in Core Classes**](https://github.com/Empiria/nucypher/issues/11).

#### Changes Made

- **`nucypher/crypto/powers.py:58`**: Fixed `NotImplmplemented` → `NotImplemented` (exception class name)
- **`nucypher/types.py:3`**: Fixed `ERC20UNits` → `ERC20Units` (type definition)
- **`nucypher/blockchain/eth/token.py`**: Updated references to above


