### PR TITLE
Fix Status Endpoint Trailing Slash

### DIFF
--- a/nucypher/network/server.py
+++ b/nucypher/network/server.py
@@ -305,7 +305,7 @@ def _make_rest_app(this_node, log: Logger) -> Flask:
             )
         return Response(response=ipv4, status=HTTPStatus.OK)
 
-    @rest_app.route("/status", methods=["GET"])
+    @rest_app.route("/status/", methods=["GET"])
     def status():
         return_json = request.args.get('json') == 'true'
         omit_known_nodes = request.args.get('omit_known_nodes') == 'true'

--- a/tests/integration/network/test_ursula_web_status.py
+++ b/tests/integration/network/test_ursula_web_status.py
@@ -16,18 +16,33 @@ def client(ursula):
 def test_ursula_html_renders(ursula, client):
     response = client.get('/')
     assert response.status_code == 404
-    response = client.get("/status")
+
+    response = client.get("/status/")
     assert response.status_code == 200
     assert b"<!DOCTYPE html>" in response.data
     assert ursula.checksum_address.encode() in response.data
     assert str(ursula.nickname).encode() in response.data
 
+    # no trailing slash
+    response = client.get("/status")
+    assert response.status_code == 308
+    redirect_url = response.headers["Location"]
+    assert redirect_url.endswith("/status/")
+
 
 @pytest.mark.parametrize('omit_known_nodes', [False, True])
 def test_json_status_endpoint(ursula, client, omit_known_nodes):
     omit_known_nodes_str = "true" if omit_known_nodes else "false"
-    response = client.get(f"/status?json=true&omit_known_nodes={omit_known_nodes_str}")
+
+    url_parameters = f"?json=true&omit_known_nodes={omit_known_nodes_str}"
+    response = client.get(f"/status/{url_parameters}")
     assert response.status_code == 200
     json_status = response.get_json()
     status = ursula.status_info(omit_known_nodes=omit_known_nodes)
     assert json_status == status.to_json()
+
+    # no trailing slash
+    response = client.get(f"/status{url_parameters}")
+    assert response.status_code == 308
+    redirect_url = response.headers["Location"]
+    assert redirect_url.endswith(f"/status/{url_parameters}")

--- a/tests/integration/utilities/test_integration_concurrency.py
+++ b/tests/integration/utilities/test_integration_concurrency.py
@@ -112,6 +112,7 @@ def test_wait_for_successes(join_worker_pool):
 
     # We have more threads in the pool than the workers,
     # so all the successful ones should be able to finish right away.
+    # worst-case time is the longest successful worker, which is 1.5s.
     assert t_end - t_start < 2
 
     # Should be able to do it several times
@@ -145,8 +146,12 @@ def test_wait_for_successes_out_of_values(join_worker_pool):
         pool.block_until_target_successes()
     t_end = time.monotonic()
 
-    # We have roughly 2 workers per thread, so it shouldn't take longer than 1.5s (max timeout) * 2
-    assert t_end - t_start < 4
+    # There are 29 (20 + 9) tasks total that are all enqueued at once at the start.
+    # In the worst case we must wait for all to complete.
+    # With 15 worker threads, tasks run in (at most) two full rounds.
+    # Each task takes up to 1.5s (timeout_max), so worst-case time is:
+    #   2 rounds * 1.5s per task ~= 3s.
+    assert t_end - t_start < 3.5
 
     message = str(exc_info.value)
 
@@ -193,7 +198,9 @@ def test_wait_for_successes_timed_out(join_worker_pool):
         pool.block_until_target_successes()
     t_end = time.monotonic()
 
-    # Even though timeout is 1, there are long-running workers which we can't interupt.
+    # We have the same number of threads in the pool as workers.
+    # Even though the overall pool timeout is 1, there are long-running workers which we can't interrupt.
+    # Therefore, worst-case time is the longest-running worker, which is 2.5s.
     assert t_end - t_start < 3
 
     message = str(exc_info.value)
@@ -228,8 +235,10 @@ def test_join(join_worker_pool):
 
     pool.join()  # should work the second time too
 
-    # Even though timeout is 1, there are long-running workers which we can't interupt.
-    assert t_end - t_start < 3
+    # We have more threads in the pool than workers.
+    # Even though the overall pool timeout is 1, there are long-running workers which we can't interrupt.
+    # Therefore, worst-case time is the longest-running worker, which is 1.5s.
+    assert t_end - t_start < 2
 
 
 class BatchTrackingBatchValueFactory(BatchValueFactory):
@@ -287,8 +296,19 @@ def test_batched_value_generation(join_worker_pool):
         for i in range(len(factory.batch_sizes) - 1)
     )
 
-    # Since we canceled the pool, no more workers will be started and we will finish faster
-    assert t_end - t_start < 4
+    # There are 80+80=160 tasks total which are enqueued in batches of size 10 at a time but the batch size
+    # can decrease as successes are collected.
+    # There are 10 worker threads
+    # So worst-case would be 8 rounds of 10 failures (80 failures), and then 1 round of 10 successes = 9 rounds
+    # 9 rounds * 1.5s/round = 13.5s > 10s timeout
+    # However, due to the seed used for shuffling of outcomes, we know that the worst case does not
+    # happen here and enough successes are achieved after 4 rounds.
+    rounds_taken = len(factory.batch_sizes)
+    assert rounds_taken == 4  # based on the seed used in generate_workers()
+
+    assert (
+        t_end - t_start < rounds_taken * 1.5 + 0.5
+    )  # 1.5s per round in worst-case + a little extra buffer
 
     successes_copy = pool.get_successes()
     pool.get_failures()
@@ -323,10 +343,12 @@ def test_cancel_waiting_workers(join_worker_pool):
     pool.join()
     t_end = time.monotonic()
 
-    # We have 10 threads in the pool and 100 workers that are all enqueued at once at the start.
-    # If we didn't check for the cancel condition, we would have to wait for 10 seconds.
-    # We get 10 successes after 1s and cancel the workers,
-    # but the next workers in each thread have already started, so we have to wait for another 1s.
+    # We have 10 threads in the pool and 100 tasks that are all enqueued at once at the start.
+    # If we didn't check for the cancel condition, we would have to wait for all tasks to complete instead of just successes.
+    # We get ~10 executions after 1s and cancel the workers,
+    # but due to slight differences in time, the next workers in each thread may have already started,
+    # so we have to wait for another execution round timeout of 1s.
+    #   Therefore, we expect the worst-case time to be ~2s.
     assert t_end - t_start < 2.5
 
 


### PR DESCRIPTION
…s an explicit rule to not match a trailing slash so /status/ returns a Not Found. Including the trailing slash matches both /status and /status/.

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**

- This commit removed the trailing slash - https://github.com/nucypher/nucypher/commit/bd6ffad08be3701e24d6ddaed125eaf27de96d04#diff-8df83dacf71b2ff2ca3636cd470cba70eb6b141e3c8843fadfab72514aafa3f6L10-L300
- This commit updated the tests - https://github.com/nucypher/nucypher/commit/ebc1d5619ac9003a9e253647bb145496ba73e5ad

Add trailing slash to status server endpoint to ensure both `/status` and `/status/` resolve correctly. Without it, `/status/` fails to match the explicit rule and returns 404.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
