### PR TITLE
Fix vague error for non-existent conditions for random chain

### DIFF
--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1480,12 +1480,12 @@ class Operator(BaseActor):
         )
 
         # evaluate condition
-        condition_string = signing_cohort.conditions[signing_request.chain_id].decode()
-        if not condition_string:
+        condition_bytes = signing_cohort.conditions.get(signing_request.chain_id)
+        if not condition_bytes:
             raise self.NoConditionConfigured(
                 f"Condition not configured on chain {signing_request.chain_id} for signing cohort {signing_request.cohort_id} "
             )
-        condition_lingo = json.loads(condition_string)
+        condition_lingo = json.loads(condition_bytes.decode("utf-8"))
 
         # add signing object to context
         context = dict()

--- a/tests/acceptance/actors/test_signing_ritual.py
+++ b/tests/acceptance/actors/test_signing_ritual.py
@@ -220,6 +220,20 @@ def test_signing_request_fulfilment(
     if random.choice([True, False]):
         context = Context(json.dumps({":randomContextForTestingContext": 5}))
 
+    print("============= SIGNING REQUEST RANDOM CHAIN (NO CONDITION)==============")
+    with pytest.raises(Ursula.NotEnoughUrsulas, match="Condition not configured"):
+        signing_request = UserOperationSignatureRequest(
+            user_op=test_user_op,
+            aa_version=AAVersion.V08,
+            chain_id=12345,  # random chain id
+            cohort_id=cohort_id,
+            context=context,
+        )
+        _ = yield bob.request_threshold_signatures(
+            signing_request=signing_request,
+        )
+    print("===================== SIGNING FAILED (AS EXPECTED) =====================")
+
     signing_request = UserOperationSignatureRequest(
         user_op=test_user_op,
         aa_version=AAVersion.V08,


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Fixed bug where using a random chain id in signing request for which cohort was not deployed produced vague error message due to `KeyError` when node tries to get condition from contract.

```
SigningRequestFailed('Node 0x90F79bf6EB2c4f870365E785982E1f101E93b906 raised 12345')
```
or
```
SigningRequestFailed('Node 0x90F79bf6EB2c4f870365E785982E1f101E93b906 raised 1')
```

Instead use `get` for conditions dictionary and check bytes before decoding.

I inadvertently encountered this problem why testing a `mainnet` cohort.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
