### PR TITLE
Switch `nucypher` to use contract code/registry from `nucypher-contracts` `main` instead of `signing` epic

### DIFF
--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -61,7 +61,7 @@ class RegistrySource(ABC):
 class GithubRegistrySource(RegistrySource):
 
     _PUBLICATION_REPO = "nucypher/nucypher-contracts"
-    _BRANCH = "signing"
+    _BRANCH = "main"
     _BASE_URL = f'https://raw.githubusercontent.com/{_PUBLICATION_REPO}'
 
     name = "GitHub Registry Source"

--- a/tests/acceptance/ape-config.yaml
+++ b/tests/acceptance/ape-config.yaml
@@ -6,7 +6,7 @@ plugins:
 dependencies:
   - name: nucypher-contracts
     github: nucypher/nucypher-contracts
-    ref: signing
+    ref: main
     config_override:
       solidity:
         version: 0.8.23

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -43,13 +43,6 @@ NU_TOTAL_SUPPLY = Web3.to_wei(
 # TACo Application
 MIN_AUTHORIZATION = Web3.to_wei(40_000, "ether")
 
-REWARD_DURATION = 7 * ONE_DAY  # one week in seconds
-DEAUTHORIZATION_DURATION = 60 * ONE_DAY  # 60 days in seconds
-
-PENALTY_DEFAULT = 1000  # 10% penalty
-PENALTY_INCREMENT = 2500  # 25% penalty increment
-PENALTY_DURATION = ONE_DAY  # 1 day in seconds
-
 
 # Coordinator
 DKG_TIMEOUT = 3600
@@ -160,11 +153,6 @@ def taco_application(
         threshold_staking.address,
         MIN_AUTHORIZATION,
         MIN_OPERATOR_SECONDS,
-        REWARD_DURATION,
-        DEAUTHORIZATION_DURATION,
-        PENALTY_DEFAULT,
-        PENALTY_DURATION,
-        PENALTY_INCREMENT,
     )
 
     proxy = deployer_account.deploy(


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Now that the signing epic in `nucypher-contracts` was merged, https://github.com/nucypher/nucypher-contracts/pull/383, `nucypher` can now switch to using the `main` branch again for `nucypher-contracts`. Uses are:
- GithubRegistrySource i.e. where nodes get their contract registries from
- Ape tests i.e. where the contracts used for tests are obtained from 

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
