### PR TITLE
Continual randomization of public rpc urls; perform `chain` ID endpoint validation once on start up

### DIFF
--- a/newsfragments/3694.feature.rst
+++ b/newsfragments/3694.feature.rst
@@ -1,0 +1,1 @@
+Randomize use of public RPC endpoints to smooth out request load and avoid rate limiting.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -347,12 +347,11 @@ class Operator(BaseActor):
                 f"{missing_mandatory}; configured: {configured_chains}, required: {mandatory_configured_chains}"
             )
 
-        providers = defaultdict(list)  # use list to maintain order
-
         # ensure that no endpoint uri for a specific chain is repeated
         duplicated_endpoint_check = defaultdict(set)
 
         # Operator-configured endpoints for chains
+        configured_endpoints = defaultdict(list)
         for chain_id, chain_rpc_endpoints in operator_configured_endpoints.items():
             if not chain_rpc_endpoints:
                 raise self.ActorError(
@@ -376,11 +375,12 @@ class Operator(BaseActor):
                     self.log.warn(
                         f"Operator-configured RPC condition endpoint {uri} is unhealthy"
                     )
-                providers[int(chain_id)].append(provider)
+                configured_endpoints[int(chain_id)].append(provider)
                 duplicated_endpoint_check[chain_id].add(uri)
 
         # Ingest default/fallback RPC providers for each chain
         default_endpoints = get_healthy_default_rpc_endpoints(self.domain)
+        public_endpoints = defaultdict(list)
         for chain_id, chain_rpc_endpoints in default_endpoints.items():
             # randomize list so that the same fallback RPC endpoints aren't always used by all nodes
             random.shuffle(chain_rpc_endpoints)
@@ -391,15 +391,17 @@ class Operator(BaseActor):
                     )
                     continue
                 provider = self._make_condition_provider(uri)
-                providers[chain_id].append(provider)
+                public_endpoints[chain_id].append(provider)
                 duplicated_endpoint_check[chain_id].add(uri)
 
         self.log.info(
-            f"Connected to {sum(len(v) for v in providers.values())} RPC endpoints for condition "
-            f"checking on chain IDs {providers.keys()}"
+            f"Connected to {sum(len(v) for v in [duplicated_endpoint_check.values()])} RPC endpoints for condition "
+            f"checking on chain IDs {list(duplicated_endpoint_check.keys())}"
         )
 
-        return ConditionProviderManager(providers=providers)
+        return ConditionProviderManager(
+            providers=public_endpoints, preferential_providers=configured_endpoints
+        )
 
     def _resolve_ritual(self, ritual_id: int) -> Coordinator.Ritual:
         if not self.coordinator_agent.is_ritual_active(ritual_id=ritual_id):

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -382,8 +382,6 @@ class Operator(BaseActor):
         default_endpoints = get_healthy_default_rpc_endpoints(self.domain)
         public_endpoints = defaultdict(list)
         for chain_id, chain_rpc_endpoints in default_endpoints.items():
-            # randomize list so that the same fallback RPC endpoints aren't always used by all nodes
-            random.shuffle(chain_rpc_endpoints)
             for uri in chain_rpc_endpoints:
                 if uri in duplicated_endpoint_check[chain_id]:
                     self.log.warn(

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -370,7 +370,7 @@ class Operator(BaseActor):
                     raise self.ActorError(
                         f"Operator-configured RPC condition endpoint {uri} does not belong to chain {chain_id}"
                     )
-                healthy = rpc_endpoint_health_check(endpoint=uri)
+                healthy = rpc_endpoint_health_check(chain_id=chain_id, endpoint=uri)
                 if not healthy:
                     self.log.warn(
                         f"Operator-configured RPC condition endpoint {uri} is unhealthy"

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -393,7 +393,7 @@ class Operator(BaseActor):
                 duplicated_endpoint_check[chain_id].add(uri)
 
         self.log.info(
-            f"Connected to {sum(len(v) for v in [duplicated_endpoint_check.values()])} RPC endpoints for condition "
+            f"Connected to {sum(len(v) for v in duplicated_endpoint_check.values())} RPC endpoints for condition "
             f"checking on chain IDs {list(duplicated_endpoint_check.keys())}"
         )
 

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -1,7 +1,7 @@
 import time
 from decimal import Decimal
 from functools import cache
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 from eth_typing import ChecksumAddress
@@ -109,49 +109,44 @@ def get_block_just_before(w3: Web3, how_far_back: int, sample_window_size=100):
     return expected_start_block.number - 1 if expected_start_block.number > 0 else 0
 
 
-def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> bool:
+def rpc_endpoint_health_check(
+    chain_id: int, endpoint: str, max_drift_seconds: int = 60
+) -> bool:
     """
     Checks the health of an Ethereum RPC endpoint by comparing the timestamp of the latest block
     with the system time. The maximum drift allowed is `max_drift_seconds`.
     """
+
+    # check chain ID
+    query = {
+        "jsonrpc": "2.0",
+        "method": "eth_chainId",
+        "params": [],
+        "id": 1,
+    }
+    LOGGER.debug(f"Checking chain ID of RPC endpoint {endpoint}")
+    result = _get_json_rpc_call_result(endpoint, query)
+    if result is None:
+        return False
+
+    provider_chain = int(result, 16)
+    if provider_chain != chain_id:
+        LOGGER.debug(
+            f"RPC endpoint is invalid for chain; expected chain ID {chain_id}, but detected {provider_chain}"
+        )
+        return False
+
+    # check latest block number timestamp
     query = {
         "jsonrpc": "2.0",
         "method": "eth_getBlockByNumber",
         "params": ["latest", False],
-        "id": 1,
+        "id": 2,
     }
     LOGGER.debug(f"Checking health of RPC endpoint {endpoint}")
-    try:
-        response = requests.post(
-            endpoint,
-            json=query,
-            headers={"Content-Type": "application/json"},
-            timeout=5,
-        )
-    except requests.exceptions.RequestException:
-        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: network error")
+    block_data = _get_json_rpc_call_result(endpoint, query)
+    if block_data is None:
         return False
-
-    if response.status_code != 200:
-        LOGGER.debug(
-            f"RPC endpoint {endpoint} is unhealthy: {response.status_code} | {response.text}"
-        )
-        return False
-
-    try:
-        data = response.json()
-        if "result" not in data:
-            LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no response data")
-            return False
-    except requests.exceptions.RequestException:
-        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: {response.text}")
-        return False
-
-    if data["result"] is None:
-        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no block data")
-        return False
-
-    block_data = data["result"]
     try:
         timestamp = int(block_data.get("timestamp"), 16)
     except TypeError:
@@ -168,6 +163,41 @@ def rpc_endpoint_health_check(endpoint: str, max_drift_seconds: int = 60) -> boo
 
     LOGGER.debug(f"RPC endpoint {endpoint} is healthy")
     return True  # finally!
+
+
+def _get_json_rpc_call_result(endpoint: str, query: dict) -> Optional[Any]:
+    try:
+        response = requests.post(
+            endpoint,
+            json=query,
+            headers={"Content-Type": "application/json"},
+            timeout=5,
+        )
+    except requests.exceptions.RequestException:
+        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: network error")
+        return None
+
+    if response.status_code != 200:
+        LOGGER.debug(
+            f"RPC endpoint {endpoint} is unhealthy: {response.status_code} | {response.text}"
+        )
+        return None
+
+    try:
+        data = response.json()
+        if "result" not in data:
+            LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no response data")
+            return None
+    except requests.exceptions.RequestException:
+        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: {response.text}")
+        return None
+
+    result = data.get("result")
+    if result is None:
+        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no result data")
+        return None
+
+    return result
 
 
 @cache
@@ -206,7 +236,7 @@ def get_healthy_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]
             chain_id: [
                 endpoint
                 for endpoint in endpoints[chain_id]
-                if rpc_endpoint_health_check(endpoint)
+                if rpc_endpoint_health_check(chain_id=chain_id, endpoint=endpoint)
             ]
             for chain_id in endpoints
         }

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -113,8 +113,9 @@ def rpc_endpoint_health_check(
     chain_id: int, endpoint: str, max_drift_seconds: int = 60
 ) -> bool:
     """
-    Checks the health of an Ethereum RPC endpoint by comparing the timestamp of the latest block
-    with the system time. The maximum drift allowed is `max_drift_seconds`.
+    Checks the health of an RPC endpoint by validating expected chain id and comparing the
+    timestamp of the latest block with the system time. The maximum drift
+    allowed is `max_drift_seconds`.
     """
 
     # check chain ID
@@ -130,9 +131,15 @@ def rpc_endpoint_health_check(
         return False
 
     provider_chain = int(result, 16)
-    if provider_chain != chain_id:
+    try:
+        if provider_chain != chain_id:
+            LOGGER.debug(
+                f"RPC endpoint is invalid for chain; expected chain ID {chain_id}, but detected {provider_chain}"
+            )
+            return False
+    except (TypeError, ValueError):
         LOGGER.debug(
-            f"RPC endpoint is invalid for chain; expected chain ID {chain_id}, but detected {provider_chain}"
+            f"RPC endpoint {endpoint} is unhealthy: invalid chain ID response {result}"
         )
         return False
 
@@ -149,7 +156,7 @@ def rpc_endpoint_health_check(
         return False
     try:
         timestamp = int(block_data.get("timestamp"), 16)
-    except TypeError:
+    except (TypeError, ValueError):
         LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: invalid block data")
         return False
 
@@ -188,7 +195,7 @@ def _get_json_rpc_call_result(endpoint: str, query: dict) -> Optional[Any]:
         if "result" not in data:
             LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no response data")
             return None
-    except requests.exceptions.RequestException:
+    except requests.exceptions.JSONDecodeError:
         LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: {response.text}")
         return None
 

--- a/nucypher/policy/conditions/exceptions.py
+++ b/nucypher/policy/conditions/exceptions.py
@@ -13,19 +13,6 @@ class NoConnectionToChain(RuntimeError):
         super().__init__(message)
 
 
-class InvalidConnectionToChain(RuntimeError):
-    """Raised when a node does not have a valid provider for a chain."""
-
-    def __init__(self, expected_chain: int, actual_chain: int, message: str = None):
-        self.expected_chain = expected_chain
-        self.actual_chain = actual_chain
-        message = (
-            message
-            or f"Invalid blockchain connection; expected chain ID {expected_chain}, but detected {actual_chain}"
-        )
-        super().__init__(message)
-
-
 class ReturnValueEvaluationError(Exception):
     """Issue with Return Value and Key"""
 

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -18,7 +18,6 @@ from nucypher.policy.conditions.exceptions import (
     ContextVariableVerificationFailed,
     InvalidCondition,
     InvalidConditionLingo,
-    InvalidConnectionToChain,
     InvalidContextVariableData,
     NoConnectionToChain,
     RequiredContextVariable,
@@ -148,15 +147,9 @@ class ConditionProviderManager:
 
         iterator_returned_at_least_one = False
         for provider in rpc_providers:
-            try:
-                w3 = self._configure_w3(provider=provider)
-                self._check_chain_id(chain_id, w3)
-                yield w3
-                iterator_returned_at_least_one = True
-            except InvalidConnectionToChain as e:
-                # don't expect to happen but must account
-                # for any misconfigurations of public endpoints
-                self.logger.warn(str(e))
+            w3 = self._configure_w3(provider=provider)
+            yield w3
+            iterator_returned_at_least_one = True
 
         # if we get here, it is because there were endpoints, but issue with configuring them
         if not iterator_returned_at_least_one:
@@ -173,18 +166,6 @@ class ConditionProviderManager:
         w3.middleware_onion.inject(geth_poa_middleware, layer=0, name="poa")
         return w3
 
-    @staticmethod
-    def _check_chain_id(chain_id: int, w3: Web3) -> None:
-        """
-        Validates that the actual web3 provider is *actually*
-        connected to the condition's chain ID by reading its RPC endpoint.
-        """
-        provider_chain = w3.eth.chain_id
-        if provider_chain != chain_id:
-            raise InvalidConnectionToChain(
-                expected_chain=chain_id,
-                actual_chain=provider_chain,
-            )
 
 
 class ConditionEvalError(Exception):

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -1,4 +1,5 @@
 import decimal
+import random
 import re
 from collections import OrderedDict
 from http import HTTPStatus
@@ -120,12 +121,28 @@ def _convert_any_decimals_to_floats(
 
 
 class ConditionProviderManager:
-    def __init__(self, providers: Dict[int, List[HTTPProvider]]):
+    def __init__(
+        self,
+        providers: Dict[int, List[HTTPProvider]],
+        preferential_providers: Optional[Dict[int, List[HTTPProvider]]] = None,
+    ):
         self.providers = providers
+        self.preferential_providers = preferential_providers
         self.logger = Logger(__name__)
 
     def web3_endpoints(self, chain_id: int) -> Iterator[Web3]:
-        rpc_providers = self.providers.get(chain_id, None)
+        rpc_providers = []
+
+        if self.preferential_providers:
+            preferential_list = self.preferential_providers.get(chain_id, None)
+            if preferential_list:
+                rpc_providers.extend(preferential_list)
+
+        other_providers = self.providers.get(chain_id, None)
+        if other_providers:
+            random.shuffle(other_providers)
+            rpc_providers.extend(other_providers)
+
         if not rpc_providers:
             raise NoConnectionToChain(chain=chain_id)
 

--- a/tests/acceptance/conditions/test_conditions.py
+++ b/tests/acceptance/conditions/test_conditions.py
@@ -118,24 +118,6 @@ def test_rpc_condition_evaluation_no_providers(
     GET_CONTEXT_VALUE_IMPORT_PATH,
     side_effect=_dont_validate_user_address,
 )
-def test_rpc_condition_evaluation_invalid_provider_for_chain(
-    get_context_value_mock, testerchain, accounts, rpc_condition
-):
-    context = {USER_ADDRESS_CONTEXT: {"address": accounts.unassigned_accounts[0]}}
-    new_chain = 23
-    rpc_condition.execution_call.chain = new_chain
-    condition_providers = ConditionProviderManager({new_chain: [testerchain.provider]})
-    with pytest.raises(
-        NoConnectionToChain,
-        match=f"Problematic provider endpoints for chain ID {new_chain}",
-    ):
-        _ = rpc_condition.verify(providers=condition_providers, **context)
-
-
-@mock.patch(
-    GET_CONTEXT_VALUE_IMPORT_PATH,
-    side_effect=_dont_validate_user_address,
-)
 def test_rpc_condition_evaluation(
     get_context_value_mock, accounts, rpc_condition, condition_providers
 ):
@@ -196,7 +178,6 @@ def test_rpc_condition_evaluation_multiple_providers_no_valid_fallback(
         }
     )
 
-    mocker.patch.object(condition_providers, "_check_chain_id", return_value=None)
     with pytest.raises(RPCExecutionFailed):
         _ = rpc_condition.verify(providers=condition_providers, **context)
 
@@ -220,8 +201,6 @@ def test_rpc_condition_evaluation_multiple_providers_valid_fallback(
             ]
         }
     )
-
-    mocker.patch.object(condition_providers, "_check_chain_id", return_value=None)
 
     condition_result, call_result = rpc_condition.verify(
         providers=condition_providers, **context

--- a/tests/unit/conditions/test_utils.py
+++ b/tests/unit/conditions/test_utils.py
@@ -210,33 +210,15 @@ def test_condition_provider_manager(mocker):
         )
         _ = list(manager.web3_endpoints(chain_id=1))
 
-    # invalid provider chain
-    manager = ConditionProviderManager(providers={2: [mocker.Mock(spec=BaseProvider)]})
-    w3 = mocker.Mock()
-    w3.eth.chain_id = (
-        1  # make w3 instance created from provider have incorrect chain id
-    )
-    with patch.object(manager, "_configure_w3", return_value=w3):
-        with pytest.raises(
-            NoConnectionToChain, match="Problematic provider endpoints for chain ID"
-        ):
-            _ = list(manager.web3_endpoints(chain_id=2))
-
-    # valid provider chain
-    manager = ConditionProviderManager(providers={2: [mocker.Mock(spec=BaseProvider)]})
-    with patch.object(manager, "_check_chain_id", return_value=None):
-        assert len(list(manager.web3_endpoints(chain_id=2))) == 1
-
     # multiple providers
     manager = ConditionProviderManager(
         providers={2: [mocker.Mock(spec=BaseProvider), mocker.Mock(spec=BaseProvider)]}
     )
-    with patch.object(manager, "_check_chain_id", return_value=None):
-        w3_instances = list(manager.web3_endpoints(chain_id=2))
-        assert len(w3_instances) == 2
-        for w3_instance in w3_instances:
-            assert w3_instance  # actual object returned
-            assert w3_instance.middleware_onion.get("poa")  # poa middleware injected
+    w3_instances = list(manager.web3_endpoints(chain_id=2))
+    assert len(w3_instances) == 2
+    for w3_instance in w3_instances:
+        assert w3_instance  # actual object returned
+        assert w3_instance.middleware_onion.get("poa")  # poa middleware injected
 
     # specific w3 instances
     w3_1 = mocker.Mock()
@@ -254,37 +236,35 @@ def test_condition_provider_manager(mocker):
         providers={2: other_providers, 3: chain_3_providers},
         preferential_providers={2: preferential_providers},
     )
-    with patch.object(manager, "_check_chain_id", return_value=None):
-        w3_instances = list(manager.web3_endpoints(chain_id=2))
-        assert len(w3_instances) == (len(preferential_providers) + len(other_providers))
+    w3_instances = list(manager.web3_endpoints(chain_id=2))
+    assert len(w3_instances) == (len(preferential_providers) + len(other_providers))
 
-        # preferential is first and order maintained
-        for i, w3_instance in enumerate(w3_instances[: len(preferential_providers)]):
-            assert w3_instance.provider == preferential_providers[i]
+    # preferential is first and order maintained
+    for i, w3_instance in enumerate(w3_instances[: len(preferential_providers)]):
+        assert w3_instance.provider == preferential_providers[i]
 
-        # other providers follow in random order
-        for w3_instance in w3_instances[len(preferential_providers) :]:
-            assert w3_instance.provider in other_providers
+    # other providers follow in random order
+    for w3_instance in w3_instances[len(preferential_providers) :]:
+        assert w3_instance.provider in other_providers
 
-        chain_3_w3_instances = list(manager.web3_endpoints(chain_id=3))
-        assert len(chain_3_w3_instances) == len(chain_3_providers)
-        for w3_instance in chain_3_w3_instances:
-            assert w3_instance.provider in chain_3_providers
+    chain_3_w3_instances = list(manager.web3_endpoints(chain_id=3))
+    assert len(chain_3_w3_instances) == len(chain_3_providers)
+    for w3_instance in chain_3_w3_instances:
+        assert w3_instance.provider in chain_3_providers
 
     # order randomized
     all_providers = [mocker.Mock(spec=BaseProvider) for _ in range(10)]
     manager = ConditionProviderManager(providers={2: all_providers})
-    with patch.object(manager, "_check_chain_id", return_value=None):
-        num_times_different = 0
-        for i in range(5):
-            w3_instances_first = list(manager.web3_endpoints(chain_id=2))
-            w3_instances_second = list(manager.web3_endpoints(chain_id=2))
-            if any(
-                w31.provider != w32.provider
-                for w31, w32 in zip(w3_instances_first, w3_instances_second)
-            ):
-                num_times_different += 1
-        assert num_times_different > 0  # at least one time the order differed
+    num_times_different = 0
+    for i in range(5):
+        w3_instances_first = list(manager.web3_endpoints(chain_id=2))
+        w3_instances_second = list(manager.web3_endpoints(chain_id=2))
+        if any(
+            w31.provider != w32.provider
+            for w31, w32 in zip(w3_instances_first, w3_instances_second)
+        ):
+            num_times_different += 1
+    assert num_times_different > 0  # at least one time the order differed
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/conditions/test_utils.py
+++ b/tests/unit/conditions/test_utils.py
@@ -246,6 +246,46 @@ def test_condition_provider_manager(mocker):
     with patch.object(manager, "_configure_w3", side_effect=[w3_1, w3_2]):
         assert list(manager.web3_endpoints(chain_id=2)) == [w3_1, w3_2]
 
+    # preferential provider
+    preferential_providers = [mocker.Mock(spec=BaseProvider) for _ in range(3)]
+    other_providers = [mocker.Mock(spec=BaseProvider) for _ in range(2)]
+    chain_3_providers = [mocker.Mock(spec=BaseProvider) for _ in range(2)]
+    manager = ConditionProviderManager(
+        providers={2: other_providers, 3: chain_3_providers},
+        preferential_providers={2: preferential_providers},
+    )
+    with patch.object(manager, "_check_chain_id", return_value=None):
+        w3_instances = list(manager.web3_endpoints(chain_id=2))
+        assert len(w3_instances) == (len(preferential_providers) + len(other_providers))
+
+        # preferential is first and order maintained
+        for i, w3_instance in enumerate(w3_instances[: len(preferential_providers)]):
+            assert w3_instance.provider == preferential_providers[i]
+
+        # other providers follow in random order
+        for w3_instance in w3_instances[len(preferential_providers) :]:
+            assert w3_instance.provider in other_providers
+
+        chain_3_w3_instances = list(manager.web3_endpoints(chain_id=3))
+        assert len(chain_3_w3_instances) == len(chain_3_providers)
+        for w3_instance in chain_3_w3_instances:
+            assert w3_instance.provider in chain_3_providers
+
+    # order randomized
+    all_providers = [mocker.Mock(spec=BaseProvider) for _ in range(10)]
+    manager = ConditionProviderManager(providers={2: all_providers})
+    with patch.object(manager, "_check_chain_id", return_value=None):
+        num_times_different = 0
+        for i in range(5):
+            w3_instances_first = list(manager.web3_endpoints(chain_id=2))
+            w3_instances_second = list(manager.web3_endpoints(chain_id=2))
+            if any(
+                w31.provider != w32.provider
+                for w31, w32 in zip(w3_instances_first, w3_instances_second)
+            ):
+                num_times_different += 1
+        assert num_times_different > 0  # at least one time the order differed
+
 
 @pytest.mark.parametrize(
     "value, expectedValue",

--- a/tests/unit/test_rpc_healthcheck.py
+++ b/tests/unit/test_rpc_healthcheck.py
@@ -22,7 +22,7 @@ def test_rpc_endpoint_health_check(mocker):
             mock_response.json.return_value = {
                 "jsonrpc": "2.0",
                 "id": 1,
-                "result": hex(chain_id),  # Chain ID 1
+                "result": hex(chain_id),  # Chain ID 2
             }
         else:
             mock_response.json.return_value = {

--- a/tests/unit/test_rpc_healthcheck.py
+++ b/tests/unit/test_rpc_healthcheck.py
@@ -9,28 +9,59 @@ from nucypher.blockchain.eth.utils import (
 
 
 def test_rpc_endpoint_health_check(mocker):
+    chain_id = 2
+
     mock_time = mocker.patch("time.time", return_value=1625247600)
     mock_post = mocker.patch("requests.post")
 
-    mock_response = mocker.Mock()
-    mock_response.status_code = 200
-    mock_response.json.return_value = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "result": {"timestamp": hex(1625247600)},
-    }
-    mock_post.return_value = mock_response
+    def mock_post_side_effect(endpoint, json, headers, timeout):
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+
+        if json["method"] == "eth_chainId":
+            mock_response.json.return_value = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": hex(chain_id),  # Chain ID 1
+            }
+        else:
+            mock_response.json.return_value = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {"timestamp": hex(1625247600)},
+            }
+        return mock_response
+
+    mock_post.side_effect = mock_post_side_effect
 
     # Test a healthy endpoint
-    assert rpc_endpoint_health_check("http://mockendpoint") is True
+    assert (
+        rpc_endpoint_health_check(chain_id=chain_id, endpoint="http://mockendpoint")
+        is True
+    )
+
+    # Test an unhealthy endpoint (wrong chain ID)
+    wrong_chain_id = 3
+    assert (
+        rpc_endpoint_health_check(
+            chain_id=wrong_chain_id, endpoint="http://mockendpoint"
+        )
+        is False
+    )
 
     # Test an unhealthy endpoint (drift too large)
     mock_time.return_value = 1625247600 + 100  # System time far ahead
-    assert rpc_endpoint_health_check("http://mockendpoint") is False
+    assert (
+        rpc_endpoint_health_check(chain_id=chain_id, endpoint="http://mockendpoint")
+        is False
+    )
 
     # Test request exception
     mock_post.side_effect = requests.exceptions.RequestException
-    assert rpc_endpoint_health_check("http://mockendpoint") is False
+    assert (
+        rpc_endpoint_health_check(chain_id=chain_id, endpoint="http://mockendpoint")
+        is False
+    )
 
 
 def test_get_default_rpc_endpoints(mocker):
@@ -75,7 +106,7 @@ def test_get_healthy_default_rpc_endpoints(mocker):
         "nucypher.blockchain.eth.utils.rpc_endpoint_health_check"
     )
     mock_health_check.side_effect = (
-        lambda endpoint: endpoint == "http://endpoint1"
+        lambda chain_id, endpoint: endpoint == "http://endpoint1"
         or endpoint == "http://endpoint3"
     )
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- Better rotation of public RPC Urls.
- Don't validate chain id on every use from `ConditionProviderManager`; instead validate it once as part of the health check on start up.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
