### PR TITLE
Always check health of default RPC endpoints

### DIFF
--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -288,17 +288,14 @@ def get_healthy_default_rpc_endpoints(domain: TACoDomain) -> Dict[int, List[str]
     """Returns a mapping of chain id to healthy RPC endpoints for a given domain."""
     endpoints = get_default_rpc_endpoints(domain)
 
-    if not domain.is_testnet:
-        # iterate over all chains and filter out unhealthy endpoints
-        healthy = {
-            chain_id: [
-                endpoint
-                for endpoint in endpoints[chain_id]
-                if rpc_endpoint_health_check(chain_id=chain_id, endpoint=endpoint)
-            ]
-            for chain_id in endpoints
-        }
-    else:
-        healthy = endpoints
+    # iterate over all chains and filter out unhealthy endpoints
+    healthy = {
+        chain_id: [
+            endpoint
+            for endpoint in endpoints[chain_id]
+            if rpc_endpoint_health_check(chain_id=chain_id, endpoint=endpoint)
+        ]
+        for chain_id in endpoints
+    }
 
     return healthy


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
In https://github.com/nucypher/nucypher/pull/3496, the decision was taken to skip health checks for default RPC endpoints when the node is running on testnet.

This PR changes that decision to always perform health checks on default RPC endpoints, regardless of whether the domain is a testnet or `mainnet`. It may slow down the start up of a node, but given usage/testing on `lynx` we should still ensure that endpoints are checked.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
