### PR TITLE
Make `message` field for ECDSA condition a string instead of raw

### DIFF
--- a/nucypher/policy/conditions/ecdsa.py
+++ b/nucypher/policy/conditions/ecdsa.py
@@ -32,7 +32,7 @@ class ECDSAVerificationCall(ExecutionCall):
     _hash_func = hashlib.sha256
 
     class Schema(ExecutionCall.Schema):
-        message = fields.Raw(required=True)
+        message = fields.Str(required=True)
         signature = fields.Str(required=True)
         verifying_key = fields.Str(required=True)
         curve = fields.Str(
@@ -43,13 +43,6 @@ class ECDSAVerificationCall(ExecutionCall):
         @post_load
         def make(self, data, **kwargs):
             return ECDSAVerificationCall(**data)
-
-        @validates("message")
-        def validate_message(self, value):
-            if not is_context_variable(value) and not isinstance(value, str):
-                raise ValidationError(
-                    f"Invalid value for message; expected a context variable, or string, but got '{value}'"
-                )
 
         @validates("signature")
         def validate_signature(self, value):


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Verify minor fix to adjust field type of message in ECDSACondition to be a string instead of raw. It should only ever be a string, either:
- context variable
- 0x-prefixed hex string to represent bytes
- raw string.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
