### PR TITLE
Always shuffle other endpoints (public) to randomize ties

### DIFF
--- a/nucypher/utilities/endpoint.py
+++ b/nucypher/utilities/endpoint.py
@@ -462,9 +462,9 @@ class RPCEndpointManager:
 
             # add non-preferred endpoints
             other_endpoints = list(self.endpoints)
-            if not endpoint_sort_strategy:
-                # shuffle if no sorting strategy to help distribute load across equally healthy endpoints
-                random.shuffle(other_endpoints)
+            # always shuffle before sorting to avoid persistent tie bias while keeping sorting
+            # strategy intact; helps distribute early traffic when stats are similar
+            random.shuffle(other_endpoints)
             other_endpoints = self._cooled_down_and_sorted(
                 other_endpoints, endpoint_sort_strategy
             )

--- a/scripts/dev/rpc_endpoint_stress_test.py
+++ b/scripts/dev/rpc_endpoint_stress_test.py
@@ -117,6 +117,7 @@ STRATEGIES = [
     "fewest_in_flight_then_latency",
     "last_used",
     "failures_then_latency",
+    "failures_then_latency_known_over_unknown",
 ]
 
 
@@ -147,6 +148,14 @@ def get_endpoint_sort_strategy(
             stats.consecutive_unreachable_failures,
             stats.consecutive_request_failures,
             stats.ewma_latency_ms,
+        )
+    elif strategy == "failures_then_latency_known_over_unknown":
+        # sort by fewest unreachable failures, then exec failures, then latency, but prioritize endpoints
+        # with known latency stats over those without any stats
+        return lambda stats: (
+            stats.consecutive_unreachable_failures,
+            stats.consecutive_request_failures,
+            stats.ewma_latency_ms if stats.ewma_latency_ms != 0.0 else float("inf"),
         )
 
     raise ValueError(f"Strategy '{strategy}' not implemented")

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -1345,9 +1345,15 @@ class TestRPCEndpointManager:
             endpoints
         ), "should have called consider_increasing_in_flight_capacity on all endpoints"
 
-    def test_sorting_endpoints_for_call(self):
+    def test_sorting_endpoints_for_call(self, mocker):
         session_manager = ThreadLocalSessionManager(max_pool_size=2)
         endpoints = ["https://a.example", "https://b.example", "https://c.example"]
+
+        # endpoints get shuffled so any ties can be random; mock the random.shuffle to keep the
+        # order deterministic for testing
+        mocked_shuffle = mocker.patch(
+            "nucypher.utilities.endpoint.random.shuffle", side_effect=lambda x: x
+        )
 
         manager = RPCEndpointManager(
             session_manager=session_manager,
@@ -1382,6 +1388,9 @@ class TestRPCEndpointManager:
                 request_timeout=1,
                 endpoint_sort_strategy=lambda stats: (stats.ewma_latency_ms,),
             )
+        assert mocked_shuffle.call_count == 1
+        mocked_shuffle.reset_mock()
+
         assert len(w3_instances) == 3, "all endpoints tried due to fallback"
         assert w3_instances[0].provider.endpoint_uri == endpoint_1.endpoint_uri
         assert w3_instances[1].provider.endpoint_uri == endpoint_0.endpoint_uri
@@ -1407,6 +1416,9 @@ class TestRPCEndpointManager:
                     stats.last_used,
                 ),
             )
+        assert mocked_shuffle.call_count == 1
+        mocked_shuffle.reset_mock()
+
         assert len(w3_instances) == 3, "all endpoints tried due to fallback"
         assert (
             w3_instances[0].provider.endpoint_uri == endpoint_1.endpoint_uri
@@ -1427,6 +1439,9 @@ class TestRPCEndpointManager:
                 request_timeout=1,
                 endpoint_sort_strategy=lambda stats: (stats.latest_latency_ms,),
             )
+
+        assert mocked_shuffle.call_count == 1
+        mocked_shuffle.reset_mock()
 
         assert len(w3_instances) == 3, "all endpoints tried due to fallback"
         assert (


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Follow-up to #3718 

- Add random shuffling of extra (non-preferred) endpoints before sorting to better spread load across endpoints, and reduce consecutive failures from endpoint overloading especially at startup.
- I experimented with a different sorting strategy in the stress test to favour known vs unkown endpoints, but after testing I didn't like the behaviour (it starved unknown endpoints, and overloaded known endpoints). Consequently, I didn't use it, but I will still commit it to the repos as part of experimentation in case it sparks ideas from someone else.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
