### PR TITLE
Update base `rust-python` image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nucypher/rust-python:3.12.0
+FROM nucypher/rust-python:3.12.9
 
 # set default user
 USER $USER

--- a/deploy/docker/rust-python/Dockerfile
+++ b/deploy/docker/rust-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim-buster
+FROM rust:slim-bullseye
 
 # prepare container
 RUN apt-get update -y


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Based over #3630 .

In the handover changes to `nucypher-core`, the `Cargo.lock` file was using version 4 (previously used version 3) due to newer version of rustc/cargo used, which isn't compatible with the `nucypher/rust-python:3.12.0` image we use as the Rust base for `nucypher` images. That image, built around two years ago, relies on the now-discontinued `slim-buster` Rust Docker base (debian).

Consequently, trying to build the docker image fails.

Since Debian `buster` is outdated and no longer supported, it's recommended to use `bullseye` instead. As a result, we need to create a new `rust-python` image based on a Rust `bullseye` base image.

This updated `rust-python` image (using python 3.12.9) has been published on docker hub - https://hub.docker.com/layers/nucypher/rust-python/3.12.9/images/sha256-f9325699df8918fe613ad21fdda22578fe83e2e15367d651326397c3c39a457b

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
