### PR TITLE
fix: obfuscate RPC endpoint URLs in logs to prevent API key exposure

### DIFF
--- a/newsfragments/3702.bugfix.rst
+++ b/newsfragments/3702.bugfix.rst
@@ -1,0 +1,1 @@
+Obfuscate RPC endpoint URLs in logs to prevent API key exposure.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -70,6 +70,7 @@ from nucypher.blockchain.eth.trackers import dkg, signing
 from nucypher.blockchain.eth.trackers.bonding import OperatorBondedTracker
 from nucypher.blockchain.eth.utils import (
     get_healthy_default_rpc_endpoints,
+    obfuscate_rpc_url,
     rpc_endpoint_health_check,
     truncate_checksum_address,
 )
@@ -368,19 +369,19 @@ class Operator(BaseActor):
             for uri in chain_rpc_endpoints:
                 if uri in duplicated_endpoint_check[chain_id]:
                     self.log.warn(
-                        f"Operator-configured condition endpoint {uri} is duplicated for condition evaluation on chain {chain_id}; skipping."
+                        f"Operator-configured condition endpoint {obfuscate_rpc_url(uri)} is duplicated for condition evaluation on chain {chain_id}; skipping."
                     )
                     continue
 
                 provider = self._make_condition_provider(uri)
                 if int(Web3(provider).eth.chain_id) != int(chain_id):
                     raise self.ActorError(
-                        f"Operator-configured RPC condition endpoint {uri} does not belong to chain {chain_id}"
+                        f"Operator-configured RPC condition endpoint {obfuscate_rpc_url(uri)} does not belong to chain {chain_id}"
                     )
                 healthy = rpc_endpoint_health_check(chain_id=chain_id, endpoint=uri)
                 if not healthy:
                     self.log.warn(
-                        f"Operator-configured RPC condition endpoint {uri} is unhealthy"
+                        f"Operator-configured RPC condition endpoint {obfuscate_rpc_url(uri)} is unhealthy"
                     )
                 configured_endpoints[int(chain_id)].append(provider)
                 duplicated_endpoint_check[chain_id].add(uri)
@@ -392,7 +393,7 @@ class Operator(BaseActor):
             for uri in chain_rpc_endpoints:
                 if uri in duplicated_endpoint_check[chain_id]:
                     self.log.warn(
-                        f"Fallback blockchain endpoint, {uri}, is duplicated for condition evaluation on chain {chain_id}; skipping"
+                        f"Fallback blockchain endpoint, {obfuscate_rpc_url(uri)}, is duplicated for condition evaluation on chain {chain_id}; skipping"
                     )
                     continue
                 provider = self._make_condition_provider(uri)

--- a/nucypher/blockchain/eth/interfaces.py
+++ b/nucypher/blockchain/eth/interfaces.py
@@ -31,6 +31,7 @@ from nucypher.blockchain.eth.registry import ContractRegistry
 from nucypher.blockchain.eth.utils import (
     get_transaction_name,
     get_tx_cost_data,
+    obfuscate_rpc_url,
     prettify_eth_amount,
 )
 from nucypher.crypto.powers import TransactingPower
@@ -125,7 +126,7 @@ class BlockchainInterface:
             else:
                 cost = transaction_fee + self.payload.get("value", 0)
                 message = (
-                    f'{self.name} from {self.payload["from"][:8]} - {self.base_message}. '
+                    f"{self.name} from {self.payload['from'][:8]} - {self.base_message}. "
                     f"Calculated cost is {prettify_eth_amount(cost)}, "
                     f"but sender only has {prettify_eth_amount(self.get_balance())}."
                 )
@@ -256,7 +257,9 @@ class BlockchainInterface:
         self.__is_initialized = False
 
     def __repr__(self):
-        r = "{name}({uri})".format(name=self.__class__.__name__, uri=self.endpoint)
+        r = "{name}({uri})".format(
+            name=self.__class__.__name__, uri=obfuscate_rpc_url(self.endpoint)
+        )
         return r
 
     def get_blocktime(self):
@@ -279,7 +282,6 @@ class BlockchainInterface:
             else:
                 gas_strategy = cls.GAS_STRATEGIES[cls.DEFAULT_GAS_STRATEGY]
         return gas_strategy
-
 
     def configure_gas_strategy(self, gas_strategy: Optional[Callable] = None) -> None:
         if gas_strategy:
@@ -312,14 +314,16 @@ class BlockchainInterface:
             return
 
         endpoint = self.endpoint
-        self.log.info(f"Using external Web3 Provider '{self.endpoint}'")
+        self.log.info(
+            f"Using external Web3 Provider '{obfuscate_rpc_url(self.endpoint)}'"
+        )
 
         # Attach Provider
         self._attach_blockchain_provider(
             provider=self._provider,
             endpoint=endpoint,
         )
-        self.log.info("Connecting to {}".format(self.endpoint))
+        self.log.info("Connecting to {}".format(obfuscate_rpc_url(self.endpoint)))
         if self._provider is NO_BLOCKCHAIN_CONNECTION:
             raise self.NoProvider("There are no configured blockchain providers")
 
@@ -342,11 +346,11 @@ class BlockchainInterface:
             )
         except requests.ConnectionError:  # RPC
             raise self.ConnectionFailed(
-                f"Connection Failed - {str(self.endpoint)} - is RPC enabled?"
+                f"Connection Failed - {obfuscate_rpc_url(self.endpoint)} - is RPC enabled?"
             )
         except FileNotFoundError:  # IPC File Protocol
             raise self.ConnectionFailed(
-                f"Connection Failed - {str(self.endpoint)} - is IPC enabled?"
+                f"Connection Failed - {obfuscate_rpc_url(self.endpoint)} - is IPC enabled?"
             )
 
         # Only set member variables once early set up is successful

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -2,6 +2,7 @@ import time
 from decimal import Decimal
 from functools import cache
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse, urlunparse
 
 import requests
 from eth_typing import ChecksumAddress
@@ -24,8 +25,6 @@ def obfuscate_rpc_url(url: str) -> str:
     Example: https://mainnet.infura.io/v3/abc123 -> https://mainnet.infura.io/v3/abc***
     """
     try:
-        from urllib.parse import urlparse, urlunparse
-
         parsed = urlparse(url)
         if parsed.path:
             # Split path into segments and obfuscate segments that look like API keys

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -17,7 +17,35 @@ from nucypher.utilities.logging import Logger
 LOGGER = Logger("utility")
 
 
-def prettify_eth_amount(amount, original_denomination: str = 'wei') -> str:
+def obfuscate_rpc_url(url: str) -> str:
+    """
+    Obfuscates sensitive parts of an RPC URL for safe logging.
+    Replaces API keys and other path segments after the host with asterisks.
+    Example: https://mainnet.infura.io/v3/abc123 -> https://mainnet.infura.io/v3/abc***
+    """
+    try:
+        from urllib.parse import urlparse, urlunparse
+
+        parsed = urlparse(url)
+        if parsed.path:
+            # Split path into segments and obfuscate segments that look like API keys
+            segments = parsed.path.split("/")
+            obfuscated_segments = []
+            for segment in segments:
+                # Obfuscate segments that are 16+ chars (likely API keys/secrets)
+                if len(segment) >= 16:
+                    obfuscated_segments.append(segment[:3] + "***")
+                else:
+                    obfuscated_segments.append(segment)
+            obfuscated_path = "/".join(obfuscated_segments)
+            parsed = parsed._replace(path=obfuscated_path)
+        return urlunparse(parsed)
+    except Exception:
+        # If parsing fails, return a safe placeholder
+        return "<RPC endpoint>"
+
+
+def prettify_eth_amount(amount, original_denomination: str = "wei") -> str:
     """
     Converts any ether `amount` in `original_denomination` and finds a suitable representation based on its length.
     The options in consideration are representing the amount in wei, gwei or ETH.
@@ -29,29 +57,33 @@ def prettify_eth_amount(amount, original_denomination: str = 'wei') -> str:
         # First obtain canonical representation in wei. Works for int, float, Decimal and str amounts
         amount_in_wei = Web3.to_wei(Decimal(amount), original_denomination)
 
-        common_denominations = ('wei', 'gwei', 'ether')
+        common_denominations = ("wei", "gwei", "ether")
 
         options = [str(Web3.from_wei(amount_in_wei, d)) for d in common_denominations]
 
         best_option = min(zip(map(len, options), options, common_denominations))
         _length, pretty_amount, denomination = best_option
 
-        if denomination == 'ether':
-            denomination = 'ETH'
+        if denomination == "ether":
+            denomination = "ETH"
         pretty_amount += " " + denomination
 
-    except Exception:  # Worst case scenario, we just print the str representation of amount
+    except (
+        Exception
+    ):  # Worst case scenario, we just print the str representation of amount
         pretty_amount = str(amount)
 
     return pretty_amount
 
 
-def get_transaction_name(contract_function: Union[ContractFunction, ContractConstructor]) -> str:
+def get_transaction_name(
+    contract_function: Union[ContractFunction, ContractConstructor],
+) -> str:
     deployment = isinstance(contract_function, ContractConstructor)
     try:
         transaction_name = contract_function.fn_name.upper()
     except AttributeError:
-        transaction_name = 'DEPLOY' if deployment else 'UNKNOWN'
+        transaction_name = "DEPLOY" if deployment else "UNKNOWN"
     return transaction_name
 
 
@@ -125,7 +157,7 @@ def rpc_endpoint_health_check(
         "params": [],
         "id": 1,
     }
-    LOGGER.debug(f"Checking chain ID of RPC endpoint {endpoint}")
+    LOGGER.debug(f"Checking chain ID of RPC endpoint {obfuscate_rpc_url(endpoint)}")
     result = _get_json_rpc_call_result(endpoint, query)
     if result is None:
         return False
@@ -139,7 +171,7 @@ def rpc_endpoint_health_check(
             return False
     except (TypeError, ValueError):
         LOGGER.debug(
-            f"RPC endpoint {endpoint} is unhealthy: invalid chain ID response {result}"
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: invalid chain ID response {result}"
         )
         return False
 
@@ -150,25 +182,27 @@ def rpc_endpoint_health_check(
         "params": ["latest", False],
         "id": 2,
     }
-    LOGGER.debug(f"Checking health of RPC endpoint {endpoint}")
+    LOGGER.debug(f"Checking health of RPC endpoint {obfuscate_rpc_url(endpoint)}")
     block_data = _get_json_rpc_call_result(endpoint, query)
     if block_data is None:
         return False
     try:
         timestamp = int(block_data.get("timestamp"), 16)
     except (TypeError, ValueError):
-        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: invalid block data")
+        LOGGER.debug(
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: invalid block data"
+        )
         return False
 
     system_time = time.time()
     drift = abs(system_time - timestamp)
     if drift > max_drift_seconds:
         LOGGER.debug(
-            f"RPC endpoint {endpoint} is unhealthy: drift too large ({drift} seconds)"
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: drift too large ({drift} seconds)"
         )
         return False
 
-    LOGGER.debug(f"RPC endpoint {endpoint} is healthy")
+    LOGGER.debug(f"RPC endpoint {obfuscate_rpc_url(endpoint)} is healthy")
     return True  # finally!
 
 
@@ -181,27 +215,35 @@ def _get_json_rpc_call_result(endpoint: str, query: dict) -> Optional[Any]:
             timeout=5,
         )
     except requests.exceptions.RequestException:
-        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: network error")
+        LOGGER.debug(
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: network error"
+        )
         return None
 
     if response.status_code != 200:
         LOGGER.debug(
-            f"RPC endpoint {endpoint} is unhealthy: {response.status_code} | {response.text}"
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: {response.status_code} | {response.text}"
         )
         return None
 
     try:
         data = response.json()
         if "result" not in data:
-            LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no response data")
+            LOGGER.debug(
+                f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: no response data"
+            )
             return None
     except requests.exceptions.JSONDecodeError:
-        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: {response.text}")
+        LOGGER.debug(
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: {response.text}"
+        )
         return None
 
     result = data.get("result")
     if result is None:
-        LOGGER.debug(f"RPC endpoint {endpoint} is unhealthy: no result data")
+        LOGGER.debug(
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: no result data"
+        )
         return None
 
     return result

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -17,6 +17,16 @@ from nucypher.utilities.logging import Logger
 
 LOGGER = Logger("utility")
 
+# Maximum length for response text in log messages
+_MAX_RESPONSE_TEXT_LENGTH = 200
+
+
+def _truncate_response_text(text: str) -> str:
+    """Truncates response text for logging to avoid huge error messages."""
+    if len(text) <= _MAX_RESPONSE_TEXT_LENGTH:
+        return text
+    return text[:_MAX_RESPONSE_TEXT_LENGTH] + "..."
+
 
 def obfuscate_rpc_url(url: str) -> str:
     """
@@ -221,7 +231,7 @@ def _get_json_rpc_call_result(endpoint: str, query: dict) -> Optional[Any]:
 
     if response.status_code != 200:
         LOGGER.debug(
-            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: {response.status_code} | {response.text}"
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: {response.status_code} | {_truncate_response_text(response.text)}"
         )
         return None
 
@@ -234,7 +244,7 @@ def _get_json_rpc_call_result(endpoint: str, query: dict) -> Optional[Any]:
             return None
     except requests.exceptions.JSONDecodeError:
         LOGGER.debug(
-            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: {response.text}"
+            f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: {_truncate_response_text(response.text)}"
         )
         return None
 
@@ -269,7 +279,7 @@ def get_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]]:
         }
     else:
         LOGGER.error(
-            f"Failed to fetch default RPC endpoints: {response.status_code} | {response.text}"
+            f"Failed to fetch default RPC endpoints: {response.status_code} | {_truncate_response_text(response.text)}"
         )
         return {}
 

--- a/tests/unit/test_blockchain_utils.py
+++ b/tests/unit/test_blockchain_utils.py
@@ -24,6 +24,8 @@ from nucypher.blockchain.eth.utils import (
         ("https://cloudflare-eth.com", "https://cloudflare-eth.com"),
         # Short path segments preserved
         ("https://example.com/v3/short", "https://example.com/v3/short"),
+        # Invalid input falls back to placeholder
+        (123, "<RPC endpoint>"),
     ],
 )
 def test_obfuscate_rpc_url(url, expected):

--- a/tests/unit/test_blockchain_utils.py
+++ b/tests/unit/test_blockchain_utils.py
@@ -1,6 +1,9 @@
 import pytest
 
-from nucypher.blockchain.eth.utils import obfuscate_rpc_url
+from nucypher.blockchain.eth.utils import (
+    _truncate_response_text,
+    obfuscate_rpc_url,
+)
 
 
 @pytest.mark.parametrize(
@@ -25,3 +28,20 @@ from nucypher.blockchain.eth.utils import obfuscate_rpc_url
 )
 def test_obfuscate_rpc_url(url, expected):
     assert obfuscate_rpc_url(url) == expected
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Short text unchanged
+        ("Short error", "Short error"),
+        # Exactly 200 chars unchanged
+        ("x" * 200, "x" * 200),
+        # Long text truncated with ellipsis
+        ("x" * 250, "x" * 200 + "..."),
+        # Empty string unchanged
+        ("", ""),
+    ],
+)
+def test_truncate_response_text(text, expected):
+    assert _truncate_response_text(text) == expected

--- a/tests/unit/test_blockchain_utils.py
+++ b/tests/unit/test_blockchain_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from nucypher.blockchain.eth.utils import obfuscate_rpc_url
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Infura-style URLs with API key
+        (
+            "https://base-sepolia.infura.io/v3/25c3f47d58494214b9cbb7bdc3db99e0",
+            "https://base-sepolia.infura.io/v3/25c***",
+        ),
+        # Alchemy-style URLs with API key
+        (
+            "https://eth-mainnet.alchemyapi.io/v2/abcdef1234567890abcdef1234567890",
+            "https://eth-mainnet.alchemyapi.io/v2/abc***",
+        ),
+        # URLs without API keys should remain unchanged
+        ("https://rpc.ankr.com/eth", "https://rpc.ankr.com/eth"),
+        ("https://cloudflare-eth.com", "https://cloudflare-eth.com"),
+        # Short path segments preserved
+        ("https://example.com/v3/short", "https://example.com/v3/short"),
+    ],
+)
+def test_obfuscate_rpc_url(url, expected):
+    assert obfuscate_rpc_url(url) == expected

--- a/tests/unit/test_rpc_healthcheck.py
+++ b/tests/unit/test_rpc_healthcheck.py
@@ -90,6 +90,7 @@ def test_get_default_rpc_endpoints(mocker):
 
     # Mock a failed response
     mock_get.return_value.status_code = 500
+    mock_get.return_value.text = "Internal Server Error"
     assert get_default_rpc_endpoints(test_domain) == {}
 
 

--- a/tests/unit/test_rpc_healthcheck.py
+++ b/tests/unit/test_rpc_healthcheck.py
@@ -1,11 +1,9 @@
-import pytest
 import requests
 
 from nucypher.blockchain.eth.domains import EthChain, PolygonChain, TACoDomain
 from nucypher.blockchain.eth.utils import (
     get_default_rpc_endpoints,
     get_healthy_default_rpc_endpoints,
-    obfuscate_rpc_url,
     rpc_endpoint_health_check,
 )
 
@@ -107,9 +105,8 @@ def test_get_healthy_default_rpc_endpoints(mocker):
     mock_health_check = mocker.patch(
         "nucypher.blockchain.eth.utils.rpc_endpoint_health_check"
     )
-    mock_health_check.side_effect = (
-        lambda chain_id, endpoint: endpoint == "http://endpoint1"
-        or endpoint == "http://endpoint3"
+    mock_health_check.side_effect = lambda chain_id, endpoint: (
+        endpoint == "http://endpoint1" or endpoint == "http://endpoint3"
     )
 
     test_domain = TACoDomain(
@@ -120,27 +117,3 @@ def test_get_healthy_default_rpc_endpoints(mocker):
 
     healthy_endpoints = get_healthy_default_rpc_endpoints(test_domain)
     assert healthy_endpoints == {1: ["http://endpoint1"], 2: ["http://endpoint3"]}
-
-
-@pytest.mark.parametrize(
-    "url,expected",
-    [
-        # Infura-style URLs with API key
-        (
-            "https://base-sepolia.infura.io/v3/25c3f47d58494214b9cbb7bdc3db99e0",
-            "https://base-sepolia.infura.io/v3/25c***",
-        ),
-        # Alchemy-style URLs with API key
-        (
-            "https://eth-mainnet.alchemyapi.io/v2/abcdef1234567890abcdef1234567890",
-            "https://eth-mainnet.alchemyapi.io/v2/abc***",
-        ),
-        # URLs without API keys should remain unchanged
-        ("https://rpc.ankr.com/eth", "https://rpc.ankr.com/eth"),
-        ("https://cloudflare-eth.com", "https://cloudflare-eth.com"),
-        # Short path segments preserved
-        ("https://example.com/v3/short", "https://example.com/v3/short"),
-    ],
-)
-def test_obfuscate_rpc_url(url, expected):
-    assert obfuscate_rpc_url(url) == expected

--- a/tests/unit/test_rpc_healthcheck.py
+++ b/tests/unit/test_rpc_healthcheck.py
@@ -1,9 +1,11 @@
+import pytest
 import requests
 
 from nucypher.blockchain.eth.domains import EthChain, PolygonChain, TACoDomain
 from nucypher.blockchain.eth.utils import (
     get_default_rpc_endpoints,
     get_healthy_default_rpc_endpoints,
+    obfuscate_rpc_url,
     rpc_endpoint_health_check,
 )
 
@@ -118,3 +120,27 @@ def test_get_healthy_default_rpc_endpoints(mocker):
 
     healthy_endpoints = get_healthy_default_rpc_endpoints(test_domain)
     assert healthy_endpoints == {1: ["http://endpoint1"], 2: ["http://endpoint3"]}
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # Infura-style URLs with API key
+        (
+            "https://base-sepolia.infura.io/v3/25c3f47d58494214b9cbb7bdc3db99e0",
+            "https://base-sepolia.infura.io/v3/25c***",
+        ),
+        # Alchemy-style URLs with API key
+        (
+            "https://eth-mainnet.alchemyapi.io/v2/abcdef1234567890abcdef1234567890",
+            "https://eth-mainnet.alchemyapi.io/v2/abc***",
+        ),
+        # URLs without API keys should remain unchanged
+        ("https://rpc.ankr.com/eth", "https://rpc.ankr.com/eth"),
+        ("https://cloudflare-eth.com", "https://cloudflare-eth.com"),
+        # Short path segments preserved
+        ("https://example.com/v3/short", "https://example.com/v3/short"),
+    ],
+)
+def test_obfuscate_rpc_url(url, expected):
+    assert obfuscate_rpc_url(url) == expected


### PR DESCRIPTION
## Summary
Obfuscates sensitive API keys in RPC endpoint URLs when logging to prevent accidental exposure of credentials.

## Changes
- Add `obfuscate_rpc_url()` function that masks path segments 16+ characters (likely API keys)
- Update all 11 log statements in `utils.py` to use obfuscation
- Add parametrized tests for URL obfuscation

## Example
**Before:** `RPC endpoint https://base-sepolia.infura.io/v3/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa is healthy`

**After:** `RPC endpoint https://base-sepolia.infura.io/v3/aaa*** is healthy`

## Testing
Added parametrized tests covering:
- Infura-style URLs with API keys
- Alchemy-style URLs with API keys  
- URLs without API keys (unchanged)
- Short path segments (preserved)