### PR TITLE
Re-enable DKG storage caching with Handover

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -937,6 +937,9 @@ class Operator(BaseActor):
         departing_participant: ChecksumAddress,
         **kwargs,
     ) -> Optional[AsyncTx]:
+        # clear ritual object and validators since handover modifies ritual
+        self.dkg_storage.clear_active_ritual_object(ritual_id)
+        self.dkg_storage.clear_validators(ritual_id)
 
         # check if there is a pending tx for this phase
         async_tx = self.dkg_storage.get_ritual_phase_async_tx(
@@ -1073,6 +1076,9 @@ class Operator(BaseActor):
     def perform_handover_blinded_share_phase(
         self, ritual_id: int, **kwargs
     ) -> Optional[AsyncTx]:
+        # clear ritual object and validators since handover modifies ritual
+        self.dkg_storage.clear_active_ritual_object(ritual_id)
+        self.dkg_storage.clear_validators(ritual_id)
 
         if not self._is_handover_blinded_share_required(ritual_id=ritual_id):
             self.log.debug(
@@ -1117,6 +1123,11 @@ class Operator(BaseActor):
             f"DKG ritual #{ritual_id}."
         )
         return async_tx
+
+    def perform_handover_finalization_phase(self, ritual_id: int, **kwargs):
+        # clear ritual object and validators since handover modifies ritual
+        self.dkg_storage.clear_active_ritual_object(ritual_id)
+        self.dkg_storage.clear_validators(ritual_id)
 
     def produce_decryption_share(
         self,

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -354,23 +354,20 @@ class Operator(BaseActor):
             self.dkg_storage.clear(ritual_id)
             raise self.ActorError(f"Ritual #{ritual_id} is not active.")
 
-        # TODO: Potential caching issue. Invalidating caches for now. See #3623
-        return self.coordinator_agent.get_ritual(ritual_id)
-        # ritual = self.dkg_storage.get_active_ritual(ritual_id)
-        # if not ritual:
-        #     ritual = self.coordinator_agent.get_ritual(ritual_id)
-        #     self.dkg_storage.store_active_ritual(active_ritual=ritual)
+        ritual = self.dkg_storage.get_active_ritual(ritual_id)
+        if not ritual:
+            ritual = self.coordinator_agent.get_ritual(ritual_id)
+            self.dkg_storage.store_active_ritual(active_ritual=ritual)
 
-        # return ritual
+        return ritual
 
     def _resolve_validators(
         self,
         ritual: Coordinator.Ritual,
     ) -> List[Validator]:
-        # TODO: Potential caching issue. Invalidating caches for now. See #3623
-        # validators = self.dkg_storage.get_validators(ritual.id)
-        # if validators:
-        #     return validators
+        validators = self.dkg_storage.get_validators(ritual.id)
+        if validators:
+            return validators
 
         result = list()
         for i, staking_provider_address in enumerate(ritual.providers):
@@ -398,7 +395,7 @@ class Operator(BaseActor):
                 )
             result.append(external_validator)
 
-        # self.dkg_storage.store_validators(ritual.id, result)  # TODO: See #3623
+        self.dkg_storage.store_validators(ritual.id, result)
 
         return result
 
@@ -690,7 +687,7 @@ class Operator(BaseActor):
             return
 
         # publish the transcript and store the receipt
-        # self.dkg_storage.store_validators(ritual_id=ritual.id, validators=validators) # TODO: See #3623
+        self.dkg_storage.store_validators(ritual_id=ritual.id, validators=validators)
         async_tx = self.publish_transcript(ritual_id=ritual.id, transcript=transcript)
 
         # logging

--- a/nucypher/blockchain/eth/models.py
+++ b/nucypher/blockchain/eth/models.py
@@ -19,7 +19,6 @@ PHASE1 = PhaseNumber(1)
 PHASE2 = PhaseNumber(2)
 HANDOVER_AWAITING_TRANSCRIPT = PhaseNumber(11)
 HANDOVER_AWAITING_BLINDED_SHARE = PhaseNumber(12)
-HANDOVER_AWAITING_FINALIZATION = PhaseNumber(13)
 
 @dataclass
 class Ferveo:

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -115,7 +115,7 @@ class ActiveRitualTracker:
             self.contract.events.StartAggregationRound: self.operator.perform_round_2,
             self.contract.events.HandoverRequest: self.operator.perform_handover_transcript_phase,
             self.contract.events.HandoverTranscriptPosted: self.operator.perform_handover_blinded_share_phase,
-            # self.contract.events.HandoverFinalized: self.operator.perform_handover_finalization_phase,  # TODO: See #3623
+            self.contract.events.HandoverFinalized: self.operator.perform_handover_finalization_phase,
         }
 
         self.events = [
@@ -124,7 +124,7 @@ class ActiveRitualTracker:
             self.contract.events.EndRitual,
             self.contract.events.HandoverRequest,
             self.contract.events.HandoverTranscriptPosted,
-            # self.contract.events.HandoverFinalized,  # TODO: See #3623
+            self.contract.events.HandoverFinalized,
         ]
 
         # TODO: Remove the default JSON-RPC retry middleware

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -72,8 +72,11 @@ class DKGStorage:
     def clear_ritual_phase_async_tx(self, phase_id: PhaseId, async_tx: AsyncTx) -> bool:
         key = self.__get_phase_key(phase_id.phase)
         if self._data[key].get(phase_id.ritual_id) is async_tx:
-            del self._data[key][phase_id.ritual_id]
-            return True
+            try:
+                del self._data[key][phase_id.ritual_id]
+                return True
+            except KeyError:
+                pass
         return False
 
     def get_ritual_phase_async_tx(self, phase_id: PhaseId) -> Optional[AsyncTx]:

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -80,6 +80,7 @@ class DKGStorage:
         key = self.__get_phase_key(phase_id.phase)
         return self._data[key].get(phase_id.ritual_id)
 
+    # Validators for rituals
     def store_validators(self, ritual_id: int, validators: List[Validator]) -> None:
         self._data[self._KEY_VALIDATORS][ritual_id] = list(validators)
 
@@ -89,6 +90,13 @@ class DKGStorage:
             return None
 
         return list(validators)
+
+    def clear_validators(self, ritual_id: int) -> bool:
+        try:
+            del self._data[self._KEY_VALIDATORS][ritual_id]
+            return True
+        except KeyError:
+            return False
 
     #
     # Active Rituals
@@ -101,3 +109,10 @@ class DKGStorage:
 
     def get_active_ritual(self, ritual_id: int) -> Optional[Coordinator.Ritual]:
         return self._data[self._KEY_ACTIVE_RITUAL].get(ritual_id)
+
+    def clear_active_ritual_object(self, ritual_id: int) -> bool:
+        try:
+            del self._data[self._KEY_ACTIVE_RITUAL][ritual_id]
+            return True
+        except KeyError:
+            return False

--- a/nucypher/datastore/dkg.py
+++ b/nucypher/datastore/dkg.py
@@ -6,7 +6,13 @@ from nucypher_core.ferveo import (
     Validator,
 )
 
-from nucypher.blockchain.eth.models import PHASE1, Coordinator
+from nucypher.blockchain.eth.models import (
+    HANDOVER_AWAITING_BLINDED_SHARE,
+    HANDOVER_AWAITING_TRANSCRIPT,
+    PHASE1,
+    PHASE2,
+    Coordinator,
+)
 from nucypher.types import PhaseId
 
 
@@ -18,6 +24,9 @@ class DKGStorage:
     _KEY_VALIDATORS = "validators"
     # round 2
     _KEY_PHASE_2_TXS = "phase_2_txs"
+    # handover phases
+    _KEY_PHASE_AWAITING_TRANSCRIPT_TXS = "handover_transcript_txs"
+    _KEY_PHASE_AWAITING_BLINDED_SHARE_TXS = "handover_blinded_share_txs"
     # active rituals
     _KEY_ACTIVE_RITUAL = "active_rituals"
 
@@ -26,6 +35,8 @@ class DKGStorage:
         _KEY_VALIDATORS,
         _KEY_PHASE_2_TXS,
         _KEY_ACTIVE_RITUAL,
+        _KEY_PHASE_AWAITING_TRANSCRIPT_TXS,
+        _KEY_PHASE_AWAITING_BLINDED_SHARE_TXS,
     ]
 
     def __init__(self):
@@ -45,7 +56,14 @@ class DKGStorage:
     def __get_phase_key(cls, phase: int):
         if phase == PHASE1:
             return cls._KEY_PHASE_1_TXS
-        return cls._KEY_PHASE_2_TXS
+        elif phase == PHASE2:
+            return cls._KEY_PHASE_2_TXS
+        elif phase == HANDOVER_AWAITING_TRANSCRIPT:
+            return cls._KEY_PHASE_AWAITING_TRANSCRIPT_TXS
+        elif phase == HANDOVER_AWAITING_BLINDED_SHARE:
+            return cls._KEY_PHASE_AWAITING_BLINDED_SHARE_TXS
+        else:
+            raise ValueError(f"Unknown phase: {phase}")
 
     def store_ritual_phase_async_tx(self, phase_id: PhaseId, async_tx: AsyncTx):
         key = self.__get_phase_key(phase_id.phase)

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -358,7 +358,6 @@ def test_authorized_decryption(
     yield
 
 
-@pytest.mark.skip("Caches are disabled - See #3623")
 @pytest_twisted.inlineCallbacks
 def test_decrypt_without_any_cached_values(
     threshold_message_kit, ritual_id, cohort, bob, coordinator_agent, plaintext

--- a/tests/integration/blockchain/test_integration_dkg_ritual.py
+++ b/tests/integration/blockchain/test_integration_dkg_ritual.py
@@ -282,21 +282,19 @@ def run_test(
                 )
                 assert bytes(cleartext) == PLAINTEXT.encode()
 
-                # TODO See #3623 - uncomment the check below once caching is used again;
-                #  it specifically checks that caching is used
                 # decrypt again (should only use cached values)
-                # with patch.object(
-                #     mock_coordinator_agent,
-                #     "get_provider_public_key",
-                #     side_effect=RuntimeError(
-                #         "should not be called to create validators; cache should be used"
-                #     ),
-                # ):
-                #     # would like to but can't patch agent.get_ritual, since bob uses it
-                #     cleartext = bob.threshold_decrypt(
-                #         threshold_message_kit=threshold_message_kit,
-                #     )
-                #     assert bytes(cleartext) == PLAINTEXT.encode()
+                with patch.object(
+                    mock_coordinator_agent,
+                    "get_provider_public_key",
+                    side_effect=RuntimeError(
+                        "should not be called to create validators; cache should be used"
+                    ),
+                ):
+                    # would like to but can't patch agent.get_ritual, since bob uses it
+                    cleartext = bob.threshold_decrypt(
+                        threshold_message_kit=threshold_message_kit,
+                    )
+                    assert bytes(cleartext) == PLAINTEXT.encode()
             print("==================== DECRYPTION SUCCESSFUL ====================")
             return threshold_message_kit
 
@@ -351,7 +349,7 @@ def run_test(
             encrypt,
             decrypt_failure_cases,
             decrypt,
-            # decrypt_without_any_cached_values,  # TODO: See #3623
+            decrypt_without_any_cached_values,
         ]
         for callback in callbacks:
             d.addCallback(callback)


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Based over #3628 

- PR #3608 removed caching for validators and ritual metadata. This PR reintroduces that caching, with the motivation explained in #3623. To mitigate previous concerns:
   - The cache for the validator list and Ritual object will now be cleared during any handover event, regardless of whether the node is actively participating in the handover. This is necessary because the handover process modifies the values within these objects, and nodes should re-fetch accurate data from the contract when needed.
   - Cache invalidation is triggered on any handover event (not just HandoverFinalization) to account for the timing gap between when a handover completes and when the node receives the event. By clearing the cache proactively, we ensure consistency.
   - Once Handover is completed and `HandoverFinalization` event is received, the cache is cleared one more time so the values will be re-fetched the next time, and then the cache can be utilized.
   
- Handover phases were previously using the same caching keys as DKG ritual phase 2 in DKG storage. This PR assigns them their own distinct keys.

**Issues fixed/closed:**

Closes #3623 

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
