### PR TITLE
Additional safety valves when using `NetworkRequestClient` for making threshold requests

### DIFF
--- a/newsfragments/3722.feature.rst
+++ b/newsfragments/3722.feature.rst
@@ -1,0 +1,1 @@
+Adds safety valves to ``NetworkRequestClient`` for threshold requests: configurable max worker threads and dynamic batch sizing that adjusts based on successes achieved so far.

--- a/nucypher/network/client.py
+++ b/nucypher/network/client.py
@@ -29,14 +29,15 @@ class ThresholdAccessControlClient:
             self._learner.learn_from_teacher_node()
 
         all_known_ursulas = self._learner.known_nodes.addresses()
-
-        # Push all unknown Ursulas from the map in the queue for learning
-        unknown_ursulas = ursulas - all_known_ursulas
+        ursulas_to_know = set(ursulas)
 
         # If we know enough to decrypt, we can proceed.
-        known_ursulas = ursulas & all_known_ursulas
+        known_ursulas = ursulas_to_know & all_known_ursulas
         if len(known_ursulas) >= threshold:
             return
+
+        # Push all unknown Ursulas from the map in the queue for learning
+        unknown_ursulas = ursulas_to_know - all_known_ursulas
 
         # | <--- shares                                            ---> |
         # | <--- threshold               ---> | <--- allow_missing ---> |

--- a/nucypher/network/concurrency.py
+++ b/nucypher/network/concurrency.py
@@ -11,7 +11,7 @@ from nucypher_core import (
 )
 
 from nucypher.network.client import ThresholdAccessControlClient
-from nucypher.utilities.concurrency import BatchValueFactory, WorkerPool
+from nucypher.utilities.concurrency import VariableBatchSizeValueFactory, WorkerPool
 
 
 class NetworkRequestClient(ThresholdAccessControlClient):
@@ -22,18 +22,50 @@ class NetworkRequestClient(ThresholdAccessControlClient):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    class RequestFactory(BatchValueFactory):
+    class RequestFactory(VariableBatchSizeValueFactory):
+        """
+        A ValueFactory for WorkerPool that allows us to specify a dynamic batch size based
+        on the number of successes so far.
+        """
+
+        """
+        :param ursulas_to_contact: The list of ursula addresses to contact.
+        :param threshold: The number of successful responses required to meet the threshold for this request.
+        :param threshold_batch_buffer_factor: A multiplier to add extra buffer to the batch size of nodes contacted in addition to the the threshold.
+        """
         def __init__(
             self,
             ursulas_to_contact: List[ChecksumAddress],
             threshold: int,
-            batch_size: int,
+            threshold_batch_buffer_factor: float = 0.25,
         ):
             super().__init__(
                 values=ursulas_to_contact,
                 required_successes=threshold,
-                batch_size=batch_size,
             )
+
+            if threshold_batch_buffer_factor is None or not (
+                0 <= threshold_batch_buffer_factor <= 1.0
+            ):
+                raise ValueError(
+                    "Threshold batch buffer factor must be between 0 and 1"
+                )
+
+            self._required_successes_plus_buffer = math.ceil(
+                threshold * (1 + threshold_batch_buffer_factor)
+            )
+
+        def get_custom_batch_size(self, successes) -> int:
+            if self.required_successes <= successes:
+                # should never get here since the WorkerPool should stop once we have enough successes
+                raise ValueError(
+                    "Current successes cannot be greater than or equal to the threshold"
+                )
+
+            additional_successes_needed = (
+                self._required_successes_plus_buffer - successes
+            )
+            return additional_successes_needed
 
     def execute(
         self,
@@ -58,7 +90,6 @@ class NetworkRequestClient(ThresholdAccessControlClient):
             worker=worker,
             value_factory=self.RequestFactory(
                 ursulas_to_contact=ursulas_to_contact,
-                batch_size=math.ceil(threshold * 1.25),
                 threshold=threshold,
             ),
             target_successes=threshold,

--- a/nucypher/network/concurrency.py
+++ b/nucypher/network/concurrency.py
@@ -28,28 +28,28 @@ class NetworkRequestClient(ThresholdAccessControlClient):
         on the number of successes so far.
         """
 
-        """
-        :param ursulas_to_contact: The list of ursula addresses to contact.
-        :param threshold: The number of successful responses required to meet the threshold for this request.
-        :param threshold_batch_buffer_factor: A multiplier to add extra buffer to the batch size of nodes contacted in addition to the the threshold.
-        """
         def __init__(
             self,
             ursulas_to_contact: List[ChecksumAddress],
             threshold: int,
             threshold_batch_buffer_factor: float = 0.25,
         ):
-            super().__init__(
-                values=ursulas_to_contact,
-                required_successes=threshold,
-            )
-
+            """
+            :param ursulas_to_contact: The list of ursula addresses to contact.
+            :param threshold: The number of successful responses required to meet the threshold for this request.
+            :param threshold_batch_buffer_factor: A multiplier to add extra buffer to the batch size of nodes contacted in addition to the threshold.
+            """
             if threshold_batch_buffer_factor is None or not (
                 0 <= threshold_batch_buffer_factor <= 1.0
             ):
                 raise ValueError(
                     "Threshold batch buffer factor must be between 0 and 1"
                 )
+
+            super().__init__(
+                values=ursulas_to_contact,
+                required_successes=threshold,
+            )
 
             self._required_successes_plus_buffer = math.ceil(
                 threshold * (1 + threshold_batch_buffer_factor)

--- a/nucypher/network/concurrency.py
+++ b/nucypher/network/concurrency.py
@@ -1,6 +1,6 @@
 import math
 from http import HTTPStatus
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from eth_typing import ChecksumAddress
 from nucypher_core import (
@@ -74,6 +74,7 @@ class NetworkRequestClient(ThresholdAccessControlClient):
         threshold: int,
         timeout: int,
         stagger_timeout: int = DEFAULT_STAGGER_TIMEOUT,
+        max_worker_threads: Optional[int] = None,
     ) -> Tuple[Dict, Dict]:
 
         ursulas_to_contact = (
@@ -84,6 +85,11 @@ class NetworkRequestClient(ThresholdAccessControlClient):
             else list(requests)
         )
 
+        if max_worker_threads is None:
+            max_worker_threads = min(
+                self.DEFAULT_MAX_WORKER_THREADS_PER_REQUEST, math.ceil(threshold * 1.5)
+            )
+
         # Discussion about WorkerPool parameters:
         # "https://github.com/nucypher/nucypher/pull/3393#discussion_r1456307991"
         worker_pool = WorkerPool(
@@ -93,9 +99,7 @@ class NetworkRequestClient(ThresholdAccessControlClient):
                 threshold=threshold,
             ),
             target_successes=threshold,
-            threadpool_size=min(
-                self.DEFAULT_MAX_WORKER_THREADS_PER_REQUEST, math.ceil(threshold * 1.5)
-            ),
+            threadpool_size=max_worker_threads,
             timeout=timeout,
             stagger_timeout=stagger_timeout,
         )
@@ -134,6 +138,7 @@ class ThresholdDecryptionClient(NetworkRequestClient):
         threshold: int,
         timeout: int = NetworkRequestClient.DEFAULT_TIMEOUT,
         stagger_timeout: int = NetworkRequestClient.DEFAULT_STAGGER_TIMEOUT,
+        max_worker_threads: Optional[int] = None,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdDecryptionResponse],
         Dict[ChecksumAddress, str],
@@ -179,6 +184,7 @@ class ThresholdDecryptionClient(NetworkRequestClient):
             threshold=threshold,
             timeout=timeout,
             stagger_timeout=stagger_timeout,
+            max_worker_threads=max_worker_threads,
         )
 
         return successes, failures
@@ -201,6 +207,7 @@ class SigningRequestClient(NetworkRequestClient):
         threshold: int,
         timeout: int = NetworkRequestClient.DEFAULT_TIMEOUT,
         stagger_timeout: int = NetworkRequestClient.DEFAULT_STAGGER_TIMEOUT,
+        max_worker_threads: Optional[int] = None,
     ) -> Tuple[
         Dict[ChecksumAddress, EncryptedThresholdSignatureResponse],
         Dict[ChecksumAddress, str],
@@ -246,6 +253,7 @@ class SigningRequestClient(NetworkRequestClient):
             threshold=threshold,
             timeout=timeout,
             stagger_timeout=stagger_timeout,
+            max_worker_threads=max_worker_threads,
         )
 
         return successes, failures

--- a/nucypher/network/concurrency.py
+++ b/nucypher/network/concurrency.py
@@ -90,6 +90,9 @@ class NetworkRequestClient(ThresholdAccessControlClient):
                 self.DEFAULT_MAX_WORKER_THREADS_PER_REQUEST, math.ceil(threshold * 1.5)
             )
 
+        if max_worker_threads < 1:
+            raise ValueError("max worker threads must be at least 1")
+
         # Discussion about WorkerPool parameters:
         # "https://github.com/nucypher/nucypher/pull/3393#discussion_r1456307991"
         worker_pool = WorkerPool(

--- a/nucypher/network/concurrency.py
+++ b/nucypher/network/concurrency.py
@@ -17,6 +17,7 @@ from nucypher.utilities.concurrency import BatchValueFactory, WorkerPool
 class NetworkRequestClient(ThresholdAccessControlClient):
     DEFAULT_TIMEOUT = 30
     DEFAULT_STAGGER_TIMEOUT = 3
+    DEFAULT_MAX_WORKER_THREADS_PER_REQUEST = 10
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -61,9 +62,9 @@ class NetworkRequestClient(ThresholdAccessControlClient):
                 threshold=threshold,
             ),
             target_successes=threshold,
-            threadpool_size=math.ceil(
-                threshold * 1.5
-            ),  # TODO should we cap this (say 40?)
+            threadpool_size=min(
+                self.DEFAULT_MAX_WORKER_THREADS_PER_REQUEST, math.ceil(threshold * 1.5)
+            ),
             timeout=timeout,
             stagger_timeout=stagger_timeout,
         )

--- a/nucypher/utilities/concurrency.py
+++ b/nucypher/utilities/concurrency.py
@@ -1,5 +1,4 @@
-
-
+import abc
 import io
 import sys
 import traceback
@@ -343,7 +342,7 @@ class BatchValueFactory:
                 f"Invalid number of successes required ({required_successes})"
             )
 
-        self.values = values
+        self.values = list(values)
         self.required_successes = required_successes
         if len(self.values) < self.required_successes:
             raise ValueError(
@@ -365,7 +364,7 @@ class BatchValueFactory:
             # no more values to process
             return None
 
-        batch_end_index = self._batch_start_index + self.batch_size
+        batch_end_index = self._batch_start_index + self._get_batch_size(successes)
         if batch_end_index <= len(self.values):
             batch = self.values[self._batch_start_index : batch_end_index]
             self._batch_start_index = batch_end_index
@@ -375,3 +374,25 @@ class BatchValueFactory:
             batch = self.values[self._batch_start_index :]
             self._batch_start_index = len(self.values)
             return batch
+
+    def _get_batch_size(self, successes) -> int:
+        return self.batch_size
+
+
+class VariableBatchSizeValueFactory(BatchValueFactory, abc.ABC):
+    """
+    A batch value factory that allows the batch size to be determined dynamically by a provided function.
+    """
+
+    def __init__(self, values: List[Any], required_successes: int):
+        super().__init__(values=values, required_successes=required_successes)
+
+    def _get_batch_size(self, successes) -> int:
+        batch_size = self.get_custom_batch_size(successes)
+        if batch_size <= 0:
+            raise ValueError(f"Invalid batch size returned by function ({batch_size})")
+        return batch_size
+
+    @abc.abstractmethod
+    def get_custom_batch_size(self, successes) -> int:
+        raise NotImplementedError

--- a/tests/acceptance/actors/test_dkg_ritual.py
+++ b/tests/acceptance/actors/test_dkg_ritual.py
@@ -344,7 +344,6 @@ def test_authorized_decryption(
     value_factory_spy.assert_called_once_with(
         ANY,
         ursulas_to_contact=expected_ursula_request_ordering,
-        batch_size=ANY,
         threshold=ANY,
     )
 

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -1,6 +1,12 @@
+import math
+
 import pytest
 
-from nucypher.utilities.concurrency import BatchValueFactory
+from nucypher.network.concurrency import NetworkRequestClient
+from nucypher.utilities.concurrency import (
+    BatchValueFactory,
+    VariableBatchSizeValueFactory,
+)
 
 NUM_VALUES = 20
 
@@ -194,3 +200,184 @@ def test_batch_value_factory_batching_non_divisible(values):
     # get list again
     value_list = value_factory(successes=0)  # successes not achieved
     assert not value_list, "no successes achieved but no more values available"
+
+
+class MyVariableBatchSizeFactory(VariableBatchSizeValueFactory):
+    def __init__(self, values, required_successes, batch_size_func):
+        super().__init__(values=values, required_successes=required_successes)
+        self.batch_size_fn = batch_size_func
+
+    def get_custom_batch_size(self, successes):
+        return self.batch_size_fn(successes)
+
+
+def test_variable_batch_size_factory_constant_batching():
+    # A constant batch size function behaves like BatchValueFactory with that batch size
+    vals = list(range(10))
+    factory = MyVariableBatchSizeFactory(
+        values=vals, required_successes=10, batch_size_func=lambda s: 3
+    )
+
+    assert factory(successes=0) == [0, 1, 2]
+    assert factory(successes=0) == [3, 4, 5]
+    assert factory(successes=0) == [6, 7, 8]
+    assert factory(successes=0) == [9]
+    assert factory(successes=0) is None
+
+
+def test_variable_batch_size_factory_zero_batch_raises():
+    # If the provided function returns a non-positive batch size, call raises ValueError
+    vals = [1, 2, 3]
+    factory = MyVariableBatchSizeFactory(
+        values=vals, required_successes=3, batch_size_func=lambda s: 0
+    )
+    with pytest.raises(ValueError):
+        factory(successes=0)
+
+
+def test_variable_batch_size_factory_respects_success_threshold():
+    # If successes already meet required_successes, factory returns None immediately
+    vals = list(range(5))
+    factory = MyVariableBatchSizeFactory(
+        values=vals, required_successes=3, batch_size_func=lambda s: 2
+    )
+    assert factory(successes=3) is None
+
+
+def test_variable_batch_size_factory_decreasing_batch_size():
+    # Batch size may change depending on successes; ensure remaining items are returned
+    vals = list(range(6))
+    factory = MyVariableBatchSizeFactory(
+        values=vals, required_successes=6, batch_size_func=lambda s: 4 if s < 2 else 1
+    )
+
+    assert factory(successes=0) == [0, 1, 2, 3]
+    # Next call asks for batch size 4 again (since successes param still < 2), but only 2 remain
+    assert factory(successes=1) == [4, 5]
+    assert factory(successes=0) is None
+
+
+@pytest.mark.parametrize("extra_buffer_factor", [-0.1, -0.01, None, 1.1, 1.5])
+def test_request_factory_invalid_extra_buffer(
+    get_random_checksum_address, extra_buffer_factor
+):
+    ursulas = [get_random_checksum_address() for _ in range(5)]
+    threshold = 3
+
+    with pytest.raises(
+        ValueError, match="Threshold batch buffer factor must be between 0 and 1"
+    ):
+        NetworkRequestClient.RequestFactory(
+            ursulas_to_contact=ursulas,
+            threshold=threshold,
+            threshold_batch_buffer_factor=extra_buffer_factor,
+        )
+
+
+def test_request_factory_required_successes_with_buffer_calc(
+    get_random_checksum_address,
+):
+    ursulas = [get_random_checksum_address() for _ in range(10)]
+    threshold = 4
+    extra_buffer = 0.5
+    req = NetworkRequestClient.RequestFactory(
+        ursulas_to_contact=ursulas,
+        threshold=threshold,
+        threshold_batch_buffer_factor=extra_buffer,
+    )
+
+    assert req._required_successes_plus_buffer == int(threshold * (1 + extra_buffer))
+
+
+def test_request_factory_get_custom_batch_size_simple(get_random_checksum_address):
+    n_ursulas = 9  # odd number
+    ursulas = [get_random_checksum_address() for _ in range(n_ursulas)]
+    threshold = 1
+    extra_buffer = 0.0  # no buffer
+    req = NetworkRequestClient.RequestFactory(
+        ursulas_to_contact=ursulas,
+        threshold=threshold,
+        threshold_batch_buffer_factor=extra_buffer,
+    )
+
+    for i in range(n_ursulas):
+        assert req(successes=0) == ursulas[i * threshold : (i + 1) * threshold]
+
+
+def test_request_factory_get_custom_batch_size_simple_remainder_at_end(
+    get_random_checksum_address,
+):
+    n_ursulas = 9  # odd number
+    ursulas = [get_random_checksum_address() for _ in range(n_ursulas)]
+    threshold = 2
+    extra_buffer = 0.0  # no buffer
+
+    req = NetworkRequestClient.RequestFactory(
+        ursulas_to_contact=ursulas,
+        threshold=threshold,
+        threshold_batch_buffer_factor=extra_buffer,
+    )
+
+    num_iterations = n_ursulas // threshold
+    for i in range(num_iterations):
+        assert req(successes=0) == ursulas[i * threshold : (i + 1) * threshold]
+
+    # extra iteration where only 1 value remains; use 1 success to trigger the last value being
+    # returned otherwise there wouldn't be sufficient values to meet threshold and error would be raised
+    assert req(successes=1) == ursulas[-1:]
+
+
+def test_request_factory_get_custom_batch_size_normal(get_random_checksum_address):
+    n_ursulas = 10  # more than needed
+    ursulas = [get_random_checksum_address() for _ in range(n_ursulas)]
+    threshold = 4
+    extra_buffer = 0.5
+    req = NetworkRequestClient.RequestFactory(
+        ursulas_to_contact=ursulas,
+        threshold=threshold,
+        threshold_batch_buffer_factor=extra_buffer,
+    )
+
+    threshold_with_buffer = math.ceil(threshold * (1 + extra_buffer))
+
+    # first iteration returns threshold_with_buffer values, second call returns remaining values
+    assert req(successes=0) == ursulas[0:threshold_with_buffer]
+    assert req(successes=0) == ursulas[threshold_with_buffer:]
+
+
+def test_request_factory_get_custom_batch_size_remaining_less_than_needed(
+    get_random_checksum_address,
+):
+    n_ursulas = 7
+    ursulas = [get_random_checksum_address() for _ in range(n_ursulas)]
+    threshold = 6
+    extra_buffer = 0.5
+    req = NetworkRequestClient.RequestFactory(
+        ursulas_to_contact=ursulas,
+        threshold=threshold,
+        threshold_batch_buffer_factor=extra_buffer,
+    )
+
+    threshold_with_buffer = math.ceil(threshold * (1 + extra_buffer))
+
+    assert (
+        threshold_with_buffer > n_ursulas
+    ), "threshold with buffer should be greater than total values"
+    assert (
+        req(successes=0) == ursulas
+    ), "should return all values since threshold with buffer is greater than total values"
+
+
+def test_request_factory_raises_on_successes_ge_threshold(get_random_checksum_address):
+    n_ursulas = 5
+    ursulas = [get_random_checksum_address() for _ in range(n_ursulas)]
+
+    threshold = 3
+    req = NetworkRequestClient.RequestFactory(
+        ursulas_to_contact=ursulas, threshold=threshold
+    )
+    with pytest.raises(
+        ValueError,
+        match="Current successes cannot be greater than or equal to the threshold",
+    ):
+        req.get_custom_batch_size(successes=threshold)

--- a/tests/unit/test_concurrency.py
+++ b/tests/unit/test_concurrency.py
@@ -274,19 +274,24 @@ def test_request_factory_invalid_extra_buffer(
         )
 
 
+@pytest.mark.parametrize(
+    ["threshold", "extra_buffer"], [(3, 0.25), (4, 0.5), (5, 1.0), (6, 0.0)]
+)
 def test_request_factory_required_successes_with_buffer_calc(
+    threshold,
+    extra_buffer,
     get_random_checksum_address,
 ):
     ursulas = [get_random_checksum_address() for _ in range(10)]
-    threshold = 4
-    extra_buffer = 0.5
     req = NetworkRequestClient.RequestFactory(
         ursulas_to_contact=ursulas,
         threshold=threshold,
         threshold_batch_buffer_factor=extra_buffer,
     )
 
-    assert req._required_successes_plus_buffer == int(threshold * (1 + extra_buffer))
+    assert req._required_successes_plus_buffer == math.ceil(
+        threshold + (threshold * extra_buffer)
+    )
 
 
 def test_request_factory_get_custom_batch_size_simple(get_random_checksum_address):

--- a/tests/unit/test_rpc_endpoint_management.py
+++ b/tests/unit/test_rpc_endpoint_management.py
@@ -1356,7 +1356,8 @@ class TestRPCEndpointManager:
         # endpoints get shuffled so any ties can be random; mock the random.shuffle to keep the
         # order deterministic for testing
         mocked_shuffle = mocker.patch(
-            "nucypher.utilities.endpoint.random.shuffle", side_effect=lambda x: x
+            "nucypher.utilities.endpoint.random.shuffle",
+            side_effect=lambda x: None,  # do nothing
         )
 
         manager = RPCEndpointManager(


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
Porter https://github.com/nucypher/nucypher-porter/pull/106 should depend on a commit from `nucypher` with these changes.

- Allow configurable max_worker_threads per request to be provided via the `NetworkRequestClient`.
- Adjust batch size over time so that we don't excessively send requests to too many uruslas over the threshold.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
