### PR TITLE
Optional condition fields wiithout a value set (i.e. set to `None`) should not be included in the serialized json

### DIFF
--- a/newsfragments/3641.bugfix.rst
+++ b/newsfragments/3641.bugfix.rst
@@ -1,0 +1,1 @@
+Condition fields that are optional and have no value assigned (i.e., set to None) should be excluded from the serialized JSON.

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -64,7 +64,6 @@ class Condition(_Serializable, ABC):
     CONDITION_TYPE = NotImplemented
 
     class Schema(CamelCaseSchema):
-        SKIP_VALUES = (None,)
         name = fields.Str(required=False, allow_none=True)
         condition_type = NotImplemented
 

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -597,7 +597,6 @@ class ReturnValueTest(_Serializable):
     COMPARATORS = tuple(_COMPARATOR_FUNCTIONS)
 
     class Schema(CamelCaseSchema):
-        SKIP_VALUES = (None,)
         comparator = fields.Str(
             required=True,
             validate=OneOf(_COMPARATOR_FUNCTIONS, error="Not a permitted comparator"),

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -1,6 +1,6 @@
 import re
 from http import HTTPStatus
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 from marshmallow import Schema, post_dump
 from marshmallow.exceptions import SCHEMA
@@ -103,15 +103,16 @@ class CamelCaseSchema(Schema):
     and snake-case for its internal representation.
     """
 
-    SKIP_VALUES: Tuple = tuple()
-
     def on_bind_field(self, field_name, field_obj):
         field_obj.data_key = to_camelcase(field_obj.data_key or field_name)
 
     @post_dump
-    def remove_skip_values(self, data, **kwargs):
+    def remove_none_for_optional_fields(self, data, **kwargs):
+        # only include None values for required fields
         return {
-            key: value for key, value in data.items() if value not in self.SKIP_VALUES
+            key: value
+            for key, value in data.items()
+            if value is not None or self.fields[camel_case_to_snake(key)].required
         }
 
 

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -191,7 +191,6 @@ def lingo_with_all_condition_types(get_random_checksum_address):
                             "comparator": "<",
                             "value": 1000000000000000,
                         },
-                        "nestedAbiValidation": None,
                     }
                 ]
             }

--- a/tests/unit/conditions/test_context_var_condition.py
+++ b/tests/unit/conditions/test_context_var_condition.py
@@ -28,14 +28,14 @@ def test_invalid_context_variable_condition():
         )
 
     # no context var
-    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+    with pytest.raises(InvalidCondition, match="Field may not be null"):
         _ = ContextVariableCondition(
             context_variable=None,
             return_value_test=ReturnValueTest(comparator="==", value=0),
         )
 
     # no return value test var
-    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+    with pytest.raises(InvalidCondition, match="Field may not be null"):
         _ = ContextVariableCondition(
             context_variable=USER_ADDRESS_CONTEXT, return_value_test=None
         )

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -48,7 +48,7 @@ def test_invalid_signing_object_attribute_condition():
         )
 
     # no attribute name
-    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+    with pytest.raises(InvalidCondition, match="Field may not be null"):
         _ = SigningObjectAttributeCondition(
             attribute_name=None,
             return_value_test=ReturnValueTest("==", 0),
@@ -258,7 +258,7 @@ def test_invalid_signing_object_abi_attribute_condition():
         )
 
     # no allowed abi calls
-    with pytest.raises(InvalidCondition, match="Missing data for required field"):
+    with pytest.raises(InvalidCondition, match="Field may not be null"):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data", abi_validation=None
         )


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Based over #3638 .

Don't serialize `None` values when the field is optional.

`SKIP_VALUES` was really a means to an end to not serialize `None` values, but it was incomplete - we shouldn't serialize `None` values IF-AND-ONLY-IF the field is optional. Therefore, we don't really need `SKIP_VALUES` to be defined since the only values being skipped was `None` historically and instead we can add the logic for optional fields and just make this capability global to all Schemas.

Without this change the serialization of conditions taco-web would be different than python.

This is purely a serialization issue.  Given the focus of `taco-web` for client-side functionality, typically python does not do the serialization of conditions, only the deserialization; so this is a relatively minor issue, but caused a problem setting conditions on the contract since python was used for serializing the condition to bytes.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
