### PR TITLE
Generalize condition not satisfied error message

### DIFF
--- a/newsfragments/3692.feature.rst
+++ b/newsfragments/3692.feature.rst
@@ -1,0 +1,1 @@
+Modify unsatisfied conditions message in exception to be generic for both signing and decryption.

--- a/nucypher/blockchain/eth/registry.py
+++ b/nucypher/blockchain/eth/registry.py
@@ -61,7 +61,7 @@ class RegistrySource(ABC):
 class GithubRegistrySource(RegistrySource):
 
     _PUBLICATION_REPO = "nucypher/nucypher-contracts"
-    _BRANCH = "signing"
+    _BRANCH = "main"
     _BASE_URL = f'https://raw.githubusercontent.com/{_PUBLICATION_REPO}'
 
     name = "GitHub Registry Source"

--- a/nucypher/characters/chaotic.py
+++ b/nucypher/characters/chaotic.py
@@ -234,7 +234,7 @@ class DoomedDecryptionClient(ThresholdDecryptionClient):
             # (to be forward-compatible with changes to Failure)
             # TODO: Dehydrate this logic in a single failure flow.
             try:
-                raise RestMiddleware.Unauthorized("Decryption conditions not satisfied")
+                raise RestMiddleware.Unauthorized("Conditions not satisfied")
             except RestMiddleware.Unauthorized:
                 failures[checksum_address] = sys.exc_info()
 

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -251,7 +251,7 @@ def evaluate_condition_lingo(
             if not result:
                 # explicit condition failure
                 error = ConditionEvalError(
-                    "Decryption conditions not satisfied", HTTPStatus.FORBIDDEN
+                    "Conditions not satisfied", HTTPStatus.FORBIDDEN
                 )
     except ReturnValueEvaluationError as e:
         error = ConditionEvalError(

--- a/tests/acceptance/actors/test_signing_ritual.py
+++ b/tests/acceptance/actors/test_signing_ritual.py
@@ -738,9 +738,7 @@ def test_signing_request_with_signing_object_attribute_condition(
         cohort_id=cohort_id,
         context=None,
     )
-    with pytest.raises(
-        Ursula.NotEnoughUrsulas, match="Decryption conditions not satisfied"
-    ):
+    with pytest.raises(Ursula.NotEnoughUrsulas, match="Conditions not satisfied"):
         _ = yield bob.request_threshold_signatures(
             signing_request=failure_user_op_erc20_signing_request,
         )

--- a/tests/acceptance/ape-config.yaml
+++ b/tests/acceptance/ape-config.yaml
@@ -6,7 +6,7 @@ plugins:
 dependencies:
   - name: nucypher-contracts
     github: nucypher/nucypher-contracts
-    ref: signing
+    ref: main
     config_override:
       solidity:
         version: 0.8.23

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -43,13 +43,6 @@ NU_TOTAL_SUPPLY = Web3.to_wei(
 # TACo Application
 MIN_AUTHORIZATION = Web3.to_wei(40_000, "ether")
 
-REWARD_DURATION = 7 * ONE_DAY  # one week in seconds
-DEAUTHORIZATION_DURATION = 60 * ONE_DAY  # 60 days in seconds
-
-PENALTY_DEFAULT = 1000  # 10% penalty
-PENALTY_INCREMENT = 2500  # 25% penalty increment
-PENALTY_DURATION = ONE_DAY  # 1 day in seconds
-
 
 # Coordinator
 DKG_TIMEOUT = 3600
@@ -160,11 +153,6 @@ def taco_application(
         threshold_staking.address,
         MIN_AUTHORIZATION,
         MIN_OPERATOR_SECONDS,
-        REWARD_DURATION,
-        DEAUTHORIZATION_DURATION,
-        PENALTY_DEFAULT,
-        PENALTY_DURATION,
-        PENALTY_INCREMENT,
     )
 
     proxy = deployer_account.deploy(


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Based over #3691 .

When signing conditions were not satisfied the error message returned "Decryption conditions not satisfied" 😅 .

Instead, generalize "condition not satisfied" error message for both signing and decryption.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
