### PR TITLE
Build metadata in version string in Docker builds

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 current_version = 7.7.0
 commit = True
 tag = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\+(?P<devnum>[0-9a-f]+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]+)(\.(?P<devnum>[0-9a-f]+))?)?
 serialize = 
 	{major}.{minor}.{patch}-{stage}.{devnum}
 	{major}.{minor}.{patch}-{stage}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 current_version = 7.7.0
 commit = True
 tag = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\+(?P<devnum>[0-9a-f]+))?
 serialize = 
 	{major}.{minor}.{patch}-{stage}.{devnum}
 	{major}.{minor}.{patch}-{stage}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,8 +33,9 @@ jobs:
       run: |
         pip install bumpversion
         export VERSION=$(bumpversion major --dry-run --list --allow-dirty | grep current_version= | sed 's/current_version=//g')
-        echo "Set development version: $VERSION-dev.${{github.sha}}"
-        bumpversion devnum --new-version $VERSION-dev.${{github.sha}} --no-tag --no-commit
+        export SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7 | tr '[:upper:]' '[:lower:]')
+        echo "Set development version: $VERSION-dev+$SHORT_SHA"
+        bumpversion devnum --new-version $VERSION-dev+$SHORT_SHA --no-tag --no-commit
 
     - name: Build and push Docker image (development)
       if: ${{ github.ref_type == 'branch' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,8 +34,8 @@ jobs:
         pip install bumpversion
         export VERSION=$(bumpversion major --dry-run --list --allow-dirty | grep current_version= | sed 's/current_version=//g')
         export SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7 | tr '[:upper:]' '[:lower:]')
-        echo "Set development version: $VERSION-dev+$SHORT_SHA"
-        bumpversion devnum --new-version $VERSION-dev+$SHORT_SHA --no-tag --no-commit
+        echo "Set development version: $VERSION-dev.$SHORT_SHA"
+        bumpversion devnum --new-version $VERSION-dev.$SHORT_SHA --no-tag --no-commit
 
     - name: Build and push Docker image (development)
       if: ${{ github.ref_type == 'branch' }}

--- a/nucypher/characters/banners.py
+++ b/nucypher/characters/banners.py
@@ -73,7 +73,5 @@ Yb, `88        88                                   IP'`Yb
      Y8b,____,d88,,dP     Y8,,8'_   8) ,d8b,  ,d8b,,d8b,_ ,d8,   ,d8b,
       "Y888888P"Y88P      `Y8P' "YY8P8P8P'"Y88P"`Y88P'"Y88P"Y8888P"`Y8
 
-
-the Untrusted Re-Encryption Proxy.
 {}
 '''

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import click
 
+import nucypher
 from nucypher.cli.actions.auth import (
     collect_mnemonic,
     get_client_password,
@@ -630,11 +631,17 @@ def run(
 ):
     """Run an "Ursula" node."""
 
-    emitter = setup_emitter(general_config)
+    emitter = setup_emitter(
+        general_config, character_options.config_options.operator_address
+    )
     dev_mode = character_options.config_options.dev
     lonely = character_options.config_options.lonely
 
     _pre_launch_warnings(emitter, dev=dev_mode, force=None)
+
+    emitter.message(
+        f"Starting Ursula node (v{nucypher.__version__}) ...", color="green", bold=True
+    )
 
     prometheus_config = None
     if prometheus:

--- a/nucypher/cli/commands/ursula.py
+++ b/nucypher/cli/commands/ursula.py
@@ -334,7 +334,7 @@ def init(
     general_config, config_options, force, config_root, key_material, with_mnemonic
 ):
     """Create a new Ursula node configuration."""
-    emitter = setup_emitter(general_config, config_options.operator_address)
+    emitter = setup_emitter(general_config)
     _pre_launch_warnings(emitter, dev=None, force=force)
 
     if not config_root:
@@ -533,7 +533,7 @@ def recover(config_file, keystore_filepath):
 @group_general_config
 def destroy(general_config, config_options, config_file, force):
     """Delete Ursula node configuration."""
-    emitter = setup_emitter(general_config, config_options.operator_address)
+    emitter = setup_emitter(general_config)
     _pre_launch_warnings(emitter, dev=config_options.dev, force=force)
     ursula_config = config_options.create_config(emitter, config_file)
     destroy_configuration(emitter, character_config=ursula_config, force=force)
@@ -631,9 +631,7 @@ def run(
 ):
     """Run an "Ursula" node."""
 
-    emitter = setup_emitter(
-        general_config, character_options.config_options.operator_address
-    )
+    emitter = setup_emitter(general_config)
     dev_mode = character_options.config_options.dev
     lonely = character_options.config_options.lonely
 
@@ -685,7 +683,7 @@ def config(general_config, config_options, config_file, force, action):
     ip-address - automatically detect and configure the external IP address.
     migrate    - migrate existing configuration file to the latest version.
     """
-    emitter = setup_emitter(general_config, config_options.operator_address)
+    emitter = setup_emitter(general_config)
 
     if not config_file:
         if action == "migrate":


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
This PR fixes the process of adding the last git commit as part of the version (specifically, as [build metadata](https://semver.org/#spec-item-10) following SemVer spec) during the docker specific workflow on CI. Specifically, `bumpversion` config is tweaked to accept SHA commits instead of only accepting numbers.

The original approach in #3701 doesn't really solve anything, because similarly to this PR, it only works when docker runs from CI. Next steps (for a subsequent PR) is to tweak the CI process to allow for custom docker builds that don't depend on tags or on merging on the current target release branch.


**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
