### PR TITLE
Fix SequentialCondition edge case

### DIFF
--- a/newsfragments/3620.bugfix.rst
+++ b/newsfragments/3620.bugfix.rst
@@ -1,0 +1,1 @@
+Added recursive duplicate detection across nested sequential conditions.

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -327,6 +327,26 @@ class SequentialCondition(MultiCondition):
     CONDITION_TYPE = ConditionType.SEQUENTIAL.value
 
     @classmethod
+    def _gather_all_nested_sequential_conditions(
+        cls, conditions: List[Condition]
+    ) -> List["SequentialCondition"]:
+        """
+        Gathers all nested sequential conditions from the condition variables.
+        """
+        sequential_conditions = []
+        for condition in conditions:
+            if isinstance(condition, SequentialCondition):
+                sequential_conditions.append(condition)
+            elif isinstance(condition, MultiCondition):
+                # recursively gather from nested multi-conditions
+                nested_conditions = cls._gather_all_nested_sequential_conditions(
+                    condition.conditions
+                )
+                sequential_conditions.extend(nested_conditions)
+
+        return sequential_conditions
+
+    @classmethod
     def _validate_condition_variables(
         cls,
         condition_variables: List[ConditionVariable],
@@ -343,9 +363,19 @@ class SequentialCondition(MultiCondition):
                 message=f"Maximum of {cls.MAX_NUM_CONDITIONS} conditions are allowed",
             )
 
-        # check for duplicate var names
+        all_condition_variables = list(condition_variables)
+        # gather all nested sequential conditions
+        nested_sequential_conditions = cls._gather_all_nested_sequential_conditions(
+            [condition_variable.condition for condition_variable in condition_variables]
+        )
+        for nested_sequential_condition in nested_sequential_conditions:
+            all_condition_variables.extend(
+                nested_sequential_condition.condition_variables
+            )
+
+        # check for duplicate var names across all sequential conditions
         var_names = set()
-        for condition_variable in condition_variables:
+        for condition_variable in all_condition_variables:
             if condition_variable.var_name in var_names:
                 raise ValidationError(
                     field_name="condition_variables",

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -327,24 +327,24 @@ class SequentialCondition(MultiCondition):
     CONDITION_TYPE = ConditionType.SEQUENTIAL.value
 
     @classmethod
-    def _gather_all_nested_sequential_conditions(
+    def _gather_all_nested_condition_variables(
         cls, conditions: List[Condition]
-    ) -> List["SequentialCondition"]:
+    ) -> List[ConditionVariable]:
         """
         Gathers all nested sequential conditions from the condition variables.
         """
-        sequential_conditions = []
+        condition_variables = []
         for condition in conditions:
             if isinstance(condition, SequentialCondition):
-                sequential_conditions.append(condition)
+                condition_variables.extend(condition.condition_variables)
             elif isinstance(condition, MultiCondition):
                 # recursively gather from nested multi-conditions
-                nested_conditions = cls._gather_all_nested_sequential_conditions(
+                nested_condition_variables = cls._gather_all_nested_condition_variables(
                     condition.conditions
                 )
-                sequential_conditions.extend(nested_conditions)
+                condition_variables.extend(nested_condition_variables)
 
-        return sequential_conditions
+        return condition_variables
 
     @classmethod
     def _validate_condition_variables(
@@ -364,14 +364,15 @@ class SequentialCondition(MultiCondition):
             )
 
         all_condition_variables = list(condition_variables)
-        # gather all nested sequential conditions
-        nested_sequential_conditions = cls._gather_all_nested_sequential_conditions(
-            [condition_variable.condition for condition_variable in condition_variables]
-        )
-        for nested_sequential_condition in nested_sequential_conditions:
-            all_condition_variables.extend(
-                nested_sequential_condition.condition_variables
+        # gather all nested condition variables
+        all_condition_variables.extend(
+            cls._gather_all_nested_condition_variables(
+                [
+                    condition_variable.condition
+                    for condition_variable in condition_variables
+                ]
             )
+        )
 
         # check for duplicate var names across all sequential conditions
         var_names = set()

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -78,6 +78,18 @@ def test_invalid_sequential_condition(rpc_condition, time_condition):
             condition_variables=[var_1, var_2, dupe_var],
         )
 
+    # duplicate var names in nested sequential condition
+    with pytest.raises(InvalidCondition, match="Duplicate"):
+        # var_1 is duplicated in the nested condition
+        _ = SequentialCondition(
+            condition_variables=[
+                var_1,
+                ConditionVariable(
+                    "var3", SequentialCondition(condition_variables=[var_1, var_2])
+                ),
+            ],
+        )
+
 
 def test_nested_sequential_condition_too_many_nested_levels(
     rpc_condition, time_condition


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Fix edge case where variable name collisions could occur in nested sequential conditions. Previously, duplicate detection only applied to a single level and did not account for nested `SequentialCondition`s. This update adds recursive checks to ensure uniqueness across all nested levels.

See added test case, which previously failed to raise an exception before this fix.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

Take a look at the unit test for clarity on what the problem was. The test did cause an exception before the code was updated.
