### PR TITLE
feat(conditions): add :nullAddress protected context variable

### DIFF
--- a/newsfragments/3668.feature.rst
+++ b/newsfragments/3668.feature.rst
@@ -1,0 +1,1 @@
+Add ``:nullAddress`` protected context variable for conditions that resolves to the Ethereum null address without requiring context data.

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 from eth_typing import ChecksumAddress
 from eth_utils import to_checksum_address
 
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.policy.conditions.auth.evm import EvmAuth
 from nucypher.policy.conditions.exceptions import (
     ContextVariableVerificationFailed,
@@ -103,9 +104,10 @@ def _resolve_null_address(
     Returns the null address (0x0000000000000000000000000000000000000000).
 
     This is a protected context variable that doesn't require any input data.
-    """
-    from nucypher.blockchain.eth.constants import NULL_ADDRESS
 
+    Note: The `providers` and `**context` parameters are unused but maintained
+    for interface consistency with other resolver functions in `_DIRECTIVES`.
+    """
     return to_checksum_address(NULL_ADDRESS)
 
 

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -18,6 +18,7 @@ from nucypher.policy.conditions.utils import (
 
 USER_ADDRESS_CONTEXT = ":userAddress"
 USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT = ":userAddressExternalEIP4361"
+NULL_ADDRESS_CONTEXT = ":nullAddress"
 
 CONTEXT_PREFIX = ":"
 CONTEXT_REGEX = re.compile(":[a-zA-Z_][a-zA-Z0-9_]*")
@@ -94,6 +95,20 @@ def _resolve_user_address(
     return expected_address
 
 
+def _resolve_null_address(
+    providers: Optional[ConditionProviderManager] = None,
+    **context,
+) -> ChecksumAddress:
+    """
+    Returns the null address (0x0000000000000000000000000000000000000000).
+
+    This is a protected context variable that doesn't require any input data.
+    """
+    from nucypher.blockchain.eth.constants import NULL_ADDRESS
+
+    return to_checksum_address(NULL_ADDRESS)
+
+
 _DIRECTIVES = {
     USER_ADDRESS_CONTEXT: partial(
         _resolve_user_address, user_address_context_variable=USER_ADDRESS_CONTEXT
@@ -102,6 +117,7 @@ _DIRECTIVES = {
         _resolve_user_address,
         user_address_context_variable=USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
     ),
+    NULL_ADDRESS_CONTEXT: _resolve_null_address,
 }
 
 

--- a/nucypher/policy/conditions/context.py
+++ b/nucypher/policy/conditions/context.py
@@ -108,7 +108,7 @@ def _resolve_null_address(
     Note: The `providers` and `**context` parameters are unused but maintained
     for interface consistency with other resolver functions in `_DIRECTIVES`.
     """
-    return to_checksum_address(NULL_ADDRESS)
+    return ChecksumAddress(NULL_ADDRESS)
 
 
 _DIRECTIVES = {

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -2,7 +2,9 @@ import copy
 import itertools
 
 import pytest
+from eth_utils import to_checksum_address
 
+from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.policy.conditions.context import (
     NULL_ADDRESS_CONTEXT,
     USER_ADDRESS_CONTEXT,
@@ -12,6 +14,7 @@ from nucypher.policy.conditions.context import (
     is_context_variable,
     resolve_any_context_variables,
 )
+from nucypher.policy.conditions.evm import ContractCondition
 from nucypher.policy.conditions.exceptions import (
     ContextVariableVerificationFailed,
     InvalidConditionContext,
@@ -20,7 +23,7 @@ from nucypher.policy.conditions.exceptions import (
 from nucypher.policy.conditions.lingo import (
     ReturnValueTest,
 )
-from tests.constants import INT256_MIN, UINT256_MAX
+from tests.constants import INT256_MIN, TESTERCHAIN_CHAIN_ID, UINT256_MAX
 
 INVALID_CONTEXT_PARAM_NAMES = [
     ":",
@@ -318,12 +321,6 @@ def test_user_address_context_variable_verification(
 
 def test_null_address_context_variable():
     """Test that :nullAddress resolves to the null address without requiring context data."""
-    from eth_utils import to_checksum_address
-
-    from nucypher.blockchain.eth.constants import NULL_ADDRESS
-    from nucypher.policy.conditions.evm import ContractCondition
-    from tests.constants import TESTERCHAIN_CHAIN_ID
-
     expected_null_address = to_checksum_address(NULL_ADDRESS)
 
     # Should work with empty context

--- a/tests/unit/conditions/test_context.py
+++ b/tests/unit/conditions/test_context.py
@@ -4,6 +4,7 @@ import itertools
 import pytest
 
 from nucypher.policy.conditions.context import (
+    NULL_ADDRESS_CONTEXT,
     USER_ADDRESS_CONTEXT,
     USER_ADDRESS_EIP4361_EXTERNAL_CONTEXT,
     _resolve_user_address,
@@ -313,3 +314,45 @@ def test_user_address_context_variable_verification(
     ] = "0xdeadbeef"  # invalid signature
     with pytest.raises(InvalidConditionContext):
         get_context_value(context_variable_name, **invalid_signature_context)
+
+
+def test_null_address_context_variable():
+    """Test that :nullAddress resolves to the null address without requiring context data."""
+    from eth_utils import to_checksum_address
+
+    from nucypher.blockchain.eth.constants import NULL_ADDRESS
+    from nucypher.policy.conditions.evm import ContractCondition
+    from tests.constants import TESTERCHAIN_CHAIN_ID
+
+    expected_null_address = to_checksum_address(NULL_ADDRESS)
+
+    # Should work with empty context
+    resolved_address = get_context_value(NULL_ADDRESS_CONTEXT)
+    assert resolved_address == expected_null_address
+
+    # Should work in lists with other context variables
+    resolved = resolve_any_context_variables(
+        [NULL_ADDRESS_CONTEXT, ":foo"], **{":foo": 123}
+    )
+    assert resolved == [expected_null_address, 123]
+
+    # Should work in ReturnValueTest
+    return_value_test = ReturnValueTest(comparator="==", value=NULL_ADDRESS_CONTEXT)
+    resolved_test = return_value_test.with_resolved_context()
+    assert resolved_test.value == expected_null_address
+
+    # Should work in a real ContractCondition
+    condition = ContractCondition(
+        contract_address="0xaDD9D957170dF6F33982001E4c22eCCdd5539118",
+        method="balanceOf",
+        standard_contract_type="ERC20",
+        chain=TESTERCHAIN_CHAIN_ID,
+        return_value_test=ReturnValueTest(">=", 0),
+        parameters=[":nullAddress"],  # Using the actual string as it would be in JSON
+    )
+    # Verify the condition stores the context variable correctly
+    assert condition.parameters == [":nullAddress"]
+
+    # Verify it resolves correctly when used
+    resolved_params = resolve_any_context_variables(condition.parameters)
+    assert resolved_params == [expected_null_address]


### PR DESCRIPTION
## Summary

Adds a new protected context variable `:nullAddress` that resolves to the Ethereum null address (0x0000000000000000000000000000000000000000) without requiring any context data.

## Motivation

This allows conditions to reference the null address directly, which is useful for:
- Checking token burns (balanceOf null address)
- Ownership validation against the zero address
- Any condition that needs to reference the standard null/zero address

## Changes

- Add `NULL_ADDRESS_CONTEXT = ":nullAddress"` constant
- Implement `_resolve_null_address()` function that returns the checksummed null address
- Register `:nullAddress` in `_DIRECTIVES` dictionary as a protected variable
- Add comprehensive unit test including usage in `ContractCondition`

## Usage Example

```python
condition = ContractCondition(
    contract_address="0x...",
    method="balanceOf",
    standard_contract_type="ERC20",
    chain=TESTERCHAIN_CHAIN_ID,
    return_value_test=ReturnValueTest(">=", 0),
    parameters=[":nullAddress"],  # Resolves to 0x0000...0000
)
```

## Testing

- All existing context tests pass (28 tests)
- New test verifies `:nullAddress` works correctly in all contexts:
  - Direct resolution
  - In lists with other context variables
  - In ReturnValueTest
  - In ContractCondition parameters