### PR TITLE
Timed out network requests yield empty errors

### DIFF
--- a/newsfragments/3686.bugfix.rst
+++ b/newsfragments/3686.bugfix.rst
@@ -1,0 +1,1 @@
+Unresponsive nodes in cohorts that don't respond to protocol requests within the timeout period are now included in reported failures.

--- a/nucypher/network/concurrency.py
+++ b/nucypher/network/concurrency.py
@@ -77,6 +77,13 @@ class NetworkRequestClient(ThresholdAccessControlClient):
             worker_pool.cancel()
 
         failures = worker_pool.get_failures()
+        if len(successes) < threshold:
+            # threshold not met and some ursulas did not respond at all; mark them as timeout failures
+            for ursula in ursulas_to_contact:
+                if ursula not in successes and ursula not in failures:
+                    failures[ursula] = (
+                        f"Node {ursula} did not respond before timeout ({timeout}s)."
+                    )
 
         return successes, failures
 

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -1,5 +1,6 @@
 import os
 import random
+import time
 from unittest.mock import ANY, patch
 
 import pytest
@@ -357,6 +358,49 @@ def test_authorized_decryption(
     # at least a threshold of ursulas were successful (concurrency)
     assert int(num_successes) >= ritual.threshold
     print("===================== DECRYPTION SUCCESSFUL =====================")
+    yield
+
+
+@pytest_twisted.inlineCallbacks
+def test_decryption_failure_node_timeout(
+    mocker, threshold_message_kit, ritual_id, cohort, bob, coordinator_agent, plaintext
+):
+    print(
+        "==================== DKG DECRYPTION FAILURE NODE TIMEOUT (EXPECTED) ===================="
+    )
+
+    # mock timeout for all ursulas in cohort
+    timeout = 1
+
+    def timed_out_request_signature(*args, **kwargs):
+        time.sleep(timeout + 2)  # ensures node never responds in time
+        raise ValueError("Fake exception should be after worker pool timeout")
+
+    mocker.patch(
+        "nucypher.network.middleware.RestMiddleware.get_encrypted_decryption_share",
+        side_effect=timed_out_request_signature,
+    )
+
+    # perform threshold decryption
+    bob.start_learning_loop(now=True)
+    with pytest.raises(
+        Ursula.NotEnoughUrsulas, match="Threshold of Ursulas unable to decrypt"
+    ) as exc_info:
+        _ = yield bob.threshold_decrypt(
+            threshold_message_kit=threshold_message_kit,
+            decryption_timeout=timeout,
+        )
+
+    message = str(exc_info.value)
+    for ursula in cohort:
+        assert (
+            f"Node {ursula.checksum_address} did not respond before timeout ({timeout}s)"
+            in message
+        )
+
+    print(
+        "===================== DECRYPTION FAILURE NODE TIMEOUT (EXPECTED) SUCCESSFUL  ====================="
+    )
     yield
 
 

--- a/tests/acceptance/actors/test_signing_ritual.py
+++ b/tests/acceptance/actors/test_signing_ritual.py
@@ -1,5 +1,6 @@
 import json
 import random
+import time
 
 import pytest
 import pytest_twisted
@@ -274,6 +275,73 @@ def test_signing_request_fulfilment(
         result == EIP1271Auth.MAGIC_VALUE_BYTES
     ), f"Invalid signature: {result} != {EIP1271Auth.MAGIC_VALUE_BYTES}"
     print("===================== SIGNING SUCCESSFUL =====================")
+    yield
+
+
+@pytest_twisted.inlineCallbacks
+def test_signing_request_failure_node_timeout(
+    mocker,
+    chain,
+    bob,
+    accounts,
+    cohort_id,
+    cohort,
+):
+    print(
+        "==================== SIGNING FAILURE NODE TIMEOUT (EXPECTED) ===================="
+    )
+    bob.start_learning_loop(now=True)
+
+    test_user_op = create_eth_transfer(
+        sender=accounts[0].address,
+        nonce=1,
+        to=accounts[1].address,
+        value=1000000000000000000,  # 1 ETH in wei
+        verification_gas_limit=100000,
+        call_gas_limit=100000,
+        pre_verification_gas=21000,
+        max_priority_fee_per_gas=1000000000,
+        max_fee_per_gas=2000000000,
+    )
+
+    signing_request = UserOperationSignatureRequest(
+        user_op=test_user_op,
+        aa_version=AAVersion.V08,
+        chain_id=chain.chain_id,
+        cohort_id=cohort_id,
+        context=None,
+    )
+
+    # mock timeout for all ursulas in cohort
+    timeout = 1
+
+    def timed_out_request_signature(*args, **kwargs):
+        time.sleep(timeout + 2)  # ensures node never responds in time
+        raise ValueError("Fake exception should be after worker pool timeout")
+
+    mocker.patch(
+        "nucypher.network.middleware.RestMiddleware.request_signature",
+        side_effect=timed_out_request_signature,
+    )
+
+    # perform threshold decryption
+    with pytest.raises(
+        Ursula.NotEnoughUrsulas, match="Threshold of Ursulas unable to sign"
+    ) as exc_info:
+        _ = yield bob.request_threshold_signatures(
+            signing_request=signing_request, timeout=timeout
+        )
+
+    message = str(exc_info.value)
+    for ursula in cohort:
+        assert (
+            f"Node {ursula.checksum_address} did not respond before timeout ({timeout}s)"
+            in message
+        )
+
+    print(
+        "===================== SIGNING FAILURE NODE TIMEOUT (EXPECTED) SUCCESSFUL ====================="
+    )
     yield
 
 


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**

Related to https://github.com/nucypher/nucypher-porter/issues/97

When decryption/signing requests are made to nodes via the `NetworkRequestClient` (concurrency utility), if an individual node request times out and decryption/signing fails, the `NetworkRequestClient` doesn't report the timeout as a failure for that node. It only reports errors directly returned by the node.

This leads to empty/incomplete decryption/signing failures being returned.

Eventually Porter will update its dependency on `nucypher` to incorporate this change, and then Porter will correctly include the timeout error to return to `taco-web`. This will resolve issue [97.](https://github.com/nucypher/nucypher-porter/issues/97).

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
