### PR TITLE
Python v3.13 support

### DIFF
--- a/.github/workflows/darker.yml
+++ b/.github/workflows/darker.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - uses: akaihola/darker@v2.1.1
         with:
           version: "2.1.1"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.12"
+        python-version: "3.13"
 
     - name: Checkout code
       uses: actions/checkout@v4

--- a/.github/workflows/lynx.yml
+++ b/.github/workflows/lynx.yml
@@ -19,9 +19,6 @@ env: # TODO: Use variables when GH supports it for forks. See https://github.com
 jobs:
   lynx-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ "3.10" ]
 
     steps:
       - name: Checkout repo
@@ -34,7 +31,7 @@ jobs:
         name: Set up Python ${{ matrix.python-version }} Environment
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.13"
 
       - id: python_cache
         name: Retrieve Cached Python Dependencies

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.12"
+        python-version: "3.13"
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.10", "3.12" ]
+        python-version: [ "3.10", "3.13" ]
 
     steps:
       - name: Checkout repo
@@ -58,54 +58,54 @@ jobs:
 
       # Unit tests
       - name: Unit Tests (Coverage)
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         run: |
           coverage run --data-file=unit_data -m pytest tests/unit
           coverage xml -i --data-file=unit_data -o unit-coverage.xml
 
       - name: Unit Tests
-        if: matrix.python-version != '3.12'
+        if: matrix.python-version != '3.13'
         run: python -m pytest tests/unit
 
       # Integration tests
       - name: Integration Tests (Coverage)
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         run: |
           coverage run --data-file=integration_data -m pytest tests/integration
           coverage xml -i --data-file=integration_data -o integration-coverage.xml
 
       - name: Integration Tests
-        if: matrix.python-version != '3.12'
+        if: matrix.python-version != '3.13'
         run: python -m pytest tests/integration
 
       # Acceptance tests
       - name: Agents Tests (Coverage)
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_agent_data -m pytest agents
           coverage xml -i --data-file=acceptance_agent_data -o acceptance-agents-coverage.xml
 
       - name: Agents Tests
-        if: matrix.python-version != '3.12'
+        if: matrix.python-version != '3.13'
         working-directory: tests/acceptance
         run: python -m pytest agents
 
       - name: Actors Tests (Coverage)
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_actors_data -m pytest actors
           coverage xml -i --data-file=acceptance_actors_data -o acceptance-actors-coverage.xml
 
       - name: Actors Tests
-        if: matrix.python-version != '3.12'
+        if: matrix.python-version != '3.13'
         working-directory: tests/acceptance
         run: python -m pytest actors
 
 
       - name: Conditions Tests (Coverage)
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         working-directory: tests/acceptance
         env:
           # Used for testing a POAP API call
@@ -115,7 +115,7 @@ jobs:
           coverage xml -i --data-file=acceptance_conditions_data -o acceptance-conditions-coverage.xml
 
       - name: Conditions Tests
-        if: matrix.python-version != '3.12'
+        if: matrix.python-version != '3.13'
         env:
           # Used for testing a POAP API call
           POAP_API_KEY: ${{ secrets.POAP_API_KEY }}
@@ -124,34 +124,34 @@ jobs:
 
 
       - name: Characters Tests (Coverage)
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_characters_data -m pytest characters
           coverage xml -i --data-file=acceptance_characters_data -o acceptance-characters-coverage.xml
 
       - name: Characters Tests
-        if: matrix.python-version != '3.12'
+        if: matrix.python-version != '3.13'
         working-directory: tests/acceptance
         run: python -m pytest characters
 
 
       - name: CLI Tests (Coverage)
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         working-directory: tests/acceptance
         run: |
           coverage run --data-file=acceptance_cli_data -m pytest cli
           coverage xml -i --data-file=acceptance_cli_data -o acceptance-cli-coverage.xml
 
       - name: CLI Tests
-        if: matrix.python-version != '3.12'
+        if: matrix.python-version != '3.13'
         working-directory: tests/acceptance
         run: python -m pytest cli
 
 
       # Only upload coverage files after all tests have passed
       - name: Upload unit tests coverage to Codecov
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -161,7 +161,7 @@ jobs:
           verbose: true
 
       - name: Upload integration tests coverage to Codecov
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -171,7 +171,7 @@ jobs:
           verbose: true
 
       - name: Upload acceptance tests coverage to Codecov
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install dependencies
         run: |

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM nucypher/rust-python:3.12.11
+FROM nucypher/rust-python:3.13.7
 
 # set default user
 USER $USER

--- a/deploy/docker/rust-python/Dockerfile
+++ b/deploy/docker/rust-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.11-slim-trixie
+FROM python:3.13.7-slim-trixie
 
 # prepare container
 RUN apt-get update -y

--- a/deploy/docker/rust-python/README.md
+++ b/deploy/docker/rust-python/README.md
@@ -2,11 +2,11 @@
 
 ### Setup
 ```bash
-# the default username in the container
+# the default username in the container ("nucypher")
 # circle ci expects the user "circleci"
 export DOCKER_USER=<USERNAME>
 
-# the version of python to build
+# the version of python to build (currently "3.13.7")
 export PYTHON_VERSION=<VERSION>
 ```
 
@@ -14,8 +14,8 @@ export PYTHON_VERSION=<VERSION>
 ```bash
 # pass local env vars as build args USER and VERSION
 docker build -t nucypher/rust-python:$PYTHON_VERSION . \
---build-arg VERSION=${PYTHON_VERSION} \
---build-arg USER=${DOCKER_USER}
+--build-arg VERSION=$PYTHON_VERSION \
+--build-arg USER=$DOCKER_USER
 ```
 
 ### Push

--- a/deploy/docker/rust-python/README.md
+++ b/deploy/docker/rust-python/README.md
@@ -2,11 +2,11 @@
 
 ### Setup
 ```bash
-# the default username in the container ("nucypher")
+# the user in the container (typically "nucypher")
 # circle ci expects the user "circleci"
 export DOCKER_USER=<USERNAME>
 
-# the version of python to build (currently "3.13.7")
+# the version of python to use
 export PYTHON_VERSION=<VERSION>
 ```
 

--- a/newsfragments/3655.feature.rst
+++ b/newsfragments/3655.feature.rst
@@ -1,0 +1,1 @@
+Add support for Python 3.13.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ PYPI_CLASSIFIERS = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Security",
 ]
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Expands our python support to v3.13.
- Our code supports python version range v3.10 - v3.13 (previously 3.10 - 3.12)
- v3.12 was the default/preferred, and now v3.13 will be the default/preferred for docker images, CI jobs, code coverage etc.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
