### PR TITLE
Registry provided to Operator in constructor should be used; don't instantiate a new one.

### DIFF
--- a/newsfragments/3663.bugfix.rst
+++ b/newsfragments/3663.bugfix.rst
@@ -1,0 +1,1 @@
+``Operator`` should use provided registry and not construct a new one.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -209,6 +209,7 @@ class Operator(BaseActor):
         self,
         eth_endpoint: str,
         polygon_endpoint: str,
+        registry: ContractRegistry,
         pre_payment_method: ContractPayment,
         transacting_power: TransactingPower,
         signer: Signer = None,
@@ -245,7 +246,9 @@ class Operator(BaseActor):
         self.pre_payment_method = pre_payment_method
         self._operator_bonded_tracker = OperatorBondedTracker(ursula=self)
 
-        super().__init__(transacting_power=transacting_power, *args, **kwargs)
+        super().__init__(
+            transacting_power=transacting_power, registry=registry, *args, **kwargs
+        )
         self.log = Logger("operator")
 
         self.__staking_provider_address = None  # set by block_until_ready
@@ -256,7 +259,6 @@ class Operator(BaseActor):
             registry=self.registry,
         )
 
-        registry = ContractRegistry.from_latest_publication(domain=self.domain)
         self.child_application_agent = ContractAgency.get_agent(
             TACoChildApplicationAgent,
             registry=registry,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -341,7 +341,7 @@ def mock_testerchain() -> MockBlockchain:
 
 
 @pytest.fixture()
-def light_ursula(temp_dir_path, random_account, mocker):
+def light_ursula(temp_dir_path, random_account, mocker, test_registry):
     mocker.patch.object(KeystoreSigner, "_get_signer", return_value=random_account)
     pre_payment_method = SubscriptionManagerPayment(
         blockchain_endpoint=MOCK_ETH_PROVIDER_URI, domain=TEMPORARY_DOMAIN_NAME
@@ -362,6 +362,7 @@ def light_ursula(temp_dir_path, random_account, mocker):
         polygon_endpoint=MOCK_ETH_PROVIDER_URI,
         signer=KeystoreSigner(path=temp_dir_path),
         condition_blockchain_endpoints={TESTERCHAIN_CHAIN_ID: [MOCK_ETH_PROVIDER_URI]},
+        registry=test_registry,
     )
     return ursula
 


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
- Don't instantiate a new registry for Operator since one is already passed in from `Ursula`.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
