### PR TITLE
The Increase of `SequentialCondition.MAX_NUM_CONDITIONS` from 5 to 10 was not being allowed when encased in a `CompoundCondition`

### DIFF
--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -130,7 +130,7 @@ class MultiCondition(Condition):
                     field_name=field_name,
                     message=f"Only {cls.MAX_MULTI_CONDITION_NESTED_LEVEL} nested levels of multi-conditions are allowed",
                 )
-            cls._validate_multi_condition_nesting(
+            condition._validate_multi_condition_nesting(
                 conditions=condition.conditions,
                 field_name=field_name,
                 current_level=level,

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -193,7 +193,7 @@ class CompoundCondition(MultiCondition):
         elif num_operands > cls.MAX_NUM_CONDITIONS:
             raise ValidationError(
                 field_name="operands",
-                message="Maximum of {cls.MAX_NUM_CONDITIONS} operands allowed for '{operator}' compound condition",
+                message=f"Maximum of {cls.MAX_NUM_CONDITIONS} operands allowed for '{operator}' compound condition",
             )
 
     class Schema(Condition.Schema):

--- a/tests/unit/conditions/test_compound_condition.py
+++ b/tests/unit/conditions/test_compound_condition.py
@@ -122,17 +122,26 @@ def test_invalid_compound_condition(time_condition, rpc_condition):
     operands = list()
     for i in range(CompoundCondition.MAX_NUM_CONDITIONS + 1):
         operands.append(rpc_condition)
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(
+        InvalidCondition,
+        match=f"Maximum of {CompoundCondition.MAX_NUM_CONDITIONS} operands",
+    ):
         _ = CompoundCondition(
             operator=CompoundCondition.OR_OPERATOR,
             operands=operands,
         )
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(
+        InvalidCondition,
+        match=f"Maximum of {CompoundCondition.MAX_NUM_CONDITIONS} operands",
+    ):
         _ = CompoundCondition(
             operator=CompoundCondition.AND_OPERATOR,
             operands=operands,
         )
-    with pytest.raises(InvalidCondition):
+    with pytest.raises(
+        InvalidCondition,
+        match=f"Maximum of {CompoundCondition.MAX_NUM_CONDITIONS} operands",
+    ):
         _ = CompoundCondition(
             operator=CompoundCondition.AT_LEAST_OPERATOR,
             operands=operands,

--- a/tests/unit/conditions/test_sequential_condition.py
+++ b/tests/unit/conditions/test_sequential_condition.py
@@ -13,6 +13,7 @@ from nucypher.policy.conditions.exceptions import (
 from nucypher.policy.conditions.json.json import JsonCondition
 from nucypher.policy.conditions.lingo import (
     MAX_VARIABLE_OPERATIONS,
+    ConditionLingo,
     ConditionType,
     ConditionVariable,
     OrCompoundCondition,
@@ -101,6 +102,24 @@ def test_invalid_sequential_condition(rpc_condition, time_condition):
                 ),
             ],
         )
+
+
+def test_sequential_condition_max_number_of_conditions(rpc_condition):
+    sequential_condition = SequentialCondition(
+        # uses MAX_NUM_CONDITIONS for SequentialCondition (10), which is more than CompoundCondition.MAX_NUM_CONDITIONS (5)
+        condition_variables=[
+            ConditionVariable(f"var{i}", rpc_condition)
+            for i in range(SequentialCondition.MAX_NUM_CONDITIONS)
+        ]
+    )
+    compound_condition = OrCompoundCondition(
+        operands=[
+            rpc_condition,
+            sequential_condition,
+        ]
+    )
+    lingo = ConditionLingo(condition=compound_condition)
+    _ = ConditionLingo.from_dict(lingo.to_dict())
 
 
 def test_nested_sequential_condition_too_many_nested_levels(


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Encountered the following error, when a `SequentialCondition` with 7 conditions was nested in a `CompoundCondition` with 2 operands (conditions).

The max number of conditions allowed for a `SequentialCondition` was increased from 5 to 10 via https://github.com/nucypher/nucypher/pull/3662, and the max for a `CompoundCondition` was left as 5. Yet due to the nesting of the `SequentialCondition` within a `CompoundCondition` and a bug in logic, the max of 5 was incorrectly being enforced for the `SequentialCondition`.
```
E           nucypher.policy.conditions.exceptions.InvalidConditionLingo: Invalid condition grammar: {'operands': ['Maximum of 5 conditions are allowed']}

nucypher/policy/conditions/base.py:91: InvalidConditionLingo
```

This is now fixed.

Also fixed a validation message that was not properly used as an f-string.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
