### PR TITLE
Do not enforce ETH funding for operators

### DIFF
--- a/newsfragments/3729.removal.rst
+++ b/newsfragments/3729.removal.rst
@@ -1,0 +1,1 @@
+Removes enforcement of the ETH balance check on node startup since not all nodes will participate in signing rituals on Ethereum; a one-time ETH balance check is still performed for logging.

--- a/nucypher/blockchain/eth/actors.py
+++ b/nucypher/blockchain/eth/actors.py
@@ -1561,7 +1561,11 @@ class Operator(BaseActor):
         return self.child_application_agent.is_operator_confirmed(self.operator_address)
 
     def _is_funded(
-        self, client: EthereumClient, funding_unit: str, emitter: StdoutEmitter
+        self,
+        client: EthereumClient,
+        funding_unit: str,
+        emitter: StdoutEmitter,
+        required: bool = True,
     ) -> bool:
         # check for funds
         wei_balance = client.get_balance(self.operator_address)
@@ -1575,7 +1579,7 @@ class Operator(BaseActor):
             return True
         else:
             emitter.message(
-                f"! Operator {self.operator_address} is not funded with {funding_unit}",
+                f"! Operator {self.operator_address} is not funded with {funding_unit}{' (optional)' if not required else ''}",
                 color="yellow",
             )
             return False
@@ -1607,7 +1611,10 @@ class Operator(BaseActor):
                 funded_pol = self._is_funded(taco_child_client, "POL", emitter)
 
             if not funded_eth:
-                funded_eth = self._is_funded(taco_app_client, "ETH", emitter)
+                # don't enforce eth_funding; only specific nodes will support signing
+                # ignore result but still print to console
+                _ = self._is_funded(taco_app_client, "ETH", emitter, required=False)
+                funded_eth = True
 
             if not bonded:
                 # check root

--- a/tests/integration/actors/test_integration_operator.py
+++ b/tests/integration/actors/test_integration_operator.py
@@ -106,11 +106,12 @@ def test_operator_block_until_ready_success(
 
     # funding
     final_balance_pol = Web3.to_wei(1, "ether")
-    final_balance_eth = Web3.to_wei(2, "ether")
+    # eth funding no longer enforced
+    # final_balance_eth = Web3.to_wei(2, "ether")
     mocker.patch.object(
         EthereumClient,
         "get_balance",
-        side_effect=[0, 0, final_balance_pol, final_balance_eth],
+        side_effect=[0, 0, final_balance_pol],
     )
 
     # bonding
@@ -143,13 +144,14 @@ def test_operator_block_until_ready_success(
         # iteration 1
         (
             "not funded with POL",
-            "not funded with ETH",
+            "not funded with ETH (optional)",
             "not bonded to a staking provider",
         ),
         # iteration 2
         (
             f"is funded with {Web3.from_wei(final_balance_pol, 'ether')} POL",
-            f"is funded with {Web3.from_wei(final_balance_eth, 'ether')} ETH",
+            # eth funding only checked once since not enforced
+            # f"is funded with {Web3.from_wei(final_balance_eth, 'ether')} ETH",
             "not bonded to a staking provider",
         ),
         # iteration 3


### PR DESCRIPTION
**Type of PR:**
- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [x] Other

**Required reviews:** 
- [ ] 1
- [x] 2
- [ ] 3

**What this does:**
Remove the ETH funding requirement on startup for nodes since only specific nodes will be used to provide signing functionality i.e. perform signing ritual txs on Ethereum.

We still log ETH balance on startup.

Basically undoes work from https://github.com/nucypher/nucypher/pull/3677.

**Issues fixed/closed:**
> - Fixes #...

**Why it's needed:**
> Explain how this PR fits in the greater context of the NuCypher Network.
> E.g., if this PR address a `nucypher/productdev` issue, let reviewers know!

**Notes for reviewers:**
> What should reviewers focus on? 
> Is there a particular commit/function/section of your PR that requires more attention from reviewers?
