### PR TITLE
Fix problematic unit test

### DIFF
--- a/tests/unit/test_external_ip_utilities.py
+++ b/tests/unit/test_external_ip_utilities.py
@@ -140,7 +140,8 @@ def test_get_external_ip_from_known_nodes(mock_client):
         known_nodes=sensor, sample_size=sample_size, eth_endpoint=MOCK_ETH_PROVIDER_URI
     )
     assert mock_client.call_count == 1
-    mock_client.call_count = 0  # reset
+
+    mock_client.reset_mock()  # reset
 
     # All sampled nodes dont respond
     mock_client.return_value = Dummy.BadResponse


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**

Properly resets mock (and call count) during test.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
Failed CI Job
```
tests/unit/test_external_ip_utilities.py ...F

=================================== FAILURES ===================================
____________________ test_get_external_ip_from_known_nodes _____________________

mock_client = <MagicMock name='invoke_method' id='139806665998416'>

    def test_get_external_ip_from_known_nodes(mock_client):
    
        # Setup FleetSensor
        sensor = FleetSensor(domain=MOCK_DOMAIN)
        sample_size = 3
        sensor.record_node(Dummy(b'deadbeefdeadbeefdead'))
        sensor.record_node(Dummy(b'deadllamadeadllamade'))
        sensor.record_node(Dummy(b'deadmousedeadmousede'))
        sensor.record_fleet_state()
        assert len(sensor) == sample_size
    
        # First sampled node replies
        get_external_ip_from_known_nodes(
            known_nodes=sensor, sample_size=sample_size, eth_endpoint=MOCK_ETH_PROVIDER_URI
        )
        assert mock_client.call_count == 1
        mock_client.call_count = 0  # reset
    
        # All sampled nodes dont respond
        mock_client.return_value = Dummy.BadResponse
        get_external_ip_from_known_nodes(
            known_nodes=sensor, sample_size=sample_size, eth_endpoint=MOCK_ETH_PROVIDER_URI
        )
>       assert mock_client.call_count == sample_size
E       AssertionError: assert 4 == 3
E        +  where 4 = <MagicMock name='invoke_method' id='139806665998416'>.call_count
```


**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
