### PR TITLE
Fix more OS docker vulnerabilities based on scout / sysdig report

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,11 +3,16 @@ FROM nucypher/rust-python:3.12.11
 # set default user
 USER $USER
 
+# update os
+RUN sudo apt-get update -y
+RUN sudo apt-get full-upgrade -y
+
 # set default in-container workdir
 WORKDIR /code
 
 # Layer 1: Install dependencies
 COPY requirements.txt /code
+RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 # Layer 2: Install nucypher entrypoint

--- a/deploy/docker/rust-python/Dockerfile
+++ b/deploy/docker/rust-python/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get install -y sudo adduser
 # full upgrade of installed packages
 RUN sudo apt-get full-upgrade -y
 
+# upgrade pip3
+RUN pip3 install --upgrade pip
+
 # install rust: obtained from https://github.com/rust-lang/docker-rust/blob/3aad80112be66bf796c202713029d7ba93dff7fa/stable/trixie/slim/Dockerfile
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/deploy/docker/rust-python/Dockerfile
+++ b/deploy/docker/rust-python/Dockerfile
@@ -1,8 +1,51 @@
-FROM rust:slim-trixie
+FROM python:3.12.11-slim-trixie
 
 # prepare container
 RUN apt-get update -y
 RUN apt-get install -y sudo adduser
+
+# full upgrade of installed packages
+RUN sudo apt-get full-upgrade -y
+
+# install rust: obtained from https://github.com/rust-lang/docker-rust/blob/3aad80112be66bf796c202713029d7ba93dff7fa/stable/trixie/slim/Dockerfile
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH \
+    RUST_VERSION=1.90.0
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        gcc \
+        libc6-dev \
+        wget \
+        ; \
+    dpkgArch="$(dpkg --print-architecture)"; \
+    case "${dpkgArch##*-}" in \
+        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='20a06e644b0d9bd2fbdbfd52d42540bdde820ea7df86e92e533c073da0cdd43c' ;; \
+        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='3b8daab6cc3135f2cd4b12919559e6adaee73a2fbefb830fadf0405c20231d61' ;; \
+        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='e3853c5a252fca15252d07cb23a1bdd9377a8c6f3efa01531109281ae47f841c' ;; \
+        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='a5db2c4b29d23e9b318b955dd0337d6b52e93933608469085c924e0d05b1df1f' ;; \
+        ppc64el) rustArch='powerpc64le-unknown-linux-gnu'; rustupSha256='acd89c42b47c93bd4266163a7b05d3f26287d5148413c0d47b2e8a7aa67c9dc0' ;; \
+        s390x) rustArch='s390x-unknown-linux-gnu'; rustupSha256='726b7fd5d8805e73eab4a024a2889f8859d5a44e36041abac0a2436a52d42572' ;; \
+        riscv64) rustArch='riscv64gc-unknown-linux-gnu'; rustupSha256='09e64cc1b7a3e99adaa15dd2d46a3aad9d44d71041e2a96100d165c98a8fd7a7' ;; \
+        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
+    esac; \
+    url="https://static.rust-lang.org/rustup/archive/1.28.2/${rustArch}/rustup-init"; \
+    wget "$url"; \
+    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
+    chmod +x rustup-init; \
+    ./rustup-init -y --no-modify-path --profile minimal --default-toolchain $RUST_VERSION --default-host ${rustArch}; \
+    rm rustup-init; \
+    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
+    rustup --version; \
+    cargo --version; \
+    rustc --version; \
+    apt-get remove -y --auto-remove \
+        wget \
+        ; \
+    rm -rf /var/lib/apt/lists/*;
 
 # setup user
 ARG USER
@@ -12,30 +55,10 @@ RUN adduser $USER sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R $USER /home/$USER
 
-# install python build dependencies
-RUN sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
-    libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev git docker-compose
-
-# get python
-ARG VERSION
-RUN echo "Building python version $VERSION"
-RUN wget https://www.python.org/ftp/python/$VERSION/Python-$VERSION.tgz
-RUN tar xzvf Python-$VERSION.tgz
-
-# build python
-WORKDIR Python-$VERSION
-RUN ./configure --enable-optimizations
-RUN make
-RUN make install
-
-# setup python
-RUN cp python /bin
-RUN apt-get install -y python3-openssl python3-dev
 
 # setup rust
-ENV CARGO_ROOT /usr/local/cargo
-ENV PATH $CARGO_ROOT/bin:$PATH
+ENV CARGO_ROOT=/usr/local/cargo
+ENV PATH=$CARGO_ROOT/bin:$PATH
 
 # echo python and rust versions
 RUN python3 --version && \

--- a/newsfragments/3653.feature.rst
+++ b/newsfragments/3653.feature.rst
@@ -1,0 +1,1 @@
+Reduce OS level vulnerabilities by improving docker image build process.


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Reduces reported vulnerabilities from docker scout / sysdig.

## Round 1

Commit: c30e86256156849dba726c6555d21fda28221e73

Looking at the report, a couple other easy wins could be:
- run `apt-get full-upgrade -y` every time we build the ursula docker image to obtain latest installed package updates
- run `pip3 install --upgrade pip` to always use the latest version of pip (one of the suggested fixes for a medium vulnerability is to use a newer pip version 25.2)

The above changes yielded (see `nucypher/nucypher:scout` image below relative to prior versions):
- Removed 2 High Severity issues
- Removed 1 Medium Severity issues
- Added 3 Low Severity issues

<img width="888" height="163" alt="Screenshot 2025-09-26 at 8 45 32 AM" src="https://github.com/user-attachments/assets/c13c693c-35f5-4307-a5b4-1041ad0cfd2c" />

## Round 2

Commit: 192aff71137fbfd3eb775fdd3cb42f3ffff80cfe

Instead of using `rust:slim-trixie` as the image then installing python for the `nucypher/rust-python` image, instead we use `python3.12.11-slim-trixie` image and install `rust` on top of it.

That yielded the following for the `nucypher/rust-python:scout` image:
- Removed all Critical and High Severity issues
- Removed 4 Medium Severity issues
- Removed 26 Low Severity issues

<img width="897" height="205" alt="Screenshot 2025-09-26 at 2 43 01 PM" src="https://github.com/user-attachments/assets/2863cd6a-bb40-4677-aa00-d8b2029ee984" />

Using this base image as the base for the `nucypher/nucypher:scout` image and then rebuilding, we get the following for the latest ursula docker image:

<img width="896" height="297" alt="Screenshot 2025-09-26 at 2 47 47 PM" src="https://github.com/user-attachments/assets/c23ffb93-c25a-4512-8d57-3ea47a9bb87f" />

--

NOTE: I've been tagging `rust-python` and `nucypher` builds as `scout` for testing. Once we are ready we can produce legit tagged images for each especially `rust-python` and then reference it from the `nucypher` Dockerfile.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
