### PR TITLE
feat(conditions): Add nestedAbiDecode for selectorless ABI data

### DIFF
--- a/newsfragments/3723.feature.rst
+++ b/newsfragments/3723.feature.rst
@@ -1,0 +1,1 @@
+Add ``nestedAbiDecode`` for validating selectorless ABI-encoded data in signing conditions, enabling ERC-7579 batch execution support.

--- a/nucypher/policy/conditions/signing/base.py
+++ b/nucypher/policy/conditions/signing/base.py
@@ -28,6 +28,7 @@ from nucypher.policy.conditions.utils import (
     is_camel_case,
 )
 from nucypher.utilities.abi import (
+    decode_abi_encoded,
     decode_human_readable_call,
     extract_arg_types,
     is_valid_human_readable_signature,
@@ -182,6 +183,11 @@ class AbiParameterValidation(_Serializable):
             lambda: AbiCallValidation.Schema(), allow_none=True, required=False
         )
 
+        # ...or a nested ABI decode (no selector) to decode and evaluate
+        nested_abi_decode = fields.Nested(
+            lambda: AbiDecodeValidation.Schema(), allow_none=True, required=False
+        )
+
         # maintain field declaration ordering
         class Meta:
             ordered = True
@@ -190,9 +196,15 @@ class AbiParameterValidation(_Serializable):
         def validate_rtv_or_nested_validation(self, data, **kwargs):
             return_value_test = data.get("return_value_test")
             nested_abi_validation = data.get("nested_abi_validation")
-            if not (bool(return_value_test) ^ bool(nested_abi_validation)):
+            nested_abi_decode = data.get("nested_abi_decode")
+            set_count = sum(
+                bool(x)
+                for x in [return_value_test, nested_abi_validation, nested_abi_decode]
+            )
+            if set_count != 1:
                 raise ValidationError(
-                    "Either return value test or nested abi validation but not both."
+                    "Exactly one of returnValueTest, nestedAbiValidation, "
+                    "or nestedAbiDecode must be defined."
                 )
 
         @post_load
@@ -205,11 +217,13 @@ class AbiParameterValidation(_Serializable):
         sub_indices: Optional[List[int]] = None,
         return_value_test: Optional[ReturnValueTest] = None,
         nested_abi_validation: Optional["AbiCallValidation"] = None,
+        nested_abi_decode: Optional["AbiDecodeValidation"] = None,
     ):
         self.parameter_index = parameter_index
         self.sub_indices = sub_indices
         self.return_value_test = return_value_test
         self.nested_abi_validation = nested_abi_validation
+        self.nested_abi_decode = nested_abi_decode
 
         self._validate()
 
@@ -256,11 +270,78 @@ class AbiParameterValidation(_Serializable):
 
             result = resolved_return_value_test.eval(modified_parameter_value_to_check)
             return result, parameter_value
-        else:
+        elif self.nested_abi_validation:
             result, value = self.nested_abi_validation.check(
                 parameter_value, providers, **context
             )
             return result, value
+        elif self.nested_abi_decode:
+            result, value = self.nested_abi_decode.check(
+                parameter_value, providers, **context
+            )
+            return result, value
+        else:
+            raise InvalidCondition("No validation method defined")
+
+
+class AbiDecodeValidation(_Serializable):
+    """Validates raw ABI-encoded data (no function selector).
+
+    Used for ERC-7579 batch execution payloads and other selectorless
+    ABI-encoded bytes.
+    """
+
+    class Schema(CamelCaseSchema):
+        type = fields.Str(required=True)
+        validations = fields.List(
+            fields.Nested(AbiParameterValidation.Schema()),
+            required=True,
+        )
+
+        class Meta:
+            ordered = True
+
+        @validates("type")
+        def validate_type(self, value: str):
+            if not value:
+                raise ValidationError("Type string must not be empty")
+            try:
+                import eth_abi as _eth_abi
+
+                if not _eth_abi.is_encodable_type(value):
+                    raise ValidationError(f"Invalid ABI type: {value}")
+            except ValidationError:
+                raise
+            except Exception as e:
+                raise ValidationError(f"Invalid ABI type: {value} - {e}")
+
+        @post_load
+        def make(self, data, **kwargs):
+            return AbiDecodeValidation(**data)
+
+    def __init__(self, type: str, validations: List[AbiParameterValidation]):
+        self.type = type
+        self.validations = validations
+        self._validate()
+
+    def check(
+        self, value: Any, providers: ConditionProviderManager, **context
+    ) -> Tuple[bool, Any]:
+        if not isinstance(value, bytes):
+            raise ValueError(f"Expected bytes for ABI decode, got {type(value)}")
+
+        args = decode_abi_encoded(self.type, value)
+
+        parameter_values = []
+        for validation in self.validations:
+            result, raw_value = validation.check(
+                args=args, providers=providers, **context
+            )
+            parameter_values.append(raw_value)
+            if not result:
+                return False, parameter_values
+
+        return True, parameter_values
 
 
 class AbiCallValidation(_Serializable):
@@ -318,6 +399,13 @@ class AbiCallValidation(_Serializable):
                         if final_type != "bytes":
                             raise ValidationError(
                                 f"Nested ABI validation is only supported for bytes type, "
+                                f"but sub indices resolve to '{final_type}'."
+                            )
+
+                    if parameter_value_check.nested_abi_decode:
+                        if final_type != "bytes":
+                            raise ValidationError(
+                                f"Nested ABI decode is only supported for bytes type, "
                                 f"but sub indices resolve to '{final_type}'."
                             )
 

--- a/nucypher/policy/conditions/types.py
+++ b/nucypher/policy/conditions/types.py
@@ -207,9 +207,10 @@ class SigningObjectAttributeCondition(_BaseSigningObjectAttributeCondition):
 class AbiParameterValidation(TypedDict):
     parameterIndex: int
     subIndices: NotRequired[List[int]]
-    # either returnValueTest or nestedAbiValidation
+    # either returnValueTest or nestedAbiValidation or nestedAbiDecode
     returnValueTest: NotRequired[ReturnValueTestDict]
     nestedAbiValidation: NotRequired["AbiCallValidation"]
+    nestedAbiDecode: NotRequired["AbiDecodeValidationDict"]
 
 
 # AbiCallValidation
@@ -220,6 +221,16 @@ class AbiParameterValidation(TypedDict):
 # }
 class AbiCallValidation(TypedDict):
     allowedAbiCalls = Dict[str, List[AbiParameterValidation]]
+
+
+# AbiDecodeValidation
+# {
+#    "type": str  (e.g. "(address,uint256)")
+#    "validations": [AbiParameterValidation]
+# }
+class AbiDecodeValidationDict(TypedDict):
+    type: str
+    validations: List[AbiParameterValidation]
 
 
 # SigningObjectAbiAttributeCondition represents:

--- a/nucypher/utilities/abi.py
+++ b/nucypher/utilities/abi.py
@@ -145,6 +145,22 @@ def resolve_abi_type_with_indices(abi_type: str, sub_indices: List[int]) -> str:
     return current_type
 
 
+def decode_abi_encoded(type_str: str, data: bytes) -> list:
+    """
+    Decode raw ABI-encoded data (no function selector) against a type string.
+
+    Unlike decode_human_readable_call, this does NOT expect a 4-byte function
+    selector prefix. Used for decoding ERC-7579 batch execution data and other
+    selectorless ABI-encoded payloads.
+    """
+    types = (
+        _split_comma_separated_types(type_str)
+        if "," in type_str and not type_str.startswith("(")
+        else [type_str]
+    )
+    return list(eth_abi.decode(types, data))
+
+
 def decode_human_readable_call(
     human_signature: str, call_data: bytes, return_method_name: bool = True
 ) -> Tuple[Union[str, bytes], List[Any]]:

--- a/tests/unit/conditions/test_signing_condition.py
+++ b/tests/unit/conditions/test_signing_condition.py
@@ -2,6 +2,7 @@ import copy
 import json
 import random
 
+import eth_abi
 import pytest
 from ecdsa import SECP256k1, SigningKey
 from ecdsa.util import sigencode_string
@@ -28,6 +29,7 @@ from nucypher.policy.conditions.lingo import (
 from nucypher.policy.conditions.signing.base import (
     SIGNING_CONDITION_OBJECT_CONTEXT_VAR,
     AbiCallValidation,
+    AbiDecodeValidation,
     AbiParameterValidation,
     SigningObjectAbiAttributeCondition,
     SigningObjectAttributeCondition,
@@ -371,7 +373,9 @@ def test_invalid_signing_object_abi_attribute_condition():
         )
 
     # both return value test and nested_validation provided which isn't allowed
-    with pytest.raises(ValueError, match="return value test or nested abi validation"):
+    with pytest.raises(
+        ValueError, match="returnValueTest, nestedAbiValidation, or nestedAbiDecode"
+    ):
         _ = SigningObjectAbiAttributeCondition(
             attribute_name="call_data",
             abi_validation=AbiCallValidation(
@@ -1327,3 +1331,259 @@ def test_signing_restriction_based_points_value_from_rest_endpoint(
         [erc20_token_address.lower(), [amount]],
     ]
     assert mocked_get.call_count == 1
+
+
+def test_abi_decode_validation_batch_execution(
+    condition_provider_manager, get_random_checksum_address
+):
+    """Test nestedAbiDecode for ERC-7579 batch execution data."""
+    recipient = get_random_checksum_address()
+    fee_recipient = get_random_checksum_address()
+
+    transfer_call = encode_human_readable_call(
+        "transfer(address,uint256)", [recipient, 1000000]
+    )
+    fee_call = encode_human_readable_call(
+        "transfer(address,uint256)", [fee_recipient, 10000]
+    )
+
+    usdc = get_random_checksum_address()
+    batch_data = eth_abi.encode(
+        ["(address,uint256,bytes)[]"],
+        [[(usdc, 0, transfer_call), (usdc, 0, fee_call)]],
+    )
+
+    BATCH_MODE = bytes.fromhex("01" + "00" * 31)
+    call_data = encode_human_readable_call(
+        "execute(bytes32,bytes)", [BATCH_MODE, batch_data]
+    )
+
+    user_op = UserOperation(
+        sender=get_random_checksum_address(),
+        nonce=0,
+        call_data=call_data,
+        call_gas_limit=1,
+        verification_gas_limit=2,
+        pre_verification_gas=3,
+        max_fee_per_gas=4,
+        max_priority_fee_per_gas=5,
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: user_op}
+
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(bytes32,bytes)": [
+                    AbiParameterValidation(
+                        parameter_index=0,
+                        return_value_test=ReturnValueTest(
+                            "==", "0x" + BATCH_MODE.hex()
+                        ),
+                    ),
+                    AbiParameterValidation(
+                        parameter_index=1,
+                        nested_abi_decode=AbiDecodeValidation(
+                            type="(address,uint256,bytes)[]",
+                            validations=[
+                                AbiParameterValidation(
+                                    parameter_index=0,
+                                    sub_indices=[0, 0],
+                                    return_value_test=ReturnValueTest("==", usdc),
+                                ),
+                                AbiParameterValidation(
+                                    parameter_index=0,
+                                    sub_indices=[0, 2],
+                                    nested_abi_validation=AbiCallValidation(
+                                        {
+                                            "transfer(address,uint256)": [
+                                                AbiParameterValidation(
+                                                    parameter_index=0,
+                                                    return_value_test=ReturnValueTest(
+                                                        "==", recipient
+                                                    ),
+                                                ),
+                                                AbiParameterValidation(
+                                                    parameter_index=1,
+                                                    return_value_test=ReturnValueTest(
+                                                        "==", 1000000
+                                                    ),
+                                                ),
+                                            ]
+                                        }
+                                    ),
+                                ),
+                                AbiParameterValidation(
+                                    parameter_index=0,
+                                    sub_indices=[1, 0],
+                                    return_value_test=ReturnValueTest("==", usdc),
+                                ),
+                                AbiParameterValidation(
+                                    parameter_index=0,
+                                    sub_indices=[1, 2],
+                                    nested_abi_validation=AbiCallValidation(
+                                        {
+                                            "transfer(address,uint256)": [
+                                                AbiParameterValidation(
+                                                    parameter_index=0,
+                                                    return_value_test=ReturnValueTest(
+                                                        "==", fee_recipient
+                                                    ),
+                                                ),
+                                                AbiParameterValidation(
+                                                    parameter_index=1,
+                                                    return_value_test=ReturnValueTest(
+                                                        "==", 10000
+                                                    ),
+                                                ),
+                                            ]
+                                        }
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ),
+                ]
+            }
+        ),
+    )
+
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is True
+
+
+def test_abi_decode_validation_serialization():
+    """Test that nestedAbiDecode serializes/deserializes correctly."""
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(bytes32,bytes)": [
+                    AbiParameterValidation(
+                        parameter_index=1,
+                        nested_abi_decode=AbiDecodeValidation(
+                            type="(address,uint256,bytes)[]",
+                            validations=[
+                                AbiParameterValidation(
+                                    parameter_index=0,
+                                    sub_indices=[0, 0],
+                                    return_value_test=ReturnValueTest(
+                                        "==",
+                                        "0x036CbD53842c5426634e7929541eC2318f3dCF7e",
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ),
+                ]
+            }
+        ),
+    )
+
+    # Serialize to dict
+    serialized = condition.to_dict()
+
+    # Check JSON structure
+    param = serialized["abiValidation"]["allowedAbiCalls"]["execute(bytes32,bytes)"][0]
+    assert "nestedAbiDecode" in param
+    assert param["nestedAbiDecode"]["type"] == "(address,uint256,bytes)[]"
+    assert len(param["nestedAbiDecode"]["validations"]) == 1
+
+    # Deserialize back
+    restored = SigningObjectAbiAttributeCondition.from_dict(serialized)
+    assert restored.to_dict() == serialized
+
+
+def test_abi_decode_validation_rejects_wrong_value(
+    condition_provider_manager, get_random_checksum_address
+):
+    """Test that nestedAbiDecode rejects when inner values don't match."""
+    recipient = get_random_checksum_address()
+    wrong_recipient = get_random_checksum_address()
+
+    transfer_call = encode_human_readable_call(
+        "transfer(address,uint256)", [wrong_recipient, 1000000]
+    )
+    usdc = get_random_checksum_address()
+    batch_data = eth_abi.encode(
+        ["(address,uint256,bytes)[]"],
+        [[(usdc, 0, transfer_call)]],
+    )
+    BATCH_MODE = bytes.fromhex("01" + "00" * 31)
+    call_data = encode_human_readable_call(
+        "execute(bytes32,bytes)", [BATCH_MODE, batch_data]
+    )
+
+    user_op = UserOperation(
+        sender=get_random_checksum_address(),
+        nonce=0,
+        call_data=call_data,
+        call_gas_limit=1,
+        verification_gas_limit=2,
+        pre_verification_gas=3,
+        max_fee_per_gas=4,
+        max_priority_fee_per_gas=5,
+    )
+    context = {SIGNING_CONDITION_OBJECT_CONTEXT_VAR: user_op}
+
+    condition = SigningObjectAbiAttributeCondition(
+        attribute_name="call_data",
+        abi_validation=AbiCallValidation(
+            {
+                "execute(bytes32,bytes)": [
+                    AbiParameterValidation(
+                        parameter_index=1,
+                        nested_abi_decode=AbiDecodeValidation(
+                            type="(address,uint256,bytes)[]",
+                            validations=[
+                                AbiParameterValidation(
+                                    parameter_index=0,
+                                    sub_indices=[0, 2],
+                                    nested_abi_validation=AbiCallValidation(
+                                        {
+                                            "transfer(address,uint256)": [
+                                                AbiParameterValidation(
+                                                    parameter_index=0,
+                                                    return_value_test=ReturnValueTest(
+                                                        "==",
+                                                        recipient,  # expects recipient, gets wrong_recipient
+                                                    ),
+                                                ),
+                                            ]
+                                        }
+                                    ),
+                                ),
+                            ],
+                        ),
+                    ),
+                ]
+            }
+        ),
+    )
+
+    allowed, _ = condition.verify(providers=condition_provider_manager, **context)
+    assert allowed is False
+
+
+def test_abi_decode_validation_invalid_schema():
+    """Test that nestedAbiDecode rejects invalid configurations at schema time."""
+    from marshmallow import ValidationError as MarshmallowValidationError
+
+    # nestedAbiDecode on non-bytes type should fail
+    with pytest.raises((MarshmallowValidationError, InvalidCondition, ValueError)):
+        SigningObjectAbiAttributeCondition(
+            attribute_name="call_data",
+            abi_validation=AbiCallValidation(
+                {
+                    "execute(bytes32,bytes)": [
+                        AbiParameterValidation(
+                            parameter_index=0,  # bytes32, not bytes
+                            nested_abi_decode=AbiDecodeValidation(
+                                type="(address,uint256)[]",
+                                validations=[],
+                            ),
+                        ),
+                    ]
+                }
+            ),
+        )

--- a/tests/unit/test_abi_utils.py
+++ b/tests/unit/test_abi_utils.py
@@ -1,5 +1,6 @@
 import os
 
+import eth_abi
 import pytest
 from eth_utils import keccak
 
@@ -232,3 +233,41 @@ def test_resolve_abi_type_with_indices_errors():
         resolve_abi_type_with_indices(
             "(address,uint256)[]", [0, 0, 0]
         )  # address is not indexable
+
+
+def test_decode_abi_encoded():
+    """Test decoding raw ABI-encoded data (no function selector)."""
+    from nucypher.utilities.abi import decode_abi_encoded
+
+    # Encode a tuple array: (address, uint256, bytes)[]
+    type_str = "(address,uint256,bytes)[]"
+    encoded = eth_abi.encode(
+        [type_str],
+        [
+            [
+                ("0x036CbD53842c5426634e7929541eC2318f3dCF7e", 0, b"\xa9\x05\x9c\xbb"),
+                ("0x036CbD53842c5426634e7929541eC2318f3dCF7e", 0, b"\xa9\x05\x9c\xbb"),
+            ]
+        ],
+    )
+
+    # Should NOT have a function selector (no leading 4 bytes to strip)
+    decoded = decode_abi_encoded(type_str, encoded)
+    assert len(decoded) == 1  # one top-level param: the array
+    assert len(decoded[0]) == 2  # two elements in the array
+    assert (
+        decoded[0][0][0].lower() == "0x036CbD53842c5426634e7929541eC2318f3dCF7e".lower()
+    )
+
+
+def test_decode_abi_encoded_simple_tuple():
+    """Test decoding a simple tuple type."""
+    from nucypher.utilities.abi import decode_abi_encoded
+
+    type_str = "(address,uint256)"
+    addr = "0x036CbD53842c5426634e7929541eC2318f3dCF7e"
+    encoded = eth_abi.encode([type_str], [(addr, 42)])
+
+    decoded = decode_abi_encoded(type_str, encoded)
+    assert decoded[0][0].lower() == addr.lower()
+    assert decoded[0][1] == 42


### PR DESCRIPTION
## Problem

`nestedAbiValidation` decodes bytes by calling `decode_human_readable_call`, which always strips a 4-byte function selector from the front. This means it can only validate bytes that contain function-call-encoded data (selector + args).

Some use cases produce ABI-encoded bytes with **no selector** — just raw `eth_abi.encode(types, values)` output. There's currently no way to validate these.

## Solution

Add `nestedAbiDecode` as a new option on `AbiParameterValidation`, alongside the existing `nestedAbiValidation`. The difference:

| | `nestedAbiValidation` | `nestedAbiDecode` |
|---|---|---|
| **Input** | Function-call bytes (selector + args) | Raw ABI-encoded bytes (no selector) |
| **Config key** | `allowedAbiCalls` with function signatures | `type` with a Solidity type string |
| **Decodes via** | `decode_human_readable_call` | `decode_abi_encoded` (new) |
| **Inner validations** | Keyed by function signature | Flat `validations` list |

After decoding, both work the same way — you use `parameterIndex`, `subIndices`, `returnValueTest`, and further nesting as usual.

## What changed

**`AbiParameterValidation`** (the existing class) now accepts exactly one of three options:
- `returnValueTest` — compare a value directly (unchanged)
- `nestedAbiValidation` — decode as a function call and validate (unchanged)
- `nestedAbiDecode` — **new** — decode as raw ABI and validate

**`AbiDecodeValidation`** (new class) has two fields:
- `type`: a Solidity type string, e.g. `(address,uint256,bytes)[]`
- `validations`: list of `AbiParameterValidation` (same structure used everywhere else)

**`decode_abi_encoded`** (new utility in `abi.py`) — thin wrapper around `eth_abi.decode` that takes a type string and raw bytes. No selector stripping.

**`AbiCallValidation`** — updated the bytes-type guard to also check `nestedAbiDecode` (same as existing `nestedAbiValidation` check).

**TypedDict** — added `AbiDecodeValidationDict`, updated `AbiParameterValidation`.

## JSON example

```json
{
  "parameterIndex": 1,
  "nestedAbiDecode": {
    "type": "(address,uint256,bytes)[]",
    "validations": [
      {
        "parameterIndex": 0,
        "subIndices": [0, 0],
        "returnValueTest": { "comparator": "==", "value": "0x036C..." }
      },
      {
        "parameterIndex": 0,
        "subIndices": [0, 2],
        "nestedAbiValidation": {
          "allowedAbiCalls": {
            "transfer(address,uint256)": [
              { "parameterIndex": 0, "returnValueTest": { "comparator": "==", "value": ":recipientAA" } }
            ]
          }
        }
      }
    ]
  }
}
```

Note: `nestedAbiDecode` validations can themselves use `nestedAbiValidation` (or another `nestedAbiDecode`) for further nesting.

## Tests

- **Integration**: Build batch calldata (outer function call wrapping raw-encoded inner data), validate the full chain including nested function calls inside the decoded data
- **Serialization**: Round-trip to dict and back
- **Rejection**: Wrong inner value → `allowed=False`
- **Schema**: `nestedAbiDecode` on a non-`bytes` parameter type is rejected