### PR TITLE
Follow-up on Variable Operation where strings returned from JSON queries were not handled properly by return value test

### DIFF
--- a/newsfragments/3662.bugfix.rst
+++ b/newsfragments/3662.bugfix.rst
@@ -1,0 +1,1 @@
+Ensure operations can be performed properly on string values returned from JSON queries before condition evaluation.

--- a/newsfragments/3662.feature.rst
+++ b/newsfragments/3662.feature.rst
@@ -1,0 +1,1 @@
+Increased the maximum number of conditions within a ``SequentialCondition`` from 5 to 10 to support more complex logic.

--- a/nucypher/policy/conditions/json/base.py
+++ b/nucypher/policy/conditions/json/base.py
@@ -17,10 +17,7 @@ from nucypher.policy.conditions.exceptions import (
     JsonRequestException,
 )
 from nucypher.policy.conditions.json.auth import AuthorizationType
-from nucypher.policy.conditions.json.utils import (
-    process_result_for_condition_eval,
-    query_json_data,
-)
+from nucypher.policy.conditions.json.utils import query_json_data
 from nucypher.policy.conditions.lingo import ExecutionCallCondition
 from nucypher.utilities.logging import Logger
 
@@ -136,10 +133,8 @@ class BaseJsonRequestCondition(ExecutionCallCondition, ABC):
         Verifies the JSON condition.
         """
         result = self.execution_call.execute(**context)
-        result_for_eval = process_result_for_condition_eval(result)
-
         resolved_return_value_test = self.return_value_test.with_resolved_context(
             **context
         )
-        eval_result = resolved_return_value_test.eval(result_for_eval)  # test
+        eval_result = resolved_return_value_test.eval(result)  # test
         return eval_result, result

--- a/nucypher/policy/conditions/json/json.py
+++ b/nucypher/policy/conditions/json/json.py
@@ -10,10 +10,7 @@ from nucypher.policy.conditions.context import (
 )
 from nucypher.policy.conditions.exceptions import InvalidCondition
 from nucypher.policy.conditions.json.base import JSONPathField
-from nucypher.policy.conditions.json.utils import (
-    process_result_for_condition_eval,
-    query_json_data,
-)
+from nucypher.policy.conditions.json.utils import query_json_data
 from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
 
 
@@ -80,13 +77,10 @@ class JsonCondition(Condition):
         # Apply JSONPath query
         result = query_json_data(resolved_data, self.query, **context)
 
-        # Process result for evaluation (handles string quoting)
-        result_for_eval = process_result_for_condition_eval(result)
-
         # Evaluate against return value test
         resolved_return_value_test = self.return_value_test.with_resolved_context(
             **context
         )
-        eval_result = resolved_return_value_test.eval(result_for_eval)
+        eval_result = resolved_return_value_test.eval(result)
 
         return eval_result, result

--- a/nucypher/policy/conditions/json/utils.py
+++ b/nucypher/policy/conditions/json/utils.py
@@ -1,22 +1,6 @@
 from typing import Any, Optional
 
 
-def process_result_for_condition_eval(result: Any):
-    # strings that are not already quoted will cause a problem for literal_eval
-    if not isinstance(result, str):
-        return result
-
-    # check if already quoted; if not, quote it
-    if not (
-        (result.startswith("'") and result.endswith("'"))
-        or (result.startswith('"') and result.endswith('"'))
-    ):
-        quote_type_to_use = '"' if "'" in result else "'"
-        result = f"{quote_type_to_use}{result}{quote_type_to_use}"
-
-    return result
-
-
 def query_json_data(data: Any, query: Optional[str], **context) -> Any:
     """
     Shared utility to query JSON data with a JSONPath expression.

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -480,6 +480,8 @@ class ConditionVariable(_Serializable):
 
 
 class SequentialCondition(MultiCondition):
+    MAX_NUM_CONDITIONS = 10
+
     """
     A series of conditions that are evaluated in a specific order, where the result of one
     condition can be used in subsequent conditions.

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -916,7 +916,7 @@ class ReturnValueTest(_Serializable):
         # leave as is
         return data
 
-    def _process_data(self, data: Any, call_level: int = 0) -> Any:
+    def _process_data(self, data: Any, top_level_call: bool = True) -> Any:
         """
         Process data for use with literal eval. Recursively processes data as needed.
         Steps:
@@ -929,24 +929,21 @@ class ReturnValueTest(_Serializable):
         if isinstance(data, (list, tuple)):
             # convert any bytes in list to hex (include nested lists/tuples); no additional indexing
             processed_data = [
-                self._process_data(data=item, call_level=call_level + 1)
-                for item in data
+                self._process_data(data=item, top_level_call=False) for item in data
             ]
             return processed_data
-
-        # convert bytes to hex if necessary
-        if isinstance(data, bytes):
+        elif isinstance(data, bytes):
+            # convert bytes to hex if necessary
             processed_data = self.__process_bytes(data)
             return processed_data
-
-        if isinstance(data, str):
+        elif isinstance(data, str):
             # only process strings at the top level call (i.e. don't need to process strings within lists/tuples)
-            if call_level > 0:
+            if not top_level_call:
                 return data
 
             return self.__process_string(data)
-
-        return data
+        else:
+            return data
 
     def eval(self, data) -> bool:
         if is_context_variable(self.value):

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -4,12 +4,13 @@ import json
 import math
 import operator as pyoperator
 import statistics
-from decimal import localcontext
+from decimal import Decimal, InvalidOperation, localcontext
 from enum import Enum
 from hashlib import md5
 from inspect import signature
 from typing import Any, List, Optional, Tuple, Type, Union
 
+from eth_utils import is_hexstr
 from hexbytes import HexBytes
 from marshmallow import (
     Schema,
@@ -874,22 +875,76 @@ class ReturnValueTest(_Serializable):
             raise cls.InvalidExpression(f'"{value}" is not a permitted value.')
 
     @staticmethod
-    def __handle_potential_bytes(data: Any) -> Any:
-        return HexBytes(data).hex() if isinstance(data, bytes) else data
+    def __process_bytes(data: bytes) -> str:
+        return HexBytes(data).hex()  # convert bytes to hex string
 
-    def _process_data(self, data: Any) -> Any:
-        """
-        Convert bytes to hex as needed, including within nested lists/tuples.
-        """
-        processed_data = data
+    @staticmethod
+    def __string_already_primitive_type(data: str) -> bool:
+        # check if boolean string
+        if data in ["True", "False"]:
+            return True
 
-        if isinstance(processed_data, (list, tuple)):
+        # check if int or float as string
+        try:
+            _ = Decimal(data)
+            return True
+        except InvalidOperation:
+            pass
+
+        return False
+
+    @staticmethod
+    def __process_string(data: str) -> str:
+        # if 0x prefixed hex string, leave as is
+        if data.startswith("0x") and is_hexstr(data):
+            return data
+
+        # check if string is already primitive type, leave as is
+        if ReturnValueTest.__string_already_primitive_type(data):
+            return data
+
+        # check if already quoted; if not, quote it
+        if not (
+            (data.startswith("'") and data.endswith("'"))
+            or (data.startswith('"') and data.endswith('"'))
+        ):
+            quote_type_to_use = '"' if "'" in data else "'"
+            return f"{quote_type_to_use}{data}{quote_type_to_use}"
+
+        # leave as is
+        return data
+
+    def _process_data(self, data: Any, call_level: int = 0) -> Any:
+        """
+        Process data for use with literal eval. Recursively processes data as needed.
+        Steps:
+        1. Convert bytes to hex as needed, including within nested lists/tuples.
+        2. Hex strings remain as is
+        3. Strings that are already primitive types (int, float, bool) remain as is
+        4. Convert non-hex strings to quoted strings at top level only i.e. individual string values
+        (literal eval can only compare quoted strings); strings within data structures are fine
+        """
+        if isinstance(data, (list, tuple)):
             # convert any bytes in list to hex (include nested lists/tuples); no additional indexing
-            processed_data = [self._process_data(data=item) for item in processed_data]
+            processed_data = [
+                self._process_data(data=item, call_level=call_level + 1)
+                for item in data
+            ]
             return processed_data
 
         # convert bytes to hex if necessary
-        return self.__handle_potential_bytes(processed_data)
+        if isinstance(data, bytes):
+            processed_data = self.__process_bytes(data)
+            return processed_data
+
+        if isinstance(data, str):
+            # only process strings at the top level call (i.e. don't need to process strings within lists/tuples)
+            if call_level > 0:
+                return data
+
+            return self.__process_string(data)
+
+        return data
 
     def eval(self, data) -> bool:
         if is_context_variable(self.value):

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -900,21 +900,19 @@ class ReturnValueTest(_Serializable):
         # if 0x prefixed hex string, leave as is
         if data.startswith("0x") and is_hexstr(data):
             return data
-
         # check if string is already primitive type, leave as is
-        if ReturnValueTest.__string_already_primitive_type(data):
+        elif ReturnValueTest.__string_already_primitive_type(data):
             return data
-
         # check if already quoted; if not, quote it
-        if not (
+        elif len(data) <= 1 or not (
             (data.startswith("'") and data.endswith("'"))
             or (data.startswith('"') and data.endswith('"'))
         ):
             quote_type_to_use = '"' if "'" in data else "'"
             return f"{quote_type_to_use}{data}{quote_type_to_use}"
-
-        # leave as is
-        return data
+        else:
+            # leave as is
+            return data
 
     def _process_data(self, data: Any, top_level_call: bool = True) -> Any:
         """

--- a/tests/unit/conditions/test_return_value.py
+++ b/tests/unit/conditions/test_return_value.py
@@ -242,6 +242,24 @@ def test_return_value_test_string():
     assert not test.eval('"foo"')
     assert test.eval('"bar"')
 
+    test = ReturnValueTest(comparator="==", value="'foo\"bar'")
+    assert test.eval('foo"bar')
+
+    test = ReturnValueTest(comparator="==", value='"foo\'bar"')
+    assert test.eval("foo'bar")
+
+    # double quote
+    test = ReturnValueTest(comparator="==", value='"\'"')
+    assert test.eval("'")
+
+    # single quote
+    test = ReturnValueTest(comparator="==", value="'\"'")
+    assert test.eval('"')
+
+    # empty string
+    test = ReturnValueTest(comparator="==", value='""')
+    assert test.eval("")
+
     # mixing types works because the value is evaluated as an int, not a string
     test = ReturnValueTest(
         comparator="==", value="0xaDD9D957170dF6F33982001E4c22eCCdd5539118"

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from web3.exceptions import Web3Exception
 
@@ -8,15 +10,18 @@ from nucypher.policy.conditions.exceptions import (
     ConditionEvaluationFailed,
     InvalidCondition,
 )
+from nucypher.policy.conditions.json.json import JsonCondition
 from nucypher.policy.conditions.lingo import (
     MAX_VARIABLE_OPERATIONS,
     ConditionType,
     ConditionVariable,
     OrCompoundCondition,
+    ReturnValueTest,
     SequentialCondition,
     VariableOperation,
 )
-from nucypher.policy.conditions.utils import ConditionProviderManager
+from nucypher.policy.conditions.utils import ConditionProviderManager, _eth_to_wei
+from nucypher.policy.conditions.var import ContextVariableCondition
 
 
 @pytest.fixture(scope="function")
@@ -397,6 +402,108 @@ def test_sequential_condition_variable_with_failed_operation(mock_condition_vari
         )
     # only a copy of the context is modified internally
     assert len(original_context) == 0, "original context remains unchanged"
+
+
+def test_sequential_condition_discord_json_message_processing():
+    mock_discord_message_json = {
+        "app_permissions": "12345",
+        "application_id": "98765",
+        "data": {
+            "id": "1384813344221040750",
+            "name": "tip",
+            "options": [
+                {"name": "amount", "type": 3, "value": "0.0001"},
+                {
+                    "name": "recipient",
+                    "type": 3,
+                    "value": "0xA87722643685B38D37ecc7637ACA9C1E09c8C5e1",
+                },
+            ],
+            "type": 1,
+        },
+        "token": "abcdefg1234567hijklmnop890",
+        "type": 2,
+        "version": 1,
+    }
+
+    amount_json_condition = JsonCondition(
+        data=":discord_message",
+        query="$.data.options[?(@.name=='amount')].value",
+        return_value_test=ReturnValueTest(
+            operations=[
+                VariableOperation(operation="float"),
+            ],
+            comparator=">",
+            value=0,
+        ),
+    )
+    recipient_json_condition = JsonCondition(
+        data=":discord_message",
+        query="$.data.options[?(@.name=='recipient')].value",
+        return_value_test=ReturnValueTest(
+            comparator="!=",
+            value="0x0",
+        ),
+    )
+    sequential_condition = SequentialCondition(
+        condition_variables=[
+            ConditionVariable(
+                var_name="amount1",
+                condition=amount_json_condition,
+                operations=[
+                    # ethToWei can covert value from string
+                    VariableOperation(operation="ethToWei"),
+                ],
+            ),
+            # amount2 is redundant, but we check that casting to float works on string value
+            ConditionVariable(
+                var_name="amount2",
+                condition=amount_json_condition,
+                operations=[
+                    VariableOperation(operation="float"),
+                    VariableOperation(operation="ethToWei"),
+                ],
+            ),
+            ConditionVariable(
+                var_name="recipient",
+                condition=recipient_json_condition,
+            ),
+            ConditionVariable(
+                var_name="amount1Check",
+                condition=ContextVariableCondition(
+                    context_variable=":amount1",
+                    return_value_test=ReturnValueTest(
+                        comparator="==", value=_eth_to_wei(0.0001)
+                    ),
+                ),
+            ),
+            ConditionVariable(
+                var_name="amount2Check",
+                condition=ContextVariableCondition(
+                    context_variable=":amount2",
+                    return_value_test=ReturnValueTest(
+                        comparator="==", value=":amount1"
+                    ),
+                ),
+            ),
+            ConditionVariable(
+                var_name="recipientCheck",
+                condition=ContextVariableCondition(
+                    context_variable=":recipient",
+                    return_value_test=ReturnValueTest(
+                        comparator="==",
+                        value="0xA87722643685B38D37ecc7637ACA9C1E09c8C5e1",
+                    ),
+                ),
+            ),
+        ]
+    )
+
+    context = {":discord_message": json.dumps(mock_discord_message_json)}
+    result, value = sequential_condition.verify(
+        providers=ConditionProviderManager({}), **context
+    )
+    assert result is True
 
 
 @pytest.mark.usefixtures("mock_skip_schema_validation")

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -68,8 +68,10 @@ def test_invalid_sequential_condition(rpc_condition, time_condition):
         )
 
     # too many variables
-    too_many_variables = [var_1, var_2, var_1, var_2]
-    too_many_variables.extend(too_many_variables)  # duplicate list length
+    too_many_variables = [
+        *(var_1,) * SequentialCondition.MAX_NUM_CONDITIONS,
+        var_2,
+    ]  # one too many
     assert len(too_many_variables) > SequentialCondition.MAX_NUM_CONDITIONS
     with pytest.raises(InvalidCondition, match="Maximum of"):
         _ = SequentialCondition(

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -451,7 +451,7 @@ def test_sequential_condition_discord_json_message_processing():
                 var_name="amount1",
                 condition=amount_json_condition,
                 operations=[
-                    # ethToWei can covert value from string
+                    # ethToWei can convert value from string
                     VariableOperation(operation="ethToWei"),
                 ],
             ),


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Increases max number of conditions within a SequentialCondition from 5 to 10 to allow for more complex logic.
- Handle strings within return value test instead of in JSON conditions, so that operations can be performed on the raw strings before needing to process them for use with `ast.literal_eval`
- Add test that utilizes parsing of values from Discord message payload to reproduce original bug/issue observed.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
