### PR TITLE
Fix v7.7.x Ritual Tracking Post v7.6.0 Rebase

### DIFF
--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional, Union
 
 from prometheus_client import REGISTRY, Gauge
 from web3.datastructures import AttributeDict
@@ -15,6 +15,9 @@ class DkgRitualTracker(RitualTracker):
     )
 
     class DkgParticipationState(RitualTracker.ParticipationState):
+        """
+        Participation state for handover rituals.
+        """
         def __init__(
             self,
             participating=False,
@@ -25,10 +28,15 @@ class DkgRitualTracker(RitualTracker):
             self.already_posted_transcript = already_posted_transcript
             self.already_posted_aggregate = already_posted_aggregate
 
-        def update(self, updated_state: "DkgParticipationState"):
-            self.participating = updated_state.participating
-            self.already_posted_transcript = updated_state.already_posted_transcript
-            self.already_posted_aggregate = updated_state.already_posted_aggregate
+    class HandoverParticipationState(RitualTracker.ParticipationState):
+        """
+        Participation state for handover rituals.
+        """
+
+        PREFIX = "handover-"
+
+        def __init__(self, participating=False):
+            super().__init__(participating)
 
     def __init__(
         self,
@@ -38,9 +46,10 @@ class DkgRitualTracker(RitualTracker):
         contract = operator.coordinator_agent.contract
 
         self.handover_event_types = [
-            contract.events.HandoverTranscriptPosted,
             contract.events.HandoverRequest,
+            contract.events.HandoverTranscriptPosted,
             contract.events.HandoverFinalized,
+            contract.events.HandoverCanceled,
         ]
 
         actions = {
@@ -49,7 +58,8 @@ class DkgRitualTracker(RitualTracker):
             contract.events.HandoverRequest: operator.perform_handover_transcript_phase,
             contract.events.HandoverTranscriptPosted: operator.perform_handover_blinded_share_phase,
         }
-        events = [
+
+        all_events = [
             contract.events.StartRitual,
             contract.events.StartAggregationRound,
             contract.events.EndRitual,
@@ -62,47 +72,64 @@ class DkgRitualTracker(RitualTracker):
             operator=operator,
             web3=operator.coordinator_agent.blockchain.w3,
             contract=contract,
-            events=events,
+            events=all_events,
             actions=actions,
             persistent=persistent,
             timeout=self.coordinator_agent.get_dkg_timeout(),
         )
 
     def _get_identifier(self, event: AttributeDict) -> str:
-        return event.args.ritualId
+        event_type = getattr(self.contract.events, event.event)
+        if event_type in self.handover_event_types:
+            return f"{self.HandoverParticipationState.PREFIX}{event.args.ritualId}"
+        else:
+            return str(event.args.ritualId)
 
     def _action_required_based_on_participation_state(
-        self, participation_state: DkgParticipationState, event: AttributeDict
+        self,
+        participation_state: Union[DkgParticipationState, HandoverParticipationState],
+        event: AttributeDict,
     ) -> bool:
         # Let's handle separately handover events and non-handover events
         event_type = getattr(self.contract.events, event.event)
         if event_type in self.handover_event_types:
             # handover modifies existing ritual metadata; so we need to proactively prune it
-            # during handover process and at the end to avoid having any stale metadata
-            # in the cache
+            # during handover process for ALL associated nodes
+            # (part of handover, ALL existing participants in ritual) to avoid having
+            # any stale metadata in the metadata storage cache
             self.operator.prune_ritual_metadata_due_to_handover(
                 event.args.ritualId
             )
 
-            if event_type == self.contract.events.HandoverFinalized:
-                # pruning metadata is sufficient when Handover is finalized;
+            if event_type in [
+                self.contract.events.HandoverFinalized,
+                self.contract.events.HandoverCanceled,
+            ]:
+                if (
+                    event_type == self.contract.events.HandoverCanceled
+                    and event.args.incomingParticipant == self.operator.checksum_address
+                ) or (
+                    event_type == self.contract.events.HandoverFinalized
+                    and event.args.departingParticipant
+                    == self.operator.checksum_address
+                ):
+                    # if handover is canceled/finalized we need to reset the participation state
+                    participation_state.participating = False
+
+                # pruning metadata/cleanup is sufficient when Handover is finalized or canceled;
                 # no further action required
                 return False
 
             is_departing_participant_in_handover = (
-                    event_type == self.contract.events.HandoverTranscriptPosted
-                    and event.args.departingParticipant
-                    == self.operator.checksum_address
+                event.args.departingParticipant == self.operator.checksum_address
             )
             is_incoming_participant_in_handover = (
-                    event_type == self.contract.events.HandoverRequest
-                    and event.args.incomingParticipant
-                    == self.operator.checksum_address
+                event.args.incomingParticipant == self.operator.checksum_address
             )
             # for handover events we need to act only if the operator is the departing or incoming participant
             return (
-                    is_departing_participant_in_handover
-                    or is_incoming_participant_in_handover
+                is_departing_participant_in_handover
+                or is_incoming_participant_in_handover
             )
 
         # Non-handover events (for the moment, DKG events)
@@ -131,60 +158,20 @@ class DkgRitualTracker(RitualTracker):
 
     def _create_participation_state(
         self, event: AttributeDict
-    ) -> DkgParticipationState:
+    ) -> Union[DkgParticipationState, HandoverParticipationState]:
         # obtain information from contract
-        participation_state = self._get_participation_state_values_from_contract(event=event)
+        participation_state = self._get_latest_participation_state_values(event=event)
         return participation_state
 
     def _update_participation_state(
-        self, participation_state: DkgParticipationState, event: AttributeDict
+        self,
+        cached_participation_state: Union[
+            DkgParticipationState, HandoverParticipationState
+        ],
+        event: AttributeDict,
     ) -> None:
-        #
-        # already tracked and participating in ritual - populate other values
-        # based on certain events, the values can be populated without consulting the contract
-        #
-        event_type = getattr(self.contract.events, event.event)
-        if event_type == self.contract.events.StartAggregationRound:
-            participation_state.already_posted_transcript = True
-        elif event_type == self.contract.events.EndRitual:
-            # while `EndRitual` signals the end of the ritual, and there is no
-            # *current* node action for EndRitual, perhaps there will
-            # be one in the future. So to be complete, and adhere to
-            # the expectations of this function we still update
-            # the participation state
-            if event.args.successful:
-                # since successful we know these values are true
-                participation_state.already_posted_transcript = True
-                participation_state.already_posted_aggregate = True
-            elif (
-                not participation_state.already_posted_transcript
-                or not participation_state.already_posted_aggregate
-            ):
-                # not successful - and unsure of state values
-                # obtain information from contract
-                (
-                    _,  # participating ignored - we know we are participating
-                    posted_transcript,
-                    posted_aggregate,
-                ) = self._get_participation_state_values_from_contract(
-                    event=event,
-                )
-                participation_state.already_posted_transcript = posted_transcript
-                participation_state.already_posted_aggregate = posted_aggregate
-        elif event_type == self.contract.events.HandoverFinalized:
-            # HandoverFinalized signals the end of the handover process
-            # node is either departing or incoming participant
-            if event.args.departingParticipant == self.operator.checksum_address:
-                # node no longer in ritual
-                participation_state.participating = False
-                participation_state.already_posted_transcript = False
-                participation_state.already_posted_aggregate = False
-            else:
-                # node newly added to ritual
-                participation_state.participating = True
-                participation_state.already_posted_transcript = True
-                participation_state.already_posted_aggregate = True
-
+        # already tracked but cache values may be out of date
+        self._get_latest_participation_state_values(event, cached_participation_state)
 
     def _get_ritual_participant_info(
         self, ritual_id: int
@@ -206,71 +193,113 @@ class DkgRitualTracker(RitualTracker):
 
         return None
 
-    def _get_participation_state_values_from_contract(
-        self, event: AttributeDict
-    ) -> DkgParticipationState:
+    def _get_latest_participation_state_values(
+        self,
+        event: AttributeDict,
+        cached_participation_state: Optional[
+            Union[DkgParticipationState, HandoverParticipationState]
+        ] = None,
+    ) -> Union[DkgParticipationState, HandoverParticipationState]:
         """
         Obtains values for current participation state.
         """
         # check if we are participating in this ritual
         event_type = getattr(self.contract.events, event.event)
         if event_type in self.handover_event_types:
-            return self.__get_handover_participation_state_value(event)
+            return self.__get_latest_state_based_on_handover_event(
+                event, cached_participation_state
+            )
         else:
-            return self.__get_dkg_participation_state_value(event)
+            return self.__get_latest_state_based_on_dkg_event(
+                event, cached_participation_state
+            )
 
-
-    def __get_dkg_participation_state_value(self, event: AttributeDict) -> DkgParticipationState:
+    def __get_latest_state_based_on_dkg_event(
+        self,
+        event: AttributeDict,
+        cached_participation_state: Optional[DkgParticipationState] = None,
+    ) -> DkgParticipationState:
         """
-        Returns the participation state value for DKG events.
+        Returns the latest participation state value for DKG rituals.
         """
-        # Handle DKG events
+        # Handle DKG events; some events have all the information we need, otherwise
+        # we go to the contract
         event_type = getattr(self.contract.events, event.event)
+        if cached_participation_state:
+            if cached_participation_state.participating:
+                # already participating in this ritual
+                if event_type == self.contract.events.StartAggregationRound:
+                    cached_participation_state.already_posted_transcript = True
+                elif (
+                    event_type == self.contract.events.EndRitual
+                    and event.args.successful
+                ):
+                    # since successful we know these values are true
+                    cached_participation_state.already_posted_transcript = True
+                    cached_participation_state.already_posted_aggregate = True
+                return cached_participation_state
+            else:
+                # not participating; nothing to do here
+                return cached_participation_state
+
+        # no previous cached participation state, establish new one for cache
+        new_participation_state = self.DkgParticipationState()
         if event_type == self.contract.events.StartRitual:
+            # start ritual has all the information we need; no need to go to contract
             participating = self.operator.checksum_address in event.args.participants
-            return self.DkgParticipationState(participating=participating)
+            new_participation_state.participating = participating
         else:
+            # get participant information from the contract
             participant_info = self._get_ritual_participant_info(ritual_id=event.args.ritualId)
             if participant_info:
-                # actually participating in this ritual; get latest information
-                participating = True
+                # actually participating in this ritual;
                 # populate information since we already hit the contract
                 already_posted_transcript = bool(participant_info.transcript)
                 already_posted_aggregate = participant_info.aggregated
-                return self.DkgParticipationState(
-                    participating=participating,
-                    already_posted_transcript=already_posted_transcript,
-                    already_posted_aggregate=already_posted_aggregate
+                new_participation_state.participating = True
+                new_participation_state.already_posted_transcript = (
+                    already_posted_transcript
+                )
+                new_participation_state.already_posted_aggregate = (
+                    already_posted_aggregate
                 )
 
-        return self.DkgParticipationState(participating=False)
+        return new_participation_state
 
-    def __get_handover_participation_state_value(self, event: AttributeDict):
+    def __get_latest_state_based_on_handover_event(
+        self,
+        event: AttributeDict,
+        cached_participation_state: Optional[HandoverParticipationState] = None,
+    ) -> HandoverParticipationState:
         """
         Returns the participation state value for handover events.
         """
-        # Handle Handover events
-        if self.operator.checksum_address == event.args.departingParticipant:
-            # operator is the departing participant so we know that ritual is active and
-            # node already posted data
-            return self.DkgParticipationState(
-                participating=True,
-                already_posted_transcript=True,
-                already_posted_aggregate=True,
-            )
-
-        event_type = getattr(self.contract.events, event.event)
-        if event_type == self.contract.events.HandoverRequest and self.operator.checksum_address == event.args.incomingParticipant:
-            return self.DkgParticipationState(participating=True)
-
-        ritual_id = event.args.ritualId
-        handover = self.coordinator_agent.get_handover(
-            ritual_id=ritual_id,
-            departing_provider=event.args.departingParticipant
+        # handover modifies "participating", either:
+        # 1) part of handover process
+        # 2) part of original ritual (handover changes metadata)
+        cached_participation_state = (
+            cached_participation_state or self.HandoverParticipationState()
         )
-        # check if operator is the incoming participant; other values aren't applicable
-        participating = (handover.incoming_validator == self.operator.checksum_address)
-        return self.DkgParticipationState(participating=participating)
+        if cached_participation_state.participating:
+            # already participating, nothing to check here
+            return cached_participation_state
+
+        # 1) part of handover
+        if self.operator.checksum_address == event.args.departingParticipant:
+            # operator is the departing participant
+            cached_participation_state.participating = True
+        elif self.operator.checksum_address == event.args.incomingParticipant:
+            # operator is the incoming participant
+            cached_participation_state.participating = True
+
+        # 2) part of original dkg
+        if not cached_participation_state.participating:
+            cached_participation_state.participating = (
+                self.coordinator_agent.is_participant(
+                    event.args.ritualId, self.operator.checksum_address
+                )
+            )
+        return cached_participation_state
 
 
     def scan(self):

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -18,6 +18,9 @@ class DkgRitualTracker(RitualTracker):
         """
         Participation state for DKG rituals.
         """
+
+        PREFIX = "dkg-"
+
         def __init__(
             self,
             participating=False,
@@ -83,7 +86,7 @@ class DkgRitualTracker(RitualTracker):
         if event_type in self.handover_event_types:
             return f"{self.CohortParticipationStateDuringHandover.PREFIX}{event.args.ritualId}"
         else:
-            return str(event.args.ritualId)
+            return f"{self.DkgParticipationState.PREFIX}{event.args.ritualId}"
 
     def _action_required_based_on_participation_state(
         self,

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -28,9 +28,9 @@ class DkgRitualTracker(RitualTracker):
             self.already_posted_transcript = already_posted_transcript
             self.already_posted_aggregate = already_posted_aggregate
 
-    class HandoverParticipationState(RitualTracker.ParticipationState):
+    class CohortParticipationStateDuringHandover(RitualTracker.ParticipationState):
         """
-        Participation state for Handover rituals.
+        Cohort participation state during handover process.
         """
 
         PREFIX = "handover-"
@@ -81,13 +81,15 @@ class DkgRitualTracker(RitualTracker):
     def _get_identifier(self, event: AttributeDict) -> str:
         event_type = getattr(self.contract.events, event.event)
         if event_type in self.handover_event_types:
-            return f"{self.HandoverParticipationState.PREFIX}{event.args.ritualId}"
+            return f"{self.CohortParticipationStateDuringHandover.PREFIX}{event.args.ritualId}"
         else:
             return str(event.args.ritualId)
 
     def _action_required_based_on_participation_state(
         self,
-        participation_state: Union[DkgParticipationState, HandoverParticipationState],
+        participation_state: Union[
+            DkgParticipationState, CohortParticipationStateDuringHandover
+        ],
         event: AttributeDict,
     ) -> bool:
         # Let's handle separately handover events and non-handover events
@@ -158,7 +160,7 @@ class DkgRitualTracker(RitualTracker):
 
     def _create_participation_state(
         self, event: AttributeDict
-    ) -> Union[DkgParticipationState, HandoverParticipationState]:
+    ) -> Union[DkgParticipationState, CohortParticipationStateDuringHandover]:
         # obtain information from contract
         participation_state = self._get_latest_participation_state_values(event=event)
         return participation_state
@@ -166,7 +168,7 @@ class DkgRitualTracker(RitualTracker):
     def _update_participation_state(
         self,
         cached_participation_state: Union[
-            DkgParticipationState, HandoverParticipationState
+            DkgParticipationState, CohortParticipationStateDuringHandover
         ],
         event: AttributeDict,
     ) -> None:
@@ -197,9 +199,12 @@ class DkgRitualTracker(RitualTracker):
         self,
         event: AttributeDict,
         cached_participation_state: Optional[
-            Union[DkgParticipationState, HandoverParticipationState]
+            Union[
+                DkgParticipationState,
+                CohortParticipationStateDuringHandover,
+            ]
         ] = None,
-    ) -> Union[DkgParticipationState, HandoverParticipationState]:
+    ) -> Union[DkgParticipationState, CohortParticipationStateDuringHandover]:
         """
         Obtains values for current participation state.
         """
@@ -269,8 +274,10 @@ class DkgRitualTracker(RitualTracker):
     def __get_latest_state_based_on_handover_event(
         self,
         event: AttributeDict,
-        cached_participation_state: Optional[HandoverParticipationState] = None,
-    ) -> HandoverParticipationState:
+        cached_participation_state: Optional[
+            CohortParticipationStateDuringHandover
+        ] = None,
+    ) -> CohortParticipationStateDuringHandover:
         """
         Returns the participation state value for handover events.
         """
@@ -278,7 +285,7 @@ class DkgRitualTracker(RitualTracker):
         # 1) part of handover process
         # 2) part of original ritual (handover changes metadata)
         cached_participation_state = (
-            cached_participation_state or self.HandoverParticipationState()
+            cached_participation_state or self.CohortParticipationStateDuringHandover()
         )
         if cached_participation_state.participating:
             # already participating, nothing to check here

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -16,7 +16,7 @@ class DkgRitualTracker(RitualTracker):
 
     class DkgParticipationState(RitualTracker.ParticipationState):
         """
-        Participation state for handover rituals.
+        Participation state for DKG rituals.
         """
         def __init__(
             self,
@@ -30,7 +30,7 @@ class DkgRitualTracker(RitualTracker):
 
     class HandoverParticipationState(RitualTracker.ParticipationState):
         """
-        Participation state for handover rituals.
+        Participation state for Handover rituals.
         """
 
         PREFIX = "handover-"

--- a/nucypher/blockchain/eth/trackers/dkg.py
+++ b/nucypher/blockchain/eth/trackers/dkg.py
@@ -106,17 +106,23 @@ class DkgRitualTracker(RitualTracker):
                 event.args.ritualId
             )
 
+            is_departing_participant_in_handover = (
+                event.args.departingParticipant == self.operator.checksum_address
+            )
+            is_incoming_participant_in_handover = (
+                event.args.incomingParticipant == self.operator.checksum_address
+            )
+
             if event_type in [
                 self.contract.events.HandoverFinalized,
                 self.contract.events.HandoverCanceled,
             ]:
                 if (
                     event_type == self.contract.events.HandoverCanceled
-                    and event.args.incomingParticipant == self.operator.checksum_address
+                    and is_incoming_participant_in_handover
                 ) or (
                     event_type == self.contract.events.HandoverFinalized
-                    and event.args.departingParticipant
-                    == self.operator.checksum_address
+                    and is_departing_participant_in_handover
                 ):
                     # if handover is canceled/finalized we need to reset the participation state
                     participation_state.participating = False
@@ -125,12 +131,6 @@ class DkgRitualTracker(RitualTracker):
                 # no further action required
                 return False
 
-            is_departing_participant_in_handover = (
-                event.args.departingParticipant == self.operator.checksum_address
-            )
-            is_incoming_participant_in_handover = (
-                event.args.incomingParticipant == self.operator.checksum_address
-            )
             # for handover events we need to act only if the operator is the departing or incoming participant
             return (
                 is_departing_participant_in_handover

--- a/nucypher/blockchain/eth/trackers/rituals.py
+++ b/nucypher/blockchain/eth/trackers/rituals.py
@@ -76,7 +76,7 @@ class RitualTracker(EventTracker, ABC):
 
     @abstractmethod
     def _update_participation_state(
-        self, participation_state: ParticipationState, event: AttributeDict
+        self, cached_participation_state: ParticipationState, event: AttributeDict
     ) -> None:
         """
         Updates the participation state with the information from the event.
@@ -135,15 +135,15 @@ class RitualTracker(EventTracker, ABC):
                 f"Unexpected event type: '{event_type}' has no id attribute"
             )
 
-        participation_state = self._participation_states[identifier]
-        if not participation_state:
-            participation_state = self._create_participation_state(event)
-            self._participation_states[identifier] = participation_state
-            return participation_state
+        cached_participation_state = self._participation_states[identifier]
+        if not cached_participation_state:
+            # no cached state, create a new one
+            cached_participation_state = self._create_participation_state(event)
+            self._participation_states[identifier] = cached_participation_state
+            return cached_participation_state
 
-        # already tracked but not participating
-        if participation_state.participating:
-            # already tracked and participating in ritual - populate other values if necessary
-            self._update_participation_state(participation_state, event)
+        # already tracked; since "participating" state can change due to handover
+        # we need to update it
+        self._update_participation_state(cached_participation_state, event)
 
-        return participation_state
+        return cached_participation_state

--- a/nucypher/blockchain/eth/trackers/signing.py
+++ b/nucypher/blockchain/eth/trackers/signing.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 from web3.datastructures import AttributeDict
 
@@ -43,7 +43,7 @@ class SigningRitualTracker(RitualTracker):
         )
 
     def _get_identifier(self, event: AttributeDict) -> str:
-        return event.args.cohortId
+        return str(event.args.cohortId)
 
     def _action_required_based_on_participation_state(
         self, participation_state: SigningParticipationState, event: AttributeDict
@@ -69,41 +69,16 @@ class SigningRitualTracker(RitualTracker):
     def _create_participation_state(
         self, event: AttributeDict
     ) -> SigningParticipationState:
-        event_type = getattr(self.contract.events, event.event)
-        args = event.args
-        if event_type == self.contract.events.InitiateSigningCohort:
-            participation_state = self.SigningParticipationState(
-                participating=(self.operator.checksum_address in args.participants)
-            )
-            return participation_state
-
-        cohort_id = args.cohortId
-        # obtain information from contract
-        (
-            participating,
-            posted_signature,
-        ) = self._get_participation_state_values_from_contract(cohort_id=cohort_id)
-        participation_state = self.SigningParticipationState(
-            participating=participating,
-            already_posted_signature=posted_signature,
-        )
+        participation_state = self._get_latest_participation_state_values(event)
         return participation_state
 
     def _update_participation_state(
-        self, participation_state: SigningParticipationState, event: AttributeDict
+        self,
+        cached_participation_state: SigningParticipationState,
+        event: AttributeDict,
     ) -> None:
-        event_type = getattr(self.contract.events, event.event)
-        if (
-            event_type == self.contract.events.SigningCohortDeployed
-            and not participation_state.already_posted_signature
-        ):
-            (
-                _,  # participating ignored - we know we are participating
-                posted_signature,
-            ) = self._get_participation_state_values_from_contract(
-                cohort_id=event.args.cohortId
-            )
-            participation_state.already_posted_signature = posted_signature
+        # already tracked but cache values may be out of date
+        self._get_latest_participation_state_values(event, cached_participation_state)
 
     def _get_cohort_participant_info(
         self, cohort_id: int
@@ -124,20 +99,43 @@ class SigningRitualTracker(RitualTracker):
 
         return None
 
-    def _get_participation_state_values_from_contract(
-        self, cohort_id: int
-    ) -> Tuple[bool, bool]:
+    def _get_latest_participation_state_values(
+        self,
+        event: AttributeDict,
+        cached_participation_state: Optional[SigningParticipationState] = None,
+    ) -> SigningParticipationState:
         """
         Obtains values for ParticipationState from the Coordinator contract.
         """
-        participating = False
-        already_posted_signature = False
+        event_type = getattr(self.contract.events, event.event)
+        if cached_participation_state:
+            if cached_participation_state.participating:
+                if event_type == self.contract.events.SigningCohortDeployed:
+                    cached_participation_state.already_posted_signature = True
 
-        participant_info = self._get_cohort_participant_info(cohort_id=cohort_id)
-        if participant_info:
-            # actually participating in this ritual; get latest information
-            participating = True
-            # populate information since we already hit the contract
-            already_posted_signature = bool(participant_info.signature)
+                return cached_participation_state
+            else:
+                # not participating, nothing to do here
+                return cached_participation_state
 
-        return participating, already_posted_signature
+        new_participation_state = self.SigningParticipationState()
+        args = event.args
+
+        if event_type == self.contract.events.InitiateSigningCohort:
+            # InitiateSigningCohort has all the information we need
+            new_participation_state.participating = (
+                self.operator.checksum_address in args.participants
+            )
+        else:
+            # obtain information from contract
+            participant_info = self._get_cohort_participant_info(
+                cohort_id=args.cohortId
+            )
+            if participant_info:
+                # actually participating in this ritual; get latest information
+                new_participation_state.participating = True
+                new_participation_state.already_posted_signature = bool(
+                    participant_info.signature
+                )
+
+        return new_participation_state

--- a/nucypher/blockchain/eth/trackers/signing.py
+++ b/nucypher/blockchain/eth/trackers/signing.py
@@ -12,6 +12,8 @@ class SigningRitualTracker(RitualTracker):
         Participation state for Signing rituals.
         """
 
+        PREFIX = "signing-"
+
         def __init__(
             self,
             participating=False,
@@ -47,7 +49,7 @@ class SigningRitualTracker(RitualTracker):
         )
 
     def _get_identifier(self, event: AttributeDict) -> str:
-        return str(event.args.cohortId)
+        return f"{self.SigningParticipationState.PREFIX}{event.args.cohortId}"
 
     def _action_required_based_on_participation_state(
         self, participation_state: SigningParticipationState, event: AttributeDict

--- a/nucypher/blockchain/eth/trackers/signing.py
+++ b/nucypher/blockchain/eth/trackers/signing.py
@@ -8,6 +8,10 @@ from nucypher.blockchain.eth.trackers.rituals import RitualTracker
 
 class SigningRitualTracker(RitualTracker):
     class SigningParticipationState(RitualTracker.ParticipationState):
+        """
+        Participation state for Signing rituals.
+        """
+
         def __init__(
             self,
             participating=False,

--- a/tests/acceptance/actors/test_dkg_ritual_tracker.py
+++ b/tests/acceptance/actors/test_dkg_ritual_tracker.py
@@ -23,6 +23,28 @@ def cohort(ursulas):
     return nodes
 
 
+def test_participation_state_identifier_based_on_event(cohort):
+    ursula = cohort[0]
+    active_ritual_tracker = DkgRitualTracker(operator=ursula)
+    for event in active_ritual_tracker.events:
+        ritual_id = 1234
+        event_data = AttributeDict(
+            {
+                "event": event.event_name,
+                "args": AttributeDict(
+                    {
+                        "ritualId": ritual_id,
+                    }
+                ),
+            }
+        )
+        state_identifier = active_ritual_tracker._get_identifier(event_data)
+        if event.event_name.startswith("Handover"):
+            assert state_identifier == f"handover-{ritual_id}"
+        else:
+            assert state_identifier == f"dkg-{ritual_id}"
+
+
 def test_action_required_not_participating(cohort, get_random_checksum_address):
     ursula = cohort[0]
     agent = ursula.coordinator_agent

--- a/tests/acceptance/actors/test_dkg_ritual_tracker.py
+++ b/tests/acceptance/actors/test_dkg_ritual_tracker.py
@@ -321,12 +321,14 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
         }
     )
 
+    state_identifier = active_ritual_tracker._get_identifier(event_data)
+
     #
     # not participating
     #
 
     # mimic already tracked prior state: not participating
-    active_ritual_tracker._participation_states[str(ritual_id)] = (
+    active_ritual_tracker._participation_states[state_identifier] = (
         active_ritual_tracker.DkgParticipationState(False, False, False)
     )
 
@@ -337,7 +339,7 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     #
 
     # mimic already tracked prior state: participating
-    active_ritual_tracker._participation_states[str(ritual_id)] = (
+    active_ritual_tracker._participation_states[state_identifier] = (
         active_ritual_tracker.DkgParticipationState(True, False, False)
     )
 
@@ -351,7 +353,7 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     # new state stored
     assert len(active_ritual_tracker._participation_states) == 1
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
 
@@ -366,7 +368,7 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     # no new state information
     assert len(active_ritual_tracker._participation_states) == 1
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
 
@@ -527,12 +529,14 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
         {"event": end_ritual_event.event_name, "args": AttributeDict(args_dict)}
     )
 
+    state_identifier = active_ritual_tracker._get_identifier(event_data)
+
     #
     # not participating
     #
 
     # mimic already tracked prior state: not participating
-    active_ritual_tracker._participation_states[str(ritual_id)] = (
+    active_ritual_tracker._participation_states[state_identifier] = (
         active_ritual_tracker.DkgParticipationState(False, False, False)
     )
 
@@ -545,7 +549,7 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
     #
 
     # mimic already tracked prior state: participating
-    active_ritual_tracker._participation_states[str(ritual_id)] = (
+    active_ritual_tracker._participation_states[state_identifier] = (
         active_ritual_tracker.DkgParticipationState(True, False, False)
     )
 
@@ -559,7 +563,7 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
 
     # no additional entry
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
     assert len(active_ritual_tracker._participation_states) == 1
@@ -615,6 +619,9 @@ def test_get_participation_state_purge_expired_cache_entries(
     ritual_id_1 = 1
     ritual_id_2 = 2
 
+    state_identifier_ritual_1 = None
+    state_identifier_ritual_2 = None
+
     ursula = cohort[0]
     agent = ursula.coordinator_agent
 
@@ -651,6 +658,7 @@ def test_get_participation_state_purge_expired_cache_entries(
         event_data = AttributeDict(
             {"event": start_ritual_event.event_name, "args": AttributeDict(args_dict)}
         )
+        state_identifier_ritual_1 = active_ritual_tracker._get_identifier(event_data)
         participation_state = active_ritual_tracker._get_participation_state(event_data)
         check_participation_state(participation_state, expected_participating=True)
 
@@ -685,6 +693,9 @@ def test_get_participation_state_purge_expired_cache_entries(
                     "args": AttributeDict(args_dict),
                 }
             )
+            state_identifier_ritual_2 = active_ritual_tracker._get_identifier(
+                event_data
+            )
             participation_state = active_ritual_tracker._get_participation_state(
                 event_data
             )
@@ -696,11 +707,11 @@ def test_get_participation_state_purge_expired_cache_entries(
     assert len(active_ritual_tracker._participation_states) == 2
     # be sure that the states are properly stored
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_1)],
+        active_ritual_tracker._participation_states[state_identifier_ritual_1],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_2)]
+        active_ritual_tracker._participation_states[state_identifier_ritual_2]
     )
 
     # modify time so that purge occurs when another event is received
@@ -740,9 +751,11 @@ def test_get_participation_state_purge_expired_cache_entries(
         mock_wrapped_purge_expired.assert_called()
 
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[str(ritual_id_1)] is None
+    assert (
+        active_ritual_tracker._participation_states[state_identifier_ritual_1] is None
+    )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_2)]
+        active_ritual_tracker._participation_states[state_identifier_ritual_2]
     )
 
 
@@ -757,6 +770,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     ritual_id_4 = 4  # ritual #4 is not being participated in
 
     ritual_ids = [ritual_id_1, ritual_id_2, ritual_id_3, ritual_id_4]
+    state_identifiers = {}
 
     ursula = cohort[0]
 
@@ -787,6 +801,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     ]
 
     # create list of events and use appropriately
+
     for i, r_id in enumerate(ritual_ids):
         event_data = AttributeDict(
             {
@@ -796,18 +811,23 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
                     {
                         "ritualId": r_id,
                         "initiator": get_random_checksum_address(),
-                        "participants": participants_when_participating
-                        if r_id != ritual_id_4
-                        else participants_when_not_participating,
+                        "participants": (
+                            participants_when_participating
+                            if r_id != ritual_id_4
+                            else participants_when_not_participating
+                        ),
                     }
                 ),
             }
         )
+        state_identifiers[r_id] = active_ritual_tracker._get_identifier(event_data)
         d = active_ritual_tracker._handle_event(event_data, get_block_when)
         yield d
 
         assert len(active_ritual_tracker._participation_states) == (i + 1)
-        participation_state = active_ritual_tracker._participation_states[str(r_id)]
+        participation_state = active_ritual_tracker._participation_states[
+            state_identifiers[r_id]
+        ]
         if r_id != ritual_id_4:
             operator.perform_round_1.assert_called_with(
                 ritual_id=r_id, initiator=ANY, participants=ANY, timestamp=ANY
@@ -842,20 +862,20 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     operator.perform_round_2.assert_called_with(ritual_id=ritual_id_2, timestamp=ANY)
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_1)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_1]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_2)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_2]],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_3)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_3]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_4)]
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_4]]
     )
 
     #
@@ -879,22 +899,22 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert operator.perform_round_2.call_count == 1  # same as before
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_1)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_1]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_2)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_2]],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_3)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_3]],
         expected_participating=True,
     )
 
     # don't care about ritual 4 since not participating - so no new information stored
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_4)]
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_4]]
     )
 
     #
@@ -923,23 +943,23 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert len(active_ritual_tracker._participation_states) == 4
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_1)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_1]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_2)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_2]],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_3)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_3]],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
     )
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_4)]
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_4]]
     )
 
     #
@@ -965,17 +985,17 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert operator.perform_round_2.call_count == 1  # same as before
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_1)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_1]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_2)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_2]],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_3)],
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_3]],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
@@ -983,7 +1003,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
 
     # don't care about ritual 4 since not participating - so no new information stored
     check_participation_state(
-        active_ritual_tracker._participation_states[str(ritual_id_4)]
+        active_ritual_tracker._participation_states[state_identifiers[ritual_id_4]]
     )
 
 
@@ -991,7 +1011,7 @@ def verify_non_participation_flow(
     active_ritual_tracker: DkgRitualTracker,
     event_data: AttributeDict,
 ):
-    ritual_id = event_data.args.ritualId
+    state_identifier = active_ritual_tracker._get_identifier(event_data)
 
     participation_state = active_ritual_tracker._get_participation_state(event_data)
     check_participation_state(participation_state)
@@ -999,7 +1019,7 @@ def verify_non_participation_flow(
     # new participation state stored
     assert len(active_ritual_tracker._participation_states) == 1
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
 
@@ -1010,7 +1030,7 @@ def verify_non_participation_flow(
     # no new information
     assert len(active_ritual_tracker._participation_states) == 1
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
 
@@ -1021,7 +1041,7 @@ def verify_participation_flow(
     expected_posted_transcript: bool,
     expected_posted_aggregate: bool,
 ):
-    ritual_id = event_data.args.ritualId
+    state_identifier = active_ritual_tracker._get_identifier(event_data)
 
     participation_state = active_ritual_tracker._get_participation_state(event_data)
     check_participation_state(
@@ -1034,7 +1054,7 @@ def verify_participation_flow(
     # new state stored
     assert len(active_ritual_tracker._participation_states) == 1
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
 
@@ -1050,7 +1070,7 @@ def verify_participation_flow(
     # no new information
     assert len(active_ritual_tracker._participation_states) == 1
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
 
@@ -1069,7 +1089,7 @@ def verify_participation_flow(
     # new state stored
     assert len(active_ritual_tracker._participation_states) == 1
     assert (
-        active_ritual_tracker._participation_states[str(ritual_id)]
+        active_ritual_tracker._participation_states[state_identifier]
         == participation_state
     )
 

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -326,7 +326,7 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     #
 
     # mimic already tracked prior state: not participating
-    active_ritual_tracker._participation_states[ritual_id] = (
+    active_ritual_tracker._participation_states[str(ritual_id)] = (
         active_ritual_tracker.DkgParticipationState(False, False, False)
     )
 
@@ -337,7 +337,7 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
     #
 
     # mimic already tracked prior state: participating
-    active_ritual_tracker._participation_states[ritual_id] = (
+    active_ritual_tracker._participation_states[str(ritual_id)] = (
         active_ritual_tracker.DkgParticipationState(True, False, False)
     )
 
@@ -350,7 +350,10 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
 
     # new state stored
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
 
     # check again
     participation_state = active_ritual_tracker._get_participation_state(event_data)
@@ -362,7 +365,10 @@ def test_get_participation_state_start_aggregation_round_participation_already_t
 
     # no new state information
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
 
 
 def test_get_participation_state_end_ritual_participation_not_already_tracked(
@@ -526,7 +532,7 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
     #
 
     # mimic already tracked prior state: not participating
-    active_ritual_tracker._participation_states[ritual_id] = (
+    active_ritual_tracker._participation_states[str(ritual_id)] = (
         active_ritual_tracker.DkgParticipationState(False, False, False)
     )
 
@@ -539,7 +545,7 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
     #
 
     # mimic already tracked prior state: participating
-    active_ritual_tracker._participation_states[ritual_id] = (
+    active_ritual_tracker._participation_states[str(ritual_id)] = (
         active_ritual_tracker.DkgParticipationState(True, False, False)
     )
 
@@ -552,7 +558,10 @@ def test_get_participation_state_end_ritual_participation_already_tracked(
     )
 
     # no additional entry
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
     assert len(active_ritual_tracker._participation_states) == 1
 
 
@@ -687,10 +696,12 @@ def test_get_participation_state_purge_expired_cache_entries(
     assert len(active_ritual_tracker._participation_states) == 2
     # be sure that the states are properly stored
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[str(ritual_id_1)],
         expected_participating=True,
     )
-    check_participation_state(active_ritual_tracker._participation_states[ritual_id_2])
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(ritual_id_2)]
+    )
 
     # modify time so that purge occurs when another event is received
     # fake event for ritual 2
@@ -729,8 +740,10 @@ def test_get_participation_state_purge_expired_cache_entries(
         mock_wrapped_purge_expired.assert_called()
 
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id_1] is None
-    check_participation_state(active_ritual_tracker._participation_states[ritual_id_2])
+    assert active_ritual_tracker._participation_states[str(ritual_id_1)] is None
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(ritual_id_2)]
+    )
 
 
 @pytest_twisted.inlineCallbacks()
@@ -794,7 +807,7 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
         yield d
 
         assert len(active_ritual_tracker._participation_states) == (i + 1)
-        participation_state = active_ritual_tracker._participation_states[r_id]
+        participation_state = active_ritual_tracker._participation_states[str(r_id)]
         if r_id != ritual_id_4:
             operator.perform_round_1.assert_called_with(
                 ritual_id=r_id, initiator=ANY, participants=ANY, timestamp=ANY
@@ -829,19 +842,21 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     operator.perform_round_2.assert_called_with(ritual_id=ritual_id_2, timestamp=ANY)
 
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[str(ritual_id_1)],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[str(ritual_id_2)],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[str(ritual_id_3)],
         expected_participating=True,
     )
-    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(ritual_id_4)]
+    )
 
     #
     # Receive StartAggregationRound for ritual id 4
@@ -864,21 +879,23 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert operator.perform_round_2.call_count == 1  # same as before
 
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[str(ritual_id_1)],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[str(ritual_id_2)],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[str(ritual_id_3)],
         expected_participating=True,
     )
 
     # don't care about ritual 4 since not participating - so no new information stored
-    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(ritual_id_4)]
+    )
 
     #
     # EndRitual received for ritual id 3 (case where sequence
@@ -906,22 +923,24 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert len(active_ritual_tracker._participation_states) == 4
 
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[str(ritual_id_1)],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[str(ritual_id_2)],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[str(ritual_id_3)],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
     )
 
-    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(ritual_id_4)]
+    )
 
     #
     # EndRitual received for ritual id 4
@@ -946,24 +965,26 @@ def test_handle_event_multiple_concurrent_rituals(cohort, get_random_checksum_ad
     assert operator.perform_round_2.call_count == 1  # same as before
 
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_1],
+        active_ritual_tracker._participation_states[str(ritual_id_1)],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_2],
+        active_ritual_tracker._participation_states[str(ritual_id_2)],
         expected_participating=True,
         expected_already_posted_transcript=True,
     )
 
     check_participation_state(
-        active_ritual_tracker._participation_states[ritual_id_3],
+        active_ritual_tracker._participation_states[str(ritual_id_3)],
         expected_participating=True,
         expected_already_posted_transcript=True,
         expected_already_posted_aggregate=True,
     )
 
     # don't care about ritual 4 since not participating - so no new information stored
-    check_participation_state(active_ritual_tracker._participation_states[ritual_id_4])
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(ritual_id_4)]
+    )
 
 
 def verify_non_participation_flow(
@@ -977,7 +998,10 @@ def verify_non_participation_flow(
 
     # new participation state stored
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
 
     # check again that not participating
     participation_state = active_ritual_tracker._get_participation_state(event_data)
@@ -985,7 +1009,10 @@ def verify_non_participation_flow(
 
     # no new information
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
 
 
 def verify_participation_flow(
@@ -1006,7 +1033,10 @@ def verify_participation_flow(
 
     # new state stored
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
 
     # check again if relevant
     participation_state = active_ritual_tracker._get_participation_state(event_data)
@@ -1019,7 +1049,10 @@ def verify_participation_flow(
 
     # no new information
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
 
     # pretend to lose previous information eg. restart of node etc.
     active_ritual_tracker._participation_states.clear()
@@ -1035,7 +1068,10 @@ def verify_participation_flow(
 
     # new state stored
     assert len(active_ritual_tracker._participation_states) == 1
-    assert active_ritual_tracker._participation_states[ritual_id] == participation_state
+    assert (
+        active_ritual_tracker._participation_states[str(ritual_id)]
+        == participation_state
+    )
 
 
 def check_event_args_match_latest_event_inputs(event: ContractEvent, args_dict: Dict):

--- a/tests/acceptance/actors/test_ritual_tracker.py
+++ b/tests/acceptance/actors/test_ritual_tracker.py
@@ -94,6 +94,10 @@ def test_action_required_only_for_events_with_corresponding_actions(
                 # must be departing participant
                 arg_values["incomingParticipant"] = get_random_checksum_address()
                 arg_values["departingParticipant"] = ursula.checksum_address
+            else:
+                # Handover events have additional fields (doesn't matter which address)
+                arg_values["incomingParticipant"] = get_random_checksum_address()
+                arg_values["departingParticipant"] = get_random_checksum_address()
 
             ritual_event = AttributeDict(
                 {

--- a/tests/acceptance/actors/test_signing_ritual_tracker.py
+++ b/tests/acceptance/actors/test_signing_ritual_tracker.py
@@ -1,0 +1,808 @@
+import datetime
+import os
+from typing import Dict
+from unittest.mock import ANY, Mock, patch
+
+import maya
+import pytest
+import pytest_twisted
+from eth_typing import ChecksumAddress
+from web3.contract.contract import ContractEvent
+from web3.datastructures import AttributeDict
+
+from nucypher.blockchain.eth.actors import Operator
+from nucypher.blockchain.eth.models import SigningCoordinator
+from nucypher.blockchain.eth.trackers.signing import SigningRitualTracker
+
+
+@pytest.fixture(scope="module")
+def cohort(ursulas):
+    """Creates a cohort of Ursulas"""
+    nodes = list(sorted(ursulas[:4], key=lambda x: int(x.checksum_address, 16)))
+    assert len(nodes) == 4  # sanity check
+    return nodes
+
+
+def test_action_required_not_participating(cohort, get_random_checksum_address):
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    participation_state = SigningRitualTracker.SigningParticipationState(
+        participating=False,  # not participating
+    )
+
+    def _my_get_participation_state(*args, **kwargs):
+        return participation_state
+
+    with patch(
+        "nucypher.blockchain.eth.trackers.signing.SigningRitualTracker._get_participation_state",
+        _my_get_participation_state,
+    ):
+        for event in agent.contract.events:
+            arg_values = {
+                "cohortId": 23,
+            }
+            ritual_event = AttributeDict(
+                {
+                    "event": event.event_name,
+                    "args": AttributeDict(arg_values),
+                }
+            )
+
+            # all events are irrelevant because not participating
+            assert not active_ritual_tracker._action_required(ritual_event)
+
+
+def test_action_required_only_for_events_with_corresponding_actions(cohort):
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    participation_state = SigningRitualTracker.SigningParticipationState(
+        participating=True,  # participating
+    )
+
+    def _my_get_participation_state(*args, **kwargs):
+        return participation_state
+
+    with patch(
+        "nucypher.blockchain.eth.trackers.signing.SigningRitualTracker._get_participation_state",
+        _my_get_participation_state,
+    ):
+        for event in agent.contract.events:
+            event_type = getattr(agent.contract.events, event.event_name)
+            arg_values = {
+                "cohortId": 23,
+            }
+            ritual_event = AttributeDict(
+                {
+                    "event": event.event_name,
+                    "args": AttributeDict(arg_values),
+                }
+            )
+
+            if event_type not in active_ritual_tracker.actions:
+                assert not active_ritual_tracker._action_required(ritual_event)
+            else:
+                # actionable events - both actions required since transcript/aggregate not posted
+                assert active_ritual_tracker._action_required(ritual_event)
+
+
+def test_action_required_depending_on_signing_participation_state(
+    cohort, get_random_checksum_address
+):
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    participation_state = SigningRitualTracker.SigningParticipationState(
+        participating=True,
+    )
+
+    def _my_get_participation_state(*args, **kwargs):
+        return participation_state
+
+    with patch(
+        "nucypher.blockchain.eth.trackers.signing.SigningRitualTracker._get_participation_state",
+        _my_get_participation_state,
+    ):
+        # address included in initiate cohort event - action required
+        initiate_cohort_event = AttributeDict(
+            {
+                "event": agent.contract.events.InitiateSigningCohort.event_name,
+                "args": AttributeDict(
+                    {
+                        "cohortId": 23,
+                        "chainId": 1,
+                        "authority": get_random_checksum_address(),
+                        "participants": [u.checksum_address for u in cohort],
+                    }
+                ),
+            }
+        )
+        assert (
+            agent.contract.events.InitiateSigningCohort in active_ritual_tracker.actions
+        )
+        assert active_ritual_tracker._action_required(initiate_cohort_event)
+
+        # already posted signature - action not required
+        participation_state.already_posted_signature = True
+        assert not active_ritual_tracker._action_required(initiate_cohort_event)
+
+
+def test_get_participation_state_initiate_signing_cohort(
+    cohort, get_random_checksum_address
+):
+    args_dict = {
+        "cohortId": 12,
+        "chainId": 1,
+        "authority": get_random_checksum_address(),
+        "participants": [
+            get_random_checksum_address(),
+            get_random_checksum_address(),
+            get_random_checksum_address(),
+        ],  # not included by default
+    }
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    # InitiateSigningCohort event
+    initiate_signing_cohort = agent.contract.events.InitiateSigningCohort()
+
+    # Ensure that test matches latest event information
+    check_event_args_match_latest_event_inputs(
+        event=initiate_signing_cohort, args_dict=args_dict
+    )
+
+    event_data = AttributeDict(
+        {"event": initiate_signing_cohort.event_name, "args": AttributeDict(args_dict)}
+    )
+
+    #
+    # not participating
+    #
+    verify_non_participation_flow(active_ritual_tracker, event_data)
+
+    #
+    # clear prior information
+    #
+    active_ritual_tracker._participation_states.clear()
+
+    #
+    # actually participating now
+    #
+    args_dict["participants"] = [
+        u.checksum_address for u in cohort
+    ]  # ursula address included
+    event_data = AttributeDict(
+        {"event": initiate_signing_cohort.event_name, "args": AttributeDict(args_dict)}
+    )
+
+    verify_participation_flow(
+        active_ritual_tracker,
+        event_data,
+        expected_posted_signature=False,
+    )
+
+
+def test_get_participation_state_signing_cohort_deployed_participation_not_already_tracked(
+    cohort,
+):
+    args_dict = {"cohortId": 12, "chainId": 1}
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    cohort_deployed_event = agent.contract.events.SigningCohortDeployed()
+
+    # ensure that test matches latest event information
+    check_event_args_match_latest_event_inputs(
+        event=cohort_deployed_event, args_dict=args_dict
+    )
+    event_data = AttributeDict(
+        {"event": cohort_deployed_event.event_name, "args": AttributeDict(args_dict)}
+    )
+
+    with patch.object(agent, "is_signer", return_value=False):
+        verify_non_participation_flow(active_ritual_tracker, event_data)
+
+    #
+    # clear prior information
+    #
+    active_ritual_tracker._participation_states.clear()
+
+    #
+    # actually participating now: signing cohort ritual successful
+    #
+    def participating(*args, **kwargs):
+        participant = SigningCoordinator.SigningCohortParticipant(
+            provider=ChecksumAddress(ursula.checksum_address),
+            operator=ChecksumAddress(ursula.operator_address),
+            signature=os.urandom(32),
+        )
+
+        return participant
+
+    with patch.object(agent, "is_signer", return_value=True):
+        with patch.object(agent, "get_signer", side_effect=participating):
+            verify_participation_flow(
+                active_ritual_tracker,
+                event_data,
+                expected_posted_signature=True,
+            )
+
+
+def test_get_participation_state_signing_cohort_deployed_participation_already_tracked(
+    cohort, get_random_checksum_address
+):
+    args_dict = {"cohortId": 12, "chainId": 1}
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    cohort_deployed_event = agent.contract.events.SigningCohortDeployed()
+
+    # ensure that test matches latest event information
+    check_event_args_match_latest_event_inputs(
+        event=cohort_deployed_event, args_dict=args_dict
+    )
+    event_data = AttributeDict(
+        {"event": cohort_deployed_event.event_name, "args": AttributeDict(args_dict)}
+    )
+
+    state_identifier = active_ritual_tracker._get_identifier(event_data)
+
+    #
+    # not participating
+    #
+
+    # mimic already tracked prior state: not participating
+    active_ritual_tracker._participation_states[state_identifier] = (
+        active_ritual_tracker.SigningParticipationState(False, False)
+    )
+
+    verify_non_participation_flow(active_ritual_tracker, event_data)
+    # no additional entry
+    assert len(active_ritual_tracker._participation_states) == 1
+
+    #
+    # actually participating now
+    #
+
+    # mimic already tracked prior state: participating
+    active_ritual_tracker._participation_states[state_identifier] = (
+        active_ritual_tracker.SigningParticipationState(True, False)
+    )
+
+    participation_state = active_ritual_tracker._get_participation_state(event_data)
+    check_participation_state(
+        participation_state,
+        expected_participating=True,
+        expected_already_posted_signature=True,
+    )
+
+    # no additional entry
+    assert (
+        active_ritual_tracker._participation_states[state_identifier]
+        == participation_state
+    )
+    assert len(active_ritual_tracker._participation_states) == 1
+
+
+def test_get_participation_state_unexpected_event_without_cohort_id_arg(cohort):
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    # MaxDkgSizeChanged
+    max_dkg_size_changed = agent.contract.events.MaxCohortSizeChanged()
+
+    # create args data
+    args_dict = {"oldSize": 24, "newSize": 30}
+
+    # ensure that test matches latest event information
+    check_event_args_match_latest_event_inputs(
+        event=max_dkg_size_changed, args_dict=args_dict
+    )
+
+    event_data = AttributeDict(
+        {"event": max_dkg_size_changed.event_name, "args": AttributeDict(args_dict)}
+    )
+
+    with pytest.raises(RuntimeError):
+        active_ritual_tracker._get_participation_state(event_data)
+
+
+def test_get_participation_state_unexpected_event_with_cohort_id_arg(
+    cohort, get_random_checksum_address
+):
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    # create args data - faked to include ritual id arg
+    args_dict = {
+        "cohortId": 0,
+        "provider": get_random_checksum_address(),
+        "signature": os.urandom(32),
+    }
+
+    # MaxDkgSizeChanged event
+    event_data = AttributeDict(
+        {
+            # this is an event we don't track but has cohortId
+            "event": agent.contract.events.SigningCohortSignaturePosted.event_name,
+            "args": AttributeDict(args_dict),
+        }
+    )
+
+    with pytest.raises(RuntimeError):
+        active_ritual_tracker._get_participation_state(event_data)
+
+
+def test_get_participation_state_purge_expired_cache_entries(
+    cohort, get_random_checksum_address
+):
+    cohort_id_1 = 1  # participation
+    cohort_id_2 = 2  # non participation
+
+    state_identifier_1 = None
+    state_identifier_2 = None
+
+    chain_id = 1234
+
+    ursula = cohort[0]
+    agent = ursula.signing_coordinator_agent
+
+    # This test hinges on the relationship between ritual timeout and the purge interval
+    # This relationship should hold: ritual timeout (ttl) + buffer == to the purge
+    # interval for ease of testing; so fake the ritual timeout
+    faked_ritual_timeout = SigningRitualTracker._PARTICIPATION_STATES_PURGE_INTERVAL - (
+        SigningRitualTracker._TIMEOUT_ADDITIONAL_TTL_BUFFER
+    )
+
+    with patch.object(agent, "get_timeout", return_value=faked_ritual_timeout):
+        # fake timeout only needed for initialization
+        active_ritual_tracker = SigningRitualTracker(operator=ursula)
+
+    now = maya.now()
+
+    initiate_signing_cohort = agent.contract.events.InitiateSigningCohort()
+    args_dict = {
+        "cohortId": cohort_id_1,
+        "chainId": chain_id,
+        "authority": get_random_checksum_address(),
+        "participants": [
+            get_random_checksum_address(),
+            get_random_checksum_address(),
+            ursula.checksum_address,  # participating
+        ],
+    }
+
+    with patch.object(
+        active_ritual_tracker._participation_states,
+        "purge_expired",
+        wraps=active_ritual_tracker._participation_states.purge_expired,
+    ) as mock_wrapped_purge_expired:
+        # start ritual event for ritual 1 (participating)
+        event_data = AttributeDict(
+            {
+                "event": initiate_signing_cohort.event_name,
+                "args": AttributeDict(args_dict),
+            }
+        )
+        state_identifier_1 = active_ritual_tracker._get_identifier(event_data)
+        participation_state = active_ritual_tracker._get_participation_state(event_data)
+        check_participation_state(participation_state, expected_participating=True)
+
+        # not enough time passed for purge_expired() to be called
+        mock_wrapped_purge_expired.assert_not_called()
+
+    assert len(active_ritual_tracker._participation_states) == 1
+
+    # modify the time that ritual id 2 is processed later on
+    def maya_now_for_ritual_2():
+        return now.add(
+            seconds=SigningRitualTracker._PARTICIPATION_STATES_PURGE_INTERVAL / 2
+        )
+
+    with patch.object(
+        active_ritual_tracker._participation_states,
+        "purge_expired",
+        wraps=active_ritual_tracker._participation_states.purge_expired,
+    ) as mock_wrapped_purge_expired:
+        with patch("maya.now", maya_now_for_ritual_2):
+            # start ritual event for ritual 2 (not participating)
+            args_dict["cohortId"] = cohort_id_2
+            args_dict["participants"] = [
+                get_random_checksum_address(),
+                get_random_checksum_address(),
+                get_random_checksum_address(),
+            ]
+
+            event_data = AttributeDict(
+                {
+                    "event": initiate_signing_cohort.event_name,
+                    "args": AttributeDict(args_dict),
+                }
+            )
+            state_identifier_2 = active_ritual_tracker._get_identifier(event_data)
+            participation_state = active_ritual_tracker._get_participation_state(
+                event_data
+            )
+            check_participation_state(participation_state)
+
+        # not enough time passed for purge_expired() to be called
+        mock_wrapped_purge_expired.assert_not_called()
+
+    assert len(active_ritual_tracker._participation_states) == 2
+    # be sure that the states are properly stored
+    check_participation_state(
+        active_ritual_tracker._participation_states[state_identifier_1],
+        expected_participating=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[state_identifier_2]
+    )
+
+    # modify time so that purge occurs when another event is received
+    # fake event for ritual 2
+    def maya_now_for_purge_interval():
+        return now.add(
+            seconds=SigningRitualTracker._PARTICIPATION_STATES_PURGE_INTERVAL + 1
+        )
+
+    with patch.object(
+        active_ritual_tracker._participation_states,
+        "purge_expired",
+        wraps=active_ritual_tracker._participation_states.purge_expired,
+    ) as mock_wrapped_purge_expired:
+        with patch("maya.now", maya_now_for_purge_interval):
+            # Receive SigningCohortDeployed for cohort_id 2
+            event_data = AttributeDict(
+                {
+                    "event": "SigningCohortDeployed",
+                    "blockNumber": 1234567,
+                    "args": AttributeDict(
+                        {
+                            "cohortId": cohort_id_2,
+                            "chainId": chain_id,
+                        }
+                    ),
+                }
+            )
+
+            participation_state = active_ritual_tracker._get_participation_state(
+                event_data
+            )
+            check_participation_state(participation_state)
+
+        # ensure that purge_expired called - enough time has passed
+        # len(states) below can call purge_expired, so this is the way
+        # to be sure it's called
+        mock_wrapped_purge_expired.assert_called()
+
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert active_ritual_tracker._participation_states[state_identifier_1] is None
+    check_participation_state(
+        active_ritual_tracker._participation_states[state_identifier_2]
+    )
+
+
+@pytest_twisted.inlineCallbacks()
+def test_handle_event_multiple_concurrent_signing_rituals(
+    cohort, get_random_checksum_address
+):
+    # test overall processing of events
+
+    # let's pretend that rituals 1, 2, 3, 4 are being tracked at the same time
+    cohort_id_1 = 1
+    cohort_id_2 = 2
+    cohort_id_3 = 3
+    cohort_id_4 = 4  # ritual #4 is not being participated in
+
+    cohort_ids = [cohort_id_1, cohort_id_2, cohort_id_3, cohort_id_4]
+    state_identifiers = {}
+
+    ursula = cohort[0]
+
+    operator = Mock(spec=Operator)
+    operator.checksum_address = ursula.checksum_address
+    operator.signing_coordinator_agent = ursula.signing_coordinator_agent
+
+    active_ritual_tracker = SigningRitualTracker(operator=operator)
+
+    block_number = 17692417  # random block number - value doesn't matter
+
+    def get_block_when(*args, **kwargs) -> datetime.datetime:
+        return datetime.datetime.now()
+
+    #
+    # InitiateSigningCohort
+    #
+    participants_when_participating = [
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+        ursula.checksum_address,
+    ]
+    participants_when_not_participating = [
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+        get_random_checksum_address(),
+    ]
+
+    chain_id = 1234
+    authority = get_random_checksum_address()
+
+    # create list of events and use appropriately
+    for i, c_id in enumerate(cohort_ids):
+        event_data = AttributeDict(
+            {
+                "event": "InitiateSigningCohort",
+                "blockNumber": block_number,
+                "args": AttributeDict(
+                    {
+                        "cohortId": c_id,
+                        "chainId": chain_id,
+                        "authority": authority,
+                        "participants": (
+                            participants_when_participating
+                            if c_id != cohort_id_4
+                            else participants_when_not_participating
+                        ),
+                    }
+                ),
+            }
+        )
+        state_identifiers[c_id] = active_ritual_tracker._get_identifier(event_data)
+        d = active_ritual_tracker._handle_event(event_data, get_block_when)
+        yield d
+
+        assert len(active_ritual_tracker._participation_states) == (i + 1)
+        participation_state = active_ritual_tracker._participation_states[
+            state_identifiers[c_id]
+        ]
+        if c_id != cohort_id_4:
+            operator.perform_post_signature.assert_called_with(
+                cohort_id=c_id,
+                chain_id=chain_id,
+                authority=authority,
+                participants=participants_when_participating,
+                timestamp=ANY,
+            )
+            check_participation_state(participation_state, expected_participating=True)
+        else:
+            check_participation_state(participation_state, expected_participating=False)
+
+    assert (
+        operator.perform_post_signature.call_count == 3
+    )  # participation and action required
+    assert len(active_ritual_tracker._participation_states) == 4
+
+    #
+    # Receive SigningCohortDeployed for cohort_id 2
+    #
+    event_data = AttributeDict(
+        {
+            "event": "SigningCohortDeployed",
+            "blockNumber": block_number,
+            "args": AttributeDict(
+                {
+                    "cohortId": cohort_id_2,
+                    "chainId": chain_id,
+                }
+            ),
+        }
+    )
+    d = active_ritual_tracker._handle_event(event_data, get_block_when)
+    yield d
+
+    assert operator.perform_post_signature.call_count == 3  # same count as before
+    assert len(active_ritual_tracker._participation_states) == 4
+
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_1)],
+        expected_participating=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_2)],
+        expected_participating=True,
+        expected_already_posted_signature=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_3)],
+        expected_participating=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_4)]
+    )
+
+    #
+    # Receive SigningCohortDeployed for cohort_id 4
+    #
+    event_data = AttributeDict(
+        {
+            "event": "SigningCohortDeployed",
+            "blockNumber": block_number,
+            "args": AttributeDict(
+                {
+                    "cohortId": cohort_id_4,
+                    "chainId": chain_id,
+                }
+            ),
+        }
+    )
+    d = active_ritual_tracker._handle_event(event_data, get_block_when)
+    yield d
+
+    assert operator.perform_post_signature.call_count == 3  # same count as before
+    assert len(active_ritual_tracker._participation_states) == 4
+
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_1)],
+        expected_participating=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_2)],
+        expected_participating=True,
+        expected_already_posted_signature=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_3)],
+        expected_participating=True,
+    )
+
+    # don't care about ritual 4 since not participating - so no new information stored
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_4)]
+    )
+
+    #
+    # SigningCohortDeployed received for cohort id 3
+    #
+    event_data = AttributeDict(
+        {
+            "event": "SigningCohortDeployed",
+            "blockNumber": block_number,
+            "args": AttributeDict(
+                {
+                    "cohortId": cohort_id_3,
+                    "chainId": chain_id,
+                }
+            ),
+        }
+    )
+    d = active_ritual_tracker._handle_event(event_data, get_block_when)
+    yield d
+
+    assert operator.perform_post_signature.call_count == 3  # same as before
+    assert len(active_ritual_tracker._participation_states) == 4
+
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_1)],
+        expected_participating=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_2)],
+        expected_participating=True,
+        expected_already_posted_signature=True,
+    )
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_3)],
+        expected_participating=True,
+        expected_already_posted_signature=True,
+    )
+
+    check_participation_state(
+        active_ritual_tracker._participation_states[str(cohort_id_4)]
+    )
+
+
+def verify_non_participation_flow(
+    active_ritual_tracker: SigningRitualTracker,
+    event_data: AttributeDict,
+):
+    state_identifier = active_ritual_tracker._get_identifier(event_data)
+
+    participation_state = active_ritual_tracker._get_participation_state(event_data)
+    check_participation_state(participation_state)
+
+    # new participation state stored
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert (
+        active_ritual_tracker._participation_states[state_identifier]
+        == participation_state
+    )
+
+    # check again that not participating
+    participation_state = active_ritual_tracker._get_participation_state(event_data)
+    check_participation_state(participation_state)
+
+    # no new information
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert (
+        active_ritual_tracker._participation_states[state_identifier]
+        == participation_state
+    )
+
+
+def verify_participation_flow(
+    active_ritual_tracker: SigningRitualTracker,
+    event_data: AttributeDict,
+    expected_posted_signature: bool,
+):
+    state_identifier = active_ritual_tracker._get_identifier(event_data)
+
+    participation_state = active_ritual_tracker._get_participation_state(event_data)
+    check_participation_state(
+        participation_state=participation_state,
+        expected_participating=True,
+        expected_already_posted_signature=expected_posted_signature,
+    )
+
+    # new state stored
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert (
+        active_ritual_tracker._participation_states[state_identifier]
+        == participation_state
+    )
+
+    # check again if relevant
+    participation_state = active_ritual_tracker._get_participation_state(event_data)
+    check_participation_state(
+        participation_state=participation_state,
+        expected_participating=True,
+        expected_already_posted_signature=expected_posted_signature,
+    )
+
+    # no new information
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert (
+        active_ritual_tracker._participation_states[state_identifier]
+        == participation_state
+    )
+
+    # pretend to lose previous information eg. restart of node etc.
+    active_ritual_tracker._participation_states.clear()
+    assert len(active_ritual_tracker._participation_states) == 0
+
+    participation_state = active_ritual_tracker._get_participation_state(event_data)
+    check_participation_state(
+        participation_state=participation_state,
+        expected_participating=True,
+        expected_already_posted_signature=expected_posted_signature,
+    )
+
+    # new state stored
+    assert len(active_ritual_tracker._participation_states) == 1
+    assert (
+        active_ritual_tracker._participation_states[state_identifier]
+        == participation_state
+    )
+
+
+def check_event_args_match_latest_event_inputs(event: ContractEvent, args_dict: Dict):
+    """Ensures that we are testing with actual event arguments."""
+    event_inputs = event.abi["inputs"]
+    assert len(event_inputs) == len(
+        args_dict
+    ), "test events don't match latest SigningCoordinator contract events"
+    for event_input in event_inputs:
+        assert (
+            event_input["name"] in args_dict
+        ), "test events don't match latest SigningCoordinator contract events"
+
+
+def check_participation_state(
+    participation_state: SigningRitualTracker.SigningParticipationState,
+    expected_participating: bool = False,
+    expected_already_posted_signature: bool = False,
+):
+    assert participation_state.participating == expected_participating
+    assert (
+        participation_state.already_posted_signature
+        == expected_already_posted_signature
+    )

--- a/tests/acceptance/actors/test_signing_ritual_tracker.py
+++ b/tests/acceptance/actors/test_signing_ritual_tracker.py
@@ -23,6 +23,25 @@ def cohort(ursulas):
     return nodes
 
 
+def test_signing_participation_state_identifier(cohort):
+    ursula = cohort[0]
+    active_ritual_tracker = SigningRitualTracker(operator=ursula)
+    cohort_id = 1234
+    for event in active_ritual_tracker.events:
+        event_data = AttributeDict(
+            {
+                "event": event.event_name,
+                "args": AttributeDict(
+                    {
+                        "cohortId": cohort_id,
+                    }
+                ),
+            }
+        )
+        state_identifier = active_ritual_tracker._get_identifier(event_data)
+        assert state_identifier == f"signing-{cohort_id}"
+
+
 def test_action_required_not_participating(cohort, get_random_checksum_address):
     ursula = cohort[0]
     agent = ursula.signing_coordinator_agent
@@ -604,20 +623,20 @@ def test_handle_event_multiple_concurrent_signing_rituals(
     assert len(active_ritual_tracker._participation_states) == 4
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_1)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_1]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_2)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_2]],
         expected_participating=True,
         expected_already_posted_signature=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_3)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_3]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_4)]
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_4]]
     )
 
     #
@@ -642,22 +661,22 @@ def test_handle_event_multiple_concurrent_signing_rituals(
     assert len(active_ritual_tracker._participation_states) == 4
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_1)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_1]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_2)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_2]],
         expected_participating=True,
         expected_already_posted_signature=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_3)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_3]],
         expected_participating=True,
     )
 
     # don't care about ritual 4 since not participating - so no new information stored
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_4)]
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_4]]
     )
 
     #
@@ -682,22 +701,22 @@ def test_handle_event_multiple_concurrent_signing_rituals(
     assert len(active_ritual_tracker._participation_states) == 4
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_1)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_1]],
         expected_participating=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_2)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_2]],
         expected_participating=True,
         expected_already_posted_signature=True,
     )
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_3)],
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_3]],
         expected_participating=True,
         expected_already_posted_signature=True,
     )
 
     check_participation_state(
-        active_ritual_tracker._participation_states[str(cohort_id_4)]
+        active_ritual_tracker._participation_states[state_identifiers[cohort_id_4]]
     )
 
 

--- a/tests/integration/blockchain/test_integration_ritual_tracker.py
+++ b/tests/integration/blockchain/test_integration_ritual_tracker.py
@@ -396,7 +396,9 @@ def test_get_handover_participation_state_values(
     participation_state = active_ritual_tracker._get_latest_participation_state_values(
         mocked_event
     )
-    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
+    assert isinstance(
+        participation_state, DkgRitualTracker.CohortParticipationStateDuringHandover
+    )
     assert not participation_state.participating
 
     # not part of handover but part of original ritual so participating should be True
@@ -406,7 +408,9 @@ def test_get_handover_participation_state_values(
     participation_state = active_ritual_tracker._get_latest_participation_state_values(
         mocked_event
     )
-    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
+    assert isinstance(
+        participation_state, DkgRitualTracker.CohortParticipationStateDuringHandover
+    )
     assert participation_state.participating
 
     # ritualist it the incoming participant (and not part of original ritual)
@@ -414,8 +418,11 @@ def test_get_handover_participation_state_values(
     mocked_event.args.incomingParticipant = ritualist.checksum_address
     mocked_agent.is_participant.return_value = False
     participation_state = active_ritual_tracker._get_latest_participation_state_values(
-        mocked_event)
-    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
+        mocked_event
+    )
+    assert isinstance(
+        participation_state, DkgRitualTracker.CohortParticipationStateDuringHandover
+    )
     assert participation_state.participating
 
     # departing participant is the ritualist
@@ -425,6 +432,9 @@ def test_get_handover_participation_state_values(
     mocked_event.args.departingParticipant = ritualist.checksum_address
     mocked_event.args.incomingParticipant = get_random_checksum_address()
     participation_state = active_ritual_tracker._get_latest_participation_state_values(
-        mocked_event)
-    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
+        mocked_event
+    )
+    assert isinstance(
+        participation_state, DkgRitualTracker.CohortParticipationStateDuringHandover
+    )
     assert participation_state.participating

--- a/tests/integration/blockchain/test_integration_ritual_tracker.py
+++ b/tests/integration/blockchain/test_integration_ritual_tracker.py
@@ -277,7 +277,6 @@ def test_get_ritual_participant_info(ritualist, get_random_checksum_address):
 def test_get_dkg_participation_state_values_start_ritual(
     ritualist, get_random_checksum_address
 ):
-    mocked_agent = ritualist.coordinator_agent
     active_ritual_tracker = DkgRitualTracker(operator=ritualist)
 
     participants = []
@@ -293,7 +292,9 @@ def test_get_dkg_participation_state_values_start_ritual(
     # contract not actually called for StartRitual, event is sufficient
 
     # not participating so everything should be False
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
     assert not participation_state.participating
     assert not participation_state.already_posted_transcript
     assert not participation_state.already_posted_aggregate
@@ -302,7 +303,9 @@ def test_get_dkg_participation_state_values_start_ritual(
     participants.append(ritualist.checksum_address)
 
     # participating, but nothing submitted
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
     assert participation_state.participating
     assert not participation_state.already_posted_transcript
     assert not participation_state.already_posted_aggregate
@@ -326,7 +329,9 @@ def test_get_dkg_participation_state_values_non_start_ritual_event(
     mocked_event.event = "StartAggregationRound"  # any event received without StartRitual first
 
     # not participating so everything should be False
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
     assert not participation_state.participating
     assert not participation_state.already_posted_transcript
     assert not participation_state.already_posted_aggregate
@@ -338,97 +343,88 @@ def test_get_dkg_participation_state_values_non_start_ritual_event(
     mocked_agent.get_participant.return_value = ritual_participant
 
     # participating, but nothing submitted
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
     assert participation_state.participating
     assert not participation_state.already_posted_transcript
     assert not participation_state.already_posted_aggregate
 
     # submit transcript
     ritual_participant.transcript = os.urandom(32)
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
     assert participation_state.participating
     assert participation_state.already_posted_transcript
     assert not participation_state.already_posted_aggregate
 
     # submit aggregate
     ritual_participant.aggregated = True
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
     assert participation_state.participating
     assert participation_state.already_posted_transcript
     assert participation_state.already_posted_aggregate
 
 
-def test_get_handover_participation_state_values_handover_request(
-    ritualist, get_random_checksum_address
+@pytest.mark.parametrize(
+    "handover_event",
+    [
+        "HandoverRequest",
+        "HandoverTranscriptPosted",
+        "HandoverFinalized",
+        "HandoverCanceled",
+    ],
+)
+def test_get_handover_participation_state_values(
+    handover_event, ritualist, get_random_checksum_address
 ):
     active_ritual_tracker = DkgRitualTracker(operator=ritualist)
 
     mocked_event = Mock()
     mocked_event.args.ritualId = 0
+    mocked_event.event = handover_event
+
+    mocked_agent = ritualist.coordinator_agent
+
+    # not part of handover or original ritual
     mocked_event.args.departingParticipant = get_random_checksum_address()
     mocked_event.args.incomingParticipant = get_random_checksum_address()
-    mocked_event.event = "HandoverRequest"
-
-    # not part of handover so everything should be False
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
+    mocked_agent.is_participant.return_value = False
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
+    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
     assert not participation_state.participating
-    assert not participation_state.already_posted_transcript
-    assert not participation_state.already_posted_aggregate
 
-    # departing provider is the ritualist i.e. already in cohort
-    mocked_event.args.departingParticipant = ritualist.checksum_address
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(
-        mocked_event)
+    # not part of handover but part of original ritual so participating should be True
+    mocked_event.args.departingParticipant = get_random_checksum_address()
+    mocked_event.args.incomingParticipant = get_random_checksum_address()
+    mocked_agent.is_participant.return_value = True
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
+        mocked_event
+    )
+    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
     assert participation_state.participating
-    assert participation_state.already_posted_transcript
-    assert participation_state.already_posted_aggregate
 
-    # incoming participant is the ritualist not yet in cohort
+    # ritualist it the incoming participant (and not part of original ritual)
     mocked_event.args.departingParticipant = get_random_checksum_address()
     mocked_event.args.incomingParticipant = ritualist.checksum_address
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(
+    mocked_agent.is_participant.return_value = False
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
         mocked_event)
+    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
     assert participation_state.participating
-    assert not participation_state.already_posted_transcript
-    assert not participation_state.already_posted_aggregate
 
-
-def test_get_handover_participation_state_values_non_handover_request_event(
-    ritualist, get_random_checksum_address
-):
-    mocked_agent = ritualist.coordinator_agent
-    active_ritual_tracker = DkgRitualTracker(operator=ritualist)
-
-    mocked_event = Mock()
-    mocked_event.args.ritualId = 0
-    mocked_event.args.departingParticipant = get_random_checksum_address()
-    mocked_event.event = "HandoverTranscriptPosted"
-
-    # not part of handover so everything should be False
-    handover = Mock()
-    handover.departing_validator = get_random_checksum_address()
-    handover.incoming_validator = get_random_checksum_address()
-
-    mocked_agent.get_handover.return_value = handover
-
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(mocked_event)
-    assert not participation_state.participating
-    assert not participation_state.already_posted_transcript
-    assert not participation_state.already_posted_aggregate
-
-    # departing provider is the ritualist i.e. already in cohort; this would be in the event
+    # departing participant is the ritualist
+    # technically you can't be a departing participant but not already be a ritual participant
+    # - just for testing coverage purposes
+    mocked_agent.is_participant.return_value = False
     mocked_event.args.departingParticipant = ritualist.checksum_address
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(
+    mocked_event.args.incomingParticipant = get_random_checksum_address()
+    participation_state = active_ritual_tracker._get_latest_participation_state_values(
         mocked_event)
+    assert isinstance(participation_state, DkgRitualTracker.HandoverParticipationState)
     assert participation_state.participating
-    assert participation_state.already_posted_transcript
-    assert participation_state.already_posted_aggregate
-
-    # incoming participant is the ritualist not yet in cohort; not in event, go to contract
-    mocked_event.args.departingParticipant = get_random_checksum_address()
-    handover.incoming_validator = ritualist.checksum_address
-    participation_state = active_ritual_tracker._get_participation_state_values_from_contract(
-        mocked_event)
-    assert participation_state.participating
-    assert not participation_state.already_posted_transcript
-    assert not participation_state.already_posted_aggregate


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [X] 2
- [ ] 3

**What this does:**
Updates needed post rebase of v7.7.x over `main` (just released v7.6.0) that included handover changes. The ritual tracker was significantly refactored in v7.7.x before the rebase as part of #3599 , and so there were some conflicts/issues with rebasing over v7.6.0. 

This PR aims to solve that problem after a basic rebase that caused ritual tracking to no longer work properly.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**

Key changes include:
- Refactored participation state management to handle both DKG and handover events separately
- Fixed participation state storage to use string keys consistently
- Updated test methods to use new participation state value retrieval methods
