### PR TITLE
Use latest debian trixie release as the base for our docker builds

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nucypher/rust-python:3.12.9
+FROM nucypher/rust-python:3.12.11
 
 # set default user
 USER $USER

--- a/deploy/docker/rust-python/Dockerfile
+++ b/deploy/docker/rust-python/Dockerfile
@@ -1,8 +1,8 @@
-FROM rust:slim-bullseye
+FROM rust:slim-trixie
 
 # prepare container
 RUN apt-get update -y
-RUN apt-get install -y sudo
+RUN apt-get install -y sudo adduser
 
 # setup user
 ARG USER

--- a/newsfragments/3643.feature.rst
+++ b/newsfragments/3643.feature.rst
@@ -1,0 +1,1 @@
+Docker images are now based on the latest Debian Trixie release.


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Switch from older debian bullseye to newer debian trixie, which reduces vulnerabilities for our docker images. Further process improvements can be made but this is a quick and relatively impactful win.

Improvements:
- rust-python image improvement:

<img width="910" height="233" alt="Screenshot 2025-09-04 at 12 35 24 PM" src="https://github.com/user-attachments/assets/1266f503-3f63-4df5-bbcb-328b157848d1" />

- corresponding nucypher image (`scout`) over the latest 7.6.0 image:

<img width="904" height="377" alt="Screenshot 2025-09-04 at 1 28 29 PM" src="https://github.com/user-attachments/assets/c34daed1-667f-4fe3-8d7b-e04103d01352" />

Updates:
- Use python 3.12.11
- `adduser` must be explicitly installed on debian trixie.


**Notes for reviewers:**

The failing lint and python-test jobs are unrelated and will be resolved by #3638 