### PR TITLE
User configured endpoint that fails health check should prevent node from starting up

### DIFF
--- a/newsfragments/3715.feature.rst
+++ b/newsfragments/3715.feature.rst
@@ -1,0 +1,1 @@
+Whenever a user-configured endpoint fails an rpc health check, the node should not start up.

--- a/newsfragments/3715.feature.rst
+++ b/newsfragments/3715.feature.rst
@@ -1,1 +1,1 @@
-Whenever a user-configured endpoint fails an rpc health check, the node should not start up.
+Whenever a user-configured endpoint fails an RPC health check, the node should not start up.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -31,7 +31,7 @@ from nucypher_core.ferveo import (
     Validator,
     ValidatorMessage,
 )
-from web3 import HTTPProvider, Web3
+from web3 import Web3
 from web3.types import TxReceipt
 
 from nucypher.acumen.nicknames import Nickname
@@ -334,11 +334,6 @@ class Operator(BaseActor):
             )
             return receipt
 
-    @staticmethod
-    def _make_condition_provider(uri: str) -> HTTPProvider:
-        provider = HTTPProvider(endpoint_uri=uri)
-        return provider
-
     def get_condition_provider_manager(
         self, operator_configured_endpoints: Dict[int, List[str]]
     ) -> ConditionProviderManager:
@@ -373,15 +368,13 @@ class Operator(BaseActor):
                     )
                     continue
 
-                provider = self._make_condition_provider(uri)
-                if int(Web3(provider).eth.chain_id) != int(chain_id):
-                    raise self.ActorError(
-                        f"Operator-configured RPC condition endpoint {obfuscate_rpc_url(uri)} does not belong to chain {chain_id}"
-                    )
-                # TODO: the chain id above is duplicated for the health check - fix logic
                 healthy = rpc_endpoint_health_check(chain_id=chain_id, endpoint=uri)
                 if not healthy:
                     self.log.warn(
+                        f"Operator-configured RPC condition endpoint {obfuscate_rpc_url(uri)} (chainID={chain_id}) is unhealthy"
+                    )
+                    # bad user configured endpoint should cause operator to not start.
+                    raise self.ActorError(
                         f"Operator-configured RPC condition endpoint {obfuscate_rpc_url(uri)} (chainID={chain_id}) is unhealthy"
                     )
                 configured_endpoints[int(chain_id)].append(uri)

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -171,8 +171,8 @@ def rpc_endpoint_health_check(
     if result is None:
         return False
 
-    provider_chain = int(result, 16)
     try:
+        provider_chain = int(result, 16)
         if provider_chain != chain_id:
             LOGGER.warn(
                 f"RPC endpoint is invalid for chain; expected chain ID {chain_id}, but detected {provider_chain}"

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -179,7 +179,7 @@ def rpc_endpoint_health_check(
             )
             return False
     except (TypeError, ValueError):
-        LOGGER.debug(
+        LOGGER.warn(
             f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: invalid chain ID response {result}"
         )
         return False
@@ -198,7 +198,7 @@ def rpc_endpoint_health_check(
     try:
         timestamp = int(block_data.get("timestamp"), 16)
     except (TypeError, ValueError):
-        LOGGER.debug(
+        LOGGER.warn(
             f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: invalid block data"
         )
         return False
@@ -206,7 +206,7 @@ def rpc_endpoint_health_check(
     system_time = time.time()
     drift = abs(system_time - timestamp)
     if drift > max_drift_seconds:
-        LOGGER.debug(
+        LOGGER.warn(
             f"RPC endpoint {obfuscate_rpc_url(endpoint)} is unhealthy: drift too large ({drift} seconds)"
         )
         return False

--- a/tests/acceptance/conftest.py
+++ b/tests/acceptance/conftest.py
@@ -1,10 +1,9 @@
 import random
 
 import pytest
-from web3 import HTTPProvider, Web3
+from web3 import Web3
 
 import tests
-from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import (
     ContractAgency,
     CoordinatorAgent,
@@ -16,7 +15,6 @@ from nucypher.blockchain.eth.constants import NULL_ADDRESS
 from nucypher.blockchain.eth.interfaces import BlockchainInterfaceFactory
 from nucypher.blockchain.eth.registry import ContractRegistry, RegistrySourceManager
 from nucypher.crypto.powers import TransactingPower
-from nucypher.utilities.endpoint import RPCEndpoint
 from nucypher.utilities.logging import Logger
 from tests.constants import (
     BONUS_TOKENS_FOR_TESTS,
@@ -577,25 +575,6 @@ def mock_condition_blockchains(module_mocker):
 
     module_mocker.patch(
         "nucypher.blockchain.eth.domains.get_domain", return_value=TEMPORARY_DOMAIN
-    )
-
-
-@pytest.fixture(scope="module", autouse=True)
-def mock_multichain_configuration(module_mocker, testerchain):
-    module_mocker.patch.object(
-        Operator, "_make_condition_provider", return_value=testerchain.provider
-    )
-
-    def _mock_make_provider(endpoint, session, request_kwargs):
-        if endpoint == TEST_ETH_PROVIDER_URI:
-            return testerchain.provider
-        else:
-            return HTTPProvider(
-                endpoint, session=session, request_kwargs=request_kwargs
-            )
-
-    module_mocker.patch.object(
-        RPCEndpoint, "_make_provider", side_effect=_mock_make_provider
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import pytest
 from eth_utils.crypto import keccak
 
-from nucypher.blockchain.eth.actors import Operator
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Learner
 from nucypher.utilities.logging import GlobalLoggerSettings
@@ -133,10 +132,3 @@ def mock_get_external_ip_from_url_source(session_mocker):
 def disable_check_grant_requirements(session_mocker):
     target = 'nucypher.characters.lawful.Alice._check_grant_requirements'
     session_mocker.patch(target, return_value=MOCK_IP_ADDRESS)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def mock_multichain_configuration(module_mocker, testerchain):
-    module_mocker.patch.object(
-        Operator, "_make_condition_provider", return_value=testerchain.provider
-    )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -914,7 +914,7 @@ def mock_rpc_endpoint_health_check(session_mocker):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def mock_web3_http_provider(session_mocker, testerchain):
+def mock_web3_http_provider(module_mocker, testerchain):
     def _mock_make_provider(endpoint, session, request_timeout):
         if endpoint == TEST_ETH_PROVIDER_URI:
             return testerchain.provider
@@ -925,6 +925,6 @@ def mock_web3_http_provider(session_mocker, testerchain):
                 request_kwargs={"timeout": request_timeout},
             )
 
-    session_mocker.patch.object(
+    module_mocker.patch.object(
         RPCEndpoint, "_make_provider", side_effect=_mock_make_provider
     )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -17,7 +17,7 @@ from eth_utils import to_checksum_address
 from nucypher_core.ferveo import AggregatedTranscript, DkgPublicKey, Keypair, Validator
 from siwe import SiweMessage
 from twisted.internet.task import Clock
-from web3 import Web3
+from web3 import HTTPProvider, Web3
 
 import tests
 from nucypher.blockchain.eth.actors import Operator
@@ -51,6 +51,7 @@ from nucypher.policy.conditions.lingo import (
 from nucypher.policy.conditions.time import TimeCondition
 from nucypher.policy.payment import SubscriptionManagerPayment
 from nucypher.utilities.emitters import StdoutEmitter
+from nucypher.utilities.endpoint import RPCEndpoint
 from nucypher.utilities.logging import GlobalLoggerSettings, Logger
 from nucypher.utilities.networking import LOOPBACK_ADDRESS
 from nucypher.utilities.task import SimpleTask
@@ -895,4 +896,35 @@ def mock_default_rpc_endpoint_fetch(session_mocker):
     session_mocker.patch(
         "nucypher.blockchain.eth.utils.get_default_rpc_endpoints",
         return_value={TESTERCHAIN_CHAIN_ID: [TEST_ETH_PROVIDER_URI]},
+    )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_rpc_endpoint_health_check(session_mocker):
+    # utils used for default endpoint health check
+    session_mocker.patch(
+        "nucypher.blockchain.eth.utils.rpc_endpoint_health_check",
+        return_value=True,
+    )
+    # actors used for user-configured endpoint health check
+    session_mocker.patch(
+        "nucypher.blockchain.eth.actors.rpc_endpoint_health_check",
+        return_value=True,
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def mock_web3_http_provider(session_mocker, testerchain):
+    def _mock_make_provider(endpoint, session, request_timeout):
+        if endpoint == TEST_ETH_PROVIDER_URI:
+            return testerchain.provider
+        else:
+            return HTTPProvider(
+                endpoint_uri=endpoint,
+                session=session,
+                request_kwargs={"timeout": request_timeout},
+            )
+
+    session_mocker.patch.object(
+        RPCEndpoint, "_make_provider", side_effect=_mock_make_provider
     )

--- a/tests/integration/characters/test_ursula_startup.py
+++ b/tests/integration/characters/test_ursula_startup.py
@@ -2,7 +2,7 @@ import pytest
 
 from nucypher.characters.lawful import Ursula
 from nucypher.config.constants import TEMPORARY_DOMAIN_NAME
-from tests.constants import TESTERCHAIN_CHAIN_ID
+from tests.constants import MOCK_ETH_PROVIDER_URI, TESTERCHAIN_CHAIN_ID
 
 
 def test_new_ursula_announces_herself(lonely_ursula_maker):
@@ -34,15 +34,32 @@ def test_node_deployer(ursulas):
         assert deployer.application == ursula.rest_app
 
 
-def test_no_corresponding_condition_blockchain_provider(lonely_ursula_maker):
-    INVALID_CHAIN_ID = 66775827584859395569954838  # If we eventually support a chain with this ID, heaven help us.
+def test_no_corresponding_valid_condition_blockchain_provider(
+    lonely_ursula_maker, mocker
+):
+    OTHER_CHAIN_ID = 66775827584859395569954838
+    other_chain_uri = "this is an invalid provider URI, but doesn't matter because the health check will fail it"
 
-    with pytest.raises(Ursula.ActorError):
+    def mock_rpc_endpoint_health_check(endpoint: str, *args, **kwargs):
+        if endpoint == other_chain_uri:
+            return False
+
+        return True
+
+    mocker.patch(
+        "nucypher.blockchain.eth.actors.rpc_endpoint_health_check",
+        side_effect=mock_rpc_endpoint_health_check,
+    )
+
+    with pytest.raises(
+        Ursula.ActorError,
+        match=f"Operator-configured RPC condition endpoint.*{OTHER_CHAIN_ID}.* is unhealthy",
+    ):
         _ursula_who_tries_to_connect_to_an_invalid_chain = lonely_ursula_maker(
             quantity=1,
             domain=TEMPORARY_DOMAIN_NAME,
             condition_blockchain_endpoints={
-                TESTERCHAIN_CHAIN_ID: "this is a provider URI.",
-                INVALID_CHAIN_ID: "this is a provider URI, but it doesn't matter what we pass here because the chain_id is invalid."
+                TESTERCHAIN_CHAIN_ID: [MOCK_ETH_PROVIDER_URI],
+                OTHER_CHAIN_ID: [other_chain_uri],
             },
         )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,6 @@ from typing import Iterable, Optional
 
 import pytest
 from eth_account.account import Account
-from web3 import HTTPProvider
 
 from nucypher.blockchain.eth.actors import Operator
 from nucypher.blockchain.eth.agents import (
@@ -28,14 +27,11 @@ from nucypher.config.characters import UrsulaConfiguration
 from nucypher.crypto.powers import TransactingPower
 from nucypher.network.nodes import Teacher
 from nucypher.policy.payment import SubscriptionManagerPayment
-from nucypher.utilities.endpoint import RPCEndpoint
 from tests.constants import (
     KEYFILE_NAME_TEMPLATE,
     MOCK_KEYSTORE_PATH,
     NUMBER_OF_MOCK_KEYSTORE_ACCOUNTS,
     TEMPORARY_DOMAIN,
-    TEST_ETH_PROVIDER_URI,
-    TESTERCHAIN_CHAIN_ID,
 )
 from tests.mock.agents import MockContractAgency
 from tests.mock.interfaces import MockBlockchain
@@ -286,34 +282,6 @@ def multichain_ids(module_mocker):
 def multichain_ursulas(ursulas, multichain_ids):
     setup_multichain_ursulas(ursulas=ursulas, chain_ids=multichain_ids)
     return ursulas
-
-
-@pytest.fixture(scope="module", autouse=True)
-def mock_rpc_endpoints(module_mocker, testerchain):
-    """Mock RPC endpoints for integration tests"""
-
-    def mock_get_default_endpoints(domain):
-        # Return test endpoints for the testerchain
-        return {TESTERCHAIN_CHAIN_ID: [TEST_ETH_PROVIDER_URI]}
-
-    module_mocker.patch(
-        "nucypher.blockchain.eth.utils.get_default_rpc_endpoints",
-        side_effect=mock_get_default_endpoints,
-    )
-
-    def _mock_make_provider(endpoint, session, request_timeout):
-        if endpoint == TEST_ETH_PROVIDER_URI:
-            return testerchain.provider
-        else:
-            return HTTPProvider(
-                endpoint_uri=endpoint,
-                session=session,
-                request_kwargs={"timeout": request_timeout},
-            )
-
-    module_mocker.patch.object(
-        RPCEndpoint, "_make_provider", side_effect=_mock_make_provider
-    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/test_condition_provider_chains.py
+++ b/tests/unit/test_condition_provider_chains.py
@@ -31,7 +31,9 @@ class TestConditionProviderChainValidation:
         )
         Operator.get_condition_provider_manager(mock_operator, endpoints)
 
-    def test_failed_rpc_health_raises_error(self, mock_operator, mocker):
+    def test_failed_rpc_health_user_configured_endpoint_raises_error(
+        self, mock_operator, mocker
+    ):
         poly2_uri = "http://poly2"
         user_configured_endpoints = {
             1: ["http://eth"],

--- a/tests/unit/test_condition_provider_chains.py
+++ b/tests/unit/test_condition_provider_chains.py
@@ -30,3 +30,71 @@ class TestConditionProviderChainValidation:
             return_value={},
         )
         Operator.get_condition_provider_manager(mock_operator, endpoints)
+
+    def test_failed_rpc_health_raises_error(self, mock_operator, mocker):
+        poly2_uri = "http://poly2"
+        user_configured_endpoints = {
+            1: ["http://eth"],
+            137: ["http://poly1", poly2_uri],
+        }
+
+        def mock_rpc_endpoint_health_check(endpoint: str, *args, **kwargs):
+            if endpoint == poly2_uri:
+                return False
+            return True
+
+        rpc_endpoint_health_check_mock = mocker.patch(
+            "nucypher.blockchain.eth.actors.rpc_endpoint_health_check",
+            side_effect=mock_rpc_endpoint_health_check,
+        )
+        mocker.patch(
+            "nucypher.blockchain.eth.actors.get_healthy_default_rpc_endpoints",
+            return_value={},
+        )
+
+        with pytest.raises(
+            Operator.ActorError,
+            match=f"Operator-configured.*{poly2_uri}.*{137}.*is unhealthy",
+        ):
+            Operator.get_condition_provider_manager(
+                mock_operator, user_configured_endpoints
+            )
+
+        assert rpc_endpoint_health_check_mock.call_count == 3  # 3 endpoints checked
+
+    def test_failed_rpc_health_default_endpoints_does_not_raise_error(
+        self, mock_operator, mocker
+    ):
+        poly_public_rpc = "http://default-poly"
+        mocker.patch(
+            "nucypher.blockchain.eth.utils.get_default_rpc_endpoints",
+            return_value={137: [poly_public_rpc]},
+        )
+
+        def mock_rpc_endpoint_health_check(endpoint: str, *args, **kwargs):
+            if endpoint == poly_public_rpc:
+                return False
+            return True
+
+        user_configured_rpc_endpoint_health_check_mock = mocker.patch(
+            "nucypher.blockchain.eth.actors.rpc_endpoint_health_check",
+            side_effect=mock_rpc_endpoint_health_check,
+        )
+        default_endpoint_rpc_health_check_mock = mocker.patch(
+            "nucypher.blockchain.eth.utils.rpc_endpoint_health_check",
+            side_effect=mock_rpc_endpoint_health_check,
+        )
+
+        # user-configured endpoint is healthy, but the default endpoint is not healthy.
+        # This should not raise an exception because the default endpoint is not required to be healthy.
+        user_configured_endpoints = {1: ["http://eth"], 137: ["http://poly1"]}
+        Operator.get_condition_provider_manager(
+            mock_operator, user_configured_endpoints
+        )
+
+        assert (
+            user_configured_rpc_endpoint_health_check_mock.call_count == 2
+        )  # 2 user-configured endpoints checked
+        assert (
+            default_endpoint_rpc_health_check_mock.call_count == 1
+        )  # 1 default endpoint checked

--- a/tests/unit/test_condition_provider_chains.py
+++ b/tests/unit/test_condition_provider_chains.py
@@ -21,29 +21,6 @@ class TestConditionProviderChainValidation:
     def test_additional_chains_pass_validation(self, mock_operator, mocker):
         endpoints = {1: ["http://eth"], 137: ["http://poly"], 8453: ["http://base"]}
 
-        # Track which URI is being processed to return correct chain_id
-        uri_to_chain = {
-            "http://eth": 1,
-            "http://poly": 137,
-            "http://base": 8453,
-        }
-        current_chain_id = [None]  # Use list to allow mutation in closure
-
-        def make_provider_side_effect(uri):
-            current_chain_id[0] = uri_to_chain[uri]
-            return mocker.Mock()
-
-        mock_operator._make_condition_provider.side_effect = make_provider_side_effect
-
-        def web3_factory(provider):
-            mock_web3 = mocker.Mock()
-            mock_web3.eth.chain_id = current_chain_id[0]
-            return mock_web3
-
-        mocker.patch(
-            "nucypher.blockchain.eth.actors.Web3",
-            side_effect=web3_factory,
-        )
         mocker.patch(
             "nucypher.blockchain.eth.actors.rpc_endpoint_health_check",
             return_value=True,


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Based over #3704 

Prevents nodes from starting when user-configured RPC endpoints fail health checks. 

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
