### PR TITLE
feat: add create2 operation for local address computation

### DIFF
--- a/newsfragments/3703.feature.rst
+++ b/newsfragments/3703.feature.rst
@@ -1,0 +1,1 @@
+Add ``create2`` operation for local computation of CREATE2 addresses, eliminating RPC calls for counterfactual address resolution.

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -10,7 +10,7 @@ from hashlib import md5
 from inspect import signature
 from typing import Any, List, Optional, Tuple, Type, Union
 
-from eth_utils import is_hexstr, keccak
+from eth_utils import is_hexstr, keccak, to_checksum_address
 from hexbytes import HexBytes
 from marshmallow import (
     Schema,
@@ -367,6 +367,58 @@ def _to_hex(value):
         raise TypeError(f"Invalid value for hex conversion: {e}")
 
 
+def _compute_create2_address(salt: bytes, value: dict) -> str:
+    """
+    Compute CREATE2 address locally.
+
+    Formula: keccak256(0xff ++ deployer ++ salt ++ bytecode_hash)[12:]
+
+    :param salt: The salt value (must be 32 bytes)
+    :param value: Dict containing 'deployerAddress' and 'bytecodeHash'
+    :return: Checksummed Ethereum address
+    :raises TypeError: If inputs are invalid
+    """
+    try:
+        deployer_address = value["deployerAddress"]
+        bytecode_hash = value["bytecodeHash"]
+    except (KeyError, TypeError) as e:
+        raise TypeError(
+            f"create2 operation requires 'deployerAddress' and 'bytecodeHash' in value: {e}"
+        )
+
+    # Validate and convert deployer address
+    try:
+        deployer_bytes = HexBytes(deployer_address)
+    except Exception as e:
+        raise TypeError(f"Invalid deployerAddress: {e}")
+    if len(deployer_bytes) != 20:
+        raise TypeError(f"deployerAddress must be 20 bytes, got {len(deployer_bytes)}")
+
+    # Validate and convert salt
+    try:
+        salt_bytes = HexBytes(salt)
+    except Exception as e:
+        raise TypeError(f"Invalid salt: {e}")
+    if len(salt_bytes) != 32:
+        raise TypeError(f"salt must be 32 bytes, got {len(salt_bytes)}")
+
+    # Validate and convert bytecode hash
+    try:
+        bytecode_hash_bytes = HexBytes(bytecode_hash)
+    except Exception as e:
+        raise TypeError(f"Invalid bytecodeHash: {e}")
+    if len(bytecode_hash_bytes) != 32:
+        raise TypeError(
+            f"bytecodeHash must be 32 bytes, got {len(bytecode_hash_bytes)}"
+        )
+
+    # CREATE2: keccak256(0xff ++ deployer ++ salt ++ bytecode_hash)[12:]
+    pre_image = b"\xff" + deployer_bytes + salt_bytes + bytecode_hash_bytes
+    address_bytes = keccak(pre_image)[12:]
+
+    return to_checksum_address(address_bytes)
+
+
 # should raise TypeError for invalid inputs
 _OPERATOR_FUNCTIONS = {
     # We can add all kinds of operators over time, this is just a base start - given that
@@ -405,6 +457,8 @@ _OPERATOR_FUNCTIONS = {
     "toHex": _to_hex,
     # hashing
     "keccak": lambda a: keccak(a.encode() if isinstance(a, str) else a),
+    # address computation
+    "create2": _compute_create2_address,
 }
 
 MAX_VARIABLE_OPERATIONS = 5
@@ -1133,7 +1187,7 @@ class ConditionLingo(_Serializable):
             raise InvalidConditionLingo(f"Invalid condition grammar: {e}")
 
     @classmethod
-    def from_json(cls, data: str) -> 'ConditionLingo':
+    def from_json(cls, data: str) -> "ConditionLingo":
         try:
             return super().from_json(data)
         except ValidationError as e:

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -383,7 +383,7 @@ def _compute_create2_address(salt: bytes, value: dict) -> str:
         bytecode_hash = value["bytecodeHash"]
     except (KeyError, TypeError) as e:
         raise TypeError(
-            f"create2 operation requires 'deployerAddress' and 'bytecodeHash' in value: {e}"
+            f"create2 operation requires dictionary with 'deployerAddress' and 'bytecodeHash' values: {e}"
         )
 
     # Validate and convert deployer address

--- a/tests/acceptance/conditions/test_create2.py
+++ b/tests/acceptance/conditions/test_create2.py
@@ -1,0 +1,99 @@
+import os
+
+import pytest
+
+from nucypher.policy.conditions.lingo import VariableOperation
+
+
+@pytest.fixture
+def create2_factory(project, deployer_account):
+    """Deploy the Create2Factory contract for testing."""
+    return deployer_account.deploy(project.Create2Factory)
+
+
+def test_create2_matches_contract_computation(create2_factory):
+    """
+    Test that our local create2 address computation matches the
+    OpenZeppelin Create2.computeAddress implementation on-chain.
+    """
+    # Use random test values
+    salt = os.urandom(32)
+    bytecode_hash = os.urandom(32)
+    deployer_address = create2_factory.address
+
+    # Compute address using our local implementation
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": deployer_address,
+                "bytecodeHash": "0x" + bytecode_hash.hex(),
+            },
+        ),
+    ]
+    local_result = VariableOperation.evaluate_operations(operations, salt)
+
+    # Compute address using the on-chain contract
+    contract_result = create2_factory.computeAddress(
+        salt, bytecode_hash, deployer_address
+    )
+
+    assert local_result == contract_result
+
+
+def test_create2_matches_contract_with_different_deployers(create2_factory, accounts):
+    """
+    Test create2 computation with various deployer addresses.
+    """
+    salt = os.urandom(32)
+    bytecode_hash = os.urandom(32)
+
+    # Test with multiple different deployer addresses
+    for account in accounts[:5]:
+        deployer_address = account.address
+
+        operations = [
+            VariableOperation(
+                operation="create2",
+                value={
+                    "deployerAddress": deployer_address,
+                    "bytecodeHash": "0x" + bytecode_hash.hex(),
+                },
+            ),
+        ]
+        local_result = VariableOperation.evaluate_operations(operations, salt)
+
+        contract_result = create2_factory.computeAddress(
+            salt, bytecode_hash, deployer_address
+        )
+
+        assert local_result == contract_result
+
+
+def test_create2_matches_contract_multiple_random_inputs(create2_factory):
+    """
+    Test create2 computation with multiple sets of random inputs
+    to ensure consistent matching with the contract.
+    """
+    deployer_address = create2_factory.address
+
+    for _ in range(10):
+        salt = os.urandom(32)
+        bytecode_hash = os.urandom(32)
+
+        operations = [
+            VariableOperation(
+                operation="create2",
+                value={
+                    "deployerAddress": deployer_address,
+                    "bytecodeHash": "0x" + bytecode_hash.hex(),
+                },
+            ),
+        ]
+        local_result = VariableOperation.evaluate_operations(operations, salt)
+
+        contract_result = create2_factory.computeAddress(
+            salt, bytecode_hash, deployer_address
+        )
+
+        assert local_result == contract_result

--- a/tests/acceptance/conditions/test_create2.py
+++ b/tests/acceptance/conditions/test_create2.py
@@ -5,43 +5,15 @@ import pytest
 from nucypher.policy.conditions.lingo import VariableOperation
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def create2_factory(project, deployer_account):
     """Deploy the Create2Factory contract for testing."""
     return deployer_account.deploy(project.Create2Factory)
 
 
-def test_create2_matches_contract_computation(create2_factory):
-    """
-    Test that our local create2 address computation matches the
-    OpenZeppelin Create2.computeAddress implementation on-chain.
-    """
-    # Use random test values
-    salt = os.urandom(32)
-    bytecode_hash = os.urandom(32)
-    deployer_address = create2_factory.address
-
-    # Compute address using our local implementation
-    operations = [
-        VariableOperation(
-            operation="create2",
-            value={
-                "deployerAddress": deployer_address,
-                "bytecodeHash": "0x" + bytecode_hash.hex(),
-            },
-        ),
-    ]
-    local_result = VariableOperation.evaluate_operations(operations, salt)
-
-    # Compute address using the on-chain contract
-    contract_result = create2_factory.computeAddress(
-        salt, bytecode_hash, deployer_address
-    )
-
-    assert local_result == contract_result
-
-
-def test_create2_matches_contract_with_different_deployers(create2_factory, accounts):
+def test_create2_matches_contract_with_different_deployers(
+    create2_factory, get_random_checksum_address
+):
     """
     Test create2 computation with various deployer addresses.
     """
@@ -49,8 +21,8 @@ def test_create2_matches_contract_with_different_deployers(create2_factory, acco
     bytecode_hash = os.urandom(32)
 
     # Test with multiple different deployer addresses
-    for account in accounts[:5]:
-        deployer_address = account.address
+    for _ in range(5):
+        deployer_address = get_random_checksum_address()
 
         operations = [
             VariableOperation(

--- a/tests/acceptance/contracts/Create2Factory.sol
+++ b/tests/acceptance/contracts/Create2Factory.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin530/contracts/utils/Create2.sol";
+
+contract Create2Factory {
+    function computeAddress(
+        bytes32 salt,
+        bytes32 bytecodeHash,
+        address deployer
+    ) external pure returns (address) {
+        return Create2.computeAddress(salt, bytecodeHash, deployer);
+    }
+}

--- a/tests/unit/conditions/test_variable_operation.py
+++ b/tests/unit/conditions/test_variable_operation.py
@@ -690,7 +690,8 @@ def test_create2_missing_value_fields():
     ]
 
     with pytest.raises(
-        TypeError, match="requires 'deployerAddress' and 'bytecodeHash'"
+        TypeError,
+        match="create2 operation requires dictionary with 'deployerAddress' and 'bytecodeHash' values",
     ):
         VariableOperation.evaluate_operations(operations, salt)
 
@@ -705,7 +706,8 @@ def test_create2_missing_value_fields():
     ]
 
     with pytest.raises(
-        TypeError, match="requires 'deployerAddress' and 'bytecodeHash'"
+        TypeError,
+        match="create2 operation requires dictionary with 'deployerAddress' and 'bytecodeHash' values",
     ):
         VariableOperation.evaluate_operations(operations, salt)
 
@@ -718,7 +720,8 @@ def test_create2_missing_value_fields():
     ]
 
     with pytest.raises(
-        TypeError, match="requires 'deployerAddress' and 'bytecodeHash'"
+        TypeError,
+        match="create2 operation requires dictionary with 'deployerAddress' and 'bytecodeHash' values",
     ):
         VariableOperation.evaluate_operations(operations, salt)
 

--- a/tests/unit/conditions/test_variable_operation.py
+++ b/tests/unit/conditions/test_variable_operation.py
@@ -564,3 +564,30 @@ def test_to_token_base_units_type_errors():
     # Test that list raises TypeError
     with pytest.raises(TypeError, match="Invalid value for toTokenBaseUnits"):
         VariableOperation.evaluate_operations([op], [1, 2, 3])
+
+
+def test_create2_operation():
+    """Test CREATE2 address computation with known values."""
+    # Known test vectors - deployer, salt, bytecode_hash -> expected address
+    # Using the Uniswap V2 pair creation as reference pattern
+    deployer = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"  # Uniswap V2 Factory
+    bytecode_hash = "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+
+    # Salt from keccak256 of token pair
+    salt = bytes.fromhex(
+        "e18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+    )
+
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": deployer,
+                "bytecodeHash": bytecode_hash,
+            },
+        ),
+    ]
+    result = VariableOperation.evaluate_operations(operations, salt)
+
+    # Expected address computed from CREATE2 formula
+    assert result == "0x879F8Ee9B69D56E3cd4bb78FBf5C0dA93E29bBAb"

--- a/tests/unit/conditions/test_variable_operation.py
+++ b/tests/unit/conditions/test_variable_operation.py
@@ -102,6 +102,18 @@ OPERATION_TEST_CASES = [
         b"testing",
         b"_\x16\xf4\xc7\xf1I\xacO\x95\x10\xd9\xcf\x8c\xf3\x84\x03\x8a\xd3H\xb3\xbc\xdc\x01\x91_\x95\xde\x12\xdf\x9d\x1b\x02",
     ),  # bytes
+    # create2 - computes CREATE2 address
+    (
+        "create2",
+        {
+            "deployerAddress": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+            "bytecodeHash": "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
+        },
+        bytes.fromhex(
+            "e18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+        ),
+        "0x879F8Ee9B69D56E3cd4bb78FBf5C0dA93E29bBAb",
+    ),
 ]
 
 
@@ -711,20 +723,62 @@ def test_create2_missing_value_fields():
         VariableOperation.evaluate_operations(operations, salt)
 
 
-def test_create2_cascading_operations():
-    """Test create2 in a chain of operations: str -> concat -> keccak -> create2."""
-    deployer = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
-    bytecode_hash = "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+def test_create2_with_context_variables():
+    """Test that create2 value fields support context variable resolution."""
+    salt = bytes.fromhex(
+        "e18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+    )
 
-    # Start with a discord-like ID
-    discord_id = 123456789012345678
+    context = {
+        ":factoryAddress": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+        ":initCodeHash": "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
+    }
 
     operations = [
-        VariableOperation(operation="str"),  # "123456789012345678"
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": ":factoryAddress",
+                "bytecodeHash": ":initCodeHash",
+            },
+        ),
+    ]
+
+    # Resolve context variables
+    resolved_operations = VariableOperation.with_resolved_context(operations, **context)
+
+    # Execute
+    result = VariableOperation.evaluate_operations(resolved_operations, salt)
+
+    assert result == "0x879F8Ee9B69D56E3cd4bb78FBf5C0dA93E29bBAb"
+
+
+def test_create2_discord_id_to_aa_address():
+    """
+    Test the full pipeline from Discord ID to AA address.
+
+    This replicates the real-world use case:
+    1. Start with a Discord user ID
+    2. Concatenate with "|Discord|Collab.Land"
+    3. Hash with keccak256 to get the salt
+    4. Compute CREATE2 address using SimpleFactory on Base Sepolia
+
+    Values from discord-taco-web validate-aa-derivation.ts script.
+    """
+    # Real Discord user ID
+    discord_id = 405651072460259339
+
+    # SimpleFactory on Base Sepolia
+    deployer = "0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c"
+    # Bytecode hash for MetaMask Delegation Toolkit MultiSig
+    bytecode_hash = "0x210ffc0da7f274285c4d6116aaef8420ecb9054faced33862197d6b951cb32f5"
+
+    operations = [
+        VariableOperation(operation="str"),  # "405651072460259339"
         VariableOperation(
             operation="+=", value="|Discord|Collab.Land"
-        ),  # "123456789012345678|Discord|Collab.Land"
-        VariableOperation(operation="keccak"),  # bytes32 hash
+        ),  # "405651072460259339|Discord|Collab.Land"
+        VariableOperation(operation="keccak"),  # salt as bytes32
         VariableOperation(
             operation="create2",
             value={
@@ -736,8 +790,5 @@ def test_create2_cascading_operations():
 
     result = VariableOperation.evaluate_operations(operations, discord_id)
 
-    # Result should be a checksummed address
-    assert result.startswith("0x")
-    assert len(result) == 42
-    # Verify it's checksummed (has mixed case)
-    assert result != result.lower()
+    # Expected AA address for this Discord ID
+    assert result == "0x420AcFa51fdB2821dFb407e212A882144807737C"

--- a/tests/unit/conditions/test_variable_operation.py
+++ b/tests/unit/conditions/test_variable_operation.py
@@ -591,3 +591,121 @@ def test_create2_operation():
 
     # Expected address computed from CREATE2 formula
     assert result == "0x879F8Ee9B69D56E3cd4bb78FBf5C0dA93E29bBAb"
+
+
+def test_create2_invalid_salt_length():
+    """Test that create2 fails with non-32-byte salt."""
+    deployer = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
+    bytecode_hash = "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+
+    # 16-byte salt (too short)
+    short_salt = bytes.fromhex("e18a34eb0e04b04f7a0ac29a6e807400")
+
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": deployer,
+                "bytecodeHash": bytecode_hash,
+            },
+        ),
+    ]
+
+    with pytest.raises(TypeError, match="salt must be 32 bytes"):
+        VariableOperation.evaluate_operations(operations, short_salt)
+
+
+def test_create2_invalid_deployer_length():
+    """Test that create2 fails with non-20-byte deployer address."""
+    # 10-byte address (too short)
+    deployer = "0x5C69bEe701ef814a2B6a"
+    bytecode_hash = "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+    salt = bytes.fromhex(
+        "e18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+    )
+
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": deployer,
+                "bytecodeHash": bytecode_hash,
+            },
+        ),
+    ]
+
+    with pytest.raises(TypeError, match="deployerAddress must be 20 bytes"):
+        VariableOperation.evaluate_operations(operations, salt)
+
+
+def test_create2_invalid_bytecode_hash_length():
+    """Test that create2 fails with non-32-byte bytecode hash."""
+    deployer = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
+    # 16-byte hash (too short)
+    bytecode_hash = "0x96e8ac4277198ff8b6f785478aa9a39f"
+    salt = bytes.fromhex(
+        "e18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+    )
+
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": deployer,
+                "bytecodeHash": bytecode_hash,
+            },
+        ),
+    ]
+
+    with pytest.raises(TypeError, match="bytecodeHash must be 32 bytes"):
+        VariableOperation.evaluate_operations(operations, salt)
+
+
+def test_create2_missing_value_fields():
+    """Test that create2 fails when required fields are missing from value."""
+    salt = bytes.fromhex(
+        "e18a34eb0e04b04f7a0ac29a6e80748dca96319b42c54d679cb821dca90c6303"
+    )
+
+    # Missing bytecodeHash
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
+            },
+        ),
+    ]
+
+    with pytest.raises(
+        TypeError, match="requires 'deployerAddress' and 'bytecodeHash'"
+    ):
+        VariableOperation.evaluate_operations(operations, salt)
+
+    # Missing deployerAddress
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={
+                "bytecodeHash": "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f",
+            },
+        ),
+    ]
+
+    with pytest.raises(
+        TypeError, match="requires 'deployerAddress' and 'bytecodeHash'"
+    ):
+        VariableOperation.evaluate_operations(operations, salt)
+
+    # Empty value
+    operations = [
+        VariableOperation(
+            operation="create2",
+            value={},
+        ),
+    ]
+
+    with pytest.raises(
+        TypeError, match="requires 'deployerAddress' and 'bytecodeHash'"
+    ):
+        VariableOperation.evaluate_operations(operations, salt)

--- a/tests/unit/conditions/test_variable_operation.py
+++ b/tests/unit/conditions/test_variable_operation.py
@@ -709,3 +709,35 @@ def test_create2_missing_value_fields():
         TypeError, match="requires 'deployerAddress' and 'bytecodeHash'"
     ):
         VariableOperation.evaluate_operations(operations, salt)
+
+
+def test_create2_cascading_operations():
+    """Test create2 in a chain of operations: str -> concat -> keccak -> create2."""
+    deployer = "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f"
+    bytecode_hash = "0x96e8ac4277198ff8b6f785478aa9a39f403cb768dd02cbee326c3e7da348845f"
+
+    # Start with a discord-like ID
+    discord_id = 123456789012345678
+
+    operations = [
+        VariableOperation(operation="str"),  # "123456789012345678"
+        VariableOperation(
+            operation="+=", value="|Discord|Collab.Land"
+        ),  # "123456789012345678|Discord|Collab.Land"
+        VariableOperation(operation="keccak"),  # bytes32 hash
+        VariableOperation(
+            operation="create2",
+            value={
+                "deployerAddress": deployer,
+                "bytecodeHash": bytecode_hash,
+            },
+        ),
+    ]
+
+    result = VariableOperation.evaluate_operations(operations, discord_id)
+
+    # Result should be a checksummed address
+    assert result.startswith("0x")
+    assert len(result) == 42
+    # Verify it's checksummed (has mixed case)
+    assert result != result.lower()


### PR DESCRIPTION
Closes #3698 

## Summary

Add a new `create2` operation to the `VariableOperation` system that computes Ethereum CREATE2 addresses locally, eliminating RPC calls to factory contracts.

## Motivation

Currently, computing counterfactual AA (Account Abstraction) addresses requires an RPC call to a factory contract's `computeAddress` method. This:
- Consumes RPC endpoint quota (Infura, etc.)
- Adds latency to condition evaluation
- Requires chain connectivity for a purely deterministic computation

The CREATE2 address formula is deterministic and can be computed locally.

## How CREATE2 Works

CREATE2 computes deterministic addresses using:
```
address = keccak256(0xff ++ deployer_address ++ salt ++ bytecode_hash)[12:]
```

## Usage

```json
{
  "operation": "create2",
  "value": {
    "deployerAddress": "0x69Aa2f9fe1572F1B640E1bbc512f5c3a734fc77c",
    "bytecodeHash": "0x210ffc0da7f274285c4d6116aaef8420ecb9054faced33862197d6b951cb32f5"
  }
}
```

Both `deployerAddress` and `bytecodeHash` support context variables.

## Example: Full Pipeline

```json
{
  "varName": "validateSender",
  "condition": {
    "conditionType": "context-variable",
    "contextVariable": ":senderId",
    "returnValueTest": {
      "comparator": "==",
      "value": ":userOpSender"
    }
  },
  "operations": [
    { "operation": "str" },
    { "operation": "+=", "value": "|Discord|Collab.Land" },
    { "operation": "keccak" },
    { "operation": "create2", "value": { "deployerAddress": "0x69Aa...", "bytecodeHash": "0x210f..." } }
  ]
}
```

## Testing

- Added comprehensive unit tests for the new operation
- All 207 tests in `test_variable_operation.py` pass
- Tests cover: valid computation, invalid inputs (salt/deployer/bytecode length), missing fields, cascading operations, and context variable resolution
