### PR TITLE
`lynx` lingo validation endpoint

### DIFF
--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -18,7 +18,7 @@ from nucypher_core import (
 from prometheus_client import REGISTRY, Counter, Summary
 
 from nucypher.blockchain.eth import domains
-from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
+from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH, TEMPORARY_DOMAIN_NAME
 from nucypher.crypto.keypairs import DecryptingKeypair
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.network.nodes import NodeSprout
@@ -313,15 +313,18 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             return Response(response=html_error, headers=headers, status=HTTPStatus.INTERNAL_SERVER_ERROR)
         return Response(response=content, headers=headers)
 
-    if this_node.domain == domains.LYNX:
-        # only available on Lynx
+    if (
+        this_node.domain == domains.LYNX
+        or this_node.domain.name == TEMPORARY_DOMAIN_NAME
+    ):
+        # only available on Lynx or for testing
         @rest_app.route("/validate_condition_lingo", methods=["POST"])
         def validate_condition_lingo():
             """
             An endpoint that validates a condition lingo
             """
             try:
-                _ = ConditionLingo.from_dict(request.get_json())
+                _ = ConditionLingo.from_json(request.get_json())
                 return Response(response="valid", status=HTTPStatus.OK)
             except Exception as e:
                 return Response(str(e), status=HTTPStatus.BAD_REQUEST)

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -17,11 +17,13 @@ from nucypher_core import (
 )
 from prometheus_client import REGISTRY, Counter, Summary
 
+from nucypher.blockchain.eth import domains
 from nucypher.config.constants import MAX_UPLOAD_CONTENT_LENGTH
 from nucypher.crypto.keypairs import DecryptingKeypair
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.network.nodes import NodeSprout
 from nucypher.network.protocols import InterfaceInfo
+from nucypher.policy.conditions.lingo import ConditionLingo
 from nucypher.policy.conditions.utils import (
     ConditionEvalError,
     evaluate_condition_lingo,
@@ -310,5 +312,18 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             log.debug("Template Rendering Exception:\n" + text_error)
             return Response(response=html_error, headers=headers, status=HTTPStatus.INTERNAL_SERVER_ERROR)
         return Response(response=content, headers=headers)
+
+    if this_node.domain == domains.LYNX:
+        # only available on Lynx
+        @rest_app.route("/validate_condition_lingo", methods=["POST"])
+        def validate_condition_lingo():
+            """
+            An endpoint that validates a condition lingo
+            """
+            try:
+                _ = ConditionLingo.from_dict(request.get_json())
+                return Response(response="valid", status=HTTPStatus.OK)
+            except Exception as e:
+                return Response(str(e), status=HTTPStatus.BAD_REQUEST)
 
     return rest_app

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -23,6 +23,7 @@ from nucypher.crypto.keypairs import DecryptingKeypair
 from nucypher.crypto.signing import InvalidSignature
 from nucypher.network.nodes import NodeSprout
 from nucypher.network.protocols import InterfaceInfo
+from nucypher.policy.conditions.exceptions import InvalidConditionLingo
 from nucypher.policy.conditions.lingo import ConditionLingo
 from nucypher.policy.conditions.utils import (
     ConditionEvalError,
@@ -325,8 +326,8 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             """
             try:
                 _ = ConditionLingo.from_json(request.get_json())
-                return Response(response="valid", status=HTTPStatus.OK)
-            except Exception as e:
+                return jsonify({"status": "valid"}), HTTPStatus.OK
+            except InvalidConditionLingo as e:
                 return Response(str(e), status=HTTPStatus.BAD_REQUEST)
 
     return rest_app

--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -314,10 +314,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             return Response(response=html_error, headers=headers, status=HTTPStatus.INTERNAL_SERVER_ERROR)
         return Response(response=content, headers=headers)
 
-    if (
-        this_node.domain == domains.LYNX
-        or this_node.domain.name == TEMPORARY_DOMAIN_NAME
-    ):
+    if this_node.domain.name in [domains.LYNX.name, TEMPORARY_DOMAIN_NAME]:
         # only available on Lynx or for testing
         @rest_app.route("/validate_condition_lingo", methods=["POST"])
         def validate_condition_lingo():

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -15,6 +15,7 @@ from nucypher.blockchain.eth.agents import (
     SubscriptionManagerAgent,
 )
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.network.middleware import RestMiddleware
 from nucypher.policy.conditions.auth.evm import EvmAuth
 from nucypher.policy.conditions.context import (
     USER_ADDRESS_CONTEXT,
@@ -1058,3 +1059,12 @@ def test_validate_condition_lingo_endpoint(ursulas, time_condition):
         json=lingo_json,
     )
     assert response.status_code == HTTPStatus.OK, "Condition Lingo validation failed"
+    assert response.get_json()["status"] == "valid", "Unexpected response"
+
+    # failure case with invalid condition
+    with pytest.raises(RestMiddleware.BadRequest):
+        _ = ursula.network_middleware.client.post(
+            node_or_sprout=ursula,
+            path="validate_condition_lingo",
+            json=json.dumps({"invalidCondition": "confirmed"}),
+        )

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -1,5 +1,6 @@
 import json
 import os
+from http import HTTPStatus
 from unittest import mock
 
 import pytest
@@ -1043,3 +1044,17 @@ def test_big_int_string_handling(
         providers=condition_providers, **context
     )
     assert condition_result, "condition executed and passes"
+
+
+def test_validate_condition_lingo_endpoint(ursulas, time_condition):
+    ursula = ursulas[0]
+
+    condition_lingo = ConditionLingo(time_condition)
+    lingo_json = condition_lingo.to_json()
+
+    response = ursula.network_middleware.client.post(
+        node_or_sprout=ursula,
+        path="validate_condition_lingo",
+        json=lingo_json,
+    )
+    assert response.status_code == HTTPStatus.OK, "Condition Lingo validation failed"


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Based over #3616 

Adds a `/validate_condition_lingo` to *only* `lynx` nodes or nodes during testing (`temporary-domain`).

This endpoint will be used for `taco-web` integration tests to validate that the `zod` schema defined in typescript is consistent with the python `marshmallow` schema defined in `nucypher`.

Until now, we've been able to do that test by attaching conditions to encrypted data, then asking the node to decrypt the data. But when nodes sign data, the conditions are obtained from the `SigningCoordinator` contract and not from the signing request, so we can't just test signing with different conditions easily

**Notes for reviewers:**
Review whether there are alternative better strategies.
