### PR TITLE
Optimize jsonpath: module-level imports and LRU cache

### DIFF
--- a/nucypher/policy/conditions/json/base.py
+++ b/nucypher/policy/conditions/json/base.py
@@ -5,7 +5,6 @@ from typing import Any, Optional, Tuple
 
 import requests
 from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
-from jsonpath_ng.ext import parse
 from marshmallow.fields import String
 
 from nucypher.policy.conditions.base import ExecutionCall
@@ -17,7 +16,7 @@ from nucypher.policy.conditions.exceptions import (
     JsonRequestException,
 )
 from nucypher.policy.conditions.json.auth import AuthorizationType
-from nucypher.policy.conditions.json.utils import query_json_data
+from nucypher.policy.conditions.json.utils import parse_jsonpath, query_json_data
 from nucypher.policy.conditions.lingo import ExecutionCallCondition
 from nucypher.utilities.logging import Logger
 
@@ -121,7 +120,7 @@ class JSONPathField(String):
             raise self.make_error("invalidType", value=type(value))
         try:
             if not string_contains_context_variable(value):
-                parse(value)
+                parse_jsonpath(value)
         except (JsonPathLexerError, JsonPathParserError) as e:
             raise self.make_error("invalid", value=value) from e
         return value

--- a/nucypher/policy/conditions/json/utils.py
+++ b/nucypher/policy/conditions/json/utils.py
@@ -37,6 +37,6 @@ def query_json_data(data: Any, query: Optional[str], **context) -> Any:
     return result
 
 
-@lru_cache(maxsize=2048)
+@lru_cache(maxsize=512)
 def parse_jsonpath(expr: str):
     return parse(expr)

--- a/nucypher/policy/conditions/json/utils.py
+++ b/nucypher/policy/conditions/json/utils.py
@@ -1,4 +1,11 @@
+from functools import lru_cache
 from typing import Any, Optional
+
+from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
+from jsonpath_ng.ext import parse
+
+from nucypher.policy.conditions.context import resolve_any_context_variables
+from nucypher.policy.conditions.exceptions import ConditionEvaluationFailed
 
 
 def query_json_data(data: Any, query: Optional[str], **context) -> Any:
@@ -9,16 +16,10 @@ def query_json_data(data: Any, query: Optional[str], **context) -> Any:
     if not query:
         return data  # no query, return raw data
 
-    from jsonpath_ng.exceptions import JsonPathLexerError, JsonPathParserError
-    from jsonpath_ng.ext import parse
-
-    from nucypher.policy.conditions.context import resolve_any_context_variables
-    from nucypher.policy.conditions.exceptions import ConditionEvaluationFailed
-
     resolved_query = resolve_any_context_variables(query, **context)
 
     try:
-        expression = parse(resolved_query)
+        expression = parse_jsonpath(resolved_query)
         matches = expression.find(data)
         if not matches:
             message = f"No matches found for the JSONPath query: {resolved_query}"
@@ -34,3 +35,8 @@ def query_json_data(data: Any, query: Optional[str], **context) -> Any:
         result = matches[0].value
 
     return result
+
+
+@lru_cache(maxsize=2048)
+def parse_jsonpath(expr: str):
+    return parse(expr)

--- a/tests/unit/conditions/test_json_utils.py
+++ b/tests/unit/conditions/test_json_utils.py
@@ -1,0 +1,29 @@
+from jsonpath_ng.ext import parse
+
+from nucypher.policy.conditions.json.utils import parse_jsonpath
+
+
+def test_json_path_parse_utility_caching():
+    expr = "$.store.book[0].price"
+
+    # First call - should parse and cache
+    json_path_1 = parse_jsonpath(expr)
+    # Second call - should retrieve from cache
+    json_path_2 = parse_jsonpath(expr)
+    assert json_path_1 is json_path_2  # Both results should be the same cached object
+
+    other_expr = "$.store.book[1].price"
+    json_path_3 = parse_jsonpath(other_expr)
+    assert (
+        json_path_3 is not json_path_1
+    )  # Different expressions should yield different objects
+
+    direct_json_path = parse(
+        other_expr
+    )  # call jsonpath library directly to get a new object
+    assert (
+        direct_json_path is not json_path_3
+    )  # Direct parse should yield a different object than the cached one
+    assert (
+        direct_json_path == json_path_3
+    )  # The parser should be "equivalent" in terms of content, even if not the same object


### PR DESCRIPTION
## Summary
- Move `jsonpath_ng` imports from inside `query_json_data()` to module level, avoiding repeated import overhead on every call
- Add `parse_jsonpath()` with `@lru_cache(maxsize=512)` so compiled jsonpath expressions are reused instead of rebuilding the parser each time
- Use cached `parse_jsonpath()` in schema deserialization as well

Split from #3704.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

via [HAPI](https://hapi.run)