### PR TITLE
fix(conditions): Catch ConditionEvaluationFailed in OR/AT_LEAST branches

### DIFF
--- a/newsfragments/3706.bugfix.rst
+++ b/newsfragments/3706.bugfix.rst
@@ -1,0 +1,4 @@
+Handle ``ConditionEvaluationFailed`` in compound OR and AT_LEAST conditions.
+Previously, if one operand raised (e.g. a JSON path with no matches), the entire
+compound condition failed even when other branches would satisfy it. Failing
+operands are now treated as ``False`` for OR and AT_LEAST operators.

--- a/nucypher/policy/conditions/lingo.py
+++ b/nucypher/policy/conditions/lingo.py
@@ -279,8 +279,15 @@ class CompoundCondition(MultiCondition):
         values = []
         num_passed_conditions = 0
         overall_result = True if self.operator == self.AND_OPERATOR else False
+        _tolerant = self.operator in (self.OR_OPERATOR, self.AT_LEAST_OPERATOR)
         for condition in self.operands:
-            current_result, current_value = condition.verify(*args, **kwargs)
+            try:
+                current_result, current_value = condition.verify(*args, **kwargs)
+            except ConditionEvaluationFailed as e:
+                if not _tolerant:
+                    raise
+                current_result = False
+                current_value = str(e)
             values.append(current_value)
             if current_result:
                 num_passed_conditions += 1

--- a/tests/unit/conditions/test_compound_condition.py
+++ b/tests/unit/conditions/test_compound_condition.py
@@ -5,6 +5,7 @@ import pytest
 
 from nucypher.policy.conditions.base import Condition
 from nucypher.policy.conditions.exceptions import (
+    ConditionEvaluationFailed,
     InvalidCondition,
     InvalidConditionLingo,
 )
@@ -611,3 +612,117 @@ def test_not_compound_condition(mock_conditions):
     assert result is True
     assert result is (not and_result)
     assert value == and_value
+
+
+@pytest.mark.usefixtures("mock_skip_schema_validation")
+def test_or_condition_evaluation_failed_does_not_propagate(mock_conditions):
+    """ConditionEvaluationFailed in one OR branch should not kill the whole
+    compound condition — the failing branch should be treated as False so that
+    other branches still have a chance to satisfy the OR."""
+    condition_1, condition_2, condition_3, condition_4 = mock_conditions
+
+    or_condition = OrCompoundCondition(
+        operands=[
+            condition_1,
+            condition_2,
+            condition_3,
+        ]
+    )
+
+    # condition_1 raises, but condition_2 is True — OR should succeed
+    condition_1.verify.side_effect = ConditionEvaluationFailed("no matches found")
+    condition_2.verify.return_value = (True, 2)
+
+    result, value = or_condition.verify(providers={})
+    assert result is True
+    assert len(value) == 2
+
+    # condition_1 raises, condition_2 is False, condition_3 is True — OR should succeed
+    condition_1.verify.side_effect = ConditionEvaluationFailed("no matches found")
+    condition_2.verify.return_value = (False, 2)
+    condition_3.verify.return_value = (True, 3)
+
+    result, value = or_condition.verify(providers={})
+    assert result is True
+    assert len(value) == 3
+
+    # all conditions raise — OR should return False (not raise)
+    condition_1.verify.side_effect = ConditionEvaluationFailed("error 1")
+    condition_2.verify.side_effect = ConditionEvaluationFailed("error 2")
+    condition_3.verify.side_effect = ConditionEvaluationFailed("error 3")
+
+    result, value = or_condition.verify(providers={})
+    assert result is False
+    assert len(value) == 3
+
+
+@pytest.mark.usefixtures("mock_skip_schema_validation")
+def test_and_condition_evaluation_failed_propagates(mock_conditions):
+    """ConditionEvaluationFailed in an AND branch should propagate — if we can't
+    evaluate a condition, we can't confirm the AND is satisfied."""
+    condition_1, condition_2, condition_3, _ = mock_conditions
+
+    and_condition = AndCompoundCondition(
+        operands=[
+            condition_1,
+            condition_2,
+            condition_3,
+        ]
+    )
+
+    # condition_1 is True, condition_2 raises — AND should propagate the error
+    condition_1.verify.return_value = (True, 1)
+    condition_2.verify.side_effect = ConditionEvaluationFailed("no matches found")
+
+    with pytest.raises(ConditionEvaluationFailed):
+        and_condition.verify(providers={})
+
+    # condition_1 raises immediately — AND should propagate
+    condition_1.verify.side_effect = ConditionEvaluationFailed("no matches found")
+
+    with pytest.raises(ConditionEvaluationFailed):
+        and_condition.verify(providers={})
+
+
+@pytest.mark.usefixtures("mock_skip_schema_validation")
+def test_at_least_condition_evaluation_failed_does_not_propagate(mock_conditions):
+    """ConditionEvaluationFailed in an AT_LEAST branch should be treated as
+    False — the failing branch simply doesn't count toward the threshold."""
+    condition_1, condition_2, condition_3, condition_4 = mock_conditions
+
+    at_least_condition = AtLeastCompoundCondition(
+        operands=[condition_1, condition_2, condition_3, condition_4],
+        threshold=2,
+    )
+
+    # condition_1 raises, but conditions 2 and 3 are True — threshold met
+    condition_1.verify.side_effect = ConditionEvaluationFailed("no matches found")
+    condition_2.verify.return_value = (True, 2)
+    condition_3.verify.return_value = (True, 3)
+
+    result, value = at_least_condition.verify(providers={})
+    assert result is True
+
+    # condition_1 and condition_2 raise, only condition_3 is True — threshold not met
+    condition_1.verify.side_effect = ConditionEvaluationFailed("error 1")
+    condition_2.verify.side_effect = ConditionEvaluationFailed("error 2")
+    condition_3.verify.return_value = (True, 3)
+    condition_4.verify.return_value = (False, 4)
+
+    result, value = at_least_condition.verify(providers={})
+    assert result is False
+    assert len(value) == 4
+
+
+@pytest.mark.usefixtures("mock_skip_schema_validation")
+def test_not_condition_evaluation_failed_propagates(mock_conditions):
+    """ConditionEvaluationFailed in a NOT condition should propagate — we can't
+    negate something we couldn't evaluate."""
+    condition_1, _, _, _ = mock_conditions
+
+    not_condition = NotCompoundCondition(operand=condition_1)
+
+    condition_1.verify.side_effect = ConditionEvaluationFailed("no matches found")
+
+    with pytest.raises(ConditionEvaluationFailed):
+        not_condition.verify(providers={})


### PR DESCRIPTION
When a JSON path query finds no matches, `ConditionEvaluationFailed` is raised. In compound OR conditions this killed the entire evaluation, even when other branches would return True.

For OR and AT_LEAST operators, catch `ConditionEvaluationFailed` per operand and treat it as False so remaining branches can still satisfy the condition. AND and NOT still propagate the exception since they require all operands to be evaluable.