### PR TITLE
Obfuscate API keys contained in endpoint query parameters

### DIFF
--- a/newsfragments/3721.bugfix.rst
+++ b/newsfragments/3721.bugfix.rst
@@ -1,0 +1,1 @@
+Obfuscate RPC endpoint URLs that have API keys provided as query parameters to prevent key exposure.

--- a/nucypher/blockchain/eth/utils.py
+++ b/nucypher/blockchain/eth/utils.py
@@ -31,11 +31,32 @@ def _truncate_response_text(text: str) -> str:
 def obfuscate_rpc_url(url: str) -> str:
     """
     Obfuscates sensitive parts of an RPC URL for safe logging.
-    Replaces API keys and other path segments after the host with asterisks.
+    Replaces API keys after the host with asterisks.
     Example: https://mainnet.infura.io/v3/abc123 -> https://mainnet.infura.io/v3/abc***
+    Example: https://eth-mainnet.rpcfast.com?api_key=abc123 -> https://eth-mainnet.rpcfast.com?api_key=abc***
     """
     try:
         parsed = urlparse(url)
+
+        if parsed.query:
+            # Obfuscate query parameters that look like API keys
+            query_params = parsed.query.split("&")
+            obfuscated_params = []
+            for param in query_params:
+                key_value = param.split("=", 1)
+                if len(key_value) == 2:
+                    key, value = key_value
+                    # Obfuscate query values that are 16+ chars (likely API keys/secrets)
+                    if len(value) >= 16:
+                        obfuscated_value = value[:3] + "***"
+                        obfuscated_params.append(f"{key}={obfuscated_value}")
+                    else:
+                        obfuscated_params.append(param)
+                else:
+                    obfuscated_params.append(param)
+            obfuscated_query = "&".join(obfuscated_params)
+            parsed = parsed._replace(query=obfuscated_query)
+
         if parsed.path:
             # Split path into segments and obfuscate segments that look like API keys
             segments = parsed.path.split("/")

--- a/tests/unit/test_blockchain_utils.py
+++ b/tests/unit/test_blockchain_utils.py
@@ -38,8 +38,20 @@ from nucypher.blockchain.eth.utils import (
             "https://andromeda.metis.io/?owner=1088&extra=param",
         ),  # no change since no API key
         (
+            "https://andromeda.metis.io/?nokeyvaluepair",
+            "https://andromeda.metis.io/?nokeyvaluepair",
+        ),  # no change since no API key
+        (
+            "https://andromeda.metis.io/?nokeyvaluepair&othervalue",
+            "https://andromeda.metis.io/?nokeyvaluepair&othervalue",
+        ),  # no change since no API key
+        (
             "https://andromeda.metis.io/?owner=1088&api_key=abcdef1234567890",
             "https://andromeda.metis.io/?owner=1088&api_key=abc***",
+        ),
+        (
+            "https://api-gateway.skymavis.com/rpc?apikey=9aqYLBbxSC6LROynQJBvKkEIsioqwHmr",
+            "https://api-gateway.skymavis.com/rpc?apikey=9aq***",
         ),
         (
             "https://andromeda.metis.io/?api_key=abcdef1234567890&owner=1088",

--- a/tests/unit/test_blockchain_utils.py
+++ b/tests/unit/test_blockchain_utils.py
@@ -24,6 +24,36 @@ from nucypher.blockchain.eth.utils import (
         ("https://cloudflare-eth.com", "https://cloudflare-eth.com"),
         # Short path segments preserved
         ("https://example.com/v3/short", "https://example.com/v3/short"),
+        # query parameters preserved but API key obfuscated
+        (
+            "https://eth-mainnet.rpcfast.com?api_key=xbhWBI1Wkguk8SNMu1bvvLurPGLXmgwYeC4S6g2H7WdwFigZSmPWVZRxrskEQwIf",
+            "https://eth-mainnet.rpcfast.com?api_key=xbh***",
+        ),
+        (
+            "https://andromeda.metis.io/?owner=1088",
+            "https://andromeda.metis.io/?owner=1088",
+        ),  # no change since no API key
+        (
+            "https://andromeda.metis.io/?owner=1088&extra=param",
+            "https://andromeda.metis.io/?owner=1088&extra=param",
+        ),  # no change since no API key
+        (
+            "https://andromeda.metis.io/?owner=1088&api_key=abcdef1234567890",
+            "https://andromeda.metis.io/?owner=1088&api_key=abc***",
+        ),
+        (
+            "https://andromeda.metis.io/?api_key=abcdef1234567890&owner=1088",
+            "https://andromeda.metis.io/?api_key=abc***&owner=1088",
+        ),
+        (
+            "https://andromeda.metis.io/?owner=1088&api_key=abcdef1234567890&extra=param",
+            "https://andromeda.metis.io/?owner=1088&api_key=abc***&extra=param",
+        ),
+        # ridiculous example of both path and query API keys obfuscated
+        (
+            "https://eth-mainnet.alchemyapi.io/v2/abcdef1234567890abcdef1234567890?alternative_key_to_use=1234567890abcdef",
+            "https://eth-mainnet.alchemyapi.io/v2/abc***?alternative_key_to_use=123***",
+        ),
         # Invalid input falls back to placeholder
         (123, "<RPC endpoint>"),
     ],


### PR DESCRIPTION
**Type of PR:**
- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Follow-up to #3702 .

It's possible for API keys to be included as part of the URL query, obfuscate those instances as well. This was noticed as part of work done for https://github.com/nucypher/chainlist/pull/9.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
