### PR TITLE
Skip `ReturnValueTest.value` type check during schema validation when operations are defined

### DIFF
--- a/nucypher/policy/conditions/evm.py
+++ b/nucypher/policy/conditions/evm.py
@@ -154,6 +154,10 @@ class RPCCondition(ExecutionCallCondition):
             method = data.get("method")
             return_value_test = data.get("return_value_test")
 
+            if return_value_test.operations:
+                # skip validation since operations modify the value to check
+                return
+
             expected_return_type = RPCCall.ALLOWED_METHODS[method]
             comparator_value = return_value_test.value
             if is_context_variable(comparator_value):
@@ -362,6 +366,10 @@ class ContractCondition(RPCCondition):
 
             # validate return type based on contract function
             return_value_test = data.get("return_value_test")
+            if return_value_test.operations:
+                # skip validation since operations modify the value to check
+                return
+
             try:
                 validate_contract_function_expected_return_type(
                     contract_function=contract_function,

--- a/nucypher/policy/conditions/time.py
+++ b/nucypher/policy/conditions/time.py
@@ -65,6 +65,10 @@ class TimeCondition(RPCCondition):
         @validates_schema
         def validate_expected_return_type(self, data, **kwargs):
             return_value_test = data.get("return_value_test")
+            if return_value_test.operations:
+                # skip validation since operations modify the value to check
+                return
+
             comparator_value = return_value_test.value
             if not isinstance(comparator_value, int):
                 raise ValidationError(

--- a/tests/unit/conditions/test_contract_condition.py
+++ b/tests/unit/conditions/test_contract_condition.py
@@ -685,8 +685,17 @@ def test_abi_bytes_output(bytes_test_scenario, contract_condition_dict):
     with pytest.raises(
         InvalidConditionLingo, match="Invalid return value comparison type"
     ):
-        contract_condition_dict["returnValueTest"]["value"] = 1.25
-        ContractCondition.from_json(json.dumps(contract_condition_dict))
+        invalid_contract_condition_dict = dict(contract_condition_dict)
+        invalid_contract_condition_dict["returnValueTest"]["value"] = 1.25
+        ContractCondition.from_json(json.dumps(invalid_contract_condition_dict))
+
+    # type does not fail if operations are present
+    contract_condition_dict_w_ops = invalid_contract_condition_dict.copy()
+    contract_condition_dict_w_ops["returnValueTest"]["operations"] = [
+        {"operation": "toHex"}
+    ]
+    # no exception should be raised here
+    ContractCondition.from_json(json.dumps(contract_condition_dict_w_ops))
 
     # test execution logic
     _check_execution_logic(

--- a/tests/unit/conditions/test_rpc_condition.py
+++ b/tests/unit/conditions/test_rpc_condition.py
@@ -5,7 +5,11 @@ from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
     InvalidConditionLingo,
 )
-from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
+from nucypher.policy.conditions.lingo import (
+    ConditionType,
+    ReturnValueTest,
+    VariableOperation,
+)
 from tests.constants import TESTERCHAIN_CHAIN_ID
 
 
@@ -120,3 +124,15 @@ def test_rpc_condition_invalid_comparator_value_type(invalid_value, rpc_conditio
                 value=invalid_value,
             ),
         )
+
+    # value type not checked if operations are present
+    _ = RPCCondition(
+        chain=rpc_condition.chain,
+        method=rpc_condition.method,
+        parameters=rpc_condition.parameters,
+        return_value_test=ReturnValueTest(
+            comparator=rpc_condition.return_value_test.comparator,
+            value=invalid_value,
+            operations=[VariableOperation("keccak")],
+        ),
+    )

--- a/tests/unit/conditions/test_time_condition.py
+++ b/tests/unit/conditions/test_time_condition.py
@@ -4,7 +4,11 @@ from nucypher.policy.conditions.exceptions import (
     InvalidCondition,
     InvalidConditionLingo,
 )
-from nucypher.policy.conditions.lingo import ConditionType, ReturnValueTest
+from nucypher.policy.conditions.lingo import (
+    ConditionType,
+    ReturnValueTest,
+    VariableOperation,
+)
 from nucypher.policy.conditions.time import TimeCondition, TimeRPCCall
 from tests.constants import TESTERCHAIN_CHAIN_ID
 
@@ -75,3 +79,13 @@ def test_time_condition_invalid_comparator_value_type(invalid_value, time_condit
                 value=invalid_value,
             ),
         )
+
+    # value type not checked if operations are present
+    _ = TimeCondition(
+        chain=time_condition.chain,
+        return_value_test=ReturnValueTest(
+            comparator=time_condition.return_value_test.comparator,
+            value=invalid_value,
+            operations=[VariableOperation("toJson")],
+        ),
+    )


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
`RPCCondition`, `ContractCondition`, and `TimeCondition` validate the type of ReturnValueTest.value against the expected return type of the condition, which is known at condition creation time because they are specific i.e. balance number (RPCCondition), contract ABI output (ContractCondition), block epoch time (TimeCondition) . However, with the introduction of operations on `ReturnValueTest` (#3658), the actual value produced at execution time for checking may differ from that original type.

Therefore, when a `ReturnValueTest` includes operations, the type check should be skipped during schema validation.

Without this update, some condition/operations combinations would incorrect fail validation when operations are used.

See "Notes for Reviewers" section.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**

**_from CoPilot_**:
_Necessary because operations introduced in PR https://github.com/nucypher/nucypher/pull/3658 can transform the return value type at runtime, making the static type validation at condition creation time inaccurate._

**Notes for reviewers:**

- Operations haven't been publicly released as yet, so while this is an internal "bugafix", it's not a publicly facing bug fix. Consequently, I'm adding a dev newsfragment instead of a bugfix newsfragment.

- When operations are defined, we skip this validation. Is there a way for us to be stricter? eg. check the return type of the last operation and then use that for type checking? The issue with doing that is some operators don't specify a return type because they can apply to multiple types. For example some operators in python don't provide a typehint because they can by overridden based on type, so something like `pyoperator.add` does `a+b` but `a` and `b` can be strings, ints, floats etc., so knowing the return type is difficult and condition creation time.
