### PR TITLE
RPC load management part 2

### DIFF
--- a/newsfragments/3718.feature.rst
+++ b/newsfragments/3718.feature.rst
@@ -1,0 +1,1 @@
+Additional RPC endpoint management involving proactive capacity expansion under high utilization without failures, enhanced endpoint sorting, and quarantine logic for persistently unreachable endpoints.

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -177,7 +177,7 @@ class ConditionProviderManager:
         """
         return (
             stats.consecutive_unreachable_failures,
-            stats.consecutive_exec_failures,
+            stats.consecutive_request_failures,
             stats.ewma_latency_ms,
         )
 

--- a/nucypher/policy/conditions/utils.py
+++ b/nucypher/policy/conditions/utils.py
@@ -171,11 +171,15 @@ class ConditionProviderManager:
         return set(self._rpc_endpoint_managers.keys())
 
     @staticmethod
-    def _sort_by_latency(stats: RPCEndpoint.EndpointStats) -> Tuple:
+    def _sort_by_failures_then_latency(stats: RPCEndpoint.EndpointStats) -> Tuple:
         """
-        Sort strategy for RPC endpoints based on EWMA latency; endpoints with lower latency will be prioritized.
+        Sort strategy for RPC endpoints based on lowest unreachable failures, then lowest consecutive failures, then EWMA latency.
         """
-        return (stats.ewma_latency_ms,)
+        return (
+            stats.consecutive_unreachable_failures,
+            stats.consecutive_exec_failures,
+            stats.ewma_latency_ms,
+        )
 
     @staticmethod
     def _get_default_middlewares() -> Sequence[Tuple[Middleware, str]]:
@@ -204,7 +208,7 @@ class ConditionProviderManager:
         return manager.call(
             fn=fn,
             request_timeout=request_timeout,
-            endpoint_sort_strategy=self._sort_by_latency,
+            endpoint_sort_strategy=self._sort_by_failures_then_latency,
             override_middleware_stack=default_middlewares,
         )
 

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -147,6 +147,49 @@ class RPCEndpoint:
         with self._lock:
             return self._cool_down_until <= now
 
+    def consider_increasing_in_flight_capacity(self) -> bool:
+        """
+        Consider increasing in-flight capacity due to already being at high utilization without
+        failures: we are not in cool down, no consecutive failures, and we are at high utilization.
+
+        This is a proactive adjustment to allow the endpoint to handle more load if current
+        in flight capacity is deemed to be the bottleneck rather than health.
+
+        NOTE: should only be called by RPCEndpointManager.
+
+        :return True if the endpoint increased capacity, False otherwise
+        """
+        now = time.monotonic()
+        with self._lock:
+            # check that not in cool down
+            if self._cool_down_until > now:
+                # if we are in cool down state, it means we had recent failures and
+                # should not increase capacity
+                return False
+
+            # check that there weren't consecutive failures recently
+            if self._consecutive_failures > 0:
+                # if we had recent failures, it means the endpoint is unstable and we should not increase
+                # capacity even if we are not currently in cool down
+                return False
+
+            # check in high-utilization state
+            utilization_factor = self._num_in_flight_usage / self._in_flight_capacity
+            if utilization_factor < self.scale_up_utilization_threshold:
+                # utilization is low, no need to increase capacity
+                return False
+
+            # check that we are not already at max capacity
+            if self._in_flight_capacity >= self.max_in_flight_capacity:
+                return False
+
+            # if we are here, it means we are not in cool down, and we are at high utilization,
+            # so we can increase capacity
+            self._in_flight_capacity = min(
+                self.max_in_flight_capacity, self._in_flight_capacity + 2
+            )
+            return True
+
     @contextmanager
     def get_web3(
         self,
@@ -381,7 +424,16 @@ class RPCEndpointManager:
                 time.sleep(self.saturated_retry_delay_s)  # brief sleep before retrying
 
         # If we get here, everything was saturated for all rounds
+        self.consider_increasing_capacity_on_saturation()
         raise self.NoEndpointsAvailable("All endpoints at capacity or in cool down")
+
+    def consider_increasing_capacity_on_saturation(self) -> None:
+        """
+        Consider proactively increasing in-flight capacity on all endpoints if endpoints are
+        hitting capacity limits without failures.
+        """
+        for endpoint in self.preferred_endpoints + self.endpoints:
+            endpoint.consider_increasing_in_flight_capacity()
 
     def call(
         self,
@@ -429,4 +481,7 @@ class RPCEndpointManager:
         if last_exc is not None:
             raise last_exc
 
+        # if we are here it means we had candidates, but they were all at capacity or in
+        # cool down by the time we tried to acquire them
+        self.consider_increasing_capacity_on_saturation()
         raise self.NoEndpointsAvailable("All endpoints at capacity or in cool down")

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -448,7 +448,7 @@ class RPCEndpointManager:
     def _get_candidates(
         self, endpoint_sort_strategy: Optional[EndpointSortStrategy] = None
     ) -> List[RPCEndpoint]:
-        # Attempt rounds: try each endpoint up to max_attempts.
+        # Attempt rounds: try each endpoint up to saturated_retries additional retries.
         # If all saturated, optionally sleep briefly and retry a few times.
         rounds = 1 + self.saturated_retries
         for round_idx in range(rounds):

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -359,12 +359,12 @@ class RPCEndpoint:
         with self._lock:
             return self.EndpointStats(
                 latest_latency_ms=self._latest_latency_ms,
+                ewma_latency_ms=self._ewma_latency_ms,
                 consecutive_request_failures=self._consecutive_request_failures,
                 consecutive_unreachable_failures=self._consecutive_unreachable_failures,
                 num_in_flight_usage=self._num_in_flight_usage,
                 in_flight_capacity=self._in_flight_capacity,
                 last_used=self._last_used,
-                ewma_latency_ms=self._ewma_latency_ms,
             )
 
 
@@ -507,7 +507,7 @@ class RPCEndpointManager:
         :param override_middleware_stack: Optional sequence of (middleware, name) tuples to override Web3 default middlewares
         :return: The result of the provided function executed with a Web3 instance from a healthy endpoint.
         """
-        endpoints = self._get_candidates(endpoint_sort_strategy)
+        endpoints = self._get_candidates(endpoint_sort_strategy=endpoint_sort_strategy)
         last_exc = None
         session = self.session_manager.get_session()
         for endpoint in endpoints:

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -68,7 +68,7 @@ class RPCEndpoint:
         Snapshot of the endpoint's current health and usage stats for external inspection or sorting.
          - latest_latency_ms: most recent latency measurement in milliseconds.
          - ewma_latency_ms: exponentially weighted moving average of latency for trend tracking.
-         - consecutive_exec_failures: number of consecutive failures since last success.
+         - consecutive_request_failures: number of consecutive non-unreachable failures since last success.
          - consecutive_unreachable_failures: number of failures that indicate the endpoint is unreachable (e.g. connection errors).
          - num_in_flight_usage: current number of in-flight usages of this endpoint.
          - in_flight_capacity: current maximum allowed in-flight usages based on health.
@@ -77,7 +77,7 @@ class RPCEndpoint:
 
         latest_latency_ms: float
         ewma_latency_ms: float
-        consecutive_exec_failures: int
+        consecutive_request_failures: int
         consecutive_unreachable_failures: int
         num_in_flight_usage: int
         in_flight_capacity: int
@@ -87,7 +87,7 @@ class RPCEndpoint:
             return (
                 f"EndpointStats(latency={self.latest_latency_ms:.2f}ms, "
                 f"ewma_latency={self.ewma_latency_ms:.2f}ms, "
-                f"consecutive_exec_failures={self.consecutive_exec_failures}, "
+                f"consecutive_request_failures={self.consecutive_request_failures}, "
                 f"consecutive_unreachable_failures={self.consecutive_unreachable_failures}, "
                 f"in_flight_usage={self.num_in_flight_usage}, "
                 f"in_flight_cap={self.in_flight_capacity}, "
@@ -126,7 +126,7 @@ class RPCEndpoint:
         self.max_backoff_s = max_backoff_s
 
         self._latest_latency_ms = 0.0
-        self._consecutive_exec_failures = 0
+        self._consecutive_request_failures = 0
         self._cool_down_until = 0.0
         self._last_used = 0.0
 
@@ -177,7 +177,7 @@ class RPCEndpoint:
                 return False
 
             # check that there weren't consecutive failures recently
-            if self._consecutive_exec_failures > 0:
+            if self._consecutive_request_failures > 0:
                 # if we had recent failures, it means the endpoint is unstable and we should
                 # not increase capacity even if we are not currently in cool down
                 return False
@@ -268,7 +268,7 @@ class RPCEndpoint:
             self._latest_latency_ms = latency_ms
 
             # reset failure counts on success
-            self._consecutive_exec_failures = 0
+            self._consecutive_request_failures = 0
             self._consecutive_unreachable_failures = 0
 
             # reset cool down on success
@@ -314,7 +314,7 @@ class RPCEndpoint:
             if is_unreachable:
                 # endpoint is unreachable
                 self._consecutive_unreachable_failures += 1
-                self._consecutive_exec_failures = 0  # reset non-unreachable failures
+                self._consecutive_request_failures = 0  # reset non-unreachable failures
 
                 # start going down in capacity more quickly on unreachable failures
                 self._in_flight_capacity = max(1, self._in_flight_capacity // 2)
@@ -336,7 +336,7 @@ class RPCEndpoint:
                 return
 
             # non-unreachable failure
-            self._consecutive_exec_failures += 1
+            self._consecutive_request_failures += 1
             self._consecutive_unreachable_failures = 0  # reset unreachable failures
 
             # decrease in flight capacity on failure, but never below minimum
@@ -345,9 +345,9 @@ class RPCEndpoint:
                 self.min_in_flight_capacity, self._in_flight_capacity // 2
             )
 
-            if self._consecutive_exec_failures >= 2:
+            if self._consecutive_request_failures >= 2:
                 backoff = min(
-                    self.max_backoff_s, 2 ** (self._consecutive_exec_failures - 1)
+                    self.max_backoff_s, 2 ** (self._consecutive_request_failures - 1)
                 )
                 # add some jitter to avoid common backoff patterns
                 backoff_jitter = min(
@@ -359,7 +359,7 @@ class RPCEndpoint:
         with self._lock:
             return self.EndpointStats(
                 latest_latency_ms=self._latest_latency_ms,
-                consecutive_exec_failures=self._consecutive_exec_failures,
+                consecutive_request_failures=self._consecutive_request_failures,
                 consecutive_unreachable_failures=self._consecutive_unreachable_failures,
                 num_in_flight_usage=self._num_in_flight_usage,
                 in_flight_capacity=self._in_flight_capacity,

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -187,14 +187,14 @@ class RPCEndpoint:
                 # we should not increase capacity even if we are not currently in cool down
                 return False
 
+            # check that we are not already at max capacity
+            if self._in_flight_capacity >= self.max_in_flight_capacity:
+                return False
+
             # check in high-utilization state
             utilization_factor = self._num_in_flight_usage / self._in_flight_capacity
             if utilization_factor < self.scale_up_utilization_threshold:
                 # utilization is low, no need to increase capacity
-                return False
-
-            # check that we are not already at max capacity
-            if self._in_flight_capacity >= self.max_in_flight_capacity:
                 return False
 
             # if we are here, it means we are not in cool down, and we are at high utilization,

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -476,9 +476,10 @@ class RPCEndpointManager:
             if round_idx < self.saturated_retries:
                 time.sleep(self.saturated_retry_delay_s)  # brief sleep before retrying
 
-        # If we get here, everything was saturated for all rounds
-        self.consider_increasing_capacity_on_saturation()
-        raise self.NoEndpointsAvailable("All endpoints at capacity or in cool down")
+        # If we get here, all endpoints are in cool down phase; and none available to use
+        raise self.NoEndpointsAvailable(
+            f"All endpoints at capacity or in cool down after {self.saturated_retries} retries"
+        )
 
     def consider_increasing_capacity_on_saturation(self) -> None:
         """

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -103,7 +103,7 @@ class RPCEndpoint:
         ewma_alpha: float = 0.5,
         target_latency_ms: float = 2000.0,  # 2s
         scale_up_utilization_threshold: float = 0.5,
-        max_unreachable_backoff_s: float = 600.0,  # 10 minutes
+        max_unreachable_quarantine_s: float = 600.0,  # 10 minutes
         unreachable_quarantine_after: int = 2,  # number of consecutive unreachable failures before considering the endpoint essentially unreachable and applying a long backoff
         rng: Optional[random.Random] = None,
     ):
@@ -143,7 +143,7 @@ class RPCEndpoint:
 
         self.scale_up_utilization_threshold = scale_up_utilization_threshold
 
-        self.max_unreachable_backoff_s = max_unreachable_backoff_s
+        self.max_unreachable_quarantine_s = max_unreachable_quarantine_s
         self.unreachable_quarantine_after = unreachable_quarantine_after
         self._consecutive_unreachable_failures = 0
 
@@ -327,11 +327,11 @@ class RPCEndpoint:
                     # until it proves it can be reachable again, at which point report_success
                     # will reset capacity and failures
                     self._in_flight_capacity = 1
-                    unreachable_backoff_jitter = min(
-                        self.rng.uniform(0.8, 1.2) * self.max_unreachable_backoff_s,
-                        self.max_unreachable_backoff_s,
+                    unreachable_quarantine_jitter = min(
+                        self.rng.uniform(0.8, 1.2) * self.max_unreachable_quarantine_s,
+                        self.max_unreachable_quarantine_s,
                     )
-                    self._cool_down_until = now + unreachable_backoff_jitter
+                    self._cool_down_until = now + unreachable_quarantine_jitter
 
                 return
 

--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -68,7 +68,8 @@ class RPCEndpoint:
         Snapshot of the endpoint's current health and usage stats for external inspection or sorting.
          - latest_latency_ms: most recent latency measurement in milliseconds.
          - ewma_latency_ms: exponentially weighted moving average of latency for trend tracking.
-         - consecutive_failures: number of consecutive failures since last success.
+         - consecutive_exec_failures: number of consecutive failures since last success.
+         - consecutive_unreachable_failures: number of failures that indicate the endpoint is unreachable (e.g. connection errors).
          - num_in_flight_usage: current number of in-flight usages of this endpoint.
          - in_flight_capacity: current maximum allowed in-flight usages based on health.
          - last_used: real-world timestamp of the last time this endpoint was used (success or failure).
@@ -76,7 +77,8 @@ class RPCEndpoint:
 
         latest_latency_ms: float
         ewma_latency_ms: float
-        consecutive_failures: int
+        consecutive_exec_failures: int
+        consecutive_unreachable_failures: int
         num_in_flight_usage: int
         in_flight_capacity: int
         last_used: float
@@ -85,7 +87,8 @@ class RPCEndpoint:
             return (
                 f"EndpointStats(latency={self.latest_latency_ms:.2f}ms, "
                 f"ewma_latency={self.ewma_latency_ms:.2f}ms, "
-                f"consecutive_failures={self.consecutive_failures}, "
+                f"consecutive_exec_failures={self.consecutive_exec_failures}, "
+                f"consecutive_unreachable_failures={self.consecutive_unreachable_failures}, "
                 f"in_flight_usage={self.num_in_flight_usage}, "
                 f"in_flight_cap={self.in_flight_capacity}, "
                 f"last_used={self.last_used})"
@@ -100,6 +103,8 @@ class RPCEndpoint:
         ewma_alpha: float = 0.5,
         target_latency_ms: float = 2000.0,  # 2s
         scale_up_utilization_threshold: float = 0.5,
+        max_unreachable_backoff_s: float = 600.0,  # 10 minutes
+        unreachable_quarantine_after: int = 2,  # number of consecutive unreachable failures before considering the endpoint essentially unreachable and applying a long backoff
         rng: Optional[random.Random] = None,
     ):
         if max_backoff_s <= 0:
@@ -121,7 +126,7 @@ class RPCEndpoint:
         self.max_backoff_s = max_backoff_s
 
         self._latest_latency_ms = 0.0
-        self._consecutive_failures = 0
+        self._consecutive_exec_failures = 0
         self._cool_down_until = 0.0
         self._last_used = 0.0
 
@@ -136,9 +141,13 @@ class RPCEndpoint:
         self.ewma_alpha = ewma_alpha
         self._ewma_latency_ms = 0.0
 
-        self.rng = rng or random.Random()
-
         self.scale_up_utilization_threshold = scale_up_utilization_threshold
+
+        self.max_unreachable_backoff_s = max_unreachable_backoff_s
+        self.unreachable_quarantine_after = unreachable_quarantine_after
+        self._consecutive_unreachable_failures = 0
+
+        self.rng = rng or random.Random()
 
         self._lock = threading.Lock()
 
@@ -168,9 +177,14 @@ class RPCEndpoint:
                 return False
 
             # check that there weren't consecutive failures recently
-            if self._consecutive_failures > 0:
-                # if we had recent failures, it means the endpoint is unstable and we should not increase
-                # capacity even if we are not currently in cool down
+            if self._consecutive_exec_failures > 0:
+                # if we had recent failures, it means the endpoint is unstable and we should
+                # not increase capacity even if we are not currently in cool down
+                return False
+
+            if self._consecutive_unreachable_failures > 0:
+                # if we had recent unreachable failures, it means the endpoint can't be reached and
+                # we should not increase capacity even if we are not currently in cool down
                 return False
 
             # check in high-utilization state
@@ -252,8 +266,13 @@ class RPCEndpoint:
         with self._lock:
             self._last_used = time.time()
             self._latest_latency_ms = latency_ms
-            self._consecutive_failures = 0
-            self._cool_down_until = 0.0  # reset cool down on success
+
+            # reset failure counts on success
+            self._consecutive_exec_failures = 0
+            self._consecutive_unreachable_failures = 0
+
+            # reset cool down on success
+            self._cool_down_until = 0.0
 
             self._ewma_latency_ms = (
                 latency_ms
@@ -264,6 +283,11 @@ class RPCEndpoint:
                     + (1 - self.ewma_alpha) * self._ewma_latency_ms
                 )
             )
+
+            if self._in_flight_capacity < self.min_in_flight_capacity:
+                # this can happen if endpoint was previously unreachable
+                self._in_flight_capacity = self.min_in_flight_capacity
+                return
 
             # proactive decrease on slow-but-successful responses
             if self._ewma_latency_ms > self.target_latency_ms * 1.5:
@@ -286,8 +310,34 @@ class RPCEndpoint:
             self._last_used = time.time()
             now = time.monotonic()
 
-            # TODO - handle rate limit failures more specifically
-            self._consecutive_failures += 1
+            is_unreachable = isinstance(exc, requests.exceptions.ConnectionError)
+            if is_unreachable:
+                # endpoint is unreachable
+                self._consecutive_unreachable_failures += 1
+                self._consecutive_exec_failures = 0  # reset non-unreachable failures
+
+                # start going down in capacity more quickly on unreachable failures
+                self._in_flight_capacity = max(1, self._in_flight_capacity // 2)
+
+                if (
+                    self._consecutive_unreachable_failures
+                    >= self.unreachable_quarantine_after
+                ):
+                    # severely limit capacity to essentially quarantine the endpoint due to being unreachable
+                    # until it proves it can be reachable again, at which point report_success
+                    # will reset capacity and failures
+                    self._in_flight_capacity = 1
+                    unreachable_backoff_jitter = min(
+                        self.rng.uniform(0.8, 1.2) * self.max_unreachable_backoff_s,
+                        self.max_unreachable_backoff_s,
+                    )
+                    self._cool_down_until = now + unreachable_backoff_jitter
+
+                return
+
+            # non-unreachable failure
+            self._consecutive_exec_failures += 1
+            self._consecutive_unreachable_failures = 0  # reset unreachable failures
 
             # decrease in flight capacity on failure, but never below minimum
             # either back to min or 1/2 of current capacity, whichever is higher
@@ -295,8 +345,10 @@ class RPCEndpoint:
                 self.min_in_flight_capacity, self._in_flight_capacity // 2
             )
 
-            if self._consecutive_failures >= 2:
-                backoff = min(self.max_backoff_s, 2 ** (self._consecutive_failures - 1))
+            if self._consecutive_exec_failures >= 2:
+                backoff = min(
+                    self.max_backoff_s, 2 ** (self._consecutive_exec_failures - 1)
+                )
                 # add some jitter to avoid common backoff patterns
                 backoff_jitter = min(
                     self.rng.uniform(0.8, 1.2) * backoff, self.max_backoff_s
@@ -307,7 +359,8 @@ class RPCEndpoint:
         with self._lock:
             return self.EndpointStats(
                 latest_latency_ms=self._latest_latency_ms,
-                consecutive_failures=self._consecutive_failures,
+                consecutive_exec_failures=self._consecutive_exec_failures,
+                consecutive_unreachable_failures=self._consecutive_unreachable_failures,
                 num_in_flight_usage=self._num_in_flight_usage,
                 in_flight_capacity=self._in_flight_capacity,
                 last_used=self._last_used,
@@ -438,7 +491,10 @@ class RPCEndpointManager:
     def call(
         self,
         fn: Callable[[Web3], Any],
-        request_timeout: Union[float, Tuple[float, float]] = 5.0,
+        request_timeout: Union[float, Tuple[float, float]] = (
+            3.05,
+            5.0,
+        ),  # https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
         endpoint_sort_strategy: Optional[EndpointSortStrategy] = None,
         override_middleware_stack: Optional[Sequence[Tuple[Middleware, str]]] = None,
     ) -> Any:

--- a/scripts/rpc_endpoint_stress_test.py
+++ b/scripts/rpc_endpoint_stress_test.py
@@ -217,8 +217,9 @@ def rpc_stress_test(
         raise click.UsageError(
             "The --sort-strategy option can only be used with the --new-strategy option."
         )
+    sort_strategy = sort_strategy or "failures_then_latency"
     endpoint_sort_strategy = get_endpoint_sort_strategy(
-        sort_strategy or "failures_then_latency"
+        sort_strategy
     )  # same default as ConditionProviderManager
 
     condition_provider_manager = None
@@ -237,7 +238,7 @@ def rpc_stress_test(
     # for testing with unreachable endpoint for chain 42
     # if chain_id == 42:
     #     public_rpc_endpoints.append("https://rpc.lukso.sigmacore.io")
-    #
+
 
     if new_strategy:
         thread_local_session_manager = ThreadLocalSessionManager()
@@ -289,7 +290,7 @@ def rpc_stress_test(
     click.secho(
         f"Strategy used: {'NEW STRATEGY' if new_strategy else 'LEGACY'}", bold=True
     )
-    if sort_strategy:
+    if new_strategy:
         click.echo(f"\tEndpoint sort strategy: {sort_strategy}")
     click.secho(
         f"\tNum failures: {failures.get_value()}",

--- a/scripts/rpc_endpoint_stress_test.py
+++ b/scripts/rpc_endpoint_stress_test.py
@@ -249,7 +249,9 @@ def rpc_stress_test(
     else:
         condition_provider_manager = OldConditionProviderManagerStrategy(
             providers=[HTTPProvider(endpoint) for endpoint in public_rpc_endpoints],
-            preferential_providers=[HTTPProvider(preferred_endpoint)],
+            preferential_providers=(
+                [HTTPProvider(preferred_endpoint)] if preferred_endpoint else []
+            ),
         )
 
     failures = AtomicCounter()

--- a/scripts/rpc_endpoint_stress_test.py
+++ b/scripts/rpc_endpoint_stress_test.py
@@ -1,4 +1,3 @@
-import os
 import random
 import time
 from collections import defaultdict
@@ -8,42 +7,12 @@ from threading import Lock
 from typing import Dict, Iterable, List, Optional
 
 import click
-from eth_utils import to_checksum_address
 from web3 import HTTPProvider, Web3
 from web3.middleware import geth_poa_middleware
 
-from nucypher.blockchain.eth.utils import obfuscate_rpc_url
+from nucypher.blockchain.eth import domains
+from nucypher.blockchain.eth.utils import get_default_rpc_endpoints, obfuscate_rpc_url
 from nucypher.utilities.endpoint import RPCEndpointManager, ThreadLocalSessionManager
-
-# ETH mainnet
-PUBLIC_RPC_ENDPOINTS = [
-    "https://eth.drpc.org",
-    "https://ethereum-public.nodies.app",
-    "https://ethereum-rpc.publicnode.com",
-    "https://mainnet.gateway.tenderly.co",
-    "https://rpc.mevblocker.io",
-    "https://rpc.mevblocker.io/fast",
-]
-
-SIGNING_COORDINATOR_ADDRESS = to_checksum_address(
-    "0x281EEE1e2261F895857Cc1eF5Bcc954E1F907386"
-)
-OPERATOR_ADDRESS = to_checksum_address(os.urandom(20))
-
-COHORT_ID = 3
-FUNCTION_ABI = """[
-    {
-        "inputs":[
-            {"internalType":"uint32","name":"cohortId","type":"uint32"},
-            {"internalType":"address","name":"operator","type":"address"}
-        ],
-        "name":"getSigningCohortDataHash",
-        "outputs":[
-            {"internalType":"bytes32","name":"","type":"bytes32"}
-        ],
-        "type":"function"
-    }
-]"""
 
 
 class AtomicCounter:
@@ -61,16 +30,10 @@ class AtomicCounter:
 
 
 def _do_w3_things(endpoint_usage_stats: Dict[str, AtomicCounter], w3: Web3) -> None:
-    # call a contract function
-    contract_instance = w3.eth.contract(
-        address=SIGNING_COORDINATOR_ADDRESS, abi=FUNCTION_ABI
-    )
-    _ = contract_instance.functions.getSigningCohortDataHash(
-        COHORT_ID, OPERATOR_ADDRESS
-    ).call()
-
-    # some other calls
+    # web3 calls
+    _ = w3.eth.chain_id
     _ = w3.eth.block_number
+    _ = w3.eth.get_block("latest")
 
     endpoint_usage_stats[w3.provider.endpoint_uri].increment()
 
@@ -183,6 +146,12 @@ def get_endpoint_sort_strategy(
 
 @click.command()
 @click.option(
+    "--chain-id",
+    help="Chain ID to perform the stress test on (used for stats tracking).",
+    type=click.INT,
+    required=True,
+)
+@click.option(
     "--new-strategy/--legacy-strategy",
     "new_strategy",
     help="Use new strategy or legacy strategy",
@@ -214,7 +183,7 @@ def get_endpoint_sort_strategy(
     "-p",
     help="Preferred endpoint to use (in addition to default rpc endpoints).",
     type=click.STRING,
-    required=True,
+    required=False,
 )
 @click.option(
     "--sort-strategy",
@@ -223,11 +192,12 @@ def get_endpoint_sort_strategy(
     required=False,
 )
 def rpc_stress_test(
+    chain_id: int,
     new_strategy: bool,
     num_threads: int,
     test_executions: int,
     timeout: int,
-    preferred_endpoint: str,
+    preferred_endpoint: Optional[str] = None,
     sort_strategy: Optional[str] = None,
 ) -> None:
     """
@@ -246,16 +216,27 @@ def rpc_stress_test(
     condition_provider_manager = None
     rpc_endpoint_manager = None
 
+    preferred_endpoints = [preferred_endpoint] if preferred_endpoint else []
+
+    default_rpc_endpoints = get_default_rpc_endpoints(domains.LYNX)
+
+    if chain_id not in default_rpc_endpoints:
+        raise click.UsageError(
+            f"Chain ID {chain_id} not supported in default RPC endpoints Available chain IDs: {list(default_rpc_endpoints.keys())}",
+        )
+
+    public_rpc_endpoints = default_rpc_endpoints.get(chain_id, [])
+
     if new_strategy:
         thread_local_session_manager = ThreadLocalSessionManager()
         rpc_endpoint_manager = RPCEndpointManager(
             session_manager=thread_local_session_manager,
-            preferred_endpoints=[preferred_endpoint],
-            endpoints=PUBLIC_RPC_ENDPOINTS,
+            preferred_endpoints=preferred_endpoints,
+            endpoints=public_rpc_endpoints,
         )
     else:
         condition_provider_manager = OldConditionProviderManagerStrategy(
-            providers=[HTTPProvider(endpoint) for endpoint in PUBLIC_RPC_ENDPOINTS],
+            providers=[HTTPProvider(endpoint) for endpoint in public_rpc_endpoints],
             preferential_providers=[HTTPProvider(preferred_endpoint)],
         )
 
@@ -298,19 +279,28 @@ def rpc_stress_test(
     )
     if sort_strategy:
         click.echo(f"\tEndpoint sort strategy: {sort_strategy}")
-    click.echo(f"\tNum failures: {failures.get_value()}")
-    click.echo("\tEndpoints:")
-    click.echo(
-        f"\t\t {obfuscate_rpc_url(preferred_endpoint)} was used {endpoint_usage_stats[preferred_endpoint].get_value()} times."
+    click.secho(
+        f"\tNum failures: {failures.get_value()}",
+        fg="red" if failures.get_value() > 0 else None,
     )
-    if new_strategy:
+    click.echo("\tEndpoints:")
+    if preferred_endpoint:
         click.echo(
-            f"\t\t\t Stats: {rpc_endpoint_manager.preferred_endpoints[0].get_stats_snapshot()}"
+            f"\t\t {obfuscate_rpc_url(preferred_endpoint)} was used {endpoint_usage_stats[preferred_endpoint].get_value()} times."
         )
-    for url in PUBLIC_RPC_ENDPOINTS:
+        if new_strategy:
+            click.echo(
+                f"\t\t\t Stats: {rpc_endpoint_manager.preferred_endpoints[0].get_stats_snapshot()}"
+            )
+    for i, url in enumerate(public_rpc_endpoints):
         click.echo(
             f"\t\t {url} was used {endpoint_usage_stats[url].get_value()} times."
         )
+        if new_strategy:
+            assert rpc_endpoint_manager.endpoints[i].endpoint_uri == url
+            click.echo(
+                f"\t\t\t Stats: {rpc_endpoint_manager.endpoints[i].get_stats_snapshot()}"
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/rpc_endpoint_stress_test.py
+++ b/scripts/rpc_endpoint_stress_test.py
@@ -116,6 +116,7 @@ STRATEGIES = [
     "headroom_then_latency",
     "fewest_in_flight_then_latency",
     "last_used",
+    "failures_then_latency",
 ]
 
 
@@ -140,6 +141,13 @@ def get_endpoint_sort_strategy(
     elif strategy == "last_used":
         # sort by last used time (oldest first)
         return lambda stats: (stats.last_used,)
+    elif strategy == "failures_then_latency":
+        # sort by fewest unreachable failures, then exec failures, then latency
+        return lambda stats: (
+            stats.consecutive_unreachable_failures,
+            stats.consecutive_exec_failures,
+            stats.ewma_latency_ms,
+        )
 
     raise ValueError(f"Strategy '{strategy}' not implemented")
 
@@ -209,9 +217,9 @@ def rpc_stress_test(
         raise click.UsageError(
             "The --sort-strategy option can only be used with the --new-strategy option."
         )
-    endpoint_sort_strategy = (
-        get_endpoint_sort_strategy(sort_strategy) if sort_strategy else None
-    )
+    endpoint_sort_strategy = get_endpoint_sort_strategy(
+        sort_strategy or "failures_then_latency"
+    )  # same default as ConditionProviderManager
 
     condition_provider_manager = None
     rpc_endpoint_manager = None
@@ -226,6 +234,10 @@ def rpc_stress_test(
         )
 
     public_rpc_endpoints = default_rpc_endpoints.get(chain_id, [])
+    # for testing with unreachable endpoint for chain 42
+    # if chain_id == 42:
+    #     public_rpc_endpoints.append("https://rpc.lukso.sigmacore.io")
+    #
 
     if new_strategy:
         thread_local_session_manager = ThreadLocalSessionManager()
@@ -285,8 +297,9 @@ def rpc_stress_test(
     )
     click.echo("\tEndpoints:")
     if preferred_endpoint:
-        click.echo(
-            f"\t\t {obfuscate_rpc_url(preferred_endpoint)} was used {endpoint_usage_stats[preferred_endpoint].get_value()} times."
+        click.secho(
+            f"\t\t Preferred Endpoint {obfuscate_rpc_url(preferred_endpoint)} was used {endpoint_usage_stats[preferred_endpoint].get_value()} times.",
+            fg="green",
         )
         if new_strategy:
             click.echo(

--- a/scripts/rpc_endpoint_stress_test.py
+++ b/scripts/rpc_endpoint_stress_test.py
@@ -145,7 +145,7 @@ def get_endpoint_sort_strategy(
         # sort by fewest unreachable failures, then exec failures, then latency
         return lambda stats: (
             stats.consecutive_unreachable_failures,
-            stats.consecutive_exec_failures,
+            stats.consecutive_request_failures,
             stats.ewma_latency_ms,
         )
 

--- a/scripts/rpc_endpoint_stress_test.py
+++ b/scripts/rpc_endpoint_stress_test.py
@@ -239,7 +239,6 @@ def rpc_stress_test(
     # if chain_id == 42:
     #     public_rpc_endpoints.append("https://rpc.lukso.sigmacore.io")
 
-
     if new_strategy:
         thread_local_session_manager = ThreadLocalSessionManager()
         rpc_endpoint_manager = RPCEndpointManager(

--- a/tests/unit/conditions/test_utils.py
+++ b/tests/unit/conditions/test_utils.py
@@ -314,7 +314,8 @@ class TestConditionProviderManager:
         stats = RPCEndpoint.EndpointStats(
             latest_latency_ms=4.2,
             ewma_latency_ms=ewma_latency_ms,
-            consecutive_failures=1,
+            consecutive_exec_failures=1,
+            consecutive_unreachable_failures=0,
             num_in_flight_usage=4,
             in_flight_capacity=20,
             last_used=time.time() - 10,

--- a/tests/unit/conditions/test_utils.py
+++ b/tests/unit/conditions/test_utils.py
@@ -321,13 +321,13 @@ class TestConditionProviderManager:
     )
     def test_sort_by_failures_then_latency(self, stats_2_sort_scenario):
         ewma_latency_ms = 6.4
-        consecutive_exec_failures = 3
+        consecutive_request_failures = 3
         consecutive_unreachable_failures = 0
 
         stats = RPCEndpoint.EndpointStats(
             latest_latency_ms=4.2,
             ewma_latency_ms=ewma_latency_ms,
-            consecutive_exec_failures=consecutive_exec_failures,
+            consecutive_request_failures=consecutive_request_failures,
             consecutive_unreachable_failures=consecutive_unreachable_failures,
             num_in_flight_usage=4,
             in_flight_capacity=20,
@@ -335,7 +335,7 @@ class TestConditionProviderManager:
         )
         assert ConditionProviderManager._sort_by_failures_then_latency(stats) == (
             consecutive_unreachable_failures,
-            consecutive_exec_failures,
+            consecutive_request_failures,
             ewma_latency_ms,
         )
 
@@ -350,16 +350,16 @@ class TestConditionProviderManager:
             if stats_2_sort_scenario != "lower_unreachable_failures"
             else stats.consecutive_unreachable_failures - 2
         )
-        stats_2_consecutive_exec_failures = (
-            stats.consecutive_exec_failures
+        stats_2_consecutive_request_failures = (
+            stats.consecutive_request_failures
             if stats_2_sort_scenario != "higher_unreachable_failures"
-            else stats.consecutive_exec_failures + 1
+            else stats.consecutive_request_failures + 1
         )
 
         stats_2 = RPCEndpoint.EndpointStats(
             latest_latency_ms=stats.latest_latency_ms,
             ewma_latency_ms=stats_2_ewma_latency_ms,
-            consecutive_exec_failures=stats_2_consecutive_exec_failures,
+            consecutive_request_failures=stats_2_consecutive_request_failures,
             consecutive_unreachable_failures=stats_2_consecutive_unreachable_failures,
             num_in_flight_usage=stats.num_in_flight_usage,
             in_flight_capacity=stats.in_flight_capacity,

--- a/tests/unit/conditions/test_utils.py
+++ b/tests/unit/conditions/test_utils.py
@@ -314,7 +314,7 @@ class TestConditionProviderManager:
         "stats_2_sort_scenario",
         [
             "lower_latency",
-            "lower_exec_failures",
+            "lower_request_failures",
             "higher_unreachable_failures",
             "equal_stats",
         ],
@@ -345,15 +345,15 @@ class TestConditionProviderManager:
             if stats_2_sort_scenario != "lower_latency"
             else stats.ewma_latency_ms - 1
         )
-        stats_2_consecutive_unreachable_failures = (
-            stats.consecutive_unreachable_failures
-            if stats_2_sort_scenario != "lower_unreachable_failures"
-            else stats.consecutive_unreachable_failures - 2
-        )
         stats_2_consecutive_request_failures = (
             stats.consecutive_request_failures
+            if stats_2_sort_scenario != "lower_request_failures"
+            else stats.consecutive_request_failures - 2
+        )
+        stats_2_consecutive_unreachable_failures = (
+            stats.consecutive_unreachable_failures
             if stats_2_sort_scenario != "higher_unreachable_failures"
-            else stats.consecutive_request_failures + 1
+            else stats.consecutive_unreachable_failures + 1
         )
 
         stats_2 = RPCEndpoint.EndpointStats(

--- a/tests/unit/conditions/test_utils.py
+++ b/tests/unit/conditions/test_utils.py
@@ -15,6 +15,7 @@
  along with nucypher.  If not, see <https://www.gnu.org/licenses/>.
 """
 
+import random
 import time
 from dataclasses import dataclass
 from http import HTTPStatus
@@ -287,7 +288,7 @@ class TestConditionProviderManager:
         mock_mgr.call.assert_called_with(
             fn=mock_fn,
             request_timeout=ConditionProviderManager._DEFAULT_WEB3_CALL_TIMEOUT,
-            endpoint_sort_strategy=ConditionProviderManager._sort_by_latency,
+            endpoint_sort_strategy=ConditionProviderManager._sort_by_failures_then_latency,
             override_middleware_stack=[(ANY, "attrdict"), (ANY, "abi")],
         )
 
@@ -305,22 +306,79 @@ class TestConditionProviderManager:
         mock_mgr.call.assert_called_with(
             fn=mock_fn,
             request_timeout=customized_timeout,
-            endpoint_sort_strategy=ConditionProviderManager._sort_by_latency,
+            endpoint_sort_strategy=ConditionProviderManager._sort_by_failures_then_latency,
             override_middleware_stack=[(ANY, "attrdict"), (ANY, "abi")],
         )
 
-    def test_sort_by_latency_returns_proper_value_in_tuple(self):
+    @pytest.mark.parametrize(
+        "stats_2_sort_scenario",
+        [
+            "lower_latency",
+            "lower_exec_failures",
+            "higher_unreachable_failures",
+            "equal_stats",
+        ],
+    )
+    def test_sort_by_failures_then_latency(self, stats_2_sort_scenario):
         ewma_latency_ms = 6.4
+        consecutive_exec_failures = 3
+        consecutive_unreachable_failures = 0
+
         stats = RPCEndpoint.EndpointStats(
             latest_latency_ms=4.2,
             ewma_latency_ms=ewma_latency_ms,
-            consecutive_exec_failures=1,
-            consecutive_unreachable_failures=0,
+            consecutive_exec_failures=consecutive_exec_failures,
+            consecutive_unreachable_failures=consecutive_unreachable_failures,
             num_in_flight_usage=4,
             in_flight_capacity=20,
             last_used=time.time() - 10,
         )
-        assert ConditionProviderManager._sort_by_latency(stats) == (ewma_latency_ms,)
+        assert ConditionProviderManager._sort_by_failures_then_latency(stats) == (
+            consecutive_unreachable_failures,
+            consecutive_exec_failures,
+            ewma_latency_ms,
+        )
+
+        # check sorting
+        stats_2_ewma_latency_ms = (
+            stats.ewma_latency_ms
+            if stats_2_sort_scenario != "lower_latency"
+            else stats.ewma_latency_ms - 1
+        )
+        stats_2_consecutive_unreachable_failures = (
+            stats.consecutive_unreachable_failures
+            if stats_2_sort_scenario != "lower_unreachable_failures"
+            else stats.consecutive_unreachable_failures - 2
+        )
+        stats_2_consecutive_exec_failures = (
+            stats.consecutive_exec_failures
+            if stats_2_sort_scenario != "higher_unreachable_failures"
+            else stats.consecutive_exec_failures + 1
+        )
+
+        stats_2 = RPCEndpoint.EndpointStats(
+            latest_latency_ms=stats.latest_latency_ms,
+            ewma_latency_ms=stats_2_ewma_latency_ms,
+            consecutive_exec_failures=stats_2_consecutive_exec_failures,
+            consecutive_unreachable_failures=stats_2_consecutive_unreachable_failures,
+            num_in_flight_usage=stats.num_in_flight_usage,
+            in_flight_capacity=stats.in_flight_capacity,
+            last_used=stats.last_used,
+        )
+
+        stats_values = [stats, stats_2]
+        random.shuffle(stats_values)
+        sorted_values = sorted(
+            stats_values, key=ConditionProviderManager._sort_by_failures_then_latency
+        )
+
+        if stats_2_sort_scenario == "higher_unreachable_failures":
+            assert sorted_values == [stats, stats_2]
+        elif stats_2_sort_scenario == "equal_stats":
+            assert sorted_values == stats_values  # no change in original order
+        else:
+            # stats_2 has lower values
+            assert sorted_values == [stats_2, stats]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -325,8 +325,8 @@ class TestRPCEndpoint:
             )
 
             # check failure counts
-            assert endpoint._consecutive_exec_failures == 0
-            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 0
+            assert endpoint._consecutive_request_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
             assert endpoint._consecutive_unreachable_failures == 0
             assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
 
@@ -391,8 +391,8 @@ class TestRPCEndpoint:
                 endpoint.report_success(latency_ms=random_latency_ms)
 
                 # check failure counts
-                assert endpoint._consecutive_exec_failures == 0
-                assert endpoint.get_stats_snapshot().consecutive_exec_failures == 0
+                assert endpoint._consecutive_request_failures == 0
+                assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
                 assert endpoint._consecutive_unreachable_failures == 0
                 assert (
                     endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
@@ -500,8 +500,8 @@ class TestRPCEndpoint:
             assert endpoint.get_stats_snapshot().in_flight_capacity == expected_capacity
 
             # failure noted
-            assert endpoint._consecutive_exec_failures == 1
-            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
+            assert endpoint._consecutive_request_failures == 1
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 1
 
             # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
             assert endpoint._consecutive_unreachable_failures == 0
@@ -523,8 +523,8 @@ class TestRPCEndpoint:
             )  # below target latency
 
             # success wipes out consecutive failures
-            assert endpoint._consecutive_exec_failures == 0
-            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 0
+            assert endpoint._consecutive_request_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
             assert endpoint._consecutive_unreachable_failures == 0
             assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
 
@@ -566,8 +566,8 @@ class TestRPCEndpoint:
             assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
 
             # failure noted
-            assert endpoint._consecutive_exec_failures == 1
-            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
+            assert endpoint._consecutive_request_failures == 1
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 1
 
 
             current_capacity = max(current_capacity // 2, initial_min_capacity)
@@ -589,8 +589,8 @@ class TestRPCEndpoint:
             assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
 
             # failure noted
-            assert endpoint._consecutive_exec_failures == 2
-            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 2
+            assert endpoint._consecutive_request_failures == 2
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 2
 
             # capacity should decrease by half since failure until at min capacity
             current_capacity = current_capacity // 2
@@ -677,8 +677,8 @@ class TestRPCEndpoint:
             endpoint.report_failure(Exception("simulated failure"))
 
             # failure noted
-            assert endpoint._consecutive_exec_failures == 1
-            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
+            assert endpoint._consecutive_request_failures == 1
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 1
 
             # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
             assert endpoint._consecutive_unreachable_failures == 0
@@ -732,9 +732,11 @@ class TestRPCEndpoint:
                 num_consecutive_failures += 1
 
                 # failure noted
-                assert endpoint._consecutive_exec_failures == num_consecutive_failures
                 assert (
-                    endpoint.get_stats_snapshot().consecutive_exec_failures
+                    endpoint._consecutive_request_failures == num_consecutive_failures
+                )
+                assert (
+                    endpoint.get_stats_snapshot().consecutive_request_failures
                     == num_consecutive_failures
                 )
 
@@ -773,9 +775,9 @@ class TestRPCEndpoint:
             num_consecutive_failures += 1
 
             # failure noted
-            assert endpoint._consecutive_exec_failures == num_consecutive_failures
+            assert endpoint._consecutive_request_failures == num_consecutive_failures
             assert (
-                endpoint.get_stats_snapshot().consecutive_exec_failures
+                endpoint.get_stats_snapshot().consecutive_request_failures
                 == num_consecutive_failures
             )
 
@@ -898,7 +900,7 @@ class TestRPCEndpointManager:
         for e in manager.endpoints:
             # each endpoint should have recorded at least 1 failure
             stats = e.get_stats_snapshot()
-            assert stats.consecutive_exec_failures >= 1
+            assert stats.consecutive_request_failures >= 1
             assert stats.last_used > 0
 
     def test_no_endpoints_available_raises_when_all_in_cooldown(self):

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -726,8 +726,8 @@ class TestRPCEndpoint:
             assert endpoint.try_acquire()
             try:
                 now = 20_002.123  # fixed time for testing
-                with mocker.patch("time.monotonic", return_value=now):
-                    endpoint.report_failure(Exception("simulated failure"))
+                mocker.patch("time.monotonic", return_value=now)
+                endpoint.report_failure(Exception("simulated failure"))
                 num_consecutive_failures += 1
 
                 # failure noted
@@ -769,8 +769,8 @@ class TestRPCEndpoint:
         assert endpoint.try_acquire()
         try:
             now = 30_123.456  # fixed time for testing
-            with mocker.patch("time.monotonic", return_value=now):
-                endpoint.report_failure(Exception("simulated failure"))
+            mocker.patch("time.monotonic", return_value=now)
+            endpoint.report_failure(Exception("simulated failure"))
             num_consecutive_failures += 1
 
             # failure noted
@@ -1370,6 +1370,7 @@ class TestRPCEndpointManager:
 
         # capture w3 instances used for calls
         w3_instances = []
+
         def failing_fn(w3):
             w3_instances.append(w3)
             raise Exception("boom")

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -962,7 +962,7 @@ class TestRPCEndpoint:
             assert endpoint._consecutive_request_failures == 0
             assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
 
-            # check unreachable failure cound
+            # check unreachable failure count
             assert (
                 endpoint._consecutive_unreachable_failures
                 == unreachable_quarantine_after

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -474,8 +474,8 @@ class TestRPCEndpoint:
             assert endpoint.get_stats_snapshot().in_flight_capacity == expected_capacity
 
             # failure noted
-            assert endpoint._consecutive_failures == 1
-            assert endpoint.get_stats_snapshot().consecutive_failures == 1
+            assert endpoint._consecutive_exec_failures == 1
+            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
         finally:
             endpoint.release()
             num_inflight_usages -= 1
@@ -493,8 +493,8 @@ class TestRPCEndpoint:
             )  # below target latency
 
             # success wipes out consecutive failures
-            assert endpoint._consecutive_failures == 0
-            assert endpoint.get_stats_snapshot().consecutive_failures == 0
+            assert endpoint._consecutive_exec_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 0
 
             # capacity should increase since successful, below target latency, and utilization > 50%
             assert endpoint._num_in_flight_usage == num_inflight_usages
@@ -530,8 +530,8 @@ class TestRPCEndpoint:
             endpoint.report_failure(Exception("simulated failure"))
 
             # failure noted
-            assert endpoint._consecutive_failures == 1
-            assert endpoint.get_stats_snapshot().consecutive_failures == 1
+            assert endpoint._consecutive_exec_failures == 1
+            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
 
             current_capacity = max(current_capacity // 2, initial_min_capacity)
             assert endpoint._in_flight_capacity == current_capacity
@@ -548,8 +548,8 @@ class TestRPCEndpoint:
             endpoint.report_failure(Exception("simulated failure"))
 
             # failure noted
-            assert endpoint._consecutive_failures == 2
-            assert endpoint.get_stats_snapshot().consecutive_failures == 2
+            assert endpoint._consecutive_exec_failures == 2
+            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 2
 
             # capacity should decrease by half since failure until at min capacity
             current_capacity = current_capacity // 2
@@ -636,8 +636,8 @@ class TestRPCEndpoint:
             endpoint.report_failure(Exception("simulated failure"))
 
             # failure noted
-            assert endpoint._consecutive_failures == 1
-            assert endpoint.get_stats_snapshot().consecutive_failures == 1
+            assert endpoint._consecutive_exec_failures == 1
+            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
 
             current_capacity = max(current_capacity // 2, initial_min_capacity)
             assert endpoint._in_flight_capacity == current_capacity
@@ -687,9 +687,9 @@ class TestRPCEndpoint:
                 num_consecutive_failures += 1
 
                 # failure noted
-                assert endpoint._consecutive_failures == num_consecutive_failures
+                assert endpoint._consecutive_exec_failures == num_consecutive_failures
                 assert (
-                    endpoint.get_stats_snapshot().consecutive_failures
+                    endpoint.get_stats_snapshot().consecutive_exec_failures
                     == num_consecutive_failures
                 )
 
@@ -722,9 +722,9 @@ class TestRPCEndpoint:
             num_consecutive_failures += 1
 
             # failure noted
-            assert endpoint._consecutive_failures == num_consecutive_failures
+            assert endpoint._consecutive_exec_failures == num_consecutive_failures
             assert (
-                endpoint.get_stats_snapshot().consecutive_failures
+                endpoint.get_stats_snapshot().consecutive_exec_failures
                 == num_consecutive_failures
             )
 
@@ -843,7 +843,7 @@ class TestRPCEndpointManager:
         for e in manager.endpoints:
             # each endpoint should have recorded at least 1 failure
             stats = e.get_stats_snapshot()
-            assert stats.consecutive_failures >= 1
+            assert stats.consecutive_exec_failures >= 1
             assert stats.last_used > 0
 
     def test_no_endpoints_available_raises_when_all_in_cooldown(self):

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -880,9 +880,23 @@ class TestRPCEndpoint:
             not endpoint.consider_increasing_in_flight_capacity()
         ), "won't because at max capacity"
         assert endpoint._in_flight_capacity == max_capacity, "capacity unchanged"
-        endpoint._in_flight_capacity = initial_min_capacity  # reset capacity
+        endpoint._in_flight_capacity = (
+            initial_min_capacity  # reset capacity to be at min
+        )
+
+        # 5. min utilization factor not met
+        endpoint._num_in_flight_usage = int(
+            (initial_min_capacity * scale_up_utilization) - 1
+        )
+        endpoint._in_flight_capacity = initial_min_capacity
+        assert (
+            not endpoint.consider_increasing_in_flight_capacity()
+        ), "won't because utilization not met"
 
         # Now let's try again with all conditions favorable and test that capacity does proactively increase
+        endpoint._num_in_flight_usage = (
+            initial_min_capacity - 1
+        )  # set usage just below full utilization
         assert (
             endpoint.consider_increasing_in_flight_capacity()
         ), "capacity proactively increased"

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -569,7 +569,6 @@ class TestRPCEndpoint:
             assert endpoint._consecutive_request_failures == 1
             assert endpoint.get_stats_snapshot().consecutive_request_failures == 1
 
-
             current_capacity = max(current_capacity // 2, initial_min_capacity)
             assert endpoint._in_flight_capacity == current_capacity
             assert endpoint.get_stats_snapshot().in_flight_capacity == current_capacity

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -989,7 +989,7 @@ class TestRPCEndpoint:
 
             endpoint.report_failure(connection_failure)  # report failure
 
-            # quanratine immediately enacted again
+            # quarantine immediately enacted again
             assert endpoint._consecutive_request_failures == 0
             assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
             assert (
@@ -1023,7 +1023,7 @@ class TestRPCEndpoint:
             return_value=first_quarantine_now + 2 * max_unreachable_quarantine_s + 1,
         )
 
-        # log fist success after coming out of quarantine
+        # log first success after coming out of quarantine
         assert endpoint.try_acquire(), "we can acquire after quarantine period"
         try:
             assert endpoint._in_flight_capacity == 1, "in quarantine so dropped to 1"

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -165,6 +165,9 @@ class TestRPCEndpoint:
         max_inflight_capacity = 500
         ewma_alpha = 0.1
         target_latency_ms = 3000.0
+        scale_up_utilization_threshold = 0.4
+        max_unreachable_quarantine_s = 900  # 15 minutes
+        unreachable_quarantine_after = 1
 
         for with_rng in [True, False]:
             rng = random.Random() if with_rng else None
@@ -175,6 +178,9 @@ class TestRPCEndpoint:
                 max_in_flight_capacity=max_inflight_capacity,
                 ewma_alpha=ewma_alpha,
                 target_latency_ms=target_latency_ms,
+                scale_up_utilization_threshold=scale_up_utilization_threshold,
+                max_unreachable_quarantine_s=max_unreachable_quarantine_s,
+                unreachable_quarantine_after=unreachable_quarantine_after,
                 rng=rng,
             )
             assert endpoint.endpoint_uri == self.URI
@@ -183,6 +189,12 @@ class TestRPCEndpoint:
             assert endpoint.max_in_flight_capacity == max_inflight_capacity
             assert endpoint.ewma_alpha == ewma_alpha
             assert endpoint.target_latency_ms == target_latency_ms
+            assert (
+                endpoint.scale_up_utilization_threshold
+                == scale_up_utilization_threshold
+            )
+            assert endpoint.max_unreachable_quarantine_s == max_unreachable_quarantine_s
+            assert endpoint.unreachable_quarantine_after == unreachable_quarantine_after
 
             if with_rng:
                 assert endpoint.rng == rng
@@ -312,6 +324,12 @@ class TestRPCEndpoint:
                 == num_in_flight_usages
             )
 
+            # check failure counts
+            assert endpoint._consecutive_exec_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_exec_failures == 0
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
+
             # capacity increased since successful, below target latency, and utilization > 50%
             if utilization >= scale_up_utilization:
                 current_capacity += 1
@@ -371,6 +389,14 @@ class TestRPCEndpoint:
                 # must be high to make ewma > 150% target latency to trigger backoff
                 random_latency_ms = endpoint.target_latency_ms * 20
                 endpoint.report_success(latency_ms=random_latency_ms)
+
+                # check failure counts
+                assert endpoint._consecutive_exec_failures == 0
+                assert endpoint.get_stats_snapshot().consecutive_exec_failures == 0
+                assert endpoint._consecutive_unreachable_failures == 0
+                assert (
+                    endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
+                )
 
                 # check current usage
                 assert endpoint._num_in_flight_usage == num_in_flight_usages
@@ -476,6 +502,10 @@ class TestRPCEndpoint:
             # failure noted
             assert endpoint._consecutive_exec_failures == 1
             assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
+
+            # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
         finally:
             endpoint.release()
             num_inflight_usages -= 1
@@ -495,6 +525,8 @@ class TestRPCEndpoint:
             # success wipes out consecutive failures
             assert endpoint._consecutive_exec_failures == 0
             assert endpoint.get_stats_snapshot().consecutive_exec_failures == 0
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
 
             # capacity should increase since successful, below target latency, and utilization > 50%
             assert endpoint._num_in_flight_usage == num_inflight_usages
@@ -529,9 +561,14 @@ class TestRPCEndpoint:
         try:
             endpoint.report_failure(Exception("simulated failure"))
 
+            # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
+
             # failure noted
             assert endpoint._consecutive_exec_failures == 1
             assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
+
 
             current_capacity = max(current_capacity // 2, initial_min_capacity)
             assert endpoint._in_flight_capacity == current_capacity
@@ -546,6 +583,10 @@ class TestRPCEndpoint:
         try:
             report_time = time.monotonic()
             endpoint.report_failure(Exception("simulated failure"))
+
+            # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
 
             # failure noted
             assert endpoint._consecutive_exec_failures == 2
@@ -639,6 +680,10 @@ class TestRPCEndpoint:
             assert endpoint._consecutive_exec_failures == 1
             assert endpoint.get_stats_snapshot().consecutive_exec_failures == 1
 
+            # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
+
             current_capacity = max(current_capacity // 2, initial_min_capacity)
             assert endpoint._in_flight_capacity == current_capacity
             assert endpoint.get_stats_snapshot().in_flight_capacity == current_capacity
@@ -693,6 +738,12 @@ class TestRPCEndpoint:
                     == num_consecutive_failures
                 )
 
+                # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
+                assert endpoint._consecutive_unreachable_failures == 0
+                assert (
+                    endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
+                )
+
                 if num_consecutive_failures >= 2:
                     backoff = 2 ** (num_consecutive_failures - 1)
 
@@ -727,6 +778,10 @@ class TestRPCEndpoint:
                 endpoint.get_stats_snapshot().consecutive_exec_failures
                 == num_consecutive_failures
             )
+
+            # check unreachable failure count (no change since separate counts for exec vs unreachable failures)
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
 
             assert endpoint._cool_down_until >= now + (
                 0.8 * endpoint.max_backoff_s

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -472,7 +472,7 @@ class TestRPCEndpoint:
         finally:
             endpoint.release()
 
-    def test_report_failure(self):
+    def test_report_request_failure(self):
         initial_min_capacity = 10
         max_capacity = 100
         endpoint = RPCEndpoint(
@@ -795,6 +795,102 @@ class TestRPCEndpoint:
         finally:
             endpoint.release()
 
+    def test_consider_increasing_in_flight_capacity(self):
+        initial_min_capacity = 10
+        max_capacity = 50
+        scale_up_utilization = 0.5
+        endpoint = RPCEndpoint(
+            endpoint_uri=self.URI,
+            min_in_flight_capacity=initial_min_capacity,
+            max_in_flight_capacity=max_capacity,
+            scale_up_utilization_threshold=scale_up_utilization,
+        )
+
+        # hasn't been used yet, so shouldn't increase capacity even if utilization is high
+        assert not endpoint.consider_increasing_in_flight_capacity()
+
+        num_inflight_usages = 0
+        # acquire just below scale up utilization (without any success reporting or release
+        # this mimics a scenario where we are hitting capacity but haven't yet had a chance to
+        # report successes to trigger capacity increase
+        for i in range(int((initial_min_capacity * scale_up_utilization) - 1)):
+            assert endpoint.try_acquire()
+            num_inflight_usages += 1
+
+            # utilization should be at threshold, so should increase capacity
+            assert not endpoint.consider_increasing_in_flight_capacity()
+
+            assert (
+                endpoint._in_flight_capacity == initial_min_capacity
+            )  # unchanged since we haven't reported successes to trigger increase yet
+            assert (
+                endpoint.get_stats_snapshot().in_flight_capacity == initial_min_capacity
+            )
+
+        # even after that we are still just below scale up utilization, so should not increase capacity
+        assert num_inflight_usages // initial_min_capacity < scale_up_utilization
+        assert endpoint._num_in_flight_usage == num_inflight_usages
+        assert num_inflight_usages < initial_min_capacity
+        assert not endpoint.consider_increasing_in_flight_capacity()
+
+        # now we go just over the utilization to consider proactively increasing capacity without any reporting
+        minimum_threshold = int((initial_min_capacity * scale_up_utilization) + 1)
+        while num_inflight_usages < minimum_threshold:
+            assert endpoint.try_acquire()
+            num_inflight_usages += 1
+
+        assert endpoint._num_in_flight_usage == num_inflight_usages
+        assert endpoint._in_flight_capacity == initial_min_capacity
+
+        # now we should be able to increase capacity proactively
+        # let's test other scenarios that would prevent increasing capacity first, eg. existing failures etc.
+        # 1. in cool down
+        endpoint._cool_down_until = time.monotonic() + 60
+        assert not endpoint.is_cooled_down()
+        assert (
+            not endpoint.consider_increasing_in_flight_capacity()
+        ), "won't because in cool down"
+        assert (
+            endpoint._in_flight_capacity == initial_min_capacity
+        ), "capacity unchanged"
+        endpoint._cool_down_until = 0.0  # reset cool down
+
+        # 2. has had consecutive request failures (some prior reporting was received)
+        endpoint._consecutive_request_failures = 3
+        assert (
+            not endpoint.consider_increasing_in_flight_capacity()
+        ), "won't because has consecutive failures"
+        assert (
+            endpoint._in_flight_capacity == initial_min_capacity
+        ), "capacity unchanged"
+        endpoint._consecutive_request_failures = 0  # reset failure count
+
+        # 3. has had consecutive unreachable failures (some prior reporting was received)
+        endpoint._consecutive_unreachable_failures = 2
+        assert (
+            not endpoint.consider_increasing_in_flight_capacity()
+        ), "won't because has consecutive unreachable failures"
+        assert (
+            endpoint._in_flight_capacity == initial_min_capacity
+        ), "capacity unchanged"
+        endpoint._consecutive_unreachable_failures = 0  # reset failure count
+
+        # 4. Already at max capacity
+        endpoint._in_flight_capacity = max_capacity
+        assert (
+            not endpoint.consider_increasing_in_flight_capacity()
+        ), "won't because at max capacity"
+        assert endpoint._in_flight_capacity == max_capacity, "capacity unchanged"
+        endpoint._in_flight_capacity = initial_min_capacity  # reset capacity
+
+        # Now let's try again with all conditions favorable and test that capacity does proactively increase
+        assert (
+            endpoint.consider_increasing_in_flight_capacity()
+        ), "capacity proactively increased"
+        assert (
+            endpoint._in_flight_capacity == initial_min_capacity + 2
+        ), "proactively increased capacity by 2"
+
 
 class TestRPCEndpointManager:
     """Focused unit tests for RPCEndpointManager behavior."""
@@ -955,3 +1051,79 @@ class TestRPCEndpointManager:
         result = manager.call(lambda w3: "worked", request_timeout=1.0)
         assert result == "worked"
         assert sleep_calls["count"] == saturated_retries
+
+    def test_consider_increasing_in_flight_capacity(self, mocker):
+        session_manager = ThreadLocalSessionManager(max_pool_size=2)
+        endpoints = ["https://a.example", "https://b.example", "https://c.example"]
+
+        manager = RPCEndpointManager(
+            session_manager=session_manager,
+            endpoints=endpoints,
+        )
+
+        consider_increasing_spy = mocker.spy(
+            RPCEndpoint, "consider_increasing_in_flight_capacity"
+        )
+
+        # call consider_increasing_in_flight_capacity multiple times and ensure it's being called
+        n_times_manager_called = 5
+        for i in range(n_times_manager_called):
+            manager.consider_increasing_capacity_on_saturation()
+
+        # manager asks endpoints to consider increasing capacity so the next call could potentially succeed
+        assert consider_increasing_spy.call_count == (
+            n_times_manager_called * len(endpoints)
+        ), "every endpoint called"
+
+    def test_proactive_increase_of_in_flight_capacity_due_to_cant_acquire_candidate(
+        self, mocker
+    ):
+        # in this test case (vs above), the exception is raised after having possible candidates
+        # but then try_acquire() on the candidate fails because candidate no longer viable i.e. there
+        # was a change in situation between getting candidate and using candidate
+        session_manager = ThreadLocalSessionManager(max_pool_size=2)
+        endpoints = ["https://a.example", "https://b.example", "https://c.example"]
+
+        manager = RPCEndpointManager(
+            session_manager=session_manager,
+            endpoints=endpoints,
+        )
+        consider_increasing_spy = mocker.spy(
+            RPCEndpoint, "consider_increasing_in_flight_capacity"
+        )
+        try_acquire_spy = mocker.spy(RPCEndpoint, "try_acquire")
+
+        def fake_sleep(duration):
+            # do nothing
+            pass
+
+        # patch the time.sleep used inside the endpoint manager to avoid real waiting
+        mocker.patch("nucypher.utilities.endpoint.time.sleep", fake_sleep)
+
+        # only first 2
+        num_candidates = 2
+        mocker.patch.object(
+            manager, "_get_candidates", return_value=manager.endpoints[:num_candidates]
+        )
+
+        # simulate all endpoints being at high utilization to trigger proactive capacity increase
+        for e in manager.endpoints:
+            e._num_in_flight_usage = (
+                e._in_flight_capacity
+            )  # max out usage to not have any endpoint candidates for use and trigger increase
+
+        with pytest.raises(
+            RPCEndpointManager.NoEndpointsAvailable,
+            match="All endpoints at capacity or in cool down",
+        ):
+            _ = manager.call(lambda w3: "worked", request_timeout=1.0)
+
+        # viable candidates available so try_acquire is called for each candidate
+        assert (
+            try_acquire_spy.call_count == num_candidates
+        ), "should have tried to acquire all candidates and failed"
+
+        # manager asks endpoints to consider increasing capacity so the next call could potentially succeed
+        assert consider_increasing_spy.call_count == len(
+            endpoints
+        ), "should have called consider_increasing_in_flight_capacity on all endpoints"

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -1344,3 +1344,92 @@ class TestRPCEndpointManager:
         assert consider_increasing_spy.call_count == len(
             endpoints
         ), "should have called consider_increasing_in_flight_capacity on all endpoints"
+
+    def test_sorting_endpoints_for_call(self):
+        session_manager = ThreadLocalSessionManager(max_pool_size=2)
+        endpoints = ["https://a.example", "https://b.example", "https://c.example"]
+
+        manager = RPCEndpointManager(
+            session_manager=session_manager,
+            endpoints=endpoints,
+        )
+
+        endpoint_0 = manager.endpoints[0]
+        endpoint_0._ewma_latency_ms = 857.2
+        endpoint_0._latest_latency_ms = 200.1
+
+        endpoint_1 = manager.endpoints[1]
+        # lower ewma, higher latest latency than endpoint_0
+        endpoint_1._ewma_latency_ms = endpoint_0._ewma_latency_ms - 123.4
+        endpoint_1._latest_latency_ms = endpoint_0._latest_latency_ms + 50.5
+
+        endpoint_2 = manager.endpoints[2]
+        # same as endpoint_0
+        endpoint_2._ewma_latency_ms = endpoint_0._ewma_latency_ms
+        endpoint_2._latest_latency_ms = endpoint_0._latest_latency_ms
+
+        # capture w3 instances used for calls
+        w3_instances = []
+        def failing_fn(w3):
+            w3_instances.append(w3)
+            raise Exception("boom")
+
+        # sort by lowest ewma latency
+        with pytest.raises(Exception, match="boom"):
+            manager.call(
+                failing_fn,
+                request_timeout=1,
+                endpoint_sort_strategy=lambda stats: (stats.ewma_latency_ms,),
+            )
+        assert len(w3_instances) == 3, "all endpoints tried due to fallback"
+        assert w3_instances[0].provider.endpoint_uri == endpoint_1.endpoint_uri
+        assert w3_instances[1].provider.endpoint_uri == endpoint_0.endpoint_uri
+        assert w3_instances[2].provider.endpoint_uri == endpoint_2.endpoint_uri
+
+        # sort by lowest ewma latency then lowest last used
+        # (careful because _last_used gets updated on call, so we set it manually here to have a deterministic order)
+        now = time.time()
+        endpoint_0._last_used = now
+        endpoint_1._last_used = endpoint_0._last_used - 100
+        endpoint_2._last_used = endpoint_0._last_used - 200
+
+        w3_instances.clear()  # reset instances
+        # reset failures so that nodes aren't excluded / set to cool down
+        for e in manager.endpoints:
+            e._consecutive_request_failures = 0
+        with pytest.raises(Exception, match="boom"):
+            manager.call(
+                failing_fn,
+                request_timeout=1,
+                endpoint_sort_strategy=lambda stats: (
+                    stats.ewma_latency_ms,
+                    stats.last_used,
+                ),
+            )
+        assert len(w3_instances) == 3, "all endpoints tried due to fallback"
+        assert (
+            w3_instances[0].provider.endpoint_uri == endpoint_1.endpoint_uri
+        )  # lowest ewma latency
+        assert (
+            w3_instances[1].provider.endpoint_uri == endpoint_2.endpoint_uri
+        )  # tie-breaker is last used so endpoint_2 should be preferred over endpoint_0
+        assert w3_instances[2].provider.endpoint_uri == endpoint_0.endpoint_uri
+
+        # sort by lowest latest latency
+        w3_instances.clear()  # reset instances
+        # reset failures so that nodes aren't excluded / set to cool down
+        for e in manager.endpoints:
+            e._consecutive_request_failures = 0
+        with pytest.raises(Exception, match="boom"):
+            manager.call(
+                failing_fn,
+                request_timeout=1,
+                endpoint_sort_strategy=lambda stats: (stats.latest_latency_ms,),
+            )
+
+        assert len(w3_instances) == 3, "all endpoints tried due to fallback"
+        assert (
+            w3_instances[0].provider.endpoint_uri == endpoint_0.endpoint_uri
+        )  # lowest latest latency (tie-breaker with endpoint_2 is pre-existing order)
+        assert w3_instances[1].provider.endpoint_uri == endpoint_2.endpoint_uri
+        assert w3_instances[2].provider.endpoint_uri == endpoint_1.endpoint_uri

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -1207,11 +1207,53 @@ class TestRPCEndpointManager:
                     e._cool_down_until = 0.0
 
         # patch the time.sleep used inside the endpoint manager to avoid real waiting
-        mocker.patch("nucypher.utilities.endpoint.time.sleep", fake_sleep)
+        mocker.patch("nucypher.utilities.endpoint.time.sleep", side_effect=fake_sleep)
 
         result = manager.call(lambda w3: "worked", request_timeout=1.0)
         assert result == "worked"
         assert sleep_calls["count"] == saturated_retries
+
+    def test_saturated_retries_exhausted_due_to_no_candidates(self, mocker):
+        # the exception is raised after trying multiple rounds to
+        # get candidate endpoints, but there are none (eg. all in cool down)
+        session_manager = ThreadLocalSessionManager(max_pool_size=2)
+        endpoints = ["https://a.example", "https://b.example", "https://c.example"]
+
+        saturated_retries = 3
+        manager = RPCEndpointManager(
+            session_manager=session_manager,
+            endpoints=endpoints,
+            saturated_retries=saturated_retries,
+        )
+
+        try_acquire_spy = mocker.spy(RPCEndpoint, "try_acquire")
+
+        def fake_sleep(duration):
+            # do nothing
+            pass
+
+        # patch the time.sleep used inside the endpoint manager to avoid real waiting
+        mocked_sleep = mocker.patch(
+            "nucypher.utilities.endpoint.time.sleep", side_effect=fake_sleep
+        )
+
+        # patch manager so that _get_candidates is actually called but has no candidates to return
+        mocker.patch.object(manager, "_cooled_down_and_sorted", return_value=[])
+
+        with pytest.raises(
+            RPCEndpointManager.NoEndpointsAvailable,
+            match=f"All endpoints at capacity or in cool down after {saturated_retries} retries",
+        ):
+            _ = manager.call(lambda w3: "worked", request_timeout=1.0)
+
+        # viable candidates available so try_acquire is called for each candidate
+        assert (
+            try_acquire_spy.call_count == 0
+        ), "no try acquire since no candidates available "
+
+        assert (
+            mocked_sleep.call_count == saturated_retries
+        ), "should have slept for each retry when no candidates available"
 
     def test_consider_increasing_in_flight_capacity(self, mocker):
         session_manager = ThreadLocalSessionManager(max_pool_size=2)
@@ -1236,11 +1278,11 @@ class TestRPCEndpointManager:
             n_times_manager_called * len(endpoints)
         ), "every endpoint called"
 
-    def test_proactive_increase_of_in_flight_capacity_due_to_cant_acquire_candidate(
+    def test_proactive_increase_of_in_flight_capacity_due_to_cant_try_acquire_candidate(
         self, mocker
     ):
-        # in this test case (vs above), the exception is raised after having possible candidates
-        # but then try_acquire() on the candidate fails because candidate no longer viable i.e. there
+        # the exception is raised after having possible candidates
+        # but then try_acquire() on the candidate fails because candidate is no longer viable i.e. there
         # was a change in situation between getting candidate and using candidate
         session_manager = ThreadLocalSessionManager(max_pool_size=2)
         endpoints = ["https://a.example", "https://b.example", "https://c.example"]

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -891,6 +891,168 @@ class TestRPCEndpoint:
             endpoint._in_flight_capacity == initial_min_capacity + 2
         ), "proactively increased capacity by 2"
 
+    def test_report_unreachable_failure(self, mocker):
+        initial_min_capacity = 10
+        max_capacity = 50
+        scale_up_utilization = 0.5
+        unreachable_quarantine_after = 3
+        max_unreachable_quarantine_s = 900
+        endpoint = RPCEndpoint(
+            endpoint_uri=self.URI,
+            min_in_flight_capacity=initial_min_capacity,
+            max_in_flight_capacity=max_capacity,
+            scale_up_utilization_threshold=scale_up_utilization,
+            unreachable_quarantine_after=unreachable_quarantine_after,
+            max_unreachable_quarantine_s=max_unreachable_quarantine_s,
+        )
+
+        connection_failure = requests.exceptions.ConnectionError(
+            "simulated connection error"
+        )
+
+        # one less than unreachable_quarantine_after failures should not trigger unreachable quarantine
+        for i in range(unreachable_quarantine_after - 1):
+            assert endpoint.try_acquire()
+            try:
+                endpoint.report_failure(connection_failure)
+
+                # check request failure count (no change since separate counts for exec vs unreachable failures)
+                assert endpoint._consecutive_request_failures == 0
+                assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
+
+                # unreachable failure noted
+                assert endpoint._consecutive_unreachable_failures == (
+                    i + 1
+                ), "should have recorded 1 consecutive unreachable failure"
+                assert (
+                    endpoint.get_stats_snapshot().consecutive_unreachable_failures
+                    == (i + 1)
+                )
+
+                # no cool down enacted as yet
+                assert endpoint._cool_down_until == 0.0, "should not be in cooldown yet"
+            finally:
+                endpoint.release()
+
+        # in flight capacity has been dropped by half twice
+        assert endpoint._in_flight_capacity == (initial_min_capacity // 2) // 2
+
+        first_quarantine_now = time.monotonic()
+
+        # last failure should trigger unreachable quarantine
+        assert endpoint.try_acquire()
+        try:
+            endpoint.report_failure(connection_failure)
+            # we should now be in quarantine
+
+            # check request failure count (no change since separate counts for exec vs unreachable failures)
+            assert endpoint._consecutive_request_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
+
+            # check unreachable failure cound
+            assert (
+                endpoint._consecutive_unreachable_failures
+                == unreachable_quarantine_after
+            )
+            assert (
+                endpoint.get_stats_snapshot().consecutive_unreachable_failures
+                == unreachable_quarantine_after
+            )
+
+            # check updated capacity
+            assert endpoint._in_flight_capacity == 1, "in quarantine so dropped to 1"
+            assert endpoint.get_stats_snapshot().in_flight_capacity == 1
+
+            # in quarantine (with some minimum jitter)
+            assert (
+                endpoint._cool_down_until
+                >= first_quarantine_now + 0.8 * endpoint.max_unreachable_quarantine_s
+            ), "cooldown should be at least 80% of quarantine time after report time"
+        finally:
+            endpoint.release()
+
+        assert not endpoint.try_acquire(), "can't acquire endpoint in quarantine"
+        assert (
+            endpoint._num_in_flight_usage == 0
+        ), "all acquires have been already released"
+
+        # jump forward to after quarantine period
+        mocker.patch(
+            "time.monotonic",
+            return_value=first_quarantine_now + max_unreachable_quarantine_s + 1,
+        )
+
+        # still failing after 1st quarantine
+        assert endpoint.try_acquire(), "we can acquire after quarantine period"
+        try:
+            assert endpoint._in_flight_capacity == 1, "in quarantine so dropped to 1"
+            assert endpoint.get_stats_snapshot().in_flight_capacity == 1
+
+            endpoint.report_failure(connection_failure)  # report failure
+
+            # quanratine immediately enacted again
+            assert endpoint._consecutive_request_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
+            assert (
+                endpoint._consecutive_unreachable_failures
+                == unreachable_quarantine_after + 1
+            )
+            assert (
+                endpoint.get_stats_snapshot().consecutive_unreachable_failures
+                == unreachable_quarantine_after + 1
+            )
+
+            # check capacity still unchanged
+            assert endpoint._in_flight_capacity == 1, "in quarantine so dropped to 1"
+            assert endpoint.get_stats_snapshot().in_flight_capacity == 1
+
+            # still in quarantine (with some minimum jitter)
+            assert endpoint._cool_down_until >= (
+                first_quarantine_now + 0.8 * endpoint.max_unreachable_quarantine_s * 2
+            ), "2nd straight quarantine"
+        finally:
+            endpoint.release()
+
+        assert not endpoint.try_acquire(), "can't acquire endpoint in quarantine"
+        assert (
+            endpoint._num_in_flight_usage == 0
+        ), "all acquires have been already released"
+
+        # jump forward to after 2nd quarantine period
+        mocker.patch(
+            "time.monotonic",
+            return_value=first_quarantine_now + 2 * max_unreachable_quarantine_s + 1,
+        )
+
+        # log fist success after coming out of quarantine
+        assert endpoint.try_acquire(), "we can acquire after quarantine period"
+        try:
+            assert endpoint._in_flight_capacity == 1, "in quarantine so dropped to 1"
+            assert endpoint.get_stats_snapshot().in_flight_capacity == 1
+
+            endpoint.report_success(
+                latency_ms=1000
+            )  # report success to exit quarantine
+
+            # failure counts reset
+            assert endpoint._consecutive_request_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_request_failures == 0
+            assert endpoint._consecutive_unreachable_failures == 0
+            assert endpoint.get_stats_snapshot().consecutive_unreachable_failures == 0
+
+            # cooled down reset
+            assert endpoint._cool_down_until == 0.0
+
+            # capacity restored in min_in_flight_capacity since a success was reported
+            assert (
+                endpoint._in_flight_capacity == initial_min_capacity
+            ), "capacity should be restored to min capacity after success"
+            assert (
+                endpoint.get_stats_snapshot().in_flight_capacity == initial_min_capacity
+            )
+        finally:
+            endpoint.release()
+
 
 class TestRPCEndpointManager:
     """Focused unit tests for RPCEndpointManager behavior."""


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Based over #3715 
Follow-up to #3704 

Prior discussion
> As a follow-up to #3704, I/we can think about adjustments we can make to the load management logic based on initial number of available rpc endpoints, and potentially removing endpoints / backing off even longer if there are connection issues.

- Proactively expand in-flight capacity when endpoints are operating at or near their current capacity without failures. This helps in scenarios where a chain has a limited number of RPC endpoints but experiences a spike in traffic. There can still be failures, since sometimes there's just not enough capacity allowed by a small number of endpoints but this hopefully reduces the likelihood of these failures.

- Improved handling of unreachable endpoints. If an endpoint encounters consecutive “unreachable” errors, a significant backoff (quarantine) is triggered (10 minutes by default). On the first occurrence, in-flight capacity is reduced by half (to account for a possible transient connectivity issue). On the second consecutive occurrence, a long quarantine is applied and capacity is reduced to 1. Only a successful request after the long quarantine will restore the endpoint to the minimum in-flight capacity, after which it can gradually scale back up.

- Enhanced endpoint sorting strategy. Endpoints are now prioritized based on the following:
   - Fewest consecutive unreachable failures, then
   - Fewest consecutive execution failures, then
   - Lowest EWMA latency

  Previously, sorting was based solely on EWMA latency.

- Update stress test script to make preferred endpoint optional, specify chain ID and pull default rpc endpoints from the `nucypher/chainlist` repos, and print stats for all endpoints at the end.

  eg.
```bash
$ python ./scripts/rpc_endpoint_stress_test.py --new-strategy --chain-id 42 --test-executions 40
![FAILURE] RPC call failed with error: NoEndpointsAvailable: All endpoints at capacity or in cool down
![FAILURE] RPC call failed with error: NoEndpointsAvailable: All endpoints at capacity or in cool down
![FAILURE] RPC call failed with error: NoEndpointsAvailable: All endpoints at capacity or in cool down

[RESULTS]: stress test with 30 threads and 40 test executions

Total time: 3.06s
Strategy used: NEW STRATEGY
	Endpoint sort strategy: failures_then_latency
	Num failures: 3
	Endpoints:
		 https://42.rpc.thirdweb.com was used 7 times.
			 Stats: EndpointStats(latency=727.75ms, ewma_latency=692.75ms, consecutive_request_failures=9, consecutive_unreachable_failures=0, in_flight_usage=0, in_flight_cap=10, last_used=1771531312.795769)
		 https://rpc.mainnet.lukso.network was used 30 times.
			 Stats: EndpointStats(latency=1257.54ms, ewma_latency=1098.52ms, consecutive_request_failures=0, consecutive_unreachable_failures=0, in_flight_usage=0, in_flight_cap=25, last_used=1771531313.997154)
```

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
