### PR TITLE
Add post signature random stagger

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -184,6 +184,7 @@ class Operator(BaseActor):
     READY_TIMEOUT = None  # (None or 0) == indefinite
     READY_POLL_RATE = 120  # seconds
     AGGREGATION_SUBMISSION_MAX_DELAY = 60
+    POST_SIGNATURE_MAX_DELAY = 60
     LOG = Logger("operator")
 
     class OperatorError(BaseActor.ActorError):
@@ -1291,6 +1292,9 @@ class Operator(BaseActor):
             )
             return async_tx
 
+        # post the signature after network-wide jitter to avoid tx
+        # congestion and gas mis-estimation issues
+        time.sleep(random.randint(0, self.POST_SIGNATURE_MAX_DELAY))
         return self._post_signature(cohort_id)
 
     def _post_signature(self, cohort_id: int) -> AsyncTx:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -830,6 +830,14 @@ def mock_operator_aggregation_delay(module_mocker):
     )
 
 
+@pytest.fixture(scope="module", autouse=True)
+def mock_post_signature_delay(module_mocker):
+    module_mocker.patch(
+        "nucypher.blockchain.eth.actors.Operator.POST_SIGNATURE_MAX_DELAY",
+        PropertyMock(return_value=1),
+    )
+
+
 @pytest.fixture
 def mock_async_hooks(mocker):
     hooks = BlockchainInterface.AsyncTxHooks(


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Add random stagger to nodes when submitting signature to handle race condition of not knowing whether they will be the last one to submit. The tx for the last node to submit their signature requires more gas due to additional processing done on the contract eg. deployment of multisig contract, crossing bridge etc.

Analogous to what was done for posting aggregation during DKG rituals - https://github.com/nucypher/nucypher/pull/3390.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
