### PR TITLE
Consistent versioning approach for development releases

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,10 +2,10 @@
 current_version = 7.7.0
 commit = True
 tag = False
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]+)(\.(?P<devnum>[0-9a-f]+))?)?
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\.(?P<stage>[^.]+)(?P<devnum>\d+)?)?
 serialize = 
-	{major}.{minor}.{patch}-{stage}.{devnum}
-	{major}.{minor}.{patch}-{stage}
+	{major}.{minor}.{patch}.{stage}{devnum}
+	{major}.{minor}.{patch}.{stage}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:stage]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,10 +32,10 @@ jobs:
       if: ${{ github.ref_type == 'branch' }}
       run: |
         pip install bumpversion
-        export VERSION=$(bumpversion major --dry-run --list --allow-dirty | grep current_version= | sed 's/current_version=//g')
+        export VERSION=$(bumpversion devnum --dry-run --serialize {major}.{minor}.{patch}.dev{devnum} --list | grep new_version= | sed 's/new_version=//g')
         export SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7 | tr '[:upper:]' '[:lower:]')
-        echo "Set development version: $VERSION-dev.$SHORT_SHA"
-        bumpversion devnum --new-version $VERSION-dev.$SHORT_SHA --no-tag --no-commit
+        echo "Set development version: $VERSION+$SHORT_SHA"
+        bumpversion devnum --serialize {major}.{minor}.{patch}.dev{devnum}+$SHORT_SHA --no-tag --no-commit
 
     - name: Build and push Docker image (development)
       if: ${{ github.ref_type == 'branch' }}


### PR DESCRIPTION
PR #3705 introduced some changes to the versioning of development releases, adhering to both bumpversion and SemVer, but we didn't realize these changes were incompatible with Python packaging versioning rules. See  https://packaging.python.org/en/latest/specifications/version-specifiers

With the new proposed approach, the following version strings are acceptable:
```
1.2.3
1.2.3.rc1
1.2.3.dev3
1.2.3.dev1+abc789
```

**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [ ] 2
- [X] 3

**What this does:**
> High-level idea of the changes introduced in this PR. 
> List relevant API changes (if any), as well as related PRs and issues.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
