### PR TITLE
JSON API/RPC Authorization Types

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -18,9 +18,6 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.9", "3.12" ]
-    env:
-      # Used by acceptance/conditions tests
-      POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
 
     steps:
       - name: Checkout repo
@@ -106,12 +103,18 @@ jobs:
       - name: Conditions Tests (Coverage)
         if: matrix.python-version == '3.12'
         working-directory: tests/acceptance
+        env:
+          # Used for testing a POAP API call
+          POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
         run: |
           coverage run --data-file=acceptance_conditions_data -m pytest conditions
           coverage xml -i --data-file=acceptance_conditions_data -o acceptance-conditions-coverage.xml
 
       - name: Conditions Tests
         if: matrix.python-version != '3.12'
+        env:
+          # Used for testing a POAP API call
+          POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
         working-directory: tests/acceptance
         run: python -m pytest conditions
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -18,6 +18,9 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.9", "3.12" ]
+    env:
+      # Used by acceptance/conditions tests
+      POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
 
     steps:
       - name: Checkout repo

--- a/newsfragments/3614.feature.rst
+++ b/newsfragments/3614.feature.rst
@@ -1,0 +1,1 @@
+Add support for multiple authentication schemes (Bearer, Basic, and X-API-KEY) to JSON API and JSON-RPC conditions.

--- a/nucypher/policy/conditions/json/api.py
+++ b/nucypher/policy/conditions/json/api.py
@@ -5,6 +5,10 @@ from marshmallow.fields import Url
 from typing_extensions import override
 
 from nucypher.policy.conditions.context import is_context_variable
+from nucypher.policy.conditions.json.auth import (
+    AuthorizationType,
+    AuthorizationTypeField,
+)
 from nucypher.policy.conditions.json.base import (
     BaseJsonRequestCondition,
     HTTPMethod,
@@ -27,6 +31,7 @@ class JsonApiCall(JsonRequestCall):
         parameters = fields.Dict(required=False, allow_none=True)
         query = JSONPathField(required=False, allow_none=True)
         authorization_token = fields.Str(required=False, allow_none=True)
+        authorization_type = AuthorizationTypeField(required=False, allow_none=True)
 
         @post_load
         def make(self, data, **kwargs):
@@ -45,6 +50,7 @@ class JsonApiCall(JsonRequestCall):
         parameters: Optional[dict] = None,
         query: Optional[str] = None,
         authorization_token: Optional[str] = None,
+        authorization_type: Optional[AuthorizationType] = None,
     ):
         self.endpoint = endpoint
         super().__init__(
@@ -52,6 +58,7 @@ class JsonApiCall(JsonRequestCall):
             parameters=parameters,
             query=query,
             authorization_token=authorization_token,
+            authorization_type=authorization_type,
         )
 
         self.logger = Logger(__name__)
@@ -87,6 +94,7 @@ class JsonApiCondition(BaseJsonRequestCondition):
         query: Optional[str] = None,
         parameters: Optional[dict] = None,
         authorization_token: Optional[str] = None,
+        authorization_type: Optional[AuthorizationType] = None,
         condition_type: Optional[str] = ConditionType.JSONAPI.value,
         name: Optional[str] = None,
     ):
@@ -96,6 +104,7 @@ class JsonApiCondition(BaseJsonRequestCondition):
             query=query,
             parameters=parameters,
             authorization_token=authorization_token,
+            authorization_type=authorization_type,
             condition_type=condition_type,
             name=name,
         )
@@ -119,3 +128,7 @@ class JsonApiCondition(BaseJsonRequestCondition):
     @property
     def authorization_token(self):
         return self.execution_call.authorization_token
+
+    @property
+    def authorization_type(self):
+        return self.execution_call.authorization_type

--- a/nucypher/policy/conditions/json/api.py
+++ b/nucypher/policy/conditions/json/api.py
@@ -1,6 +1,13 @@
 from typing import Any, Optional
 
-from marshmallow import ValidationError, fields, post_load, validate, validates
+from marshmallow import (
+    ValidationError,
+    fields,
+    post_load,
+    validate,
+    validates,
+    validates_schema,
+)
 from marshmallow.fields import Url
 from typing_extensions import override
 
@@ -42,6 +49,13 @@ class JsonApiCall(JsonRequestCall):
             if value and not is_context_variable(value):
                 raise ValidationError(
                     f"Invalid value for authorization token; expected a context variable, but got '{value}'"
+                )
+
+        @validates_schema
+        def validate_auth_type_and_token(self, data, **kwargs):
+            if data.get("authorization_type") and not data.get("authorization_token"):
+                raise ValidationError(
+                    "Authorization token must be provided if authorization type is set."
                 )
 
     def __init__(

--- a/nucypher/policy/conditions/json/auth.py
+++ b/nucypher/policy/conditions/json/auth.py
@@ -1,0 +1,55 @@
+from enum import Enum
+from typing import List
+
+from marshmallow.fields import String
+from marshmallow.validate import OneOf
+
+
+class AuthorizationType(Enum):
+    BEARER = "Bearer"
+    X_API_KEY = "X-API-KEY"
+    BASIC = "Basic"
+
+    @classmethod
+    def values(cls) -> List[str]:
+        return [auth_type.value for auth_type in cls]
+
+    def __str__(self):
+        return self.value
+
+    def header_name(self) -> str:
+        if self.value in (self.BEARER.value, self.BASIC.value):
+            return "Authorization"
+        else:
+            return "X-API-KEY"
+
+    def header_value(self, token: str) -> str:
+        if self.value == self.BEARER.value:
+            return f"Bearer {token}"
+        elif self.value == self.BASIC.value:
+            return f"Basic {token}"
+        else:
+            return token
+
+
+class AuthorizationTypeField(String):
+    default_error_messages = {
+        "invalidType": "Expression of type {value} is not valid for Authorization type",
+        "invalid": "'{value}' is not a valid Authorization type",
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(validate=OneOf(AuthorizationType), *args, **kwargs)
+
+    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+        if value is None:
+            return None
+        return str(value)
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        if not isinstance(value, str):
+            raise self.make_error("invalidType", value=type(value))
+        try:
+            return AuthorizationType(value)
+        except ValueError as e:
+            raise self.make_error("invalid", value=value) from e

--- a/nucypher/policy/conditions/json/auth.py
+++ b/nucypher/policy/conditions/json/auth.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import List
+from typing import List, Union
 
 from marshmallow.fields import String
 from marshmallow.validate import OneOf
@@ -41,7 +41,7 @@ class AuthorizationTypeField(String):
     def __init__(self, *args, **kwargs):
         super().__init__(validate=OneOf(AuthorizationType), *args, **kwargs)
 
-    def _serialize(self, value, attr, obj, **kwargs) -> str | None:
+    def _serialize(self, value, attr, obj, **kwargs) -> Union[str, None]:
         if value is None:
             return None
         return str(value)

--- a/nucypher/policy/conditions/json/auth.py
+++ b/nucypher/policy/conditions/json/auth.py
@@ -7,7 +7,7 @@ from marshmallow.validate import OneOf
 
 class AuthorizationType(Enum):
     BEARER = "Bearer"
-    X_API_KEY = "X-API-KEY"
+    X_API_KEY = "X-API-Key"
     BASIC = "Basic"
 
     @classmethod
@@ -18,32 +18,35 @@ class AuthorizationType(Enum):
         return self.value
 
     def header_name(self) -> str:
-        if self.value in (self.BEARER.value, self.BASIC.value):
+        if self in [self.BEARER, self.BASIC]:
             return "Authorization"
         else:
-            return "X-API-KEY"
+            return self.value
 
     def header_value(self, token: str) -> str:
-        if self.value == self.BEARER.value:
-            return f"Bearer {token}"
-        elif self.value == self.BASIC.value:
-            return f"Basic {token}"
+        if self in [self.BEARER, self.BASIC]:
+            return f"{self.value} {token}"
         else:
             return token
 
 
 class AuthorizationTypeField(String):
     default_error_messages = {
-        "invalidType": "Expression of type {value} is not valid for Authorization type",
-        "invalid": "'{value}' is not a valid Authorization type",
+        "invalidType": "Expression of type {value} is not valid for AuthorizationType",
+        "invalid": "'{value}' is not a valid AuthorizationType",
     }
 
     def __init__(self, *args, **kwargs):
         super().__init__(validate=OneOf(AuthorizationType), *args, **kwargs)
 
     def _serialize(self, value, attr, obj, **kwargs) -> Union[str, None]:
+        # If value is None, return None to allow for optional fields
         if value is None:
             return None
+
+        if not isinstance(value, AuthorizationType):
+            raise self.make_error("invalidType", value=type(value))
+
         return str(value)
 
     def _deserialize(self, value, attr, data, **kwargs):

--- a/nucypher/policy/conditions/json/base.py
+++ b/nucypher/policy/conditions/json/base.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Tuple
 import requests
 from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
 from jsonpath_ng.ext import parse
-from marshmallow.fields import Field
+from marshmallow.fields import String
 
 from nucypher.policy.conditions.base import ExecutionCall
 from nucypher.policy.conditions.context import (
@@ -17,6 +17,7 @@ from nucypher.policy.conditions.exceptions import (
     ConditionEvaluationFailed,
     JsonRequestException,
 )
+from nucypher.policy.conditions.json.auth import AuthorizationType
 from nucypher.policy.conditions.json.utils import process_result_for_condition_eval
 from nucypher.policy.conditions.lingo import ExecutionCallCondition
 from nucypher.utilities.logging import Logger
@@ -36,12 +37,14 @@ class JsonRequestCall(ExecutionCall, ABC):
         parameters: Optional[dict] = None,
         query: Optional[str] = None,
         authorization_token: Optional[str] = None,
+        authorization_type: Optional[AuthorizationType] = None,
     ):
 
         self.http_method = http_method
         self.parameters = parameters or {}
         self.query = query
         self.authorization_token = authorization_token
+        self.authorization_type = authorization_type
 
         self.timeout = self.TIMEOUT
         self.logger = Logger(__name__)
@@ -62,7 +65,11 @@ class JsonRequestCall(ExecutionCall, ABC):
             resolved_authorization_token = resolve_any_context_variables(
                 self.authorization_token, **context
             )
-            headers["Authorization"] = f"Bearer {resolved_authorization_token}"
+            # use Bearer token if none is provided
+            authorization_type = self.authorization_type or AuthorizationType.BEARER
+            headers[authorization_type.header_name()] = authorization_type.header_value(
+                resolved_authorization_token
+            )
 
         try:
             if self.http_method == HTTPMethod.GET:
@@ -127,7 +134,7 @@ class JsonRequestCall(ExecutionCall, ABC):
         return result
 
 
-class JSONPathField(Field):
+class JSONPathField(String):
     default_error_messages = {
         "invalidType": "Expression of type {value} is not valid for JSONPath",
         "invalid": "'{value}' is not a valid JSONPath expression",

--- a/nucypher/policy/conditions/json/rpc.py
+++ b/nucypher/policy/conditions/json/rpc.py
@@ -10,6 +10,10 @@ from nucypher.policy.conditions.context import is_context_variable
 from nucypher.policy.conditions.exceptions import (
     JsonRequestException,
 )
+from nucypher.policy.conditions.json.auth import (
+    AuthorizationType,
+    AuthorizationTypeField,
+)
 from nucypher.policy.conditions.json.base import (
     BaseJsonRequestCondition,
     HTTPMethod,
@@ -30,6 +34,7 @@ class BaseJsonRPCCall(JsonRequestCall, ABC):
         params = AnyField(required=False, allow_none=True)
         query = JSONPathField(required=False, allow_none=True)
         authorization_token = fields.Str(required=False, allow_none=True)
+        authorization_type = AuthorizationTypeField(required=False, allow_none=True)
 
         @validates("authorization_token")
         def validate_auth_token(self, value):
@@ -44,6 +49,7 @@ class BaseJsonRPCCall(JsonRequestCall, ABC):
         params: Optional[Any] = None,
         query: Optional[str] = None,
         authorization_token: Optional[str] = None,
+        authorization_type: Optional[AuthorizationType] = None,
     ):
         self.method = method
         self.params = params or []
@@ -59,6 +65,7 @@ class BaseJsonRPCCall(JsonRequestCall, ABC):
             parameters=parameters,
             query=query,
             authorization_token=authorization_token,
+            authorization_type=authorization_type,
         )
 
     @override
@@ -97,6 +104,7 @@ class JsonEndpointRPCCall(BaseJsonRPCCall):
         params: Optional[Any] = None,
         query: Optional[str] = None,
         authorization_token: Optional[str] = None,
+        authorization_type: Optional[AuthorizationType] = None,
     ):
         self.endpoint = endpoint
         super().__init__(
@@ -104,6 +112,7 @@ class JsonEndpointRPCCall(BaseJsonRPCCall):
             params=params,
             query=query,
             authorization_token=authorization_token,
+            authorization_type=authorization_type,
         )
 
     @override
@@ -138,6 +147,7 @@ class JsonRpcCondition(BaseJsonRequestCondition):
         params: Optional[Any] = None,
         query: Optional[str] = None,
         authorization_token: Optional[str] = None,
+        authorization_type: Optional[AuthorizationType] = None,
         condition_type: Optional[str] = ConditionType.JSONRPC.value,
         name: Optional[str] = None,
     ):
@@ -148,6 +158,7 @@ class JsonRpcCondition(BaseJsonRequestCondition):
             params=params,
             query=query,
             authorization_token=authorization_token,
+            authorization_type=authorization_type,
             condition_type=condition_type,
             name=name,
         )
@@ -171,6 +182,10 @@ class JsonRpcCondition(BaseJsonRequestCondition):
     @property
     def authorization_token(self):
         return self.execution_call.authorization_token
+
+    @property
+    def authorization_type(self):
+        return self.execution_call.authorization_type
 
     @property
     def timeout(self):

--- a/nucypher/policy/conditions/json/rpc.py
+++ b/nucypher/policy/conditions/json/rpc.py
@@ -2,7 +2,14 @@ from abc import ABC
 from typing import Any, Optional
 from uuid import uuid4
 
-from marshmallow import ValidationError, fields, post_load, validate, validates
+from marshmallow import (
+    ValidationError,
+    fields,
+    post_load,
+    validate,
+    validates,
+    validates_schema,
+)
 from marshmallow.fields import Url
 from typing_extensions import override
 
@@ -41,6 +48,13 @@ class BaseJsonRPCCall(JsonRequestCall, ABC):
             if value and not is_context_variable(value):
                 raise ValidationError(
                     f"Invalid value for authorization token; expected a context variable, but got '{value}'"
+                )
+
+        @validates_schema
+        def validate_auth_type_and_token(self, data, **kwargs):
+            if data.get("authorization_type") and not data.get("authorization_token"):
+                raise ValidationError(
+                    "Authorization token must be provided if authorization type is set."
                 )
 
     def __init__(

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -909,7 +909,7 @@ def test_contract_condition_using_overloaded_function(
 
 
 @pytest.mark.xfail(reason="This test uses a public rpc endpoint")
-def test_json_rpc_condition_non_evm_prototyping_example():
+def test_json_rpc_condition_non_evm_prototyping_example_solana():
     condition = JsonRpcCondition(
         endpoint="https://api.mainnet-beta.solana.com",
         method="getBlockTime",
@@ -929,6 +929,9 @@ def test_json_rpc_condition_non_evm_prototyping_example():
     success, _ = condition.verify()
     assert success
 
+
+@pytest.mark.xfail(reason="This test uses a public rpc endpoint")
+def test_json_rpc_condition_non_evm_prototyping_example_bitcoin():
     condition = JsonRpcCondition(
         endpoint="https://bitcoin.drpc.org",
         method="getblock",

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -1154,7 +1154,7 @@ def test_poap_contract_condition(get_context_value_mock):
         operands=[
             ownership_condition,
             event_id_condition,
-        ]
+        ],
     )
     gnosis_providers = ConditionProviderManager(
         {

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 from eth_account.messages import defunct_hash_message, encode_defunct
 from hexbytes import HexBytes
-from web3 import Web3
+from web3 import HTTPProvider, Web3
 from web3.providers import BaseProvider
 from web3.types import ABIFunction
 
@@ -34,6 +34,7 @@ from nucypher.policy.conditions.json.api import JsonApiCondition
 from nucypher.policy.conditions.json.auth import AuthorizationType
 from nucypher.policy.conditions.json.rpc import JsonRpcCondition
 from nucypher.policy.conditions.lingo import (
+    CompoundAccessControlCondition,
     ConditionLingo,
     ConditionType,
     NotCompoundCondition,
@@ -1079,22 +1080,89 @@ def test_validate_condition_lingo_endpoint(ursulas, time_condition):
 )
 def test_poap_api_condition(get_context_value_mock, condition_providers):
     eth_denver_2025_event_id = 185704
+    user_address = "0x19570deAFd7Cbe25B30A5A72c95A8E7658672436"
 
+    #
+    # POAP API
+    #
     # get an API key from https://documentation.poap.tech/docs/authentication
     authorization_token = "abcd1234"
 
     context = {
-        USER_ADDRESS_CONTEXT: {"address": "0x19570deAFd7Cbe25B30A5A72c95A8E7658672436"},
+        USER_ADDRESS_CONTEXT: {"address": user_address},
         ":authToken": authorization_token,
     }
 
     # check whether user has attended eth denver 2025
-    condition = JsonApiCondition(
+    json_api_condition = JsonApiCondition(
         endpoint=f"https://api.poap.tech/actions/scan/:userAddress/{eth_denver_2025_event_id}",
         authorization_token=":authToken",
         authorization_type=AuthorizationType.X_API_KEY,
         query="$.tokenId",
         return_value_test=ReturnValueTest("!=", '""'),
     )
-    success, _ = condition.verify(providers=condition_providers, **context)
+    success, _ = json_api_condition.verify(providers=condition_providers, **context)
+    assert success
+
+
+@pytest.mark.xfail(reason="This test uses public RPC endpoint for Gnosis")
+@mock.patch(
+    GET_CONTEXT_VALUE_IMPORT_PATH,
+    side_effect=_dont_validate_user_address,
+)
+def test_poap_contract_condition(get_context_value_mock):
+    eth_denver_2025_event_id = 185704
+    user_address = "0x19570deAFd7Cbe25B30A5A72c95A8E7658672436"
+
+    #
+    # POAP Contract
+    #
+    context = {
+        USER_ADDRESS_CONTEXT: {"address": user_address},
+        ":tokenId": 7323049,
+    }
+    ownership_condition = ContractCondition(
+        contract_address="0x22c1f6050e56d2876009903609a2cc3fef83b415",
+        function_abi={
+            "type": "function",
+            "name": "ownerOf",
+            "inputs": [{"name": "tokenId", "type": "uint256"}],
+            "outputs": [{"name": "", "type": "address"}],
+            "stateMutability": "view",
+        },
+        method="ownerOf",
+        parameters=[":tokenId"],
+        chain=100,
+        return_value_test=ReturnValueTest("==", ":userAddress"),
+    )
+    event_id_condition = ContractCondition(
+        contract_address="0x22c1f6050e56d2876009903609a2cc3fef83b415",
+        function_abi={
+            "type": "function",
+            "name": "tokenEvent",
+            "inputs": [{"name": "tokenId", "type": "uint256"}],
+            "outputs": [{"name": "", "type": "uint256"}],
+            "stateMutability": "view",
+        },
+        method="tokenEvent",
+        parameters=[":tokenId"],
+        chain=100,
+        return_value_test=ReturnValueTest("==", eth_denver_2025_event_id),
+    )
+    and_condition = CompoundAccessControlCondition(
+        operator="and",
+        operands=[
+            ownership_condition,
+            event_id_condition,
+        ]
+    )
+    gnosis_providers = ConditionProviderManager(
+        {
+            100: [
+                HTTPProvider("https://gnosis.drpc.org"),
+                HTTPProvider("https://gnosis-public.nodies.app"),
+            ]
+        }
+    )
+    success, _ = and_condition.verify(providers=gnosis_providers, **context)
     assert success

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -1086,7 +1086,9 @@ def test_poap_api_condition(get_context_value_mock, condition_providers):
     # POAP API
     #
     # get an API key from https://documentation.poap.tech/docs/authentication
-    authorization_token = "abcd1234"
+    authorization_token = os.environ.get(
+        "POAP_API_KEY", "abcd1234"
+    )  # default to fake if N/A
 
     context = {
         USER_ADDRESS_CONTEXT: {"address": user_address},

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -34,7 +34,7 @@ from nucypher.policy.conditions.json.api import JsonApiCondition
 from nucypher.policy.conditions.json.auth import AuthorizationType
 from nucypher.policy.conditions.json.rpc import JsonRpcCondition
 from nucypher.policy.conditions.lingo import (
-    CompoundAccessControlCondition,
+    CompoundCondition,
     ConditionLingo,
     ConditionType,
     NotCompoundCondition,
@@ -1154,7 +1154,7 @@ def test_poap_contract_condition(get_context_value_mock):
         chain=100,
         return_value_test=ReturnValueTest("==", eth_denver_2025_event_id),
     )
-    and_condition = CompoundAccessControlCondition(
+    and_condition = CompoundCondition(
         operator="and",
         operands=[
             ownership_condition,

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -30,6 +30,8 @@ from nucypher.policy.conditions.exceptions import (
     RequiredContextVariable,
     RPCExecutionFailed,
 )
+from nucypher.policy.conditions.json.api import JsonApiCondition
+from nucypher.policy.conditions.json.auth import AuthorizationType
 from nucypher.policy.conditions.json.rpc import JsonRpcCondition
 from nucypher.policy.conditions.lingo import (
     ConditionLingo,
@@ -1068,3 +1070,31 @@ def test_validate_condition_lingo_endpoint(ursulas, time_condition):
             path="validate_condition_lingo",
             json=json.dumps({"invalidCondition": "confirmed"}),
         )
+
+
+@pytest.mark.xfail(reason="This test requires a valid POAP API Key")
+@mock.patch(
+    GET_CONTEXT_VALUE_IMPORT_PATH,
+    side_effect=_dont_validate_user_address,
+)
+def test_poap_api_condition(get_context_value_mock, condition_providers):
+    eth_denver_2025_event_id = 185704
+
+    # get an API key from https://documentation.poap.tech/docs/authentication
+    authorization_token = "abcd1234"
+
+    context = {
+        USER_ADDRESS_CONTEXT: {"address": "0x19570deAFd7Cbe25B30A5A72c95A8E7658672436"},
+        ":authToken": authorization_token,
+    }
+
+    # check whether user has attended eth denver 2025
+    condition = JsonApiCondition(
+        endpoint=f"https://api.poap.tech/actions/scan/:userAddress/{eth_denver_2025_event_id}",
+        authorization_token=":authToken",
+        authorization_type=AuthorizationType.X_API_KEY,
+        query="$.tokenId",
+        return_value_test=ReturnValueTest("!=", '""'),
+    )
+    success, _ = condition.verify(providers=condition_providers, **context)
+    assert success

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -131,11 +131,41 @@ def lingo_with_all_condition_types(get_random_checksum_address):
             },
         ],
     }
+    json_api_condition_w_auth_type = {
+        # JSON API
+        "conditionType": ConditionType.JSONAPI.value,
+        "endpoint": "https://api.example.com/data",
+        "parameters": {
+            "ids": "ethereum",
+            "vs_currencies": "usd",
+        },
+        "authorizationToken": ":authToken",
+        "authorizationType": "Bearer",
+        "query": "$.store.book[0].price",
+        "returnValueTest": {
+            "comparator": "==",
+            "value": 2,
+        },
+    }
+    json_rpc_condition_w_auth_type = {
+        # JSON RPC
+        "conditionType": ConditionType.JSONRPC.value,
+        "endpoint": "https://math.example.com/",
+        "method": "subtract",
+        "params": [42, 23],
+        "query": "$.mathresult",
+        "authorizationToken": ":authToken",
+        "authorizationType": "X-API-Key",
+        "returnValueTest": {
+            "comparator": "==",
+            "value": 19,
+        },
+    }
     if_then_else_condition = {
         "conditionType": ConditionType.IF_THEN_ELSE.value,
-        "ifCondition": rpc_condition,
-        "thenCondition": json_api_condition,
-        "elseCondition": json_rpc_condition,
+        "ifCondition": json_rpc_condition,
+        "thenCondition": json_api_condition_w_auth_type,
+        "elseCondition": json_rpc_condition_w_auth_type,
     }
     return {
         "version": ConditionLingo.VERSION,

--- a/tests/unit/conditions/test_json_api_condition.py
+++ b/tests/unit/conditions/test_json_api_condition.py
@@ -8,6 +8,7 @@ from nucypher.policy.conditions.exceptions import (
     JsonRequestException,
 )
 from nucypher.policy.conditions.json.api import JsonApiCondition
+from nucypher.policy.conditions.json.auth import AuthorizationType
 from nucypher.policy.conditions.lingo import ConditionLingo, ReturnValueTest
 
 
@@ -49,6 +50,17 @@ def test_json_api_invalid_authorization_token():
         _ = JsonApiCondition(
             endpoint="https://api.example.com/data",
             authorization_token="1234",  # doesn't make sense hardcoding the token
+            query="$.store.book[0].price",
+            return_value_test=ReturnValueTest("==", 0),
+        )
+
+
+def test_json_api_authorization_type_provided_with_no_auth_token():
+    with pytest.raises(InvalidCondition, match="Authorization token must be provided"):
+        _ = JsonApiCondition(
+            endpoint="https://api.example.com/data",
+            # no auth token even though authorization type is set
+            authorization_type=AuthorizationType.BEARER,
             query="$.store.book[0].price",
             return_value_test=ReturnValueTest("==", 0),
         )
@@ -247,6 +259,48 @@ def test_json_api_condition_evaluation_with_auth_token(mocker):
         mocked_get.call_args.kwargs["headers"]["Authorization"]
         == f"Bearer {auth_token}"
     )
+
+
+@pytest.mark.parametrize(
+    "auth_type",
+    [auth_type for auth_type in AuthorizationType],
+)
+def test_json_api_condition_evaluation_with_auth_token_and_auth_type(auth_type, mocker):
+    mocked_get = mocker.patch(
+        "requests.get",
+        return_value=mocker.Mock(
+            status_code=200, json=lambda: {"ethereum": {"usd": 0.0}}
+        ),
+    )
+
+    condition = JsonApiCondition(
+        endpoint="https://api.coingecko.com/api/v3/simple/price",
+        parameters={
+            "ids": "ethereum",
+            "vs_currencies": "usd",
+        },
+        authorization_token=":authToken",
+        authorization_type=auth_type,
+        query="ethereum.usd",
+        return_value_test=ReturnValueTest("==", 0.0),
+    )
+    assert condition.authorization_token == ":authToken"
+
+    auth_token = "1234567890"
+    context = {":authToken": f"{auth_token}"}
+    assert condition.verify(**context) == (True, 0.0)
+    assert mocked_get.call_count == 1
+
+    if auth_type == AuthorizationType.X_API_KEY:
+        assert mocked_get.call_args.kwargs["headers"]["X-API-Key"] == f"{auth_token}"
+        assert "Authorization" not in mocked_get.call_args.kwargs["headers"]
+    else:
+        assert mocked_get.call_args.kwargs["headers"]["Authorization"] == (
+            f"Bearer {auth_token}"
+            if auth_type == AuthorizationType.BEARER
+            else f"Basic {auth_token}"
+        )
+        assert "X-API-Key" not in mocked_get.call_args.kwargs["headers"]
 
 
 def test_json_api_condition_evaluation_with_user_address_context_variable(

--- a/tests/unit/conditions/test_json_auth_type.py
+++ b/tests/unit/conditions/test_json_auth_type.py
@@ -1,0 +1,74 @@
+import pytest
+from marshmallow import ValidationError
+
+from nucypher.policy.conditions.json.auth import (
+    AuthorizationType,
+    AuthorizationTypeField,
+)
+
+
+@pytest.fixture
+def token():
+    return "abcd-1234"
+
+
+def test_bearer_auth_type(token):
+    auth_type = AuthorizationType.BEARER
+    assert str(auth_type) == "Bearer"
+    assert auth_type.header_name() == "Authorization"
+    assert auth_type.header_value(token) == f"Bearer {token}"
+
+
+def test_basic_auth_type(token):
+    auth_type = AuthorizationType.BASIC
+    assert str(auth_type) == "Basic"
+    assert auth_type.header_name() == "Authorization"
+    assert auth_type.header_value(token) == f"Basic {token}"
+
+
+def test_x_api_key_auth_type(token):
+    auth_type = AuthorizationType.X_API_KEY
+    assert str(auth_type) == "X-API-Key"
+    assert auth_type.header_name() == "X-API-Key"
+    assert auth_type.header_value(token) == token
+
+
+@pytest.mark.parametrize("auth_type_str", AuthorizationType.values())
+def test_auth_type_field(auth_type_str):
+    auth_type = AuthorizationType(auth_type_str)
+
+    auth_type_field = AuthorizationTypeField()
+
+    serialized = auth_type_field._serialize(value=auth_type, attr=None, obj=None)
+    assert serialized == auth_type_str
+
+    deserialized = auth_type_field.deserialize(value=serialized)
+    assert deserialized == auth_type
+
+
+def test_auth_type_field_invalid_auth_type():
+    auth_type_field = AuthorizationTypeField()
+
+    with pytest.raises(ValidationError, match="is not a valid AuthorizationType"):
+        auth_type_field.deserialize(value="invalid_auth_type")
+
+    with pytest.raises(
+        ValidationError, match="type <class 'int'> is not valid for AuthorizationType"
+    ):
+        auth_type_field.deserialize(value=1234)
+
+    with pytest.raises(ValidationError, match="is not valid for AuthorizationType"):
+        auth_type_field._serialize(value="invalid_auth_type", attr=None, obj=None)
+
+
+# old conditions wouldn't have this field so it would be None
+def test_auth_type_field_none_value():
+    auth_type_field = AuthorizationTypeField(allow_none=True)
+
+    # Test serialization of None
+    serialized = auth_type_field._serialize(value=None, attr=None, obj=None)
+    assert serialized is None
+
+    # Test deserialization of None
+    deserialized = auth_type_field.deserialize(value=None)
+    assert deserialized is None

--- a/tests/unit/conditions/test_json_rpc_condition.py
+++ b/tests/unit/conditions/test_json_rpc_condition.py
@@ -8,6 +8,7 @@ from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
     JsonRequestException,
 )
+from nucypher.policy.conditions.json.auth import AuthorizationType
 from nucypher.policy.conditions.json.rpc import JsonRpcCondition
 from nucypher.policy.conditions.lingo import (
     ConditionLingo,
@@ -72,6 +73,18 @@ def test_invalid_authorization_token():
             params=[42, 23],
             return_value_test=ReturnValueTest("==", 19),
             authorization_token="github_pat_123456789",
+        )
+
+
+def test_json_rpc_authorization_type_provided_with_no_auth_token():
+    with pytest.raises(InvalidCondition, match="Authorization token must be provided"):
+        _ = JsonRpcCondition(
+            endpoint="https://math.example.com/",
+            method="subtract",
+            params=[42, 23],
+            return_value_test=ReturnValueTest("==", 19),
+            # no auth token even though authorization type is set
+            authorization_type=AuthorizationType.BASIC,
         )
 
 
@@ -215,6 +228,53 @@ def test_json_rpc_condition_evaluation_with_auth_token(mocker):
         mocked_method.call_args.kwargs["headers"]["Authorization"]
         == f"Bearer {auth_token}"
     )
+
+
+@pytest.mark.parametrize(
+    "auth_type",
+    [auth_type for auth_type in AuthorizationType],
+)
+def test_json_rpc_condition_evaluation_with_auth_token_and_auth_type(auth_type, mocker):
+    mock_response = mocker.Mock(status_code=200)
+    mock_response.json.return_value = {"jsonrpc": "2.0", "result": 19, "id": 1}
+    mocked_method = mocker.patch("requests.post", return_value=mock_response)
+
+    condition = JsonRpcCondition(
+        endpoint="https://math.example.com/",
+        method="subtract",
+        params=[42, 23],
+        return_value_test=ReturnValueTest("==", 19),
+        authorization_token=":authToken",
+        authorization_type=auth_type,
+    )
+
+    assert condition.authorization_token == ":authToken"
+    auth_token = "1234567890"
+    context = {":authToken": f"{auth_token}"}
+
+    success, result = condition.verify(**context)
+    assert success is True
+    assert result == 19
+
+    assert mocked_method.call_count == 1
+    assert mocked_method.call_args.kwargs["json"] == {
+        "jsonrpc": "2.0",
+        "id": UUID4_STR,
+        "method": condition.method,
+        "params": condition.params,
+    }
+
+    assert mocked_method.call_count == 1
+    if auth_type == AuthorizationType.X_API_KEY:
+        assert mocked_method.call_args.kwargs["headers"]["X-API-Key"] == f"{auth_token}"
+        assert "Authorization" not in mocked_method.call_args.kwargs["headers"]
+    else:
+        assert mocked_method.call_args.kwargs["headers"]["Authorization"] == (
+            f"Bearer {auth_token}"
+            if auth_type == AuthorizationType.BEARER
+            else f"Basic {auth_token}"
+        )
+        assert "X-API-Key" not in mocked_method.call_args.kwargs["headers"]
 
 
 def test_json_rpc_condition_evaluation_with_various_context_variables(mocker):


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
The `JsonApiCondition` only allows the use of `Bearer` tokens for authentication and the `Authorization` header. In addition to `Bearer` tokens , this PR allows additional authorization types:
- Use of `X-API-KEY` header with the provided auth token
- Use of `Basic` token with `Authorization` header instead of `Bearer`

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
