### PR TITLE
Skip redundant schema validation on marshmallow post_load construction

### DIFF
--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -73,13 +73,16 @@ class _Serializable:
         instance = cls.from_json(json_payload)
         return instance
 
+    def _force_validate_with_schema(self):
+        # perform actual validation since object instantiation is not being done by marshmallow's post_load
+        errors = self.Schema().validate(data=self.to_dict())
+        if errors:
+            error_message = extract_single_error_message_from_schema_errors(errors)
+            raise ValueError(f"Invalid {self.__class__.__name__}: {error_message}")
+
     def _validate(self, **kwargs):
         if not constructed_from_marshmallow_postload():
-            # perform actual validation since object instantiation is not being done by marshmallow's post_load
-            errors = self.Schema().validate(data=self.to_dict())
-            if errors:
-                error_message = extract_single_error_message_from_schema_errors(errors)
-                raise ValueError(f"Invalid {self.__class__.__name__}: {error_message}")
+            self._force_validate_with_schema()
 
 
 class Condition(_Serializable, ABC):

--- a/nucypher/policy/conditions/base.py
+++ b/nucypher/policy/conditions/base.py
@@ -1,6 +1,8 @@
 import json
 from abc import ABC, abstractmethod
 from base64 import b64decode, b64encode
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import Any, List, Optional, Tuple
 
 from marshmallow import Schema, ValidationError, fields
@@ -14,6 +16,24 @@ from nucypher.policy.conditions.utils import (
     extract_single_error_message_from_schema_errors,
 )
 
+_in_marshmallow_postload_construction: ContextVar[bool] = ContextVar(
+    "_in_marshmallow_postload_construction",
+    default=False,
+)
+
+
+@contextmanager
+def marshmallow_postload_construction():
+    token = _in_marshmallow_postload_construction.set(True)
+    try:
+        yield
+    finally:
+        _in_marshmallow_postload_construction.reset(token)
+
+
+def constructed_from_marshmallow_postload() -> bool:
+    return _in_marshmallow_postload_construction.get()
+
 
 class _Serializable:
     class Schema(Schema):
@@ -26,10 +46,8 @@ class _Serializable:
 
     @classmethod
     def from_json(cls, data) -> '_Serializable':
-        data = json.loads(data)
-        schema = cls.Schema()
-        instance = schema.load(data)
-        return instance
+        data_dict = json.loads(data)
+        return cls.from_dict(data_dict)
 
     def to_dict(self):
         schema = self.Schema()
@@ -39,7 +57,9 @@ class _Serializable:
     @classmethod
     def from_dict(cls, data) -> '_Serializable':
         schema = cls.Schema()
-        instance = schema.load(data)
+        with marshmallow_postload_construction():
+            # set context variable to indicate that we're constructing from marshmallow's post_load
+            instance = schema.load(data)
         return instance
 
     def __bytes__(self) -> bytes:
@@ -54,10 +74,12 @@ class _Serializable:
         return instance
 
     def _validate(self, **kwargs):
-        errors = self.Schema().validate(data=self.to_dict())
-        if errors:
-            error_message = extract_single_error_message_from_schema_errors(errors)
-            raise ValueError(f"Invalid {self.__class__.__name__}: {error_message}")
+        if not constructed_from_marshmallow_postload():
+            # perform actual validation since object instantiation is not being done by marshmallow's post_load
+            errors = self.Schema().validate(data=self.to_dict())
+            if errors:
+                error_message = extract_single_error_message_from_schema_errors(errors)
+                raise ValueError(f"Invalid {self.__class__.__name__}: {error_message}")
 
 
 class Condition(_Serializable, ABC):

--- a/tests/unit/conditions/test_condition_lingo.py
+++ b/tests/unit/conditions/test_condition_lingo.py
@@ -7,6 +7,7 @@ from packaging.version import parse as parse_version
 
 import nucypher
 from nucypher.blockchain.eth.constants import NULL_ADDRESS
+from nucypher.policy.conditions.base import Condition
 from nucypher.policy.conditions.context import USER_ADDRESS_CONTEXT
 from nucypher.policy.conditions.exceptions import (
     InvalidConditionLingo,
@@ -18,6 +19,7 @@ from nucypher.policy.conditions.lingo import (
     ConditionType,
 )
 from nucypher.policy.conditions.signing.base import SIGNING_CONDITION_OBJECT_CONTEXT_VAR
+from nucypher.policy.conditions.time import TimeCondition
 from tests.constants import INT256_MIN, TESTERCHAIN_CHAIN_ID, UINT256_MAX
 
 
@@ -590,3 +592,38 @@ def test_any_large_integer_field(json_value, expected_deserialized_value):
         # expected to fail
         with pytest.raises(ValidationError, match="Not a valid integer."):
             _ = field.deserialize(json_value)
+
+
+def test_single_schema_validation_on_condition_creation(mocker, time_condition):
+    time_condition_lingo = ConditionLingo(time_condition)
+
+    validate_spy = mocker.spy(Condition, "_force_validate_with_schema")
+
+    # from dict
+    condition_dict = time_condition_lingo.to_dict()
+    _ = ConditionLingo.from_dict(condition_dict)
+    assert validate_spy.call_count == 0  # already validated since created from lingo
+
+    # from json
+    condition_json = time_condition_lingo.to_json()
+    _ = ConditionLingo.from_json(condition_json)
+    assert validate_spy.call_count == 0  # already validated since created from lingo
+
+    # from bytes
+    condition_bytes = bytes(time_condition_lingo)
+    _ = ConditionLingo.from_bytes(condition_bytes)
+    assert validate_spy.call_count == 0  # already validated since created from lingo
+
+    # directly from constructor
+    new_time_condition = TimeCondition(
+        return_value_test=time_condition.return_value_test,
+        chain=time_condition.chain,
+        method=time_condition.method,
+    )
+    # actually validated since created directly from constructor, not from lingo
+    assert validate_spy.call_count == 1
+
+    # condition lingo from condition constructor
+    _ = ConditionLingo(new_time_condition)
+    # no change in call count since condition already previously created in previous step
+    assert validate_spy.call_count == 1


### PR DESCRIPTION
## Summary
- When condition objects are constructed via `Schema.load()` (e.g. from JSON/dict), marshmallow already validates the data during deserialization
- The `__init__` then calls `_validate()` which runs `Schema().validate()` again — redundant work
- Use a `ContextVar` (`_in_marshmallow_postload_construction`) to track when construction is happening inside `from_dict()` / `from_json()` and skip the extra validation in that case
- Direct construction (e.g. `MyCondition(param=...)`) still validates as before

Split from #3704.

## Test plan
- [x] All existing condition serialization/deserialization tests pass
- [x] Direct construction still validates (invalid params raise `ValueError`)
- [x] Construction via `from_dict()` / `from_json()` skips redundant validation without changing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

via [HAPI](https://hapi.run)