### PR TITLE
Remove unused end_block_timestamp from scan_chunk

### DIFF
--- a/newsfragments/3700.dev.rst
+++ b/newsfragments/3700.dev.rst
@@ -1,0 +1,1 @@
+Remove unused end_block_timestamp from scan_chunk to reduce RPC calls.

--- a/nucypher/utilities/events.py
+++ b/nucypher/utilities/events.py
@@ -291,9 +291,9 @@ class EventScanner:
         """Purge old data in the case of blockchain reorganisation."""
         self.state.delete_data(after_block)
 
-    def scan_chunk(self, start_block, end_block) -> Tuple[int, datetime.datetime, list]:
+    def scan_chunk(self, start_block, end_block) -> Tuple[int, list]:
         """Read and process events between to block numbers.
-        :return: tuple(actual end block number, when this block was mined, processed events)
+        :return: tuple(actual end block number, processed events)
         """
 
         block_timestamps = {}
@@ -323,8 +323,7 @@ class EventScanner:
             processed = self.process_event(event=evt, get_block_when=get_block_when)
             all_processed.append(processed)
 
-        end_block_timestamp = get_block_when(actual_end_block)
-        return actual_end_block, end_block_timestamp, all_processed
+        return actual_end_block, all_processed
 
     def process_event(
         self, event: AttributeDict, get_block_when: Callable[[int], datetime.datetime]
@@ -420,7 +419,7 @@ class EventScanner:
             )
 
             start = time.time()
-            actual_end_block, end_block_timestamp, new_entries = self.scan_chunk(
+            actual_end_block, new_entries = self.scan_chunk(
                 current_block, estimated_end_block
             )
 

--- a/tests/acceptance/actors/test_event_scanner.py
+++ b/tests/acceptance/actors/test_event_scanner.py
@@ -47,5 +47,5 @@ def test_scan_chunk_actual_alchemy_free_tier_detection():
     start_block = end_block - (
         ALCHEMY_FREE_TIER_MAX_CHUNK_NUM_BLOCKS * 5
     )  # must be > Alchemy Free tier limit of 10
-    completed_block, _, _ = scanner.scan_chunk(start_block, end_block)
+    completed_block, _ = scanner.scan_chunk(start_block, end_block)
     assert completed_block == start_block + ALCHEMY_FREE_TIER_MAX_CHUNK_NUM_BLOCKS

--- a/tests/unit/test_event_scanner.py
+++ b/tests/unit/test_event_scanner.py
@@ -328,12 +328,12 @@ class MyEventScanner(EventScanner):
         self.chunk_calls_made = []
         self.return_chunk_scan_event = return_event_for_scan_chunk
 
-    def scan_chunk(self, start_block, end_block) -> Tuple[int, datetime, list]:
+    def scan_chunk(self, start_block, end_block) -> Tuple[int, list]:
         assert start_block <= end_block
         assert end_block <= self.target_end_block
         self.chunk_calls_made.append((start_block, end_block))
         event = ["event"] if self.return_chunk_scan_event else []
-        return end_block, datetime.now(), event  # results
+        return end_block, event  # results
 
     @property
     def scan_chunk_calls_made(self):
@@ -454,7 +454,7 @@ def test_scan_chunk_alchemy_free_tier(mocker, get_random_checksum_address):
 
     get_logs_spy = mocker.spy(web3.eth, "get_logs")
 
-    actual_end_block, _, events = scanner.scan_chunk(from_block, to_block)
+    actual_end_block, events = scanner.scan_chunk(from_block, to_block)
 
     assert events == []
     assert get_logs_spy.call_count == 2  # first raises error, second returns empty list
@@ -527,7 +527,7 @@ def test_scan_chunk_not_alchemy_free_tier(mocker, get_random_checksum_address):
 
     # no decreases
     web3.eth.get_logs.side_effect = [[]]  # everything works, returns empty list
-    actual_end_block, _, events = scanner.scan_chunk(
+    actual_end_block, events = scanner.scan_chunk(
         from_block,
         to_block,
     )
@@ -549,7 +549,7 @@ def test_scan_chunk_not_alchemy_free_tier(mocker, get_random_checksum_address):
         [],
     ]  # first call raises error, second returns empty list
     get_logs_spy.reset_mock()
-    actual_end_block, _, events = scanner.scan_chunk(
+    actual_end_block, events = scanner.scan_chunk(
         from_block,
         to_block,
     )
@@ -574,7 +574,7 @@ def test_scan_chunk_not_alchemy_free_tier(mocker, get_random_checksum_address):
         [],
     ]  # first two calls raises error, third returns empty list
     get_logs_spy.reset_mock()
-    actual_end_block, _, events = scanner.scan_chunk(
+    actual_end_block, events = scanner.scan_chunk(
         from_block,
         to_block,
     )
@@ -631,7 +631,7 @@ def test_scan_chunk_not_alchemy_free_tier(mocker, get_random_checksum_address):
         [],
     ]  # first two calls raise exception but last call uses MIN_CHUNK_NUM_BLOCKS instead of lower value from calc
     get_logs_spy.reset_mock()
-    actual_end_block, _, events = scanner.scan_chunk(
+    actual_end_block, events = scanner.scan_chunk(
         from_block,
         to_block,
     )


### PR DESCRIPTION
The `end_block_timestamp` was fetched via `get_block` RPC call on every chunk scan but never used by callers. This removes the unnecessary RPC call, reducing idle network traffic to providers like Infura.

**Type of PR:**
- Bugfix

**Required reviews:** 
- 2
