### PR TITLE
Makes `curve` a required parameter for ECDSA condition API

### DIFF
--- a/nucypher/policy/conditions/ecdsa.py
+++ b/nucypher/policy/conditions/ecdsa.py
@@ -1,7 +1,7 @@
 import hashlib
 from typing import Any, Optional, Tuple
 
-from ecdsa import BadSignatureError, NIST192p, VerifyingKey
+from ecdsa import BadSignatureError, VerifyingKey
 from ecdsa.curves import Curve, curves
 from ecdsa.util import sigdecode_string
 from hexbytes import HexBytes
@@ -25,7 +25,6 @@ from nucypher.policy.conditions.exceptions import (
 from nucypher.utilities.logging import Logger
 
 SUPPORTED_ECDSA_CONDITION_CURVES = {c.name: c for c in curves}
-DEFAULT_ECDSA_CONDITION_CURVE = NIST192p
 
 
 class ECDSAVerificationCall(ExecutionCall):
@@ -37,7 +36,7 @@ class ECDSAVerificationCall(ExecutionCall):
         signature = fields.Str(required=True)
         verifying_key = fields.Str(required=True)
         curve = fields.Str(
-            required=False,
+            required=True,
             validate=validate.OneOf(list(SUPPORTED_ECDSA_CONDITION_CURVES)),
         )
 
@@ -63,14 +62,13 @@ class ECDSAVerificationCall(ExecutionCall):
         def validate_verifying_key(self, data, **kwargs):
             value = data.get("verifying_key")
             curve_name = data.get("curve")
-            if curve_name:
-                if curve_name not in SUPPORTED_ECDSA_CONDITION_CURVES:
-                    raise ValidationError(
-                        f"Unsupported curve: {curve_name}. Supported curves are: {SUPPORTED_ECDSA_CONDITION_CURVES.keys()}"
-                    )
-                curve = SUPPORTED_ECDSA_CONDITION_CURVES[curve_name]
-            else:
-                curve = DEFAULT_ECDSA_CONDITION_CURVE
+
+            if curve_name not in SUPPORTED_ECDSA_CONDITION_CURVES:
+                raise ValidationError(
+                    f"Unsupported curve: {curve_name}. Supported curves are: {SUPPORTED_ECDSA_CONDITION_CURVES.keys()}"
+                )
+            curve = SUPPORTED_ECDSA_CONDITION_CURVES[curve_name]
+
             try:
                 verifying_key_bytes = bytes.fromhex(value)
             except ValueError:
@@ -159,6 +157,7 @@ class ECDSACondition(Condition):
     - message: The message that was signed
     - signature: The DER-encoded signature as a base64 string
     - verifying_key: The PEM-encoded ECDSA verifying key
+    - curve: The elliptic curve to use for verification (required)
     """
 
     CONDITION_TYPE = "ecdsa"  # Add this to ConditionType enum
@@ -175,7 +174,7 @@ class ECDSACondition(Condition):
         message: Any,
         signature: str,
         verifying_key: str,
-        curve: Optional[str] = DEFAULT_ECDSA_CONDITION_CURVE.name,
+        curve: str,
         condition_type: str = CONDITION_TYPE,
         name: Optional[str] = None,
     ):

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -147,11 +147,13 @@ class IfThenElseConditionDict(_Condition):
 #     "message": [bytes | str]
 #     "signature": str
 #     "verifyingKey": str
+#     "curve": str
 # }
 class ECDSAConditionDict(_Condition):
     message: Union[bytes, str]
     signature: str
     verifyingKey: str
+    curve: str
 
 
 # _SigningObjectCondition abstract class represents:

--- a/tests/acceptance/conditions/test_ecdsa_condition.py
+++ b/tests/acceptance/conditions/test_ecdsa_condition.py
@@ -5,7 +5,7 @@ from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCa
 from nucypher.policy.conditions.lingo import ConditionLingo
 
 # Create test key pair for ECDSA signing
-TEST_SIGNING_KEY = SigningKey.generate(curve=NIST192p)
+TEST_SIGNING_KEY = SigningKey.generate(curve=SECP256k1)
 TEST_VERIFYING_KEY = TEST_SIGNING_KEY.verifying_key
 TEST_VERIFYING_KEY_HEX = TEST_VERIFYING_KEY.to_string().hex()
 

--- a/tests/acceptance/conditions/test_ecdsa_condition.py
+++ b/tests/acceptance/conditions/test_ecdsa_condition.py
@@ -1,4 +1,4 @@
-from ecdsa import NIST192p, SigningKey
+from ecdsa import NIST192p, SECP256k1, SigningKey
 from ecdsa.util import sigencode_string
 
 from nucypher.policy.conditions.ecdsa import ECDSACondition, ECDSAVerificationCall
@@ -29,7 +29,7 @@ def test_ecdsa_condition_verification_flow():
         message=":message",  # Use regular context variable instead of USER_ADDRESS_CONTEXT
         signature=":signature",
         verifying_key=TEST_VERIFYING_KEY_HEX,
-        curve=NIST192p.name,
+        curve=SECP256k1.name,
     )
 
     # Create a complete condition lingo
@@ -80,7 +80,7 @@ def test_ecdsa_condition_in_compound_condition():
         message=":message",
         signature=":signature",
         verifying_key=TEST_VERIFYING_KEY_HEX,
-        curve=NIST192p.name,
+        curve=SECP256k1.name,
     )
 
     # Create a second ECDSA condition with different requirements

--- a/tests/integration/conditions/test_ecdsa_condition_json.py
+++ b/tests/integration/conditions/test_ecdsa_condition_json.py
@@ -1,6 +1,6 @@
 import json
 
-from ecdsa import SigningKey
+from ecdsa import NIST192p, SigningKey
 from ecdsa.util import sigencode_string
 from hexbytes import HexBytes
 
@@ -11,7 +11,7 @@ from nucypher.policy.conditions.lingo import (
 )
 
 # Create test key pair for ECDSA signing
-TEST_SIGNING_KEY = SigningKey.generate()
+TEST_SIGNING_KEY = SigningKey.generate(curve=NIST192p)
 TEST_VERIFYING_KEY = TEST_SIGNING_KEY.verifying_key
 TEST_VERIFYING_KEY_HEX = TEST_VERIFYING_KEY.to_string().hex()
 
@@ -33,6 +33,7 @@ def test_ecdsa_condition_json_serialization():
         message=":message",
         signature=":signature",
         verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=NIST192p.name,
     )
 
     # Convert condition to JSON
@@ -73,6 +74,7 @@ def test_ecdsa_condition_lingo_json_serialization():
         message=":message",
         signature=":signature",
         verifying_key=TEST_VERIFYING_KEY_HEX,
+        curve=NIST192p.name,
     )
 
     # Create condition lingo
@@ -101,7 +103,7 @@ def test_complex_condition_with_ecdsa_json_serialization():
     key1 = TEST_SIGNING_KEY
     key1_vk_hex = TEST_VERIFYING_KEY_HEX
 
-    key2 = SigningKey.generate()
+    key2 = SigningKey.generate(curve=NIST192p)
     key2_vk = key2.verifying_key
     key2_vk_hex = key2_vk.to_string().hex()
 
@@ -126,6 +128,7 @@ def test_complex_condition_with_ecdsa_json_serialization():
         message=":msg1",
         signature=":sig1",
         verifying_key=key1_vk_hex,
+        curve=NIST192p.name,
         name="First Signer",
     )
 
@@ -133,6 +136,7 @@ def test_complex_condition_with_ecdsa_json_serialization():
         message=":msg2",
         signature=":sig2",
         verifying_key=key2_vk_hex,
+        curve=NIST192p.name,
         name="Second Signer",
     )
 
@@ -208,7 +212,7 @@ def test_real_world_example_json():
     # - In a compound condition with other potential access methods
 
     # Create a sample service key for verification
-    service_key = SigningKey.generate()
+    service_key = SigningKey.generate(curve=NIST192p)
     service_vk = service_key.verifying_key
     service_vk_hex = service_vk.to_string().hex()
 
@@ -228,6 +232,7 @@ def test_real_world_example_json():
                         "message": ":request_data",
                         "signature": ":request_signature",
                         "verifyingKey": service_vk_hex,
+                        "curve": "NIST192p",
                     },
                     # Option 2: Could combine with other conditions
                     # (e.g., a time-based condition as a fallback)
@@ -241,6 +246,7 @@ def test_real_world_example_json():
                                 "message": ":admin_request",
                                 "signature": ":admin_signature",
                                 "verifyingKey": TEST_VERIFYING_KEY_HEX,
+                                "curve": "NIST192p",
                             },
                             # Add a second condition to satisfy the minimum requirement
                             {
@@ -249,6 +255,7 @@ def test_real_world_example_json():
                                 "message": ":admin_request",
                                 "signature": ":admin_signature",
                                 "verifyingKey": TEST_VERIFYING_KEY_HEX,
+                                "curve": "NIST192p",
                             },
                         ],
                     },

--- a/tests/unit/conditions/test_ecdsa_condition.py
+++ b/tests/unit/conditions/test_ecdsa_condition.py
@@ -66,7 +66,9 @@ def test_ecdsa_condition_missing_message():
     with pytest.raises(
         InvalidCondition, match="'message' field - Field may not be null."
     ):
-        _ = ECDSACondition(message=None, signature=None, verifying_key=None)
+        _ = ECDSACondition(
+            message=None, signature=None, verifying_key=None, curve=NIST192p.name
+        )
 
 
 def test_ecdsa_condition_missing_signature():
@@ -74,7 +76,10 @@ def test_ecdsa_condition_missing_signature():
         InvalidCondition, match="'signature' field - Field may not be null."
     ):
         _ = ECDSACondition(
-            message=":message_variable", signature=None, verifying_key=None
+            message=":message_variable",
+            signature=None,
+            verifying_key=None,
+            curve=NIST192p.name,
         )
 
 
@@ -86,6 +91,7 @@ def test_ecdsa_condition_missing_verifying_key():
             message=":message_variable",
             signature=":signature_variable",
             verifying_key=None,
+            curve=NIST192p.name,
         )
 
 
@@ -97,6 +103,7 @@ def test_ecdsa_condition_invalid_verifying_key():
             message=":message_variable",
             signature=":signature_variable",
             verifying_key="-----BEGIN PUBLIC KEY----- invalid key -----END PUBLIC KEY-----",
+            curve=NIST192p.name,
         )
 
 


### PR DESCRIPTION
**Rationale**

As the old adage goes: "explicit is better than implicit".   Particularly for cross-language interoperability and testing ease, and misuse resistance, using an explicit elliptic curve for ecdsa conditions is advantageous.