### PR TITLE
Scan for DKG/Signing events less often

### DIFF
--- a/newsfragments/3690.feature.rst
+++ b/newsfragments/3690.feature.rst
@@ -1,0 +1,1 @@
+Reduce event scanning frequency to remain within common free tier RPC limits now that both DKG and Signing ritual events are being scanned.

--- a/nucypher/blockchain/eth/trackers/events.py
+++ b/nucypher/blockchain/eth/trackers/events.py
@@ -45,7 +45,7 @@ class EventActuator(EventScanner):
 class EventScannerTask(SimpleTask):
     """Task that runs the event scanner in a looping call."""
 
-    INTERVAL = 120  # seconds
+    INTERVAL = 180  # 3 mins in seconds
 
     def __init__(self, scanner: Callable):
         self.scanner = scanner

--- a/nucypher/blockchain/eth/trackers/events.py
+++ b/nucypher/blockchain/eth/trackers/events.py
@@ -45,7 +45,7 @@ class EventActuator(EventScanner):
 class EventScannerTask(SimpleTask):
     """Task that runs the event scanner in a looping call."""
 
-    INTERVAL = 180  # 3 mins in seconds
+    INTERVAL = 240  # 4 mins in seconds
 
     def __init__(self, scanner: Callable):
         self.scanner = scanner


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Now that we are scanning for both DKG and Signing ritual events, this could exhaust RPC free tier usage credits. The biggest consumption of credits is for event scanning, so we should do it less often.

There's a balance between not exhausting all free tier credits and ensuring nodes remain responsive to ritual events. That being said, given current usage patterns, nodes don't need to be THAT responsive - rituals tend to occur way before usage.

Let's start with cutting the calls in half by doubling the interval. We can adjust in a separate PR once we collect some data. It's been tricky always having the base this PR over updated changes and then update lynx nodes. Instead let's have this change be the base that we potentially modify later on if needed.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
