### PR TITLE
Fix `ConditionLingo` bytes bug

### DIFF
--- a/newsfragments/3616.bugfix.rst
+++ b/newsfragments/3616.bugfix.rst
@@ -1,0 +1,3 @@
+Fix inconsistency between ConditionLingo's ``__bytes__`` and ``from_bytes`` implementations.
+It originally defined a custom ``__bytes__`` method but relied on the ``from_bytes`` implementation from the
+superclass, which expected a different format.

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -43,13 +43,13 @@ class _Serializable:
         return instance
 
     def __bytes__(self) -> bytes:
-        json_payload = self.to_json().encode()
+        json_payload = self.to_json().encode("utf-8")
         b64_json_payload = b64encode(json_payload)
         return b64_json_payload
 
     @classmethod
-    def from_bytes(cls, data: bytes) -> '_Serializable':
-        json_payload = b64decode(data).decode()
+    def from_bytes(cls, data: bytes) -> "_Serializable":
+        json_payload = b64decode(data).decode("utf-8")
         instance = cls.from_json(json_payload)
         return instance
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -732,6 +732,12 @@ class ConditionLingo(_Serializable):
         data = self.to_json().encode()
         return data
 
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "ConditionLingo":
+        json_payload = data.decode()
+        instance = cls.from_json(json_payload)
+        return instance
+
     def __repr__(self):
         return f"{self.__class__.__name__} (version={self.version} | id={self.id} | size={len(bytes(self))}) | condition=({self.condition})"
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -719,22 +719,22 @@ class ConditionLingo(_Serializable):
             raise InvalidConditionLingo(f"Invalid condition grammar: {e}")
 
     def to_base64(self) -> bytes:
-        data = base64.b64encode(self.to_json().encode())
+        data = base64.b64encode(self.to_json().encode("utf-8"))
         return data
 
     @classmethod
-    def from_base64(cls, data: bytes) -> 'ConditionLingo':
-        decoded_json = base64.b64decode(data).decode()
+    def from_base64(cls, data: bytes) -> "ConditionLingo":
+        decoded_json = base64.b64decode(data).decode("utf-8")
         instance = cls.from_json(decoded_json)
         return instance
 
     def __bytes__(self) -> bytes:
-        data = self.to_json().encode()
+        data = self.to_json().encode("utf-8")
         return data
 
     @classmethod
     def from_bytes(cls, data: bytes) -> "ConditionLingo":
-        json_payload = data.decode()
+        json_payload = data.decode("utf-8")
         instance = cls.from_json(json_payload)
         return instance
 

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -345,6 +345,13 @@ def test_condition_lingo_to_from_bytes(lingo_with_all_condition_types):
     assert clingo_from_bytes.to_dict() == lingo_with_all_condition_types
 
 
+def test_condition_lingo_to_from_base64(lingo_with_all_condition_types):
+    clingo = ConditionLingo.from_dict(lingo_with_all_condition_types)
+    clingo_base64 = clingo.to_base64()
+    clingo_from_base64 = ConditionLingo.from_base64(clingo_base64)
+    assert clingo_from_base64.to_dict() == lingo_with_all_condition_types
+
+
 def test_compound_condition_lingo_repr(lingo_with_all_condition_types):
     clingo = ConditionLingo.from_dict(lingo_with_all_condition_types)
     clingo_string = f"{clingo}"

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -338,6 +338,13 @@ def test_condition_lingo_to_from_json(lingo_with_all_condition_types):
     assert clingo_from_json.to_dict() == lingo_with_all_condition_types
 
 
+def test_condition_lingo_to_from_bytes(lingo_with_all_condition_types):
+    clingo = ConditionLingo.from_dict(lingo_with_all_condition_types)
+    clingo_bytes = bytes(clingo)
+    clingo_from_bytes = ConditionLingo.from_bytes(clingo_bytes)
+    assert clingo_from_bytes.to_dict() == lingo_with_all_condition_types
+
+
 def test_compound_condition_lingo_repr(lingo_with_all_condition_types):
     clingo = ConditionLingo.from_dict(lingo_with_all_condition_types)
     clingo_string = f"{clingo}"


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
`ConditionLingo`'s `bytes` and `from_bytes` methods were inconsistent. It defined a custom `bytes` method but relied on the `from_bytes` implementation from the `_Serializable` superclass, which expected a different format. This has been corrected by implementing a custom `from_bytes` method in ConditionLingo to align with its `bytes` method.

Luckily, `from_bytes` isn't ever used as part of node functionality. Added a unit test to ensure that it gets tested appropriately.

**Notes for reviewers:**

I'm assuming that specifying 'utf-8' as the encoding is backwards compatible. If you think otherwise let me know.