### PR TITLE
Fixes: obfuscate rpc url in one more location; log exception when Ursula can't start

### DIFF
--- a/nucypher/blockchain/eth/agents.py
+++ b/nucypher/blockchain/eth/agents.py
@@ -61,6 +61,7 @@ from nucypher.blockchain.eth.models import (
 from nucypher.blockchain.eth.registry import (
     ContractRegistry,
 )
+from nucypher.blockchain.eth.utils import obfuscate_rpc_url
 from nucypher.config.constants import (
     NUCYPHER_ENVVAR_STAKING_PROVIDERS_PAGINATION_SIZE,
     NUCYPHER_ENVVAR_STAKING_PROVIDERS_PAGINATION_SIZE_LIGHT_NODE,
@@ -120,12 +121,8 @@ class EthereumContractAgent:
         self.transaction_gas = transaction_gas
 
         self.log.info(
-            "Initialized new {} for {} with {} and {}".format(
-                self.__class__.__name__,
-                self.contract.address,
-                self.blockchain.endpoint,
-                str(self.registry),
-            )
+            f"Initialized new {self.__class__.__name__} for {self.contract.address} "
+            f"with {obfuscate_rpc_url(self.blockchain.endpoint)} and {str(self.registry)}"
         )
 
     def __repr__(self) -> str:

--- a/nucypher/characters/lawful.py
+++ b/nucypher/characters/lawful.py
@@ -888,9 +888,10 @@ class Ursula(Teacher, Character, Operator):
                     transacting_power=transacting_power,
                 )
 
-            except Exception:
+            except Exception as e:
                 # It's not possible to finish constructing this node...
                 # This block is here to ensure that the reactor is stopped in tests.
+                self.log.critical(f"Failed to initialize Ursula: {e}")
                 self.stop(halt_reactor=False)
                 raise
 


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [x] 1
- [ ] 2
- [ ] 3

**What this does:**
- One more location to obfuscate an RPC URL in logs.
- Log exception when Ursula can't be properly initialized so that the reason is obvious.

_Encountered during separate testing with @cygnusv and @KPrasch_

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
